### PR TITLE
feat(auth,onboarding,paywall): phone at signup, Betinho flow, WhatsAp…

### DIFF
--- a/src/components/WhatsAppOnboarding.tsx
+++ b/src/components/WhatsAppOnboarding.tsx
@@ -69,25 +69,25 @@ export default function WhatsAppOnboarding({ userId, onComplete }: WhatsAppOnboa
           <div className="mx-auto mb-4 w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
             <Send className="w-6 h-6 text-green-600" />
           </div>
-          <CardTitle>Configure seu Telegram</CardTitle>
+          <CardTitle>Número para o Betinho</CardTitle>
           <CardDescription>
-            Para receber notificações e enviar apostas via Telegram
+            Este número será usado para conectar ao bot no Telegram e enviar apostas.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleWhatsAppNumberSubmit} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="whatsapp">Número do Telegram</Label>
+              <Label htmlFor="whatsapp">Número para o Betinho</Label>
               <Input
                 id="whatsapp"
                 type="tel"
                 placeholder="(11) 99999-9999"
                 value={whatsappNumber}
-                onChange={(e) => setWhatsappNumber(e.target.value)}
+                onChange={(e) => setWhatsappNumber(e.target.value.replace(/\D/g, ''))}
                 required
               />
               <p className="text-sm text-gray-500">
-                Inclua o código do país (ex: +55 para Brasil)
+                Inclua o código do país (ex: +55 para Brasil). Você pode colar o número.
               </p>
             </div>
 
@@ -159,9 +159,9 @@ export default function WhatsAppOnboarding({ userId, onComplete }: WhatsAppOnboa
           <div className="mx-auto mb-4 w-12 h-12 bg-green-100 rounded-full flex items-center justify-center">
             <CheckCircle className="w-6 h-6 text-green-600" />
           </div>
-          <CardTitle>Telegram configurado!</CardTitle>
+          <CardTitle>Betinho configurado!</CardTitle>
           <CardDescription>
-            Sua conta foi sincronizada com sucesso
+            Sua conta foi sincronizada com o bot no Telegram.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { BarChart3 } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { LanguageToggle } from "@/components/LanguageToggle";
@@ -24,6 +25,8 @@ const Auth = () => {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [name, setName] = useState("");
   const [referralCode, setReferralCode] = useState("");
+  const [phoneCountryCode, setPhoneCountryCode] = useState("+55");
+  const [phoneNumber, setPhoneNumber] = useState("");
   
   const supabase = createClient();
 
@@ -103,6 +106,16 @@ const Auth = () => {
       return;
     }
 
+    const cleanPhone = phoneNumber.replace(/\D/g, '');
+    if (cleanPhone.length < 8) {
+      toast({
+        title: "Error",
+        description: "Informe um telefone válido",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setLoading(true);
 
     try {
@@ -122,11 +135,13 @@ const Auth = () => {
         const { data: { user } } = await supabase.auth.getUser();
         if (user) {
           const normalizedReferralCode = referralCode.trim() ? referralCode.toUpperCase().trim() : null;
+          const whatsappNumber = phoneCountryCode.replace(/\D/g, '') + cleanPhone;
           const userData: any = {
             id: user.id,
             email: user.email!,
             name: name,
-            referred_by: normalizedReferralCode
+            referred_by: normalizedReferralCode,
+            whatsapp_number: whatsappNumber,
           };
 
           // Create user record in our users table
@@ -307,6 +322,41 @@ const Auth = () => {
                       onChange={(e) => setConfirmPassword(e.target.value)}
                       required
                     />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="signup-phone">Telefone</Label>
+                    <div className="flex gap-2">
+                      <Select
+                        value={phoneCountryCode}
+                        onValueChange={setPhoneCountryCode}
+                      >
+                        <SelectTrigger className="w-[100px]">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="+55">🇧🇷 +55</SelectItem>
+                          <SelectItem value="+1">🇺🇸 +1</SelectItem>
+                          <SelectItem value="+54">🇦🇷 +54</SelectItem>
+                          <SelectItem value="+56">🇨🇱 +56</SelectItem>
+                          <SelectItem value="+57">🇨🇴 +57</SelectItem>
+                          <SelectItem value="+351">🇵🇹 +351</SelectItem>
+                          <SelectItem value="+34">🇪🇸 +34</SelectItem>
+                          <SelectItem value="+39">🇮🇹 +39</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Input
+                        id="signup-phone"
+                        type="tel"
+                        placeholder="(11) 99999-9999"
+                        value={phoneNumber}
+                        onChange={(e) => setPhoneNumber(e.target.value.replace(/\D/g, ''))}
+                        className="flex-1"
+                        required
+                      />
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Será usado para conectar ao bot no Telegram
+                    </p>
                   </div>
                   <div className="space-y-2">
                     <Label htmlFor="referral-code">Código do amigo (opcional)</Label>

--- a/src/pages/Paywall.tsx
+++ b/src/pages/Paywall.tsx
@@ -147,8 +147,8 @@ export default function Paywall() {
   };
 
   const handleUpgrade = () => {
-    // Open WhatsApp with pre-filled message for upgrade
-    const message = "Oi, gostaria de fazer upgrade do meu plano Smartbetting";
+    // Open WhatsApp with pre-filled message for upgrade (Betinho)
+    const message = "Oi, gostaria de fazer upgrade do meu plano Betinho (registro de apostas)";
     const whatsappUrl = `https://wa.me/5511952136845?text=${encodeURIComponent(message)}`;
     
     // Open WhatsApp with pre-filled message

--- a/src/pages/PaywallPlatform.tsx
+++ b/src/pages/PaywallPlatform.tsx
@@ -139,9 +139,9 @@ export default function PaywallPlatform() {
   };
 
   const handleUpgrade = () => {
-    // Open WhatsApp with pre-filled message for upgrade
-    const message = "Oi, gostaria de fazer upgrade do meu plano Smartbetting";
-    const whatsappUrl = `https://wa.me/554391482828?text=${encodeURIComponent(message)}`;
+    // Open WhatsApp with pre-filled message for upgrade (Plataforma de Análise)
+    const message = "Oi, gostaria de fazer upgrade do meu plano na Plataforma de Análise";
+    const whatsappUrl = `https://wa.me/5511952136845?text=${encodeURIComponent(message)}`;
     
     // Open WhatsApp with pre-filled message
     window.open(whatsappUrl, '_blank');

--- a/supabase/migrations/029_add_missing_subscription_columns.sql
+++ b/supabase/migrations/029_add_missing_subscription_columns.sql
@@ -1,0 +1,10 @@
+-- Fix: Add subscription metadata columns if missing (e.g. when 027 wasn't applied)
+-- Run this in Supabase SQL Editor if you get "column users.betinho_subscription_period_end does not exist"
+
+ALTER TABLE users
+ADD COLUMN IF NOT EXISTS betinho_subscription_period_end TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS betinho_subscription_cancel_at TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS betinho_subscription_cancel_at_period_end BOOLEAN DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS analytics_subscription_period_end TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS analytics_subscription_cancel_at TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS analytics_subscription_cancel_at_period_end BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
…p fixes

- Auth: add required phone field at signup, persist to users.whatsapp_number
- Onboarding: remove redundant name/email step, pre-fill phone, Betinho labels
- Paywall: unify WhatsApp number (5511952136845), differentiate messages per product
- WhatsAppOnboarding: align labels to Número para o Betinho
- use-settings-data: fallback when betinho_subscription_period_end column missing
- Migration 029: add missing subscription metadata columns