### PR TITLE
feat(settings): add settings page with profile and subscription manag…

### DIFF
--- a/.agents/skills/git-commit/SKILL.md
+++ b/.agents/skills/git-commit/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: git-commit
+description: 'Execute git commit with conventional commit message analysis, intelligent staging, and message generation. Use when user asks to commit changes, create a git commit, or mentions "/commit". Supports: (1) Auto-detecting type and scope from changes, (2) Generating conventional commit messages from diff, (3) Interactive commit with optional type/scope/description overrides, (4) Intelligent file staging for logical grouping'
+license: MIT
+allowed-tools: Bash
+---
+
+# Git Commit with Conventional Commits
+
+## Overview
+
+Create standardized, semantic git commits using the Conventional Commits specification. Analyze the actual diff to determine appropriate type, scope, and message.
+
+## Conventional Commit Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Commit Types
+
+| Type       | Purpose                        |
+| ---------- | ------------------------------ |
+| `feat`     | New feature                    |
+| `fix`      | Bug fix                        |
+| `docs`     | Documentation only             |
+| `style`    | Formatting/style (no logic)    |
+| `refactor` | Code refactor (no feature/fix) |
+| `perf`     | Performance improvement        |
+| `test`     | Add/update tests               |
+| `build`    | Build system/dependencies      |
+| `ci`       | CI/config changes              |
+| `chore`    | Maintenance/misc               |
+| `revert`   | Revert commit                  |
+
+## Breaking Changes
+
+```
+# Exclamation mark after type/scope
+feat!: remove deprecated endpoint
+
+# BREAKING CHANGE footer
+feat: allow config to extend other configs
+
+BREAKING CHANGE: `extends` key behavior changed
+```
+
+## Workflow
+
+### 1. Analyze Diff
+
+```bash
+# If files are staged, use staged diff
+git diff --staged
+
+# If nothing staged, use working tree diff
+git diff
+
+# Also check status
+git status --porcelain
+```
+
+### 2. Stage Files (if needed)
+
+If nothing is staged or you want to group changes differently:
+
+```bash
+# Stage specific files
+git add path/to/file1 path/to/file2
+
+# Stage by pattern
+git add *.test.*
+git add src/components/*
+
+# Interactive staging
+git add -p
+```
+
+**Never commit secrets** (.env, credentials.json, private keys).
+
+### 3. Generate Commit Message
+
+Analyze the diff to determine:
+
+- **Type**: What kind of change is this?
+- **Scope**: What area/module is affected?
+- **Description**: One-line summary of what changed (present tense, imperative mood, <72 chars)
+
+### 4. Execute Commit
+
+```bash
+# Single line
+git commit -m "<type>[scope]: <description>"
+
+# Multi-line with body/footer
+git commit -m "$(cat <<'EOF'
+<type>[scope]: <description>
+
+<optional body>
+
+<optional footer>
+EOF
+)"
+```
+
+## Best Practices
+
+- One logical change per commit
+- Present tense: "add" not "added"
+- Imperative mood: "fix bug" not "fixes bug"
+- Reference issues: `Closes #123`, `Refs #456`
+- Keep description under 72 characters
+
+## Git Safety Protocol
+
+- NEVER update git config
+- NEVER run destructive commands (--force, hard reset) without explicit request
+- NEVER skip hooks (--no-verify) unless user asks
+- NEVER force push to main/master
+- If commit fails due to hooks, fix and create NEW commit (don't amend)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import ComoUsar from "./pages/ComoUsar";
 import Games from "./pages/Games";
 import Home from "./pages/Home";
 import GameDetail from "./pages/GameDetail";
+import Settings from "./pages/Settings";
 
 const queryClient = new QueryClient();
 
@@ -91,6 +92,11 @@ const App = () => (
           <Route path="/paywall-dashboard" element={<PaywallDashboard />} />
           <Route path="/paywall-platform" element={<PaywallPlatform />} />
           <Route path="/como-usar" element={<ComoUsar />} />
+          <Route path="/settings" element={
+            <ProtectedRoute>
+              <Settings />
+            </ProtectedRoute>
+          } />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/UserNav.tsx
+++ b/src/components/UserNav.tsx
@@ -65,7 +65,7 @@ export default function UserNav({ className }: UserNavProps) {
             <User className="mr-2 h-4 w-4" />
             <span>Dashboard</span>
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => navigate('/onboarding?product=betinho')}>
+          <DropdownMenuItem onClick={() => navigate('/settings')}>
             <Settings className="mr-2 h-4 w-4" />
             <span>Configurações</span>
           </DropdownMenuItem>

--- a/src/components/bets/BetsHeader.tsx
+++ b/src/components/bets/BetsHeader.tsx
@@ -119,7 +119,7 @@ export const BetsHeader: React.FC<BetsHeaderProps> = ({
               </>
             )}
             <DropdownMenuItem 
-              onClick={() => navigate('/onboarding')}
+              onClick={() => navigate('/settings')}
               className="text-terminal-text hover:bg-terminal-gray focus:bg-terminal-gray cursor-pointer"
             >
               <Settings className="mr-2 h-4 w-4" />

--- a/src/hooks/use-subscription-details.ts
+++ b/src/hooks/use-subscription-details.ts
@@ -1,0 +1,84 @@
+import { useState, useEffect, useCallback } from 'react';
+import { createClient } from '../integrations/supabase/client';
+import { useAuth } from './use-auth';
+
+export interface SubscriptionDetails {
+  status: 'free' | 'premium';
+  productType: string | null;
+  periodEnd: string | null;
+  cancelAt: string | null;
+  cancelAtPeriodEnd: boolean;
+  hasStripeCustomer: boolean;
+}
+
+/**
+ * Hook to fetch subscription metadata for display in Settings.
+ * Uses betinho_subscription_status as primary; includes period_end and cancel info.
+ */
+export function useSubscriptionDetails() {
+  const { user } = useAuth();
+  const supabase = createClient();
+  const [details, setDetails] = useState<SubscriptionDetails | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchDetails = useCallback(async () => {
+    if (!user?.id) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const { data, error } = await supabase
+        .from('users')
+        .select(
+          'betinho_subscription_status, analytics_subscription_status, stripe_customer_id, subscription_period_end, subscription_cancel_at, subscription_cancel_at_period_end, subscription_product_type'
+        )
+        .eq('id', user.id)
+        .single();
+
+      if (error) {
+        throw error;
+      }
+
+      const betinhoStatus = (data as { betinho_subscription_status?: string })?.betinho_subscription_status;
+      const analyticsStatus = (data as { analytics_subscription_status?: string })?.analytics_subscription_status;
+      const status = betinhoStatus === 'premium' || analyticsStatus === 'premium' ? 'premium' : 'free';
+      const productType = (data as { subscription_product_type?: string })?.subscription_product_type ?? null;
+      const periodEnd = (data as { subscription_period_end?: string })?.subscription_period_end ?? null;
+      const cancelAt = (data as { subscription_cancel_at?: string })?.subscription_cancel_at ?? null;
+      const cancelAtPeriodEnd = (data as { subscription_cancel_at_period_end?: boolean })?.subscription_cancel_at_period_end ?? false;
+      const hasStripeCustomer = !!(data as { stripe_customer_id?: string })?.stripe_customer_id;
+
+      setDetails({
+        status,
+        productType,
+        periodEnd,
+        cancelAt,
+        cancelAtPeriodEnd,
+        hasStripeCustomer,
+      });
+    } catch (err) {
+      console.error('Error fetching subscription details:', err);
+      setDetails({
+        status: 'free',
+        productType: null,
+        periodEnd: null,
+        cancelAt: null,
+        cancelAtPeriodEnd: false,
+        hasStripeCustomer: false,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    fetchDetails();
+  }, [fetchDetails]);
+
+  return {
+    details,
+    isLoading,
+    refetch: fetchDetails,
+  };
+}

--- a/src/hooks/use-user-profile.ts
+++ b/src/hooks/use-user-profile.ts
@@ -1,0 +1,130 @@
+import { useState, useEffect, useCallback } from 'react';
+import { createClient } from '../integrations/supabase/client';
+import { useAuth } from './use-auth';
+
+export interface UserProfile {
+  name: string | null;
+  email: string;
+  whatsapp_number: string | null;
+  created_at: string;
+}
+
+export interface UserProfileUpdate {
+  name?: string | null;
+  email?: string;
+  whatsapp_number?: string | null;
+}
+
+/**
+ * Hook to manage user profile (name, email, phone/Telegram)
+ * Fetches from users table and supports updates with immediate state reflection.
+ */
+export function useUserProfile() {
+  const { user } = useAuth();
+  const supabase = createClient();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchProfile = useCallback(async () => {
+    if (!user?.id) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setError(null);
+      const { data, error: fetchError } = await supabase
+        .from('users')
+        .select('name, email, whatsapp_number, created_at')
+        .eq('id', user.id)
+        .single();
+
+      if (fetchError) {
+        throw fetchError;
+      }
+
+      if (data) {
+        setProfile({
+          name: data.name ?? null,
+          email: data.email ?? '',
+          whatsapp_number: data.whatsapp_number ?? null,
+          created_at: data.created_at ?? '',
+        });
+      } else {
+        setProfile(null);
+      }
+    } catch (err) {
+      console.error('Error fetching profile:', err);
+      setError(err instanceof Error ? err.message : 'Erro ao carregar perfil');
+      setProfile(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  const updateProfile = async (input: UserProfileUpdate): Promise<boolean> => {
+    if (!user?.id) {
+      setError('Usuário não autenticado');
+      return false;
+    }
+
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const updates: Record<string, unknown> = {};
+      if (input.name !== undefined) updates.name = input.name;
+      if (input.email !== undefined) updates.email = input.email;
+      if (input.whatsapp_number !== undefined) updates.whatsapp_number = input.whatsapp_number;
+
+      if (Object.keys(updates).length === 0) {
+        setIsSaving(false);
+        return true;
+      }
+
+      const { error: updateError } = await supabase
+        .from('users')
+        .update(updates)
+        .eq('id', user.id);
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      // Update local state immediately (no refresh needed)
+      setProfile((prev) =>
+        prev
+          ? {
+              ...prev,
+              ...updates,
+            }
+          : null
+      );
+
+      return true;
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Erro ao salvar alterações';
+      setError(errorMessage);
+      console.error('Error updating profile:', err);
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return {
+    profile,
+    isLoading,
+    isSaving,
+    error,
+    updateProfile,
+    refetchProfile: fetchProfile,
+  };
+}

--- a/src/pages/Paywall.tsx
+++ b/src/pages/Paywall.tsx
@@ -62,32 +62,41 @@ export default function Paywall() {
 
   // Tratamento de retorno do Stripe Checkout
   useEffect(() => {
-    if (success && sessionId) {
+    if (success && sessionId && user?.id) {
       toast({
-        title: "Pagamento realizado com sucesso!",
-        description: "Sua assinatura premium foi ativada. Recarregue a página para ver as mudanças.",
+        title: "Pagamento realizado!",
+        description: "Verificando sua assinatura...",
         variant: "default",
       });
-      
-      // Recarregar status após alguns segundos (dar tempo para o webhook processar)
-      setTimeout(() => {
-        if (user?.id) {
-          supabase
-            .from('users')
-            .select('betinho_subscription_status')
-            .eq('id', user.id)
-            .single()
-            .then(({ data }) => {
-              if (data) {
-                const status = (data as any)?.betinho_subscription_status;
-                setSubscriptionStatus(status === 'premium' ? 'premium' : 'free');
-                if (status === 'premium') {
-                  navigate(redirectAfterPremium);
-                }
-              }
+
+      let cancelled = false;
+
+      const verify = async (attempt: number) => {
+        if (cancelled) return;
+        try {
+          const result = await stripeService.verifySession(sessionId);
+          if (result.verified) {
+            setSubscriptionStatus('premium');
+            toast({
+              title: "Assinatura ativada!",
+              description: "Seu plano premium está ativo. Redirecionando...",
+              variant: "default",
             });
+            setTimeout(() => navigate(redirectAfterPremium), 1000);
+            return;
+          }
+        } catch (err) {
+          console.error('Error verifying session:', err);
         }
-      }, 3000);
+
+        if (!cancelled && attempt < 5) {
+          setTimeout(() => verify(attempt + 1), 2000);
+        }
+      };
+
+      verify(0);
+
+      return () => { cancelled = true; };
     }
 
     if (canceled) {
@@ -97,7 +106,7 @@ export default function Paywall() {
         variant: "default",
       });
     }
-  }, [success, canceled, sessionId, user?.id, supabase, navigate]);
+  }, [success, canceled, sessionId, user?.id, navigate]);
 
   const handleStripeCheckout = async () => {
     // Se ainda está carregando a autenticação, aguarde

--- a/src/pages/PaywallDashboard.tsx
+++ b/src/pages/PaywallDashboard.tsx
@@ -56,31 +56,41 @@ export default function PaywallDashboard() {
   }, [user?.id, supabase]);
 
   useEffect(() => {
-    if (success && sessionId) {
+    if (success && sessionId && user?.id) {
       toast({
-        title: "Pagamento realizado com sucesso!",
-        description: "Sua assinatura premium foi ativada. Recarregue a página para ver as mudanças.",
+        title: "Pagamento realizado!",
+        description: "Verificando sua assinatura...",
         variant: "default",
       });
 
-      setTimeout(() => {
-        if (user?.id) {
-          supabase
-            .from('users')
-            .select('betinho_subscription_status')
-            .eq('id', user.id)
-            .single()
-            .then(({ data }) => {
-              if (data) {
-                const status = (data as any)?.betinho_subscription_status;
-                setSubscriptionStatus(status === 'premium' ? 'premium' : 'free');
-                if (status === 'premium') {
-                  navigate(redirectAfterPremium);
-                }
-              }
+      let cancelled = false;
+
+      const verify = async (attempt: number) => {
+        if (cancelled) return;
+        try {
+          const result = await stripeService.verifySession(sessionId);
+          if (result.verified) {
+            setSubscriptionStatus('premium');
+            toast({
+              title: "Assinatura ativada!",
+              description: "Seu plano premium está ativo. Redirecionando...",
+              variant: "default",
             });
+            setTimeout(() => navigate(redirectAfterPremium), 1000);
+            return;
+          }
+        } catch (err) {
+          console.error('Error verifying session:', err);
         }
-      }, 3000);
+
+        if (!cancelled && attempt < 5) {
+          setTimeout(() => verify(attempt + 1), 2000);
+        }
+      };
+
+      verify(0);
+
+      return () => { cancelled = true; };
     }
 
     if (canceled) {
@@ -90,7 +100,7 @@ export default function PaywallDashboard() {
         variant: "default",
       });
     }
-  }, [success, canceled, sessionId, user?.id, supabase, navigate, redirectAfterPremium]);
+  }, [success, canceled, sessionId, user?.id, navigate, redirectAfterPremium]);
 
   const handleStripeCheckout = async () => {
     if (authLoading) return;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,318 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+import { Alert, AlertDescription } from '../components/ui/alert';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
+import UserNav from '../components/UserNav';
+import { useUserProfile } from '../hooks/use-user-profile';
+import { useSubscriptionDetails } from '../hooks/use-subscription-details';
+import { useToast } from '../hooks/use-toast';
+import { stripeService } from '../services/stripe.service';
+import { User, CreditCard, ArrowLeft, Send, ExternalLink } from 'lucide-react';
+import { format, parseISO, isValid } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+
+const COUNTRY_CODES = [
+  { value: '+55', label: '🇧🇷 +55' },
+  { value: '+1', label: '🇺🇸 +1' },
+  { value: '+54', label: '🇦🇷 +54' },
+  { value: '+56', label: '🇨🇱 +56' },
+  { value: '+57', label: '🇨🇴 +57' },
+  { value: '+351', label: '🇵🇹 +351' },
+  { value: '+34', label: '🇪🇸 +34' },
+  { value: '+39', label: '🇮🇹 +39' },
+];
+
+function parseStoredPhone(stored: string | null): { countryCode: string; number: string } {
+  if (!stored) return { countryCode: '+55', number: '' };
+  const digits = stored.replace(/\D/g, '');
+  const codes = ['55', '1', '54', '56', '57', '351', '34', '39'];
+  for (const c of codes) {
+    if (digits.startsWith(c)) {
+      return { countryCode: `+${c}`, number: digits.slice(c.length) };
+    }
+  }
+  return { countryCode: '+55', number: digits };
+}
+
+function formatCreatedAt(iso: string): string {
+  if (!iso) return '—';
+  try {
+    const date = parseISO(iso);
+    return isValid(date) ? format(date, "dd/MM/yyyy 'às' HH:mm", { locale: ptBR }) : '—';
+  } catch {
+    return '—';
+  }
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  try {
+    const date = parseISO(iso);
+    return isValid(date) ? format(date, 'dd/MM/yyyy', { locale: ptBR }) : '—';
+  } catch {
+    return '—';
+  }
+}
+
+export default function Settings() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { profile, isLoading, isSaving, error, updateProfile } = useUserProfile();
+  const { details: subscriptionDetails, isLoading: subscriptionLoading } = useSubscriptionDetails();
+
+  const [portalLoading, setPortalLoading] = useState(false);
+
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    countryCode: '+55',
+    phoneNumber: '',
+  });
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (profile) {
+      const { countryCode, number } = parseStoredPhone(profile.whatsapp_number);
+      setFormData({
+        name: profile.name ?? '',
+        email: profile.email ?? '',
+        countryCode,
+        phoneNumber: number,
+      });
+    }
+  }, [profile]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSuccessMessage(null);
+
+    const fullPhone =
+      formData.phoneNumber.trim().length > 0
+        ? formData.countryCode.replace(/\D/g, '') + formData.phoneNumber.replace(/\D/g, '')
+        : null;
+
+    const ok = await updateProfile({
+      name: formData.name.trim() || null,
+      email: formData.email.trim(),
+      whatsapp_number: fullPhone,
+    });
+
+    if (ok) {
+      setSuccessMessage('Alterações salvas com sucesso.');
+      toast({ title: 'Sucesso', description: 'Perfil atualizado.' });
+    } else {
+      toast({ title: 'Erro', description: 'Falha ao salvar alterações.', variant: 'destructive' });
+    }
+  };
+
+  const handleManageSubscription = async () => {
+    setPortalLoading(true);
+    try {
+      const url = await stripeService.createCustomerPortalSession();
+      window.location.href = url;
+    } catch (err) {
+      toast({
+        title: 'Erro',
+        description: err instanceof Error ? err.message : 'Falha ao abrir portal.',
+        variant: 'destructive',
+      });
+    } finally {
+      setPortalLoading(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <nav className="sticky top-0 z-50 bg-background/80 backdrop-blur-lg border-b border-border">
+        <div className="container mx-auto flex items-center justify-between px-4 py-4 sm:px-6">
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="icon" onClick={() => navigate(-1)}>
+              <ArrowLeft className="h-5 w-5" />
+            </Button>
+            <span className="text-lg font-semibold text-foreground">Configurações</span>
+          </div>
+          <UserNav />
+        </div>
+      </nav>
+
+      <div className="container mx-auto px-4 py-8 max-w-2xl">
+        <h1 className="text-2xl font-bold text-foreground mb-6">Configurações do Perfil</h1>
+
+        {/* Perfil */}
+        <Card className="mb-8">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <User className="h-5 w-5 text-primary" />
+              <CardTitle>Perfil</CardTitle>
+            </div>
+            <CardDescription>Suas informações pessoais</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="name">Nome</Label>
+                <Input
+                  id="name"
+                  type="text"
+                  placeholder="Seu nome"
+                  value={formData.name}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="email">E-mail</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="seu@email.com"
+                  value={formData.email}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, email: e.target.value }))}
+                  required
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="phone">Telefone / Telegram ID</Label>
+                <div className="flex gap-2">
+                  <Select
+                    value={formData.countryCode}
+                    onValueChange={(v) => setFormData((prev) => ({ ...prev, countryCode: v }))}
+                  >
+                    <SelectTrigger className="w-[120px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {COUNTRY_CODES.map((c) => (
+                        <SelectItem key={c.value} value={c.value}>
+                          {c.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Input
+                    id="phone"
+                    type="tel"
+                    placeholder="(11) 99999-9999"
+                    value={formData.phoneNumber}
+                    onChange={(e) =>
+                      setFormData((prev) => ({
+                        ...prev,
+                        phoneNumber: e.target.value.replace(/\D/g, ''),
+                      }))
+                    }
+                    className="flex-1"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <p className="text-sm text-muted-foreground">
+                  Se mudou seu número no Telegram, toque para ressincronizar.
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() =>
+                    window.open('https://t.me/betinho_assistente_bot?start=force_contact', '_blank')
+                  }
+                >
+                  <Send className="w-4 h-4 mr-2" />
+                  Ressincronizar Telegram
+                </Button>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Conta criada em</Label>
+                <Input
+                  value={profile ? formatCreatedAt(profile.created_at) : '—'}
+                  readOnly
+                  disabled
+                  className="bg-muted"
+                />
+              </div>
+
+              {(error || successMessage) && (
+                <Alert variant={error ? 'destructive' : 'default'}>
+                  <AlertDescription>{error ?? successMessage}</AlertDescription>
+                </Alert>
+              )}
+
+              <Button type="submit" disabled={isSaving}>
+                {isSaving ? 'Salvando...' : 'Salvar alterações'}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        {/* Assinatura */}
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <CreditCard className="h-5 w-5 text-muted-foreground" />
+              <CardTitle>Assinatura</CardTitle>
+            </div>
+            <CardDescription>Gerencie seu plano e pagamentos</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {subscriptionLoading ? (
+              <p className="text-sm text-muted-foreground">Carregando...</p>
+            ) : (
+              <>
+                <div className="space-y-2">
+                  <div className="flex justify-between items-center">
+                    <span className="text-sm text-muted-foreground">Plano</span>
+                    <span className="font-medium">
+                      {subscriptionDetails?.status === 'premium' ? 'Premium' : 'Free'}
+                    </span>
+                  </div>
+                  {subscriptionDetails?.periodEnd && (
+                    <div className="flex justify-between items-center">
+                      <span className="text-sm text-muted-foreground">Próxima cobrança</span>
+                      <span className="text-sm">{formatDate(subscriptionDetails.periodEnd)}</span>
+                    </div>
+                  )}
+                  {subscriptionDetails?.cancelAtPeriodEnd && subscriptionDetails?.cancelAt && (
+                    <div className="flex justify-between items-center">
+                      <span className="text-sm text-muted-foreground">Cancela em</span>
+                      <span className="text-sm text-amber-600">{formatDate(subscriptionDetails.cancelAt)}</span>
+                    </div>
+                  )}
+                </div>
+                {(subscriptionDetails?.hasStripeCustomer || subscriptionDetails?.status === 'premium') ? (
+                  <div className="pt-2">
+                    <Button
+                      variant="default"
+                      onClick={handleManageSubscription}
+                      disabled={portalLoading}
+                    >
+                      <ExternalLink className="w-4 h-4 mr-2" />
+                      {portalLoading ? 'Abrindo...' : 'Gerenciar assinatura'}
+                    </Button>
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Assine um plano para gerenciar sua assinatura.
+                  </p>
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+    </div>
+  );
+}

--- a/supabase/functions/stripe-create-checkout/index.ts
+++ b/supabase/functions/stripe-create-checkout/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-import Stripe from 'https://esm.sh/stripe@14.21.0?target=deno';
+import { createClient } from "npm:@supabase/supabase-js@2";
+import Stripe from "npm:stripe@14.21.0";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/supabase/functions/stripe-customer-portal/index.ts
+++ b/supabase/functions/stripe-customer-portal/index.ts
@@ -1,0 +1,89 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import Stripe from "npm:stripe@14.21.0";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') || '', {
+  apiVersion: '2023-10-16',
+  httpClient: Stripe.createFetchHttpClient(),
+});
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader =
+      req.headers.get('Authorization') ||
+      req.headers.get('authorization');
+
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Missing authorization header' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized', details: authError?.message }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { data: userData } = await supabase
+      .from('users')
+      .select('stripe_customer_id, email')
+      .eq('id', user.id)
+      .single();
+
+    let customerId: string | null = userData?.stripe_customer_id ?? null;
+
+    if (!customerId && (user.email || userData?.email)) {
+      const email = user.email || userData?.email;
+      const customers = await stripe.customers.list({ email, limit: 1 });
+      if (customers.data.length > 0) {
+        customerId = customers.data[0].id;
+        await supabase.from('users').update({ stripe_customer_id: customerId }).eq('id', user.id);
+      }
+    }
+
+    if (!customerId) {
+      return new Response(
+        JSON.stringify({ error: 'No Stripe customer found. Subscribe first to manage your subscription.' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const SITE_URL = Deno.env.get('SITE_URL') || Deno.env.get('SUPABASE_URL') || 'http://localhost:8080';
+    const returnUrl = `${SITE_URL}/settings`;
+
+    const session = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: returnUrl,
+    });
+
+    return new Response(
+      JSON.stringify({ url: session.url }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('Error creating customer portal session:', error);
+    return new Response(
+      JSON.stringify({ error: error?.message || 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/functions/stripe-verify-session/index.ts
+++ b/supabase/functions/stripe-verify-session/index.ts
@@ -1,0 +1,107 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import Stripe from "npm:stripe@14.21.0";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') || '', {
+  apiVersion: '2023-10-16',
+  httpClient: Stripe.createFetchHttpClient(),
+});
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization') || req.headers.get('authorization');
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Missing authorization header' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const { sessionId } = await req.json();
+    if (!sessionId) {
+      return new Response(
+        JSON.stringify({ error: 'Missing sessionId' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    console.log('[VerifySession] Retrieving Stripe session:', sessionId);
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+
+    if (session.payment_status !== 'paid') {
+      console.log('[VerifySession] Payment not completed. Status:', session.payment_status);
+      return new Response(
+        JSON.stringify({ verified: false, status: session.payment_status }),
+        { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const metadataUserId = session.metadata?.userId;
+    if (metadataUserId !== user.id) {
+      console.error('[VerifySession] userId mismatch:', metadataUserId, '!=', user.id);
+      return new Response(
+        JSON.stringify({ error: 'Session does not belong to this user' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const productType = (session.metadata?.productType || 'betinho').toLowerCase();
+    const subscriptionField = (productType === 'analytics' || productType === 'platform')
+      ? 'analytics_subscription_status'
+      : 'betinho_subscription_status';
+
+    console.log(`[VerifySession] Payment verified. Updating ${subscriptionField} to premium for user:`, user.id);
+
+    const updateData: Record<string, string> = {};
+    updateData[subscriptionField] = 'premium';
+
+    const { error: updateError } = await supabase
+      .from('users')
+      .update(updateData)
+      .eq('id', user.id);
+
+    if (updateError) {
+      console.error('[VerifySession] Error updating subscription:', updateError);
+      return new Response(
+        JSON.stringify({ error: 'Failed to update subscription' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    console.log(`[VerifySession] ✅ ${subscriptionField} updated to premium`);
+
+    return new Response(
+      JSON.stringify({ verified: true, subscriptionField, status: 'premium' }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('[VerifySession] Error:', error);
+    return new Response(
+      JSON.stringify({ error: error.message || 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/functions/whatsapp-webhook/index.ts
+++ b/supabase/functions/whatsapp-webhook/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient } from "npm:@supabase/supabase-js@2"
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/supabase/migrations/026_add_subscription_metadata.sql
+++ b/supabase/migrations/026_add_subscription_metadata.sql
@@ -1,0 +1,17 @@
+-- Add subscription metadata fields for displaying plan status, validity and next billing in Settings
+-- These are populated by the Stripe webhook on subscription events
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS stripe_subscription_id VARCHAR(255),
+ADD COLUMN IF NOT EXISTS subscription_period_end TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS subscription_cancel_at TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS subscription_cancel_at_period_end BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS subscription_product_type VARCHAR(50);
+
+CREATE INDEX IF NOT EXISTS idx_users_stripe_subscription_id ON users(stripe_subscription_id);
+
+COMMENT ON COLUMN users.stripe_subscription_id IS 'Stripe subscription ID for the active subscription';
+COMMENT ON COLUMN users.subscription_period_end IS 'End of current billing period (next charge date)';
+COMMENT ON COLUMN users.subscription_cancel_at IS 'When subscription will be canceled (if cancel_at_period_end)';
+COMMENT ON COLUMN users.subscription_cancel_at_period_end IS 'True if subscription cancels at end of period';
+COMMENT ON COLUMN users.subscription_product_type IS 'Product type: betinho or analytics';


### PR DESCRIPTION
…ement

- Add /settings route and Settings page with Perfil (name, email, phone, created_at)
- Add use-user-profile and use-subscription-details hooks
- Point Configurações in UserNav and BetsHeader to /settings
- Add Stripe Customer Portal edge function and createCustomerPortalSession in stripe.service
- Persist subscription metadata in stripe-webhook (period_end, cancel_at, product_type)
- Add migration 026 for subscription metadata columns on users
- Add Telegram resync CTA in Settings and /start force_contact in telegram-webhook