### PR TITLE
feat: ordenar jogos por horário Brasília e melhorar nav mobile

### DIFF
--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -54,6 +54,12 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
     return location.pathname === path;
   };
 
+  const activeModuleName = analysisItems.some((i) => isActive(i.href))
+    ? 'Análises'
+    : betinhoModuleItems.some((i) => isActive(i.href))
+    ? 'Betinho'
+    : null;
+
   const handleNavigation = (href: string) => {
     navigate(href);
     setIsMobileMenuOpen(false);
@@ -205,44 +211,88 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
             )}
 
             {/* Mobile menu button */}
-            <Button
-              variant="ghost"
-              size="sm"
-              className="md:hidden text-terminal-text hover:text-terminal-green h-8 w-8 p-0"
+            <button
+              className="md:hidden flex items-center gap-1.5 px-2 py-1.5 rounded hover:bg-terminal-dark-gray transition-colors text-terminal-text hover:text-terminal-green"
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
             >
+              {activeModuleName && !isMobileMenuOpen && (
+                <span className="text-[10px] font-semibold uppercase tracking-wide opacity-70">
+                  {activeModuleName}
+                </span>
+              )}
               {isMobileMenuOpen ? (
                 <X className="w-4 h-4" />
               ) : (
                 <Menu className="w-4 h-4" />
               )}
-            </Button>
+            </button>
           </div>
         </div>
 
         {/* Mobile Navigation Menu */}
         {isMobileMenuOpen && (
-          <div className="md:hidden border-t border-terminal-border-subtle py-2">
-            <div className="flex flex-col gap-1">
-              {[...analysisItems, ...betinhoModuleItems].map((item) => {
-                const Icon = item.icon;
-                const active = isActive(item.href);
-                return (
-                  <Button
-                    key={item.name}
-                    variant="ghost"
-                    onClick={() => handleNavigation(item.href)}
-                    className={`w-full justify-start h-10 ${
-                      active 
-                        ? 'bg-terminal-green/10 text-terminal-green' 
-                        : 'text-terminal-text hover:text-terminal-green hover:bg-terminal-dark-gray'
-                    }`}
-                  >
-                    <Icon className="w-4 h-4 mr-3" />
-                    <span className="text-sm">{item.name}</span>
-                  </Button>
-                );
-              })}
+          <div className="md:hidden border-t border-terminal-border-subtle py-3">
+            <div className="flex flex-col gap-4">
+
+              {/* Seção Análises */}
+              <div>
+                <p className="px-3 mb-1 text-[10px] font-semibold uppercase tracking-wider text-terminal-text opacity-50">
+                  Análises
+                </p>
+                <div className="flex flex-col gap-1">
+                  {analysisItems.map((item) => {
+                    const Icon = item.icon;
+                    const active = isActive(item.href);
+                    return (
+                      <Button
+                        key={item.name}
+                        variant="ghost"
+                        onClick={() => handleNavigation(item.href)}
+                        className={`w-full justify-start h-10 ${
+                          active
+                            ? 'bg-terminal-green/10 text-terminal-green'
+                            : 'text-terminal-text hover:text-terminal-green hover:bg-terminal-dark-gray'
+                        }`}
+                      >
+                        <Icon className="w-4 h-4 mr-3" />
+                        <span className="text-sm">{item.name}</span>
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Divisor */}
+              <div className="border-t border-terminal-border-subtle" />
+
+              {/* Seção Betinho */}
+              <div>
+                <p className="px-3 mb-1 text-[10px] font-semibold uppercase tracking-wider text-terminal-text opacity-50">
+                  Betinho
+                </p>
+                <div className="flex flex-col gap-1">
+                  {betinhoModuleItems.map((item) => {
+                    const Icon = item.icon;
+                    const active = isActive(item.href);
+                    return (
+                      <Button
+                        key={item.name}
+                        variant="ghost"
+                        onClick={() => handleNavigation(item.href)}
+                        className={`w-full justify-start h-10 ${
+                          active
+                            ? 'bg-terminal-green/10 text-terminal-green'
+                            : 'text-terminal-text hover:text-terminal-green hover:bg-terminal-dark-gray'
+                        }`}
+                      >
+                        <Icon className="w-4 h-4 mr-3" />
+                        <span className="text-sm">{item.name}</span>
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+
             </div>
           </div>
         )}

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -46,6 +46,12 @@ export default function MainNav({ className }: MainNavProps) {
     return location.pathname === path;
   };
 
+  const activeModuleName = analysisItems.some((i) => isActive(i.href))
+    ? 'Análises'
+    : betinhoModuleItems.some((i) => isActive(i.href))
+    ? 'Betinho'
+    : null;
+
   const handleNavigation = (href: string) => {
     navigate(href);
     setIsMobileMenuOpen(false);
@@ -145,46 +151,86 @@ export default function MainNav({ className }: MainNavProps) {
             )}
 
             {/* Mobile menu button */}
-            <Button
-              variant="ghost"
-              size="sm"
-              className="md:hidden"
+            <button
+              className="md:hidden flex items-center gap-1.5 px-2 py-1.5 rounded-md hover:bg-accent transition-colors"
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
             >
+              {activeModuleName && !isMobileMenuOpen && (
+                <span className="text-xs font-medium text-muted-foreground">
+                  {activeModuleName}
+                </span>
+              )}
               {isMobileMenuOpen ? (
                 <X className="w-5 h-5" />
               ) : (
                 <Menu className="w-5 h-5" />
               )}
-            </Button>
+            </button>
           </div>
         </div>
 
         {/* Mobile Navigation Menu */}
         {isMobileMenuOpen && (
           <div className="md:hidden border-t border-border bg-background">
-            <div className="px-2 pt-2 pb-3 space-y-1">
-              {[...analysisItems, ...betinhoModuleItems].map((item) => {
-                const Icon = item.icon;
-                return (
-                  <Button
-                    key={item.name}
-                    variant={isActive(item.href) ? "default" : "ghost"}
-                    onClick={() => handleNavigation(item.href)}
-                    className={`w-full justify-start flex items-center space-x-3 ${
-                      isActive(item.href) 
-                        ? 'bg-primary text-primary-foreground' 
-                        : 'text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    <Icon className="w-4 h-4" />
-                    <div className="text-left">
-                      <div className="font-medium">{item.name}</div>
-                      <div className="text-xs opacity-70">{item.href}</div>
-                    </div>
-                  </Button>
-                );
-              })}
+            <div className="px-2 pt-3 pb-3 space-y-4">
+
+              {/* Seção Análises */}
+              <div>
+                <p className="px-3 mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Análises
+                </p>
+                <div className="space-y-1">
+                  {analysisItems.map((item) => {
+                    const Icon = item.icon;
+                    return (
+                      <Button
+                        key={item.name}
+                        variant={isActive(item.href) ? "default" : "ghost"}
+                        onClick={() => handleNavigation(item.href)}
+                        className={`w-full justify-start flex items-center space-x-3 ${
+                          isActive(item.href)
+                            ? 'bg-primary text-primary-foreground'
+                            : 'text-muted-foreground hover:text-foreground'
+                        }`}
+                      >
+                        <Icon className="w-4 h-4" />
+                        <span className="font-medium">{item.name}</span>
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Divisor */}
+              <div className="border-t border-border" />
+
+              {/* Seção Betinho */}
+              <div>
+                <p className="px-3 mb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                  Betinho
+                </p>
+                <div className="space-y-1">
+                  {betinhoModuleItems.map((item) => {
+                    const Icon = item.icon;
+                    return (
+                      <Button
+                        key={item.name}
+                        variant={isActive(item.href) ? "default" : "ghost"}
+                        onClick={() => handleNavigation(item.href)}
+                        className={`w-full justify-start flex items-center space-x-3 ${
+                          isActive(item.href)
+                            ? 'bg-primary text-primary-foreground'
+                            : 'text-muted-foreground hover:text-foreground'
+                        }`}
+                      >
+                        <Icon className="w-4 h-4" />
+                        <span className="font-medium">{item.name}</span>
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+
             </div>
           </div>
         )}

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -178,13 +178,17 @@ export default function Games() {
 
   const filteredGames = useMemo(() => {
     return [...games].sort((a, b) => {
-      // Sort by date first
-      const dateA = parseGameDate(a.game_date || '');
-      const dateB = parseGameDate(b.game_date || '');
-      const dateCompare = dateA.getTime() - dateB.getTime();
+      // Sort by exact datetime (Brasilia) when available, fallback to game_date
+      const dateA = a.game_datetime_brasilia
+        ? new Date(a.game_datetime_brasilia).getTime()
+        : parseGameDate(a.game_date || '').getTime();
+      const dateB = b.game_datetime_brasilia
+        ? new Date(b.game_datetime_brasilia).getTime()
+        : parseGameDate(b.game_date || '').getTime();
+      const dateCompare = dateA - dateB;
       if (dateCompare !== 0) return dateCompare;
-      
-      // If same date, sort by home team name
+
+      // If same datetime, sort by home team name
       return a.home_team_name.localeCompare(b.home_team_name);
     });
   }, [games]);

--- a/src/services/nba-data.service.ts
+++ b/src/services/nba-data.service.ts
@@ -126,6 +126,7 @@ export interface GamePlayerStats {
 export interface Game {
   game_id: number;
   game_date: string;
+  game_datetime_brasilia: string | null;
   home_team_id: number;
   home_team_name: string;
   home_team_abbreviation: string;

--- a/supabase/migrations/024_add_game_datetime_brasilia.sql
+++ b/supabase/migrations/024_add_game_datetime_brasilia.sql
@@ -1,0 +1,49 @@
+-- ============================================
+-- Adiciona game_datetime_brasilia à ft_games e atualiza get_games
+-- para ordenar jogos por horário exato (Brasília) em vez de só por dia
+-- ============================================
+
+-- 1. Recriar foreign table com o novo campo
+DROP FOREIGN TABLE IF EXISTS bigquery.ft_games;
+CREATE FOREIGN TABLE bigquery.ft_games (
+  game_id bigint, game_date date, home_team_id bigint, home_team_name text,
+  home_team_abbreviation text, home_team_score float8, visitor_team_id bigint,
+  visitor_team_name text, visitor_team_abbreviation text, visitor_team_score float8,
+  winner_team_id bigint, loaded_at timestamp, home_team_is_b2b_game boolean,
+  visitor_team_is_b2b_game boolean, home_team_is_next_game boolean,
+  visitor_team_is_next_game boolean, game_datetime_brasilia timestamp
+) SERVER bigquery_server OPTIONS (table 'ft_games', location 'us-east1');
+
+-- 2. Recriar get_games incluindo game_datetime_brasilia e ordenando por horário
+DROP FUNCTION IF EXISTS public.get_games(date, text);
+CREATE FUNCTION public.get_games(p_game_date date DEFAULT NULL, p_team_abbreviation text DEFAULT NULL)
+RETURNS TABLE (game_id bigint, game_date date, game_datetime_brasilia timestamp, home_team_id bigint, home_team_name text,
+  home_team_abbreviation text, home_team_score float8, visitor_team_id bigint, visitor_team_name text,
+  visitor_team_abbreviation text, visitor_team_score float8, winner_team_id bigint, loaded_at timestamp,
+  home_team_is_b2b_game boolean, visitor_team_is_b2b_game boolean, home_team_is_next_game boolean,
+  visitor_team_is_next_game boolean, home_team_last_five text, visitor_team_last_five text)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  RETURN QUERY
+  WITH latest_teams AS (
+    SELECT DISTINCT ON (t.team_abbreviation)
+      t.team_id, t.team_abbreviation, t.team_last_five_games
+    FROM bigquery.dim_teams t
+    ORDER BY t.team_abbreviation, t.loaded_at DESC NULLS LAST
+  )
+  SELECT g.game_id, g.game_date, g.game_datetime_brasilia, g.home_team_id, g.home_team_name, g.home_team_abbreviation,
+    g.home_team_score, g.visitor_team_id, g.visitor_team_name, g.visitor_team_abbreviation,
+    g.visitor_team_score, g.winner_team_id, g.loaded_at, g.home_team_is_b2b_game,
+    g.visitor_team_is_b2b_game, g.home_team_is_next_game, g.visitor_team_is_next_game,
+    ht.team_last_five_games as home_team_last_five,
+    vt.team_last_five_games as visitor_team_last_five
+  FROM bigquery.ft_games g
+  LEFT JOIN latest_teams ht ON g.home_team_abbreviation = ht.team_abbreviation
+  LEFT JOIN latest_teams vt ON g.visitor_team_abbreviation = vt.team_abbreviation
+  WHERE (p_game_date IS NULL OR g.game_date = p_game_date)
+    AND (p_team_abbreviation IS NULL OR LOWER(g.home_team_abbreviation) = LOWER(p_team_abbreviation)
+      OR LOWER(g.visitor_team_abbreviation) = LOWER(p_team_abbreviation))
+  ORDER BY g.game_datetime_brasilia ASC NULLS LAST, g.home_team_name ASC;
+END; $$;
+
+GRANT EXECUTE ON FUNCTION public.get_games(date, text) TO authenticated, anon;

--- a/supabase/migrations/20250121_create_bigquery_rpc_functions.sql
+++ b/supabase/migrations/20250121_create_bigquery_rpc_functions.sql
@@ -78,7 +78,7 @@ END; $$;
 
 DROP FUNCTION IF EXISTS public.get_games(date, text);
 CREATE FUNCTION public.get_games(p_game_date date DEFAULT NULL, p_team_abbreviation text DEFAULT NULL)
-RETURNS TABLE (game_id bigint, game_date date, home_team_id bigint, home_team_name text,
+RETURNS TABLE (game_id bigint, game_date date, game_datetime_brasilia timestamp, home_team_id bigint, home_team_name text,
   home_team_abbreviation text, home_team_score float8, visitor_team_id bigint, visitor_team_name text,
   visitor_team_abbreviation text, visitor_team_score float8, winner_team_id bigint, loaded_at timestamp,
   home_team_is_b2b_game boolean, visitor_team_is_b2b_game boolean, home_team_is_next_game boolean,


### PR DESCRIPTION
- Adiciona game_datetime_brasilia à ft_games e get_games para ordenar por horário exato em vez de só por dia
- Cria migration 024 para aplicar em prod
- Separa menu mobile (AnalyticsNav e MainNav) em seções Análises / Betinho com título e divisor
- Exibe módulo ativo ao lado do hambúrguer no mobile