### PR TITLE
feat(settings): improve performance and split subscription by product

### DIFF
--- a/src/hooks/use-settings-data.ts
+++ b/src/hooks/use-settings-data.ts
@@ -1,0 +1,162 @@
+import { useState, useEffect, useCallback } from 'react';
+import { createClient } from '../integrations/supabase/client';
+import { useAuth } from './use-auth';
+
+export interface UserProfile {
+  name: string | null;
+  email: string;
+  whatsapp_number: string | null;
+  created_at: string;
+}
+
+export interface UserProfileUpdate {
+  name?: string | null;
+  email?: string;
+  whatsapp_number?: string | null;
+}
+
+export interface ProductSubscription {
+  status: 'free' | 'premium';
+  periodEnd: string | null;
+  cancelAt: string | null;
+  cancelAtPeriodEnd: boolean;
+}
+
+export interface SubscriptionDetails {
+  betinho: ProductSubscription;
+  analytics: ProductSubscription;
+  hasStripeCustomer: boolean;
+}
+
+/**
+ * Unified hook for Settings page: single query for profile + subscription.
+ * Reduces roundtrips and avoids blocking the whole page.
+ */
+export function useSettingsData() {
+  const { user } = useAuth();
+  const supabase = createClient();
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [subscription, setSubscription] = useState<SubscriptionDetails | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    if (!user?.id) {
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      setError(null);
+      const { data, error: fetchError } = await supabase
+        .from('users')
+        .select(
+          'name, email, whatsapp_number, created_at, betinho_subscription_status, analytics_subscription_status, stripe_customer_id, betinho_subscription_period_end, analytics_subscription_period_end, betinho_subscription_cancel_at, analytics_subscription_cancel_at, betinho_subscription_cancel_at_period_end, analytics_subscription_cancel_at_period_end'
+        )
+        .eq('id', user.id)
+        .single();
+
+      if (fetchError) {
+        throw fetchError;
+      }
+
+      const row = data as Record<string, unknown>;
+
+      if (data) {
+        setProfile({
+          name: (row.name as string) ?? null,
+          email: (row.email as string) ?? '',
+          whatsapp_number: (row.whatsapp_number as string) ?? null,
+          created_at: (row.created_at as string) ?? '',
+        });
+
+        const betinhoStatus = (row.betinho_subscription_status as string) === 'premium' ? 'premium' : 'free';
+        const analyticsStatus = (row.analytics_subscription_status as string) === 'premium' ? 'premium' : 'free';
+
+        setSubscription({
+          betinho: {
+            status: betinhoStatus,
+            periodEnd: (row.betinho_subscription_period_end as string) ?? null,
+            cancelAt: (row.betinho_subscription_cancel_at as string) ?? null,
+            cancelAtPeriodEnd: (row.betinho_subscription_cancel_at_period_end as boolean) ?? false,
+          },
+          analytics: {
+            status: analyticsStatus,
+            periodEnd: (row.analytics_subscription_period_end as string) ?? null,
+            cancelAt: (row.analytics_subscription_cancel_at as string) ?? null,
+            cancelAtPeriodEnd: (row.analytics_subscription_cancel_at_period_end as boolean) ?? false,
+          },
+          hasStripeCustomer: !!(row.stripe_customer_id as string),
+        });
+      } else {
+        setProfile(null);
+        setSubscription(null);
+      }
+    } catch (err) {
+      console.error('Error fetching settings data:', err);
+      setError(err instanceof Error ? err.message : 'Erro ao carregar dados');
+      setProfile(null);
+      setSubscription(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [user?.id]);
+
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
+
+  const updateProfile = async (input: UserProfileUpdate): Promise<boolean> => {
+    if (!user?.id) {
+      setError('Usuário não autenticado');
+      return false;
+    }
+
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const updates: Record<string, unknown> = {};
+      if (input.name !== undefined) updates.name = input.name;
+      if (input.email !== undefined) updates.email = input.email;
+      if (input.whatsapp_number !== undefined) updates.whatsapp_number = input.whatsapp_number;
+
+      if (Object.keys(updates).length === 0) {
+        setIsSaving(false);
+        return true;
+      }
+
+      const { error: updateError } = await supabase
+        .from('users')
+        .update(updates)
+        .eq('id', user.id);
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      setProfile((prev) =>
+        prev ? { ...prev, ...updates } : null
+      );
+
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Erro ao salvar alterações');
+      console.error('Error updating profile:', err);
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return {
+    profile,
+    subscription,
+    isLoading,
+    isSaving,
+    error,
+    updateProfile,
+    refetch: fetchAll,
+  };
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,8 +7,7 @@ import { Label } from '../components/ui/label';
 import { Alert, AlertDescription } from '../components/ui/alert';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../components/ui/select';
 import UserNav from '../components/UserNav';
-import { useUserProfile } from '../hooks/use-user-profile';
-import { useSubscriptionDetails } from '../hooks/use-subscription-details';
+import { useSettingsData } from '../hooks/use-settings-data';
 import { useToast } from '../hooks/use-toast';
 import { stripeService } from '../services/stripe.service';
 import { User, CreditCard, ArrowLeft, Send, ExternalLink } from 'lucide-react';
@@ -61,8 +60,7 @@ function formatDate(iso: string | null): string {
 export default function Settings() {
   const navigate = useNavigate();
   const { toast } = useToast();
-  const { profile, isLoading, isSaving, error, updateProfile } = useUserProfile();
-  const { details: subscriptionDetails, isLoading: subscriptionLoading } = useSubscriptionDetails();
+  const { profile, subscription, isLoading, isSaving, error, updateProfile } = useSettingsData();
 
   const [portalLoading, setPortalLoading] = useState(false);
 
@@ -124,14 +122,6 @@ export default function Settings() {
       setPortalLoading(false);
     }
   };
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary" />
-      </div>
-    );
-  }
 
   return (
     <div className="min-h-screen bg-background">
@@ -237,7 +227,7 @@ export default function Settings() {
               <div className="space-y-2">
                 <Label>Conta criada em</Label>
                 <Input
-                  value={profile ? formatCreatedAt(profile.created_at) : '—'}
+                  value={isLoading ? 'Carregando...' : (profile ? formatCreatedAt(profile.created_at) : '—')}
                   readOnly
                   disabled
                   className="bg-muted"
@@ -267,31 +257,55 @@ export default function Settings() {
             <CardDescription>Gerencie seu plano e pagamentos</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            {subscriptionLoading ? (
+            {isLoading ? (
               <p className="text-sm text-muted-foreground">Carregando...</p>
             ) : (
               <>
-                <div className="space-y-2">
+                {/* Betinho */}
+                <div className="space-y-2 rounded-lg border p-4">
+                  <h4 className="font-medium text-sm">Betinho</h4>
                   <div className="flex justify-between items-center">
                     <span className="text-sm text-muted-foreground">Plano</span>
                     <span className="font-medium">
-                      {subscriptionDetails?.status === 'premium' ? 'Premium' : 'Free'}
+                      {subscription?.betinho.status === 'premium' ? 'Premium' : 'Free'}
                     </span>
                   </div>
-                  {subscriptionDetails?.periodEnd && (
+                  {subscription?.betinho.periodEnd && (
                     <div className="flex justify-between items-center">
                       <span className="text-sm text-muted-foreground">Próxima cobrança</span>
-                      <span className="text-sm">{formatDate(subscriptionDetails.periodEnd)}</span>
+                      <span className="text-sm">{formatDate(subscription.betinho.periodEnd)}</span>
                     </div>
                   )}
-                  {subscriptionDetails?.cancelAtPeriodEnd && subscriptionDetails?.cancelAt && (
+                  {subscription?.betinho.cancelAtPeriodEnd && subscription?.betinho.cancelAt && (
                     <div className="flex justify-between items-center">
                       <span className="text-sm text-muted-foreground">Cancela em</span>
-                      <span className="text-sm text-amber-600">{formatDate(subscriptionDetails.cancelAt)}</span>
+                      <span className="text-sm text-amber-600">{formatDate(subscription.betinho.cancelAt)}</span>
                     </div>
                   )}
                 </div>
-                {(subscriptionDetails?.hasStripeCustomer || subscriptionDetails?.status === 'premium') ? (
+                {/* Plataforma */}
+                <div className="space-y-2 rounded-lg border p-4">
+                  <h4 className="font-medium text-sm">Plataforma</h4>
+                  <div className="flex justify-between items-center">
+                    <span className="text-sm text-muted-foreground">Plano</span>
+                    <span className="font-medium">
+                      {subscription?.analytics.status === 'premium' ? 'Premium' : 'Free'}
+                    </span>
+                  </div>
+                  {subscription?.analytics.periodEnd && (
+                    <div className="flex justify-between items-center">
+                      <span className="text-sm text-muted-foreground">Próxima cobrança</span>
+                      <span className="text-sm">{formatDate(subscription.analytics.periodEnd)}</span>
+                    </div>
+                  )}
+                  {subscription?.analytics.cancelAtPeriodEnd && subscription?.analytics.cancelAt && (
+                    <div className="flex justify-between items-center">
+                      <span className="text-sm text-muted-foreground">Cancela em</span>
+                      <span className="text-sm text-amber-600">{formatDate(subscription.analytics.cancelAt)}</span>
+                    </div>
+                  )}
+                </div>
+                {(subscription?.hasStripeCustomer || subscription?.betinho.status === 'premium' || subscription?.analytics.status === 'premium') ? (
                   <div className="pt-2">
                     <Button
                       variant="default"

--- a/supabase/migrations/027_add_product_subscription_metadata.sql
+++ b/supabase/migrations/027_add_product_subscription_metadata.sql
@@ -1,0 +1,24 @@
+-- Add per-product subscription metadata for Betinho and Analytics
+-- Enables separate display of status and billing per product in Settings
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS betinho_subscription_period_end TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS betinho_subscription_cancel_at TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS betinho_subscription_cancel_at_period_end BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS analytics_subscription_period_end TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS analytics_subscription_cancel_at TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS analytics_subscription_cancel_at_period_end BOOLEAN DEFAULT FALSE;
+
+-- Migrate existing generic metadata to product-specific (one-time)
+UPDATE users
+SET
+  betinho_subscription_period_end = CASE WHEN subscription_product_type = 'betinho' THEN subscription_period_end ELSE betinho_subscription_period_end END,
+  betinho_subscription_cancel_at = CASE WHEN subscription_product_type = 'betinho' THEN subscription_cancel_at ELSE betinho_subscription_cancel_at END,
+  betinho_subscription_cancel_at_period_end = CASE WHEN subscription_product_type = 'betinho' THEN COALESCE(subscription_cancel_at_period_end, false) ELSE betinho_subscription_cancel_at_period_end END,
+  analytics_subscription_period_end = CASE WHEN subscription_product_type = 'analytics' OR subscription_product_type = 'platform' THEN subscription_period_end ELSE analytics_subscription_period_end END,
+  analytics_subscription_cancel_at = CASE WHEN subscription_product_type = 'analytics' OR subscription_product_type = 'platform' THEN subscription_cancel_at ELSE analytics_subscription_cancel_at END,
+  analytics_subscription_cancel_at_period_end = CASE WHEN subscription_product_type = 'analytics' OR subscription_product_type = 'platform' THEN COALESCE(subscription_cancel_at_period_end, false) ELSE analytics_subscription_cancel_at_period_end END
+WHERE subscription_period_end IS NOT NULL OR subscription_cancel_at IS NOT NULL;
+
+COMMENT ON COLUMN users.betinho_subscription_period_end IS 'Betinho: end of current billing period';
+COMMENT ON COLUMN users.analytics_subscription_period_end IS 'Analytics: end of current billing period';


### PR DESCRIPTION
- Add unified useSettingsData hook with single query for profile + subscription
- Remove global loading block, show layout immediately with local fallbacks
- Add migration 027 for per-product subscription metadata (betinho/analytics)
- Update stripe-webhook to persist period_end and cancel_at per product
- Display Betinho and Plataforma status separately in Settings