### PR TITLE
feat(share): add public bet sharing via link

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,5 +35,7 @@ jobs:
           supabase functions deploy stripe-webhook
           supabase functions deploy telegram-webhook --no-verify-jwt
           supabase functions deploy whatsapp-webhook --no-verify-jwt
+          supabase functions deploy share-create
+          supabase functions deploy share-resolve --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -35,5 +35,7 @@ jobs:
           supabase functions deploy stripe-webhook
           supabase functions deploy telegram-webhook --no-verify-jwt
           supabase functions deploy whatsapp-webhook --no-verify-jwt
+          supabase functions deploy share-create
+          supabase functions deploy share-resolve --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/SHARE_LINK_IMPLEMENTATION_PLAN.md
+++ b/SHARE_LINK_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,153 @@
+# Plano de Implementação — Compartilhamento por Link
+
+> **Status: IMPLEMENTADO** — Este documento reflete o que foi construído.
+
+---
+
+## Visão Geral
+
+Funcionalidade que permite ao usuário gerar um link público com uma visão filtrada das suas apostas, acessível por qualquer pessoa sem necessidade de login.
+
+**Branch:** `feat/compartilhar_apostas_link`
+
+---
+
+## Decisões Técnicas
+
+| Decisão | Escolha |
+|---------|---------|
+| "Histórico de operações" | Lista de apostas da tabela `bets` (sem entidade separada) |
+| Meta tags na página pública | Estáticas/genéricas (SPA não suporta meta tags dinâmicas sem SSR) |
+| Componentes de KPI/gráficos | Novos, específicos para a página pública |
+| Cálculo de KPIs | Frontend, reaproveitando `src/utils/bettingStats.ts` |
+| Token | UUID v4 via `gen_random_uuid()` — o próprio `id` da linha é o token |
+| Expiração de links | `expires_at` nullable — sem expiração por padrão em V1 |
+| Paginação | Paginação simples (não scroll infinito) |
+| URL do link | Montada no backend via `APP_BASE_URL` (secret do Supabase) |
+| Endpoint share-resolve | POST (não GET) — passa token no body para evitar logs de URL |
+
+---
+
+## Arquivos Implementados
+
+### Backend
+
+| Arquivo | Descrição |
+|---------|-----------|
+| `supabase/migrations/030_create_share_links.sql` | Tabela `share_links` com RLS e índice |
+| `supabase/functions/share-create/index.ts` | Edge function autenticada — cria o link |
+| `supabase/functions/share-resolve/index.ts` | Edge function pública — resolve o token e retorna apostas |
+
+### Frontend — Hooks
+
+| Arquivo | Descrição |
+|---------|-----------|
+| `src/hooks/use-share-link.ts` | Mutation para criar links (`useShareLink`) |
+| `src/hooks/use-share-resolve.ts` | Query para resolver tokens (`useShareResolve`) |
+
+### Frontend — Modal de geração
+
+| Arquivo | Descrição |
+|---------|-----------|
+| `src/components/bets/ShareLinkModal.tsx` | Modal com chips de filtros, botão gerar e copiar URL |
+
+> Botão "Compartilhar" adicionado em `src/pages/Bets.tsx` na toolbar.
+
+### Frontend — Página pública
+
+| Arquivo | Descrição |
+|---------|-----------|
+| `src/pages/SharePage.tsx` | Orquestra todos os estados da página |
+| `src/components/share/ShareLayout.tsx` | Header com nome do dono e chips de filtros |
+| `src/components/share/ShareKpiCards.tsx` | Cards: lucro, ROI, win rate, total de apostas |
+| `src/components/share/ShareBankrollChart.tsx` | Gráfico de P&L acumulado ao longo do tempo |
+| `src/components/share/ShareBreakdownCharts.tsx` | Breakdown por esporte, liga e mercado |
+| `src/components/share/ShareBetsTable.tsx` | Tabela paginada com legs expandíveis para múltiplas |
+| `src/components/share/ShareLoadingSkeleton.tsx` | Skeleton loader |
+| `src/components/share/ShareErrorState.tsx` | Estados de erro: 404, 410 e genérico |
+| `src/components/share/ShareEmptyState.tsx` | Empty state quando nenhuma aposta bate o filtro |
+
+> Rota `/share/:token` adicionada em `src/App.tsx` **sem** `ProtectedRoute`.
+
+---
+
+## Detalhes Técnicos Relevantes
+
+### Migration (`030_create_share_links.sql`)
+
+```sql
+CREATE TABLE share_links (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,  -- o id É o token
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+  filters_snapshot JSONB NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  expires_at TIMESTAMPTZ  -- nullable, sem expiração por padrão
+);
+
+CREATE INDEX idx_share_links_user_id ON share_links(user_id);
+```
+
+RLS: `owner_select` e `owner_insert` por `auth.uid() = user_id`.
+
+### Mapeamento de filtros (frontend → API)
+
+O frontend usa nomes internos que são mapeados em `use-share-link.ts`:
+
+| Frontend | API (filters_snapshot) |
+|----------|------------------------|
+| `sport` | `sports` |
+| `league` | `leagues` |
+| `betting_market` | `markets` |
+| `selectedTags` | `tags` |
+| `dateFrom` | `date_from` |
+| `dateTo` | `date_to` |
+| `searchQuery` | `search` |
+
+### Edge Function: `share-create`
+
+- JWT obrigatório (verificado manualmente via `supabase.auth.getUser`)
+- URL montada como: `APP_BASE_URL/share/<token>`
+- Fallback: `APP_BASE_URL` → `SITE_URL` → `https://smartbetting.app`
+- Retorna: `{ token, url }`
+
+### Edge Function: `share-resolve`
+
+- **Sem JWT** (`--no-verify-jwt` no deploy)
+- Aceita GET (`?token=`) e POST (token no body)
+- Usa `SUPABASE_SERVICE_ROLE_KEY` para bypassar RLS
+- Retorna apenas campos seguros — nunca email, whatsapp, dados de pagamento
+- Resolve tags via join em `bet_tags`
+- Inclui `bet_legs` para apostas do tipo `multipla` ou `multiple`
+- Limite de 500 apostas
+- Erros: `404` (não encontrado), `410` (expirado), `500` (genérico)
+
+### Hook `use-share-resolve`
+
+Usa `fetch` direto (não `supabase.functions.invoke`) para capturar corretamente os status HTTP 404 e 410 — o cliente Supabase normaliza erros de forma que dificulta distinguir os códigos.
+
+Retry desabilitado para 404 e 410 (não adianta tentar novamente).
+
+---
+
+## CI/CD — Pendência
+
+As duas novas edge functions precisam ser adicionadas aos workflows de deploy:
+
+**`deploy-staging.yml` e `deploy-production.yml`** — adicionar no bloco "Deploy Edge Functions":
+
+```yaml
+supabase functions deploy share-create
+supabase functions deploy share-resolve --no-verify-jwt
+```
+
+---
+
+## Checklist de Deploy
+
+- [ ] Migration aplicada: `supabase db push` (automático via CI ao mergear)
+- [ ] Edge functions adicionadas nos workflows de CI/CD (ver seção acima)
+- [ ] Secret `APP_BASE_URL` configurado no Supabase Dashboard:
+  - Staging: URL do ambiente de staging
+  - Produção: `https://smartbetting.app`
+- [ ] Types TypeScript regenerados após migration: `supabase gen types typescript --local > src/integrations/supabase/types.ts`
+- [ ] Verificar que a rota `/share/:token` está sem `ProtectedRoute` no `App.tsx`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import Games from "./pages/Games";
 import Home from "./pages/Home";
 import GameDetail from "./pages/GameDetail";
 import Settings from "./pages/Settings";
+import SharePage from "./pages/SharePage";
 
 const queryClient = new QueryClient();
 
@@ -94,6 +95,7 @@ const App = () => (
           <Route path="/paywall-dashboard" element={<PaywallDashboard />} />
           <Route path="/paywall-platform" element={<PaywallPlatform />} />
           <Route path="/como-usar" element={<ComoUsar />} />
+          <Route path="/share/:token" element={<SharePage />} />
           <Route path="/settings" element={
             <ProtectedRoute>
               <Settings />

--- a/src/components/bets/ShareLinkModal.tsx
+++ b/src/components/bets/ShareLinkModal.tsx
@@ -1,0 +1,159 @@
+import React, { useEffect } from 'react';
+import { Link2, Copy, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { useShareLink, type ShareLinkFilters } from '@/hooks/use-share-link';
+import { toast } from 'sonner';
+
+const STATUS_LABELS: Record<string, string> = {
+  pending: 'Pendente',
+  won: 'Ganhou',
+  lost: 'Perdeu',
+  half_won: '1/2 Green',
+  half_lost: '1/2 Red',
+  cashout: 'Cashout',
+  void: 'Void',
+};
+
+interface Tag {
+  id: string;
+  name: string;
+  color: string;
+}
+
+interface ShareLinkModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  filters: ShareLinkFilters;
+  userTags: Tag[];
+}
+
+function hasActiveFilters(filters: ShareLinkFilters): boolean {
+  return (
+    filters.status.length > 0 ||
+    filters.sport.length > 0 ||
+    filters.league.length > 0 ||
+    filters.betting_market.length > 0 ||
+    filters.selectedTags.length > 0 ||
+    !!filters.dateFrom ||
+    !!filters.dateTo ||
+    !!filters.searchQuery?.trim()
+  );
+}
+
+export const ShareLinkModal: React.FC<ShareLinkModalProps> = ({
+  open,
+  onOpenChange,
+  filters,
+  userTags,
+}) => {
+  const { generateLink, isLoading, shareUrl, reset } = useShareLink();
+
+  useEffect(() => {
+    if (!open) {
+      reset();
+    }
+  }, [open, reset]);
+
+  const handleGenerate = async () => {
+    try {
+      await generateLink(filters);
+      toast.success('Link gerado com sucesso!');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Falha ao gerar link');
+    }
+  };
+
+  const handleCopy = () => {
+    if (!shareUrl) return;
+    navigator.clipboard.writeText(shareUrl);
+    toast.success('Link copiado!');
+  };
+
+  const activeFilters = hasActiveFilters(filters);
+
+  const filterChips: { label: string }[] = [];
+  filters.status.forEach((v) => {
+    filterChips.push({ label: STATUS_LABELS[v] || v });
+  });
+  filters.sport.filter((v) => v !== '__empty__').forEach((v) => filterChips.push({ label: v }));
+  filters.league.filter((v) => v !== '__empty__').forEach((v) => filterChips.push({ label: v }));
+  filters.betting_market.filter((v) => v !== '__empty__').forEach((v) => filterChips.push({ label: v }));
+  filters.selectedTags.forEach((tagId) => {
+    const tag = userTags.find((t) => t.id === tagId);
+    filterChips.push({ label: tag?.name || tagId });
+  });
+  if (filters.dateFrom) filterChips.push({ label: `De ${filters.dateFrom}` });
+  if (filters.dateTo) filterChips.push({ label: `Até ${filters.dateTo}` });
+  if (filters.searchQuery?.trim()) filterChips.push({ label: `Busca: "${filters.searchQuery.trim()}"` });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-terminal-dark-gray border-terminal-border text-terminal-text max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-terminal-green flex items-center gap-2">
+            <Link2 className="w-5 h-5" />
+            Compartilhar apostas
+          </DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          {filterChips.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {filterChips.map((chip, i) => (
+                <Badge
+                  key={i}
+                  variant="secondary"
+                  className="bg-terminal-gray border-terminal-border text-terminal-text text-xs"
+                >
+                  {chip.label}
+                </Badge>
+              ))}
+            </div>
+          )}
+          {!activeFilters && (
+            <p className="text-xs text-terminal-yellow/90">
+              Este link compartilhará todas as suas apostas.
+            </p>
+          )}
+          {!shareUrl ? (
+            <Button
+              onClick={handleGenerate}
+              disabled={isLoading}
+              className="w-full terminal-button border-terminal-green text-terminal-green hover:bg-terminal-green hover:text-terminal-black"
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                  Gerando...
+                </>
+              ) : (
+                <>
+                  <Link2 className="w-4 h-4 mr-2" />
+                  Gerar link
+                </>
+              )}
+            </Button>
+          ) : (
+            <div className="flex gap-2">
+              <Input
+                readOnly
+                value={shareUrl}
+                className="bg-terminal-black border-terminal-border text-terminal-text text-xs"
+              />
+              <Button
+                onClick={handleCopy}
+                variant="outline"
+                size="icon"
+                className="shrink-0 terminal-button border-terminal-green text-terminal-green hover:bg-terminal-green hover:text-terminal-black"
+              >
+                <Copy className="w-4 h-4" />
+              </Button>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/share/ShareBankrollChart.tsx
+++ b/src/components/share/ShareBankrollChart.tsx
@@ -1,0 +1,108 @@
+import React, { useMemo } from 'react';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { ShareResolveBet } from '@/hooks/use-share-resolve';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+
+interface ShareBankrollChartProps {
+  bets: ShareResolveBet[];
+}
+
+function getBetProfit(bet: ShareResolveBet): number {
+  if (bet.status === 'won') return bet.potential_return - bet.stake_amount;
+  if (bet.status === 'lost') return -bet.stake_amount;
+  if (bet.status === 'cashout' && bet.cashout_amount != null)
+    return bet.cashout_amount - bet.stake_amount;
+  if (bet.status === 'half_won')
+    return (bet.stake_amount + bet.potential_return) / 2 - bet.stake_amount;
+  if (bet.status === 'half_lost') return bet.stake_amount / 2 - bet.stake_amount;
+  return 0;
+}
+
+export const ShareBankrollChart: React.FC<ShareBankrollChartProps> = ({ bets }) => {
+  const chartData = useMemo(() => {
+    const settled = bets
+      .filter((b) =>
+        ['won', 'lost', 'cashout', 'half_won', 'half_lost'].includes(b.status)
+      )
+      .map((b) => ({
+        date: new Date(b.bet_date),
+        profit: getBetProfit(b),
+      }))
+      .sort((a, b) => a.date.getTime() - b.date.getTime());
+
+    let cumulative = 0;
+    const result: { date: string; fullDate: string; balance: number }[] = [
+      { date: 'Início', fullDate: 'Início', balance: 0 },
+    ];
+
+    for (const { date, profit } of settled) {
+      cumulative += profit;
+      result.push({
+        date: format(date, 'dd/MM', { locale: ptBR }),
+        fullDate: format(date, "dd/MM/yyyy 'às' HH:mm", { locale: ptBR }),
+        balance: cumulative,
+      });
+    }
+
+    return result;
+  }, [bets]);
+
+  if (chartData.length <= 1) return null;
+
+  return (
+    <Card className="bg-terminal-dark-gray border-terminal-border">
+      <CardHeader>
+        <CardTitle className="text-sm font-medium text-terminal-green">
+          Evolução do saldo acumulado
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="h-[280px] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartData} margin={{ top: 5, right: 5, left: 5, bottom: 5 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.1)" />
+              <XAxis
+                dataKey="date"
+                stroke="rgba(255,255,255,0.5)"
+                tick={{ fontSize: 11 }}
+              />
+              <YAxis
+                stroke="rgba(255,255,255,0.5)"
+                tick={{ fontSize: 11 }}
+                tickFormatter={(v) => `R$ ${v}`}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'var(--terminal-dark-gray)',
+                  border: '1px solid var(--terminal-border)',
+                  borderRadius: '4px',
+                }}
+                labelStyle={{ color: 'var(--terminal-text)' }}
+                formatter={(value: number) => [`R$ ${value.toFixed(2)}`, 'Saldo']}
+                labelFormatter={(label) => label}
+              />
+              <Line
+                type="monotone"
+                dataKey="balance"
+                stroke="var(--terminal-green)"
+                strokeWidth={2}
+                dot={{ fill: 'var(--terminal-green)', r: 3 }}
+                activeDot={{ r: 5 }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/share/ShareBetsTable.tsx
+++ b/src/components/share/ShareBetsTable.tsx
@@ -1,0 +1,217 @@
+import React, { useState, useMemo } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+} from '@/components/ui/collapsible';
+import type { ShareResolveBet } from '@/hooks/use-share-resolve';
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+
+const PAGE_SIZE = 20;
+
+const STATUS_STYLES: Record<string, string> = {
+  won: 'text-terminal-green bg-terminal-green/10',
+  lost: 'text-terminal-red bg-terminal-red/10',
+  half_won: 'text-terminal-green bg-terminal-green/20',
+  half_lost: 'text-terminal-red bg-terminal-red/20',
+  pending: 'text-terminal-yellow bg-terminal-yellow/10',
+  cashout: 'text-terminal-blue bg-terminal-blue/10',
+  void: 'opacity-70 bg-terminal-gray/50',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  won: 'Ganhou',
+  lost: 'Perdeu',
+  half_won: '1/2 Green',
+  half_lost: '1/2 Red',
+  pending: 'Pendente',
+  cashout: 'Cashout',
+  void: 'Void',
+};
+
+function getResult(bet: ShareResolveBet): number | null {
+  if (bet.status === 'won') return bet.potential_return;
+  if (bet.status === 'cashout' && bet.cashout_amount != null) return bet.cashout_amount;
+  if (bet.status === 'half_won') return (bet.stake_amount + bet.potential_return) / 2;
+  if (bet.status === 'half_lost') return bet.stake_amount / 2;
+  if (bet.status === 'lost') return 0;
+  return null;
+}
+
+interface ShareBetsTableProps {
+  bets: ShareResolveBet[];
+}
+
+export const ShareBetsTable: React.FC<ShareBetsTableProps> = ({ bets }) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  const sortedBets = useMemo(
+    () => [...bets].sort((a, b) => new Date(b.bet_date).getTime() - new Date(a.bet_date).getTime()),
+    [bets]
+  );
+
+  const totalPages = Math.ceil(sortedBets.length / PAGE_SIZE) || 1;
+  const paginatedBets = useMemo(() => {
+    const start = (currentPage - 1) * PAGE_SIZE;
+    return sortedBets.slice(start, start + PAGE_SIZE);
+  }, [sortedBets, currentPage]);
+
+  const toggleExpand = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const isMultiple = (bet: ShareResolveBet) =>
+    (bet.bet_type === 'multiple' || bet.bet_type === 'multipla') && (bet.bet_legs?.length ?? 0) > 0;
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-sm font-semibold text-terminal-green">Apostas</h2>
+      <div className="rounded-md border border-terminal-border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-terminal-border hover:bg-transparent">
+              <TableHead className="text-terminal-text/80 text-xs w-8" />
+              <TableHead className="text-terminal-text/80 text-xs">Data</TableHead>
+              <TableHead className="text-terminal-text/80 text-xs">Descrição</TableHead>
+              <TableHead className="text-terminal-text/80 text-xs">Esporte / Liga</TableHead>
+              <TableHead className="text-terminal-text/80 text-xs text-right">Odds</TableHead>
+              <TableHead className="text-terminal-text/80 text-xs text-right">Stake</TableHead>
+              <TableHead className="text-terminal-text/80 text-xs text-right">Resultado</TableHead>
+              <TableHead className="text-terminal-text/80 text-xs text-center">Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {paginatedBets.map((bet) => (
+              <React.Fragment key={bet.id}>
+                <TableRow className="border-terminal-border">
+                  <TableCell className="w-8 p-2">
+                    {isMultiple(bet) ? (
+                      <button
+                        type="button"
+                        onClick={() => toggleExpand(bet.id)}
+                        className="p-0.5 hover:bg-terminal-gray/50 rounded"
+                      >
+                        {expandedIds.has(bet.id) ? (
+                          <ChevronDown className="w-4 h-4" />
+                        ) : (
+                          <ChevronRight className="w-4 h-4" />
+                        )}
+                      </button>
+                    ) : null}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {format(new Date(bet.bet_date), 'dd/MM/yyyy', { locale: ptBR })}
+                  </TableCell>
+                  <TableCell className="text-xs max-w-[200px] truncate" title={bet.bet_description}>
+                    {bet.bet_description}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    {[bet.sport, bet.league].filter(Boolean).join(' / ') || '-'}
+                  </TableCell>
+                  <TableCell className="text-xs text-right">{bet.odds.toFixed(2)}</TableCell>
+                  <TableCell className="text-xs text-right">
+                    R$ {bet.stake_amount.toFixed(2)}
+                  </TableCell>
+                  <TableCell className="text-xs text-right">
+                    {getResult(bet) != null ? (
+                      <>R$ {getResult(bet)!.toFixed(2)}</>
+                    ) : (
+                      '-'
+                    )}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <Badge
+                      variant="secondary"
+                      className={STATUS_STYLES[bet.status] || 'bg-terminal-gray/50'}
+                    >
+                      {STATUS_LABELS[bet.status] || bet.status}
+                    </Badge>
+                  </TableCell>
+                </TableRow>
+                {isMultiple(bet) && (
+                  <TableRow className="border-terminal-border">
+                    <TableCell colSpan={8} className="p-0">
+                      <Collapsible open={expandedIds.has(bet.id)}>
+                        <CollapsibleContent>
+                          <div className="bg-terminal-black/50 px-4 py-2 pl-12">
+                            <div className="text-xs font-medium text-terminal-text/80 mb-2">
+                              Legs da aposta
+                            </div>
+                            <div className="space-y-1.5">
+                              {bet.bet_legs!.map((leg, i) => (
+                                <div
+                                  key={leg.bet_id + i}
+                                  className="flex items-center gap-4 text-xs"
+                                >
+                                  <span className="text-terminal-green/80 w-6">
+                                    {leg.leg_number}.
+                                  </span>
+                                  <span className="flex-1 truncate">{leg.bet_description}</span>
+                                  <span className="opacity-70">{leg.odds.toFixed(2)}</span>
+                                  <Badge
+                                    variant="secondary"
+                                    className={STATUS_STYLES[leg.status] || 'bg-terminal-gray/50'}
+                                  >
+                                    {STATUS_LABELS[leg.status] || leg.status}
+                                  </Badge>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        </CollapsibleContent>
+                      </Collapsible>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </React.Fragment>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      {totalPages > 1 && (
+        <div className="flex justify-between items-center">
+          <span className="text-xs text-terminal-text/70">
+            Página {currentPage} de {totalPages}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+              disabled={currentPage === 1}
+              className="terminal-button border-terminal-border"
+            >
+              Anterior
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+              disabled={currentPage === totalPages}
+              className="terminal-button border-terminal-border"
+            >
+              Próxima
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/share/ShareBreakdownCharts.tsx
+++ b/src/components/share/ShareBreakdownCharts.tsx
@@ -1,0 +1,149 @@
+import React, { useMemo } from 'react';
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { ShareResolveBet } from '@/hooks/use-share-resolve';
+
+function getBetProfit(bet: ShareResolveBet): number {
+  if (bet.status === 'won') return bet.potential_return - bet.stake_amount;
+  if (bet.status === 'lost') return -bet.stake_amount;
+  if (bet.status === 'cashout' && bet.cashout_amount != null)
+    return bet.cashout_amount - bet.stake_amount;
+  if (bet.status === 'half_won')
+    return (bet.stake_amount + bet.potential_return) / 2 - bet.stake_amount;
+  if (bet.status === 'half_lost') return bet.stake_amount / 2 - bet.stake_amount;
+  return 0;
+}
+
+function formatAxis(v: number): string {
+  if (Math.abs(v) >= 1000) return `${(v / 1000).toFixed(1)}k`;
+  return v.toFixed(0);
+}
+
+interface ShareBreakdownChartsProps {
+  bets: ShareResolveBet[];
+}
+
+export const ShareBreakdownCharts: React.FC<ShareBreakdownChartsProps> = ({ bets }) => {
+  const bySport = useMemo(() => {
+    const settled = bets.filter((b) =>
+      ['won', 'lost', 'cashout', 'half_won', 'half_lost'].includes(b.status)
+    );
+    const countBySport = new Map<string, number>();
+    const profitBySport = new Map<string, number>();
+    settled.forEach((bet) => {
+      const sport = bet.sport || 'Outros';
+      countBySport.set(sport, (countBySport.get(sport) ?? 0) + 1);
+      profitBySport.set(sport, (profitBySport.get(sport) ?? 0) + getBetProfit(bet));
+    });
+    return Array.from(profitBySport.entries())
+      .filter(([name]) => (countBySport.get(name) ?? 0) >= 2)
+      .map(([name, profit]) => ({ name, profit: Number(profit.toFixed(2)) }))
+      .sort((a, b) => b.profit - a.profit)
+      .slice(0, 8);
+  }, [bets]);
+
+  const byLeague = useMemo(() => {
+    const settled = bets.filter((b) =>
+      ['won', 'lost', 'cashout', 'half_won', 'half_lost'].includes(b.status)
+    );
+    const countByLeague = new Map<string, number>();
+    const profitByLeague = new Map<string, number>();
+    settled.forEach((bet) => {
+      const league = bet.league || 'Outros';
+      countByLeague.set(league, (countByLeague.get(league) ?? 0) + 1);
+      profitByLeague.set(league, (profitByLeague.get(league) ?? 0) + getBetProfit(bet));
+    });
+    return Array.from(profitByLeague.entries())
+      .filter(([name]) => (countByLeague.get(name) ?? 0) >= 2)
+      .map(([name, profit]) => ({ name, profit: Number(profit.toFixed(2)) }))
+      .sort((a, b) => b.profit - a.profit)
+      .slice(0, 8);
+  }, [bets]);
+
+  const byMarket = useMemo(() => {
+    const settled = bets.filter((b) =>
+      ['won', 'lost', 'cashout', 'half_won', 'half_lost'].includes(b.status)
+    );
+    const countByMarket = new Map<string, number>();
+    const profitByMarket = new Map<string, number>();
+    settled.forEach((bet) => {
+      const market = bet.betting_market || 'Outros';
+      countByMarket.set(market, (countByMarket.get(market) ?? 0) + 1);
+      profitByMarket.set(market, (profitByMarket.get(market) ?? 0) + getBetProfit(bet));
+    });
+    return Array.from(profitByMarket.entries())
+      .filter(([name]) => (countByMarket.get(name) ?? 0) >= 2)
+      .map(([name, profit]) => ({ name, profit: Number(profit.toFixed(2)) }))
+      .sort((a, b) => b.profit - a.profit)
+      .slice(0, 8);
+  }, [bets]);
+
+  const charts = [
+    { data: bySport, title: 'Por esporte' },
+    { data: byLeague, title: 'Por liga' },
+    { data: byMarket, title: 'Por mercado' },
+  ].filter((c) => c.data.length > 0);
+
+  if (charts.length === 0) return null;
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      {charts.map(({ data, title }) => (
+        <Card key={title} className="bg-terminal-dark-gray border-terminal-border">
+          <CardHeader>
+            <CardTitle className="text-sm font-medium text-terminal-green">
+              {title}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="h-[280px] w-full">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={data} layout="vertical" margin={{ left: 8, right: 8 }}>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="rgba(255,255,255,0.1)"
+                    horizontal={false}
+                  />
+                  <XAxis
+                    type="number"
+                    stroke="rgba(255,255,255,0.5)"
+                    tick={{ fontSize: 10 }}
+                    tickFormatter={formatAxis}
+                  />
+                  <YAxis
+                    type="category"
+                    dataKey="name"
+                    width={80}
+                    stroke="rgba(255,255,255,0.5)"
+                    tick={{ fontSize: 10 }}
+                  />
+                  <Tooltip
+                    contentStyle={{
+                      backgroundColor: 'var(--terminal-dark-gray)',
+                      border: '1px solid var(--terminal-border)',
+                      borderRadius: '4px',
+                    }}
+                    formatter={(value: number) => [`R$ ${value.toFixed(2)}`, 'Lucro']}
+                  />
+                  <Bar
+                    dataKey="profit"
+                    fill="var(--terminal-green)"
+                    radius={[0, 4, 4, 0]}
+                  />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};

--- a/src/components/share/ShareEmptyState.tsx
+++ b/src/components/share/ShareEmptyState.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Target } from 'lucide-react';
+
+export const ShareEmptyState: React.FC = () => {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <Target className="w-16 h-16 text-terminal-text/30 mb-4" />
+      <h2 className="text-lg font-medium text-terminal-text mb-2">
+        Nenhuma aposta encontrada
+      </h2>
+      <p className="text-sm text-terminal-text/70 max-w-sm">
+        Não há apostas que correspondam aos filtros aplicados neste link de compartilhamento.
+      </p>
+    </div>
+  );
+};

--- a/src/components/share/ShareErrorState.tsx
+++ b/src/components/share/ShareErrorState.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { AlertCircle, Link2Off, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ShareErrorStateProps {
+  status?: number;
+  message?: string;
+  onRetry: () => void;
+}
+
+export const ShareErrorState: React.FC<ShareErrorStateProps> = ({
+  status,
+  message,
+  onRetry,
+}) => {
+  const is404 = status === 404 || message?.includes('não encontrado');
+  const is410 = status === 410 || message?.includes('expirou');
+
+  const title = is404
+    ? 'Este link não existe ou foi removido'
+    : is410
+      ? 'Este link expirou'
+      : 'Erro ao carregar';
+
+  const description = is404
+    ? 'O link de compartilhamento pode ter sido excluído ou o endereço está incorreto.'
+    : is410
+      ? 'O prazo de validade deste link acabou.'
+      : 'Não foi possível carregar as apostas. Verifique sua conexão e tente novamente.';
+
+  return (
+    <div className="min-h-screen bg-terminal-black flex items-center justify-center px-4">
+      <div className="text-center max-w-md">
+        <div className="flex justify-center mb-4">
+          {is404 || is410 ? (
+            <Link2Off className="w-16 h-16 text-terminal-yellow/80" />
+          ) : (
+            <AlertCircle className="w-16 h-16 text-terminal-red/80" />
+          )}
+        </div>
+        <h1 className="text-xl font-semibold text-terminal-text mb-2">{title}</h1>
+        <p className="text-sm text-terminal-text/70 mb-6">{description}</p>
+        <Button
+          onClick={onRetry}
+          className="terminal-button border-terminal-green text-terminal-green hover:bg-terminal-green hover:text-terminal-black"
+        >
+          <RefreshCw className="w-4 h-4 mr-2" />
+          Tentar novamente
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/components/share/ShareKpiCards.tsx
+++ b/src/components/share/ShareKpiCards.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { statsForDateRange } from '@/utils/bettingStats';
+import type { ShareResolveBet } from '@/hooks/use-share-resolve';
+import type { Bet } from '@/hooks/use-bets';
+import { TrendingUp, Target, Percent, Hash } from 'lucide-react';
+
+interface ShareKpiCardsProps {
+  bets: ShareResolveBet[];
+}
+
+export const ShareKpiCards: React.FC<ShareKpiCardsProps> = ({ bets }) => {
+  const stats = statsForDateRange(bets as unknown as Bet[]);
+
+  const cards = [
+    {
+      title: 'Lucro / Prejuízo',
+      value: stats.profit,
+      format: (v: number) => `R$ ${v >= 0 ? '' : '-'}${Math.abs(v).toFixed(2)}`,
+      icon: TrendingUp,
+      positive: stats.profit >= 0,
+    },
+    {
+      title: 'ROI',
+      value: stats.roi,
+      format: (v: number) => `${v.toFixed(1)}%`,
+      icon: Percent,
+      positive: stats.roi >= 0,
+    },
+    {
+      title: 'Win Rate',
+      value: stats.winRate,
+      format: (v: number) => `${v.toFixed(1)}%`,
+      icon: Target,
+      positive: true,
+    },
+    {
+      title: 'Total de apostas',
+      value: stats.totalBets,
+      format: (v: number) => String(v),
+      icon: Hash,
+      positive: true,
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      {cards.map((card) => {
+        const Icon = card.icon;
+        return (
+          <Card
+            key={card.title}
+            className="bg-terminal-dark-gray border-terminal-border"
+          >
+            <CardHeader className="flex flex-row items-center justify-between pb-1 pt-4 px-4">
+              <CardTitle className="text-xs font-medium text-terminal-text/80">
+                {card.title}
+              </CardTitle>
+              <Icon className="w-4 h-4 text-terminal-green/70" />
+            </CardHeader>
+            <CardContent className="px-4 pb-4">
+              <span
+                className={
+                  card.title === 'Lucro / Prejuízo'
+                    ? card.positive
+                      ? 'text-terminal-green text-lg font-semibold'
+                      : 'text-terminal-red text-lg font-semibold'
+                    : 'text-terminal-text text-lg font-semibold'
+                }
+              >
+                {card.format(card.value)}
+              </span>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/share/ShareLayout.tsx
+++ b/src/components/share/ShareLayout.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Badge } from '@/components/ui/badge';
+
+interface ShareLayoutProps {
+  ownerName: string;
+  filtersSnapshot: Record<string, unknown>;
+  children: React.ReactNode;
+}
+
+function getFilterChips(filters: Record<string, unknown>): string[] {
+  const chips: string[] = [];
+  const status = filters.status as string[] | undefined;
+  if (status?.length) chips.push(`Status: ${status.join(', ')}`);
+  const sports = filters.sports as string[] | undefined;
+  if (sports?.length) chips.push(...sports.filter((v: string) => v !== '__empty__'));
+  const leagues = filters.leagues as string[] | undefined;
+  if (leagues?.length) chips.push(...leagues.filter((v: string) => v !== '__empty__'));
+  const markets = filters.markets as string[] | undefined;
+  if (markets?.length) chips.push(...markets.filter((v: string) => v !== '__empty__'));
+  const dateFrom = filters.date_from as string | undefined;
+  if (dateFrom) chips.push(`De ${dateFrom}`);
+  const dateTo = filters.date_to as string | undefined;
+  if (dateTo) chips.push(`Até ${dateTo}`);
+  const search = filters.search as string | undefined;
+  if (search?.trim()) chips.push(`Busca: "${search.trim()}"`);
+  return chips;
+}
+
+export const ShareLayout: React.FC<ShareLayoutProps> = ({
+  ownerName,
+  filtersSnapshot,
+  children,
+}) => {
+  const filterChips = getFilterChips(filtersSnapshot);
+
+  return (
+    <div className="min-h-screen bg-terminal-black text-terminal-text">
+      <header className="border-b border-terminal-border bg-terminal-dark-gray">
+        <div className="max-w-6xl mx-auto px-4 py-4">
+          <div className="flex flex-wrap items-center gap-2 mb-2">
+            <h1 className="text-lg font-semibold text-terminal-green">
+              Apostas de {ownerName}
+            </h1>
+            <Badge
+              variant="secondary"
+              className="bg-terminal-gray/50 border-terminal-border text-terminal-text text-xs"
+            >
+              Visão compartilhada — somente leitura
+            </Badge>
+          </div>
+          {filterChips.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {filterChips.map((label, i) => (
+                <Badge
+                  key={i}
+                  variant="secondary"
+                  className="bg-terminal-gray border-terminal-border text-terminal-text text-xs"
+                >
+                  {label}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      </header>
+      <main className="max-w-6xl mx-auto px-4 py-6">
+        {children}
+      </main>
+    </div>
+  );
+};

--- a/src/components/share/ShareLoadingSkeleton.tsx
+++ b/src/components/share/ShareLoadingSkeleton.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+
+export const ShareLoadingSkeleton: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-terminal-black">
+      <header className="border-b border-terminal-border bg-terminal-dark-gray">
+        <div className="max-w-6xl mx-auto px-4 py-4">
+          <Skeleton className="h-6 w-48 bg-terminal-gray mb-2" />
+          <Skeleton className="h-5 w-64 bg-terminal-gray" />
+        </div>
+      </header>
+      <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Card key={i} className="bg-terminal-dark-gray border-terminal-border">
+              <CardHeader className="pb-1 pt-4 px-4">
+                <Skeleton className="h-4 w-24 bg-terminal-gray" />
+              </CardHeader>
+              <CardContent className="px-4 pb-4">
+                <Skeleton className="h-7 w-20 bg-terminal-gray" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <Skeleton className="h-[280px] w-full bg-terminal-gray rounded-md" />
+        <div className="space-y-2">
+          <Skeleton className="h-10 w-full bg-terminal-gray" />
+          <Skeleton className="h-10 w-full bg-terminal-gray" />
+          <Skeleton className="h-10 w-full bg-terminal-gray" />
+          <Skeleton className="h-10 w-full bg-terminal-gray" />
+          <Skeleton className="h-10 w-full bg-terminal-gray" />
+        </div>
+      </main>
+    </div>
+  );
+};

--- a/src/hooks/use-share-link.ts
+++ b/src/hooks/use-share-link.ts
@@ -1,0 +1,57 @@
+import { useMutation } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface ShareLinkFilters {
+  status: string[];
+  sport: string[];
+  league: string[];
+  betting_market: string[];
+  searchQuery: string;
+  dateFrom: string;
+  dateTo: string;
+  selectedTags: string[];
+}
+
+function mapFiltersToPayload(filters: ShareLinkFilters) {
+  return {
+    status: filters.status,
+    sports: filters.sport,
+    leagues: filters.league,
+    markets: filters.betting_market,
+    tags: filters.selectedTags,
+    date_from: filters.dateFrom || null,
+    date_to: filters.dateTo || null,
+    search: filters.searchQuery || '',
+  };
+}
+
+async function createShareLink(filters: ShareLinkFilters): Promise<{ token: string; url: string }> {
+  const payload = mapFiltersToPayload(filters);
+  const { data, error } = await supabase.functions.invoke('share-create', {
+    body: { filters: payload },
+  });
+
+  if (error) {
+    throw new Error(error.message || 'Falha ao gerar link');
+  }
+
+  if (!data?.token || !data?.url) {
+    throw new Error(data?.error || 'Resposta inválida do servidor');
+  }
+
+  return { token: data.token, url: data.url };
+}
+
+export function useShareLink() {
+  const mutation = useMutation({
+    mutationFn: createShareLink,
+  });
+
+  return {
+    generateLink: mutation.mutateAsync,
+    isLoading: mutation.isPending,
+    shareUrl: mutation.data?.url ?? null,
+    error: mutation.error,
+    reset: mutation.reset,
+  };
+}

--- a/src/hooks/use-share-resolve.ts
+++ b/src/hooks/use-share-resolve.ts
@@ -1,0 +1,86 @@
+import { useQuery } from '@tanstack/react-query';
+
+export interface ShareResolveBet {
+  id: string;
+  bet_date: string;
+  sport: string;
+  league: string | null;
+  bet_description: string;
+  odds: number;
+  stake_amount: number;
+  potential_return: number;
+  status: string;
+  cashout_amount: number | null;
+  cashout_odds: number | null;
+  is_cashout: boolean | null;
+  bet_type: string;
+  betting_market: string | null;
+  bet_legs?: Array<{
+    bet_id: string;
+    leg_number: number;
+    sport: string;
+    match_description: string;
+    bet_description: string;
+    odds: number;
+    status: string;
+  }>;
+}
+
+export interface ShareResolveData {
+  owner: { name: string };
+  filters_snapshot: Record<string, unknown>;
+  bets: ShareResolveBet[];
+  total: number;
+}
+
+async function resolveShareToken(token: string): Promise<ShareResolveData> {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || '';
+  const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || '';
+  const res = await fetch(`${supabaseUrl}/functions/v1/share-resolve`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${anonKey}`,
+    },
+    body: JSON.stringify({ token }),
+  });
+
+  const data = await res.json().catch(() => ({}));
+
+  if (!res.ok) {
+    const err = new Error(data?.error || 'Erro ao carregar') as Error & { status?: number };
+    err.status = res.status;
+    throw err;
+  }
+
+  if (data?.error) {
+    const err = new Error(data.error) as Error & { status?: number };
+    err.status = data.error === 'Link não encontrado' ? 404 : data.error === 'Este link expirou' ? 410 : 500;
+    throw err;
+  }
+
+  if (!data?.owner || !Array.isArray(data?.bets)) {
+    throw new Error('Resposta inválida');
+  }
+
+  return data as ShareResolveData;
+}
+
+export const shareResolveQueryKeys = {
+  all: ['share-resolve'] as const,
+  byToken: (token: string) => [...shareResolveQueryKeys.all, token] as const,
+};
+
+export function useShareResolve(token: string | undefined) {
+  return useQuery({
+    queryKey: shareResolveQueryKeys.byToken(token ?? ''),
+    queryFn: () => resolveShareToken(token!),
+    enabled: !!token,
+    staleTime: 2 * 60 * 1000,
+    retry: (failureCount, error) => {
+      const err = error as Error & { status?: number };
+      if (err?.status === 404 || err?.status === 410) return false;
+      return failureCount < 2;
+    },
+  });
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -7,311 +7,39 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instanciate createClient with right options
-  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
-  __InternalSupabase: {
-    PostgrestVersion: "12.2.3 (519615d)"
-  }
-  public: {
+  bigquery: {
     Tables: {
-      waitlist: {
-        Row: {
-          id: number
-          name: string
-          email: string
-          phone: string | null
-          created_at: string
-        }
-        Insert: {
-          id?: number
-          name: string
-          email: string
-          phone?: string | null
-          created_at?: string
-        }
-        Update: {
-          id?: number
-          name?: string
-          email?: string
-          phone?: string | null
-          created_at?: string
-        }
-        Relationships: []
-      }
-      users: {
-        Row: {
-          id: string
-          email: string
-          whatsapp_number: string | null
-          conversation_id: string | null
-          name: string | null
-          whatsapp_synced: boolean
-          whatsapp_sync_token: string | null
-          unit_value: number | null
-          unit_calculation_method: string | null
-          bank_amount: number | null
-          created_at: string
-          updated_at: string
-        }
-        Insert: {
-          id?: string
-          email: string
-          whatsapp_number?: string | null
-          conversation_id?: string | null
-          name?: string | null
-          whatsapp_synced?: boolean
-          whatsapp_sync_token?: string | null
-          unit_value?: number | null
-          unit_calculation_method?: string | null
-          bank_amount?: number | null
-          created_at?: string
-          updated_at?: string
-        }
-        Update: {
-          id?: string
-          email?: string
-          whatsapp_number?: string | null
-          conversation_id?: string | null
-          name?: string | null
-          whatsapp_synced?: boolean
-          whatsapp_sync_token?: string | null
-          unit_value?: number | null
-          unit_calculation_method?: string | null
-          bank_amount?: number | null
-          created_at?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
-      bets: {
-        Row: {
-          id: string
-          user_id: string
-          bet_type: string
-          sport: string
-          league: string | null
-          match_description: string | null
-          bet_description: string
-          odds: number
-          stake_amount: number
-          potential_return: number
-          status: string
-          bet_date: string
-          match_date: string | null
-          created_at: string
-          updated_at: string
-          raw_input: string | null
-          processed_data: any | null
-          cashout_amount: number | null
-          cashout_date: string | null
-          cashout_odds: number | null
-          is_cashout: boolean | null
-          channel: string | null
-        }
-        Insert: {
-          id?: string
-          user_id: string
-          bet_type: string
-          sport: string
-          league?: string | null
-          match_description?: string | null
-          bet_description: string
-          odds: number
-          stake_amount: number
-          potential_return: number
-          status?: string
-          bet_date: string
-          match_date?: string | null
-          created_at?: string
-          updated_at?: string
-          raw_input?: string | null
-          processed_data?: any | null
-          cashout_amount?: number | null
-          cashout_date?: string | null
-          cashout_odds?: number | null
-          is_cashout?: boolean | null
-          channel?: string | null
-        }
-        Update: {
-          id?: string
-          user_id?: string
-          bet_type?: string
-          sport?: string
-          league?: string | null
-          match_description?: string | null
-          bet_description?: string
-          odds?: number
-          stake_amount?: number
-          potential_return?: number
-          status?: string
-          bet_date?: string
-          match_date?: string | null
-          created_at?: string
-          updated_at?: string
-          raw_input?: string | null
-          processed_data?: any | null
-          cashout_amount?: number | null
-          cashout_date?: string | null
-          cashout_odds?: number | null
-          is_cashout?: boolean | null
-          channel?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "bets_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          }
-        ]
-      }
-      bet_legs: {
-        Row: {
-          id: string
-          bet_id: string
-          leg_number: number
-          sport: string
-          match_description: string
-          bet_description: string
-          odds: number
-          status: string
-          created_at: string
-        }
-        Insert: {
-          id?: string
-          bet_id: string
-          leg_number: number
-          sport: string
-          match_description: string
-          bet_description: string
-          odds: number
-          status?: string
-          created_at?: string
-        }
-        Update: {
-          id?: string
-          bet_id?: string
-          leg_number?: number
-          sport?: string
-          match_description?: string
-          bet_description?: string
-          odds?: number
-          status?: string
-          created_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "bet_legs_bet_id_fkey"
-            columns: ["bet_id"]
-            isOneToOne: false
-            referencedRelation: "bets"
-            referencedColumns: ["id"]
-          }
-        ]
-      }
-      message_queue: {
-        Row: {
-          id: string
-          user_id: string
-          message_type: string
-          content: string | null
-          media_url: string | null
-          status: string
-          processing_attempts: number
-          error_message: string | null
-          created_at: string
-          processed_at: string | null
-        }
-        Insert: {
-          id?: string
-          user_id: string
-          message_type: string
-          content?: string | null
-          media_url?: string | null
-          status?: string
-          processing_attempts?: number
-          error_message?: string | null
-          created_at?: string
-          processed_at?: string | null
-        }
-        Update: {
-          id?: string
-          user_id?: string
-          message_type?: string
-          content?: string | null
-          media_url?: string | null
-          status?: string
-          processing_attempts?: number
-          error_message?: string | null
-          created_at?: string
-          processed_at?: string | null
-        }
-        Relationships: [
-          {
-            foreignKeyName: "message_queue_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          }
-        ]
-      }
-      capital_movements: {
-        Row: {
-          id: string
-          user_id: string
-          type: string
-          amount: number
-          movement_date: string
-          description: string | null
-          source: string
-          affects_balance: boolean
-          created_at: string
-          updated_at: string
-        }
-        Insert: {
-          id?: string
-          user_id: string
-          type: string
-          amount: number
-          movement_date?: string
-          description?: string | null
-          source?: string
-          affects_balance?: boolean
-          created_at?: string
-          updated_at?: string
-        }
-        Update: {
-          id?: string
-          user_id?: string
-          type?: string
-          amount?: number
-          movement_date?: string
-          description?: string | null
-          source?: string
-          affects_balance?: boolean
-          created_at?: string
-          updated_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: "capital_movements_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["id"]
-          }
-        ]
-      }
+      [_ in never]: never
     }
     Views: {
       [_ in never]: never
     }
     Functions: {
-      [key: string]: {
-        Args: any
-        Returns: any
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
       }
     }
     Enums: {
@@ -320,99 +48,958 @@ export type Database = {
     CompositeTypes: {
       [_ in never]: never
     }
-  },
-  bigquery: {
+  }
+  public: {
     Tables: {
-      dim_players: {
+      bet_legs: {
         Row: {
-          player_id: number
-          player_name: string
-          position: string
-          team_id: number
-          team_name: string
-          team_abbreviation: string
-          age: number
-          last_game_text: string
-          current_status: string
+          bet_description: string
+          bet_id: string | null
+          created_at: string | null
+          id: string
+          leg_number: number
+          match_description: string
+          odds: number
+          sport: string
+          status: string | null
         }
-        Insert: never
-        Update: never
+        Insert: {
+          bet_description: string
+          bet_id?: string | null
+          created_at?: string | null
+          id?: string
+          leg_number: number
+          match_description: string
+          odds: number
+          sport: string
+          status?: string | null
+        }
+        Update: {
+          bet_description?: string
+          bet_id?: string | null
+          created_at?: string | null
+          id?: string
+          leg_number?: number
+          match_description?: string
+          odds?: number
+          sport?: string
+          status?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bet_legs_bet_id_fkey"
+            columns: ["bet_id"]
+            isOneToOne: false
+            referencedRelation: "bets"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bet_tags: {
+        Row: {
+          bet_id: string
+          created_at: string | null
+          id: string
+          tag_id: string
+        }
+        Insert: {
+          bet_id: string
+          created_at?: string | null
+          id?: string
+          tag_id: string
+        }
+        Update: {
+          bet_id?: string
+          created_at?: string | null
+          id?: string
+          tag_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bet_tags_bet_id_fkey"
+            columns: ["bet_id"]
+            isOneToOne: false
+            referencedRelation: "bets"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "bet_tags_tag_id_fkey"
+            columns: ["tag_id"]
+            isOneToOne: false
+            referencedRelation: "tags"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bets: {
+        Row: {
+          bet_date: string
+          bet_description: string
+          bet_type: string
+          betting_house: string | null
+          betting_market: string | null
+          cashout_amount: number | null
+          cashout_date: string | null
+          cashout_odds: number | null
+          channel: string | null
+          created_at: string | null
+          id: string
+          is_cashout: boolean | null
+          league: string | null
+          match_date: string | null
+          match_description: string | null
+          odds: number
+          potential_return: number
+          processed_data: Json | null
+          raw_input: string | null
+          sport: string
+          stake_amount: number
+          status: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Insert: {
+          bet_date: string
+          bet_description: string
+          bet_type: string
+          betting_house?: string | null
+          betting_market?: string | null
+          cashout_amount?: number | null
+          cashout_date?: string | null
+          cashout_odds?: number | null
+          channel?: string | null
+          created_at?: string | null
+          id?: string
+          is_cashout?: boolean | null
+          league?: string | null
+          match_date?: string | null
+          match_description?: string | null
+          odds: number
+          potential_return: number
+          processed_data?: Json | null
+          raw_input?: string | null
+          sport: string
+          stake_amount: number
+          status?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          bet_date?: string
+          bet_description?: string
+          bet_type?: string
+          betting_house?: string | null
+          betting_market?: string | null
+          cashout_amount?: number | null
+          cashout_date?: string | null
+          cashout_odds?: number | null
+          channel?: string | null
+          created_at?: string | null
+          id?: string
+          is_cashout?: boolean | null
+          league?: string | null
+          match_date?: string | null
+          match_description?: string | null
+          odds?: number
+          potential_return?: number
+          processed_data?: Json | null
+          raw_input?: string | null
+          sport?: string
+          stake_amount?: number
+          status?: string | null
+          updated_at?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bets_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      capital_movements: {
+        Row: {
+          affects_balance: boolean
+          amount: number
+          created_at: string | null
+          description: string | null
+          id: string
+          movement_date: string
+          source: string
+          type: string
+          updated_at: string | null
+          user_id: string
+        }
+        Insert: {
+          affects_balance?: boolean
+          amount: number
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          movement_date?: string
+          source?: string
+          type: string
+          updated_at?: string | null
+          user_id: string
+        }
+        Update: {
+          affects_balance?: boolean
+          amount?: number
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          movement_date?: string
+          source?: string
+          type?: string
+          updated_at?: string | null
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "capital_movements_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      message_queue: {
+        Row: {
+          channel: string | null
+          content: string | null
+          created_at: string | null
+          error_message: string | null
+          id: string
+          media_url: string | null
+          message_type: string
+          processed_at: string | null
+          processing_attempts: number | null
+          status: string | null
+          user_id: string | null
+        }
+        Insert: {
+          channel?: string | null
+          content?: string | null
+          created_at?: string | null
+          error_message?: string | null
+          id?: string
+          media_url?: string | null
+          message_type: string
+          processed_at?: string | null
+          processing_attempts?: number | null
+          status?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          channel?: string | null
+          content?: string | null
+          created_at?: string | null
+          error_message?: string | null
+          id?: string
+          media_url?: string | null
+          message_type?: string
+          processed_at?: string | null
+          processing_attempts?: number | null
+          status?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "message_queue_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      performance_semanal: {
+        Row: {
+          apostas_pendentes: number
+          breakdown_por_esporte: Json | null
+          cashout: number
+          created_at: string | null
+          ganhos: number
+          id: string
+          lucro_liquido: number
+          mensagem_whatsapp: string
+          perdas: number
+          semana_fim: string
+          semana_inicio: string
+          total_apostas: number
+          updated_at: string | null
+          user_email: string | null
+          user_id: string
+          user_name: string | null
+          user_whatsapp_number: string | null
+          valor_apostado: number
+        }
+        Insert: {
+          apostas_pendentes?: number
+          breakdown_por_esporte?: Json | null
+          cashout?: number
+          created_at?: string | null
+          ganhos?: number
+          id?: string
+          lucro_liquido?: number
+          mensagem_whatsapp: string
+          perdas?: number
+          semana_fim: string
+          semana_inicio: string
+          total_apostas?: number
+          updated_at?: string | null
+          user_email?: string | null
+          user_id: string
+          user_name?: string | null
+          user_whatsapp_number?: string | null
+          valor_apostado?: number
+        }
+        Update: {
+          apostas_pendentes?: number
+          breakdown_por_esporte?: Json | null
+          cashout?: number
+          created_at?: string | null
+          ganhos?: number
+          id?: string
+          lucro_liquido?: number
+          mensagem_whatsapp?: string
+          perdas?: number
+          semana_fim?: string
+          semana_inicio?: string
+          total_apostas?: number
+          updated_at?: string | null
+          user_email?: string | null
+          user_id?: string
+          user_name?: string | null
+          user_whatsapp_number?: string | null
+          valor_apostado?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "performance_semanal_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      referrals: {
+        Row: {
+          created_at: string | null
+          id: string
+          referral_code: string
+          referred_id: string
+          referrer_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          id?: string
+          referral_code: string
+          referred_id: string
+          referrer_id: string
+        }
+        Update: {
+          created_at?: string | null
+          id?: string
+          referral_code?: string
+          referred_id?: string
+          referrer_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "referrals_referred_id_fkey"
+            columns: ["referred_id"]
+            isOneToOne: true
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "referrals_referrer_id_fkey"
+            columns: ["referrer_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      share_links: {
+        Row: {
+          created_at: string | null
+          expires_at: string | null
+          filters_snapshot: Json
+          id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string | null
+          expires_at?: string | null
+          filters_snapshot: Json
+          id?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string | null
+          expires_at?: string | null
+          filters_snapshot?: Json
+          id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "share_links_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      tags: {
+        Row: {
+          color: string
+          created_at: string | null
+          id: string
+          name: string
+          user_id: string
+        }
+        Insert: {
+          color: string
+          created_at?: string | null
+          id?: string
+          name: string
+          user_id: string
+        }
+        Update: {
+          color?: string
+          created_at?: string | null
+          id?: string
+          name?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "tags_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      users: {
+        Row: {
+          analytics_subscription_cancel_at: string | null
+          analytics_subscription_cancel_at_period_end: boolean | null
+          analytics_subscription_period_end: string | null
+          analytics_subscription_status: string | null
+          bank_amount: number | null
+          betinho_subscription_cancel_at: string | null
+          betinho_subscription_cancel_at_period_end: boolean | null
+          betinho_subscription_period_end: string | null
+          betinho_subscription_status: string | null
+          conversation_id: string | null
+          created_at: string | null
+          email: string
+          id: string
+          name: string | null
+          referral_code: string | null
+          referred_by: string | null
+          stripe_customer_id: string | null
+          stripe_subscription_id: string | null
+          subscription_cancel_at: string | null
+          subscription_cancel_at_period_end: boolean | null
+          subscription_period_end: string | null
+          subscription_product_type: string | null
+          subscription_status: string | null
+          telegram_chat_id: string | null
+          telegram_phone: string | null
+          telegram_sync_source: string | null
+          telegram_synced: boolean | null
+          telegram_synced_at: string | null
+          telegram_user_id: string | null
+          telegram_username: string | null
+          unit_calculation_method: string | null
+          unit_value: number | null
+          updated_at: string | null
+          whatsapp_number: string | null
+          whatsapp_sync_token: string | null
+          whatsapp_synced: boolean | null
+        }
+        Insert: {
+          analytics_subscription_cancel_at?: string | null
+          analytics_subscription_cancel_at_period_end?: boolean | null
+          analytics_subscription_period_end?: string | null
+          analytics_subscription_status?: string | null
+          bank_amount?: number | null
+          betinho_subscription_cancel_at?: string | null
+          betinho_subscription_cancel_at_period_end?: boolean | null
+          betinho_subscription_period_end?: string | null
+          betinho_subscription_status?: string | null
+          conversation_id?: string | null
+          created_at?: string | null
+          email: string
+          id?: string
+          name?: string | null
+          referral_code?: string | null
+          referred_by?: string | null
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string | null
+          subscription_cancel_at?: string | null
+          subscription_cancel_at_period_end?: boolean | null
+          subscription_period_end?: string | null
+          subscription_product_type?: string | null
+          subscription_status?: string | null
+          telegram_chat_id?: string | null
+          telegram_phone?: string | null
+          telegram_sync_source?: string | null
+          telegram_synced?: boolean | null
+          telegram_synced_at?: string | null
+          telegram_user_id?: string | null
+          telegram_username?: string | null
+          unit_calculation_method?: string | null
+          unit_value?: number | null
+          updated_at?: string | null
+          whatsapp_number?: string | null
+          whatsapp_sync_token?: string | null
+          whatsapp_synced?: boolean | null
+        }
+        Update: {
+          analytics_subscription_cancel_at?: string | null
+          analytics_subscription_cancel_at_period_end?: boolean | null
+          analytics_subscription_period_end?: string | null
+          analytics_subscription_status?: string | null
+          bank_amount?: number | null
+          betinho_subscription_cancel_at?: string | null
+          betinho_subscription_cancel_at_period_end?: boolean | null
+          betinho_subscription_period_end?: string | null
+          betinho_subscription_status?: string | null
+          conversation_id?: string | null
+          created_at?: string | null
+          email?: string
+          id?: string
+          name?: string | null
+          referral_code?: string | null
+          referred_by?: string | null
+          stripe_customer_id?: string | null
+          stripe_subscription_id?: string | null
+          subscription_cancel_at?: string | null
+          subscription_cancel_at_period_end?: boolean | null
+          subscription_period_end?: string | null
+          subscription_product_type?: string | null
+          subscription_status?: string | null
+          telegram_chat_id?: string | null
+          telegram_phone?: string | null
+          telegram_sync_source?: string | null
+          telegram_synced?: boolean | null
+          telegram_synced_at?: string | null
+          telegram_user_id?: string | null
+          telegram_username?: string | null
+          unit_calculation_method?: string | null
+          unit_value?: number | null
+          updated_at?: string | null
+          whatsapp_number?: string | null
+          whatsapp_sync_token?: string | null
+          whatsapp_synced?: boolean | null
+        }
         Relationships: []
       }
-      dim_prop_player: {
+      waitlist: {
         Row: {
-          player_id: number
-          team_id: number
-          stat_type: string
-          rating_stars: number
-          is_leader_with_injury: boolean
-          is_available_backup: boolean
-          stat_rank: number
-          next_available_player_name: string
-          next_player_stats_when_leader_out: number
-          next_player_stats_normal: number
-          loaded_at: string
+          created_at: string
+          email: string
+          id: number
+          name: string
+          phone: string | null
         }
-        Insert: never
-        Update: never
+        Insert: {
+          created_at?: string
+          email: string
+          id?: number
+          name: string
+          phone?: string | null
+        }
+        Update: {
+          created_at?: string
+          email?: string
+          id?: number
+          name?: string
+          phone?: string | null
+        }
         Relationships: []
       }
-      dim_teams: {
+      weekly_performance: {
         Row: {
-          team_id: number
-          team_name: string
-          team_abbreviation: string
-          conference: string
-          team_city: string
-          season: number
-          conference_rank: number
-          wins: number
-          losses: number
-          team_last_five_games: string
-          team_rating_rank: number
-          team_offensive_rating_rank: number
-          team_defensive_rating_rank: number
-          next_opponent_id: number
-          next_opponent_name: string
-          next_opponent_abbreviation: string
-          is_next_game_home: boolean
-          next_opponent_team_last_five_games: string
-          next_opponent_conference_rank: number
-          next_opponent_team_rating_rank: number
-          next_opponent_team_offensive_rating_rank: number
-          next_opponent_team_defensive_rating_rank: number
-          team_injury_report_time_brasilia: string
-          next_game_injury_report_time_brasilia: string
-          loaded_at: string
+          created_at: string | null
+          id: string
+          net_profit: number
+          sport_breakdown: Json | null
+          total_bets: number
+          total_cashout: number
+          total_lost: number
+          total_pending: number
+          total_staked: number
+          total_won: number
+          updated_at: string | null
+          user_email: string | null
+          user_id: string
+          user_name: string | null
+          user_whatsapp_number: string | null
+          week_end_date: string
+          week_start_date: string
         }
-        Insert: never
-        Update: never
-        Relationships: []
-      }
-      ft_game_player_stats: {
-        Row: {
-          player_id: number
-          game_date: string
-          game_id: number
-          stat_type: string
-          stat_value: number
-          line: number
-          is_b2b_game: boolean
-          stat_vs_line: string
-          played_against: string
-          home_away: string
-          is_played: string
+        Insert: {
+          created_at?: string | null
+          id?: string
+          net_profit?: number
+          sport_breakdown?: Json | null
+          total_bets?: number
+          total_cashout?: number
+          total_lost?: number
+          total_pending?: number
+          total_staked?: number
+          total_won?: number
+          updated_at?: string | null
+          user_email?: string | null
+          user_id: string
+          user_name?: string | null
+          user_whatsapp_number?: string | null
+          week_end_date: string
+          week_start_date: string
         }
-        Insert: never
-        Update: never
-        Relationships: []
+        Update: {
+          created_at?: string | null
+          id?: string
+          net_profit?: number
+          sport_breakdown?: Json | null
+          total_bets?: number
+          total_cashout?: number
+          total_lost?: number
+          total_pending?: number
+          total_staked?: number
+          total_won?: number
+          updated_at?: string | null
+          user_email?: string | null
+          user_id?: string
+          user_name?: string | null
+          user_whatsapp_number?: string | null
+          week_end_date?: string
+          week_start_date?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "weekly_performance_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
       }
     }
     Views: {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      add_message_to_queue: {
+        Args: {
+          p_content?: string
+          p_media_url?: string
+          p_message_type: string
+          p_user_id: string
+        }
+        Returns: string
+      }
+      add_tag_to_bet: {
+        Args: { p_bet_id: string; p_tag_id: string }
+        Returns: boolean
+      }
+      calcular_performance_semanal: {
+        Args: { p_semana_inicio?: string }
+        Returns: undefined
+      }
+      calculate_weekly_performance: {
+        Args: { p_week_start_date?: string }
+        Returns: undefined
+      }
+      create_referral: {
+        Args: {
+          p_referral_code: string
+          p_referred_id: string
+          p_referrer_id: string
+        }
+        Returns: boolean
+      }
+      format_currency: { Args: { value: number }; Returns: string }
+      format_date_br: { Args: { date_value: string }; Returns: string }
+      generate_referral_code: { Args: never; Returns: string }
+      generate_whatsapp_message: {
+        Args: {
+          p_apostas_pendentes: number
+          p_cashout: number
+          p_ganhos: number
+          p_lucro_liquido: number
+          p_perdas: number
+          p_semana_fim: string
+          p_semana_inicio: string
+          p_total_apostas: number
+          p_user_name: string
+          p_valor_apostado: number
+        }
+        Returns: string
+      }
+      generate_whatsapp_sync_token: { Args: never; Returns: string }
+      get_all_players: {
+        Args: never
+        Returns: {
+          age: number
+          current_status: string
+          last_game_text: string
+          player_id: number
+          player_name: string
+          position: string
+          rating_stars: number
+          team_abbreviation: string
+          team_id: number
+          team_name: string
+        }[]
+      }
+      get_bet_tags: {
+        Args: { p_bet_id: string }
+        Returns: {
+          color: string
+          id: string
+          name: string
+        }[]
+      }
+      get_games: {
+        Args: { p_game_date?: string; p_team_abbreviation?: string }
+        Returns: {
+          game_date: string
+          game_datetime_brasilia: string
+          game_id: number
+          home_team_abbreviation: string
+          home_team_id: number
+          home_team_is_b2b_game: boolean
+          home_team_is_next_game: boolean
+          home_team_name: string
+          home_team_score: number
+          loaded_at: string
+          visitor_team_abbreviation: string
+          visitor_team_id: number
+          visitor_team_is_b2b_game: boolean
+          visitor_team_is_next_game: boolean
+          visitor_team_name: string
+          visitor_team_score: number
+          winner_team_id: number
+        }[]
+      }
+      get_pending_messages: {
+        Args: { limit_count?: number }
+        Returns: {
+          content: string
+          created_at: string
+          id: string
+          media_url: string
+          message_type: string
+          user_id: string
+        }[]
+      }
+      get_player_by_id: {
+        Args: { p_player_id: number }
+        Returns: {
+          age: number
+          current_status: string
+          last_game_text: string
+          player_id: number
+          player_name: string
+          position: string
+          team_abbreviation: string
+          team_id: number
+          team_name: string
+        }[]
+      }
+      get_player_by_name: {
+        Args: { p_player_name: string }
+        Returns: {
+          age: number
+          current_status: string
+          last_game_text: string
+          player_id: number
+          player_name: string
+          position: string
+          rating_stars: number
+          team_abbreviation: string
+          team_id: number
+          team_name: string
+        }[]
+      }
+      get_player_dashboard_bundle: {
+        Args: { p_games_limit?: number; p_player_id: number }
+        Returns: Json
+      }
+      get_player_game_stats: {
+        Args: { p_limit?: number; p_player_id: number }
+        Returns: {
+          game_date: string
+          game_id: number
+          home_away: string
+          is_b2b_game: boolean
+          is_played: string
+          line: number
+          played_against: string
+          player_id: number
+          stat_type: string
+          stat_value: number
+          stat_vs_line: string
+        }[]
+      }
+      get_player_props: {
+        Args: { p_player_id: number }
+        Returns: {
+          is_available_backup: boolean
+          is_leader_with_injury: boolean
+          loaded_at: string
+          next_available_player_name: string
+          next_player_stats_normal: number
+          next_player_stats_when_leader_out: number
+          player_id: number
+          rating_stars: number
+          stat_rank: number
+          stat_type: string
+          team_id: number
+        }[]
+      }
+      get_player_shooting_zones: {
+        Args: { p_player_id: number }
+        Returns: {
+          above_the_break_3_fg_pct: number
+          above_the_break_3_fga: number
+          above_the_break_3_fgm: number
+          backcourt_fg_pct: number
+          backcourt_fga: number
+          backcourt_fgm: number
+          corner_3_fg_pct: number
+          corner_3_fga: number
+          corner_3_fgm: number
+          in_the_paint_non_ra_fg_pct: number
+          in_the_paint_non_ra_fga: number
+          in_the_paint_non_ra_fgm: number
+          left_corner_3_fg_pct: number
+          left_corner_3_fga: number
+          left_corner_3_fgm: number
+          loaded_at: string
+          mid_range_fg_pct: number
+          mid_range_fga: number
+          mid_range_fgm: number
+          player_id: number
+          player_name: string
+          restricted_area_fg_pct: number
+          restricted_area_fga: number
+          restricted_area_fgm: number
+          right_corner_3_fg_pct: number
+          right_corner_3_fga: number
+          right_corner_3_fgm: number
+        }[]
+      }
+      get_referral_count: { Args: { p_user_id: string }; Returns: number }
+      get_referred_users: {
+        Args: { p_user_referral_code: string }
+        Returns: {
+          created_at: string
+          referral_code: string
+          user_email: string
+          user_id: string
+          user_name: string
+        }[]
+      }
+      get_team_by_id: {
+        Args: { p_team_id: number }
+        Returns: {
+          conference: string
+          conference_rank: number
+          is_next_game_home: boolean
+          loaded_at: string
+          losses: number
+          next_game_injury_report_time_brasilia: string
+          next_opponent_abbreviation: string
+          next_opponent_conference_rank: number
+          next_opponent_id: number
+          next_opponent_name: string
+          next_opponent_team_defensive_rating_rank: number
+          next_opponent_team_last_five_games: string
+          next_opponent_team_offensive_rating_rank: number
+          next_opponent_team_rating_rank: number
+          season: number
+          team_abbreviation: string
+          team_city: string
+          team_defensive_rating_rank: number
+          team_id: number
+          team_injury_report_time_brasilia: string
+          team_last_five_games: string
+          team_name: string
+          team_offensive_rating_rank: number
+          team_rating_rank: number
+          wins: number
+        }[]
+      }
+      get_team_players: {
+        Args: { p_team_id: number }
+        Returns: {
+          age: number
+          current_status: string
+          player_id: number
+          player_name: string
+          position: string
+          rating_stars: number
+          team_id: number
+        }[]
+      }
+      get_user_referrals: {
+        Args: { p_user_id: string }
+        Returns: {
+          created_at: string
+          referral_code: string
+          referred_email: string
+          referred_id: string
+          referred_name: string
+        }[]
+      }
+      get_user_referrals_from_users: {
+        Args: { p_user_id: string }
+        Returns: {
+          created_at: string
+          referral_code: string
+          referred_email: string
+          referred_id: string
+          referred_name: string
+        }[]
+      }
+      remove_tag_from_bet: {
+        Args: { p_bet_id: string; p_tag_id: string }
+        Returns: boolean
+      }
+      setup_weekly_performance_cron: { Args: never; Returns: undefined }
+      sync_whatsapp: {
+        Args: {
+          conversation_id: string
+          user_id: string
+          whatsapp_number: string
+        }
+        Returns: boolean
+      }
+      update_message_status: {
+        Args: {
+          p_error_message?: string
+          p_message_id: string
+          p_status: string
+        }
+        Returns: boolean
+      }
     }
     Enums: {
       [_ in never]: never
@@ -541,7 +1128,14 @@ export type CompositeTypes<
     : never
 
 export const Constants = {
+  bigquery: {
+    Enums: {},
+  },
+  graphql_public: {
+    Enums: {},
+  },
   public: {
     Enums: {},
   },
 } as const
+

--- a/src/pages/Bets.tsx
+++ b/src/pages/Bets.tsx
@@ -7,6 +7,7 @@ import { TagSelector } from '../components/bets/TagSelector';
 import { UnitConfigurationModal } from '../components/UnitConfigurationModal';
 import { BankrollEvolutionChart } from '@/components/bets/BankrollEvolutionChart';
 import { CreateBetModal, CreateBetFormData } from '@/components/bets/CreateBetModal';
+import { ShareLinkModal } from '@/components/bets/ShareLinkModal';
 import { ReferralModal } from '../components/ReferralModal';
 import { useUserUnit } from '@/hooks/use-user-unit';
 import { useCapitalMovements } from '@/hooks/use-capital-movements';
@@ -35,7 +36,8 @@ import {
   ChevronDown,
   Plus,
   BarChart3,
-  Send
+  Send,
+  Share2
 } from 'lucide-react';
 import { telegramBotUrl } from '../config/environment';
 import {
@@ -541,6 +543,7 @@ export default function Bets() {
     : formatCurrency;
   const [dailyBetCount, setDailyBetCount] = useState<number | null>(null);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const [referralModalOpen, setReferralModalOpen] = useState(false);
   const [referralCode, setReferralCode] = useState<string | null>(null);
   const [stats, setStats] = useState({
@@ -1949,6 +1952,14 @@ export default function Bets() {
             <div className="flex items-center gap-3">
             <button
               type="button"
+              onClick={() => setIsShareModalOpen(true)}
+              className="terminal-button px-4 py-2 text-sm flex items-center gap-2 border-terminal-border hover:border-terminal-green transition-colors"
+            >
+              <Share2 className="w-4 h-4" />
+              COMPARTILHAR
+            </button>
+            <button
+              type="button"
               onClick={() => {
                 if (isBetinhoFree && (dailyBetCount ?? 0) >= DAILY_BET_LIMIT) {
                   navigate('/paywall');
@@ -2590,6 +2601,13 @@ export default function Bets() {
         bettingMarketsList={BETTING_MARKETS_LIST}
         userTags={userTags}
         onTagsUpdated={fetchUserTags}
+      />
+
+      <ShareLinkModal
+        open={isShareModalOpen}
+        onOpenChange={setIsShareModalOpen}
+        filters={filters}
+        userTags={userTags}
       />
 
       <UnitConfigurationModal 

--- a/src/pages/SharePage.tsx
+++ b/src/pages/SharePage.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { useShareResolve } from '@/hooks/use-share-resolve';
+import { ShareLayout } from '@/components/share/ShareLayout';
+import { ShareKpiCards } from '@/components/share/ShareKpiCards';
+import { ShareBankrollChart } from '@/components/share/ShareBankrollChart';
+import { ShareBreakdownCharts } from '@/components/share/ShareBreakdownCharts';
+import { ShareBetsTable } from '@/components/share/ShareBetsTable';
+import { ShareLoadingSkeleton } from '@/components/share/ShareLoadingSkeleton';
+import { ShareErrorState } from '@/components/share/ShareErrorState';
+import { ShareEmptyState } from '@/components/share/ShareEmptyState';
+
+export default function SharePage() {
+  const { token } = useParams<{ token: string }>();
+  const { data, isLoading, isError, error, refetch } = useShareResolve(token);
+
+  if (isLoading) {
+    return <ShareLoadingSkeleton />;
+  }
+
+  if (isError) {
+    const err = error as Error & { status?: number; message?: string };
+    const status = err?.status;
+    const message = err?.message ?? '';
+    return (
+      <ShareErrorState
+        status={status}
+        message={message}
+        onRetry={() => refetch()}
+      />
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  if (data.bets.length === 0) {
+    return (
+      <ShareLayout
+        ownerName={data.owner.name}
+        filtersSnapshot={data.filters_snapshot}
+      >
+        <ShareEmptyState />
+      </ShareLayout>
+    );
+  }
+
+  return (
+    <ShareLayout
+      ownerName={data.owner.name}
+      filtersSnapshot={data.filters_snapshot}
+    >
+      <div className="space-y-6">
+        <ShareKpiCards bets={data.bets} />
+        <ShareBankrollChart bets={data.bets} />
+        <ShareBreakdownCharts bets={data.bets} />
+        <ShareBetsTable bets={data.bets} />
+      </div>
+    </ShareLayout>
+  );
+}

--- a/supabase/functions/share-create/index.ts
+++ b/supabase/functions/share-create/index.ts
@@ -1,0 +1,84 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader =
+      req.headers.get('Authorization') ||
+      req.headers.get('authorization') ||
+      req.headers.get('x-authorization');
+
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Missing authorization header' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const token = authHeader.replace('Bearer ', '');
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized', details: authError?.message }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const body = await req.json();
+    const { filters } = body;
+
+    if (!filters || typeof filters !== 'object') {
+      return new Response(
+        JSON.stringify({ error: 'Missing or invalid filters' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const appBaseUrl = Deno.env.get('APP_BASE_URL') || Deno.env.get('SITE_URL') || 'https://smartbetting.app';
+
+    const { data: row, error: insertError } = await supabase
+      .from('share_links')
+      .insert({
+        user_id: user.id,
+        filters_snapshot: filters,
+      })
+      .select('id')
+      .single();
+
+    if (insertError) {
+      console.error('Error inserting share link:', insertError);
+      return new Response(
+        JSON.stringify({ error: 'Failed to create share link', details: insertError.message }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const shareToken = row.id;
+    const url = `${appBaseUrl.replace(/\/$/, '')}/share/${shareToken}`;
+
+    return new Response(
+      JSON.stringify({ token: shareToken, url }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('Share create error:', error);
+    return new Response(
+      JSON.stringify({ error: error?.message || 'Internal server error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/functions/share-resolve/index.ts
+++ b/supabase/functions/share-resolve/index.ts
@@ -1,0 +1,223 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+const BET_COLUMNS = 'id,bet_date,sport,league,bet_description,odds,stake_amount,potential_return,status,cashout_amount,cashout_odds,is_cashout,bet_type,betting_market';
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    let token: string | null = null;
+
+    if (req.method === 'GET') {
+      const url = new URL(req.url);
+      token = url.searchParams.get('token');
+    } else {
+      const body = await req.json().catch(() => ({}));
+      token = body.token ?? null;
+    }
+
+    if (!token) {
+      return new Response(
+        JSON.stringify({ error: 'Token obrigatório' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') || '';
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    const { data: shareLink, error: linkError } = await supabase
+      .from('share_links')
+      .select('user_id, filters_snapshot, expires_at')
+      .eq('id', token)
+      .single();
+
+    if (linkError || !shareLink) {
+      return new Response(
+        JSON.stringify({ error: 'Link não encontrado' }),
+        { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    if (shareLink.expires_at && new Date(shareLink.expires_at) < new Date()) {
+      return new Response(
+        JSON.stringify({ error: 'Este link expirou' }),
+        { status: 410, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const userId = shareLink.user_id;
+    const filters = shareLink.filters_snapshot as Record<string, unknown> || {};
+
+    const { data: userRow } = await supabase
+      .from('users')
+      .select('name')
+      .eq('id', userId)
+      .single();
+
+    const ownerName = userRow?.name || 'Usuário';
+
+    let betIdsWithTags: string[] | null = null;
+    const tags = filters.tags as string[] | undefined;
+    if (tags && Array.isArray(tags) && tags.length > 0) {
+      const { data: taggedBets } = await supabase
+        .from('bet_tags')
+        .select('bet_id')
+        .in('tag_id', tags);
+      if (taggedBets && taggedBets.length > 0) {
+        betIdsWithTags = [...new Set(taggedBets.map((r: { bet_id: string }) => r.bet_id))];
+      } else {
+        betIdsWithTags = [];
+      }
+    }
+
+    let query = supabase
+      .from('bets')
+      .select(BET_COLUMNS)
+      .eq('user_id', userId)
+      .order('bet_date', { ascending: false })
+      .limit(500);
+
+    const status = filters.status as string[] | undefined;
+    if (status && Array.isArray(status) && status.length > 0) {
+      query = query.in('status', status);
+    }
+
+    const sports = filters.sports as string[] | undefined;
+    if (sports && Array.isArray(sports) && sports.length > 0) {
+      const sportValues = sports.filter((v: string) => v !== '__empty__');
+      const includeEmpty = sports.includes('__empty__');
+      if (sportValues.length > 0 && !includeEmpty) {
+        query = query.in('sport', sportValues);
+      } else if (sportValues.length > 0 && includeEmpty) {
+        query = query.or(`sport.in.(${sportValues.join(',')}),sport.is.null`);
+      } else if (includeEmpty) {
+        query = query.is('sport', null);
+      }
+    }
+
+    const leagues = filters.leagues as string[] | undefined;
+    if (leagues && Array.isArray(leagues) && leagues.length > 0) {
+      const leagueValues = leagues.filter((v: string) => v !== '__empty__');
+      const includeEmpty = leagues.includes('__empty__');
+      if (leagueValues.length > 0 && !includeEmpty) {
+        query = query.in('league', leagueValues);
+      } else if (leagueValues.length > 0 && includeEmpty) {
+        query = query.or(`league.in.(${leagueValues.join(',')}),league.is.null`);
+      } else if (includeEmpty) {
+        query = query.is('league', null);
+      }
+    }
+
+    const markets = filters.markets as string[] | undefined;
+    if (markets && Array.isArray(markets) && markets.length > 0) {
+      const marketValues = markets.filter((v: string) => v !== '__empty__');
+      const includeEmpty = markets.includes('__empty__');
+      if (marketValues.length > 0 && !includeEmpty) {
+        query = query.in('betting_market', marketValues);
+      } else if (marketValues.length > 0 && includeEmpty) {
+        query = query.or(`betting_market.in.(${marketValues.join(',')}),betting_market.is.null`);
+      } else if (includeEmpty) {
+        query = query.is('betting_market', null);
+      }
+    }
+
+    const dateFrom = filters.date_from as string | undefined;
+    if (dateFrom) {
+      query = query.gte('bet_date', dateFrom);
+    }
+
+    const dateTo = filters.date_to as string | undefined;
+    if (dateTo) {
+      const endOfDay = new Date(dateTo);
+      endOfDay.setHours(23, 59, 59, 999);
+      query = query.lte('bet_date', endOfDay.toISOString());
+    }
+
+    const search = filters.search as string | undefined;
+    if (search && typeof search === 'string' && search.trim()) {
+      const term = `*${search.trim()}*`;
+      query = query.or(`bet_description.ilike.${term},match_description.ilike.${term},league.ilike.${term},betting_market.ilike.${term}`);
+    }
+
+    if (betIdsWithTags !== null) {
+      if (betIdsWithTags.length === 0) {
+        return new Response(
+          JSON.stringify({
+            owner: { name: ownerName },
+            filters_snapshot: filters,
+            bets: [],
+            total: 0,
+          }),
+          { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+      query = query.in('id', betIdsWithTags);
+    }
+
+    const { data: bets, error: betsError } = await query;
+
+    if (betsError) {
+      console.error('Error fetching bets:', betsError);
+      return new Response(
+        JSON.stringify({ error: 'Erro ao carregar apostas' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const betsList = bets || [];
+    const multipleBetIds = betsList
+      .filter((b: { bet_type: string }) => b.bet_type === 'multiple' || b.bet_type === 'multipla')
+      .map((b: { id: string }) => b.id);
+
+    const betLegsMap: Record<string, unknown[]> = {};
+    if (multipleBetIds.length > 0) {
+      const { data: legs } = await supabase
+        .from('bet_legs')
+        .select('bet_id,leg_number,sport,match_description,bet_description,odds,status')
+        .in('bet_id', multipleBetIds)
+        .order('leg_number', { ascending: true });
+
+      if (legs) {
+        for (const leg of legs) {
+          const bid = (leg as { bet_id: string }).bet_id;
+          if (!betLegsMap[bid]) betLegsMap[bid] = [];
+          betLegsMap[bid].push(leg);
+        }
+      }
+    }
+
+    const betsWithLegs = betsList.map((bet: Record<string, unknown>) => {
+      const b = { ...bet };
+      if (betLegsMap[bet.id as string]) {
+        (b as Record<string, unknown>).bet_legs = betLegsMap[bet.id as string];
+      }
+      return b;
+    });
+
+    return new Response(
+      JSON.stringify({
+        owner: { name: ownerName },
+        filters_snapshot: filters,
+        bets: betsWithLegs,
+        total: betsWithLegs.length,
+      }),
+      { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('Share resolve error:', error);
+    return new Response(
+      JSON.stringify({ error: error?.message || 'Erro interno' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/migrations/030_create_share_links.sql
+++ b/supabase/migrations/030_create_share_links.sql
@@ -1,0 +1,17 @@
+-- Create share_links table for bet sharing feature
+-- Migration: 030_create_share_links.sql
+
+CREATE TABLE share_links (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+  filters_snapshot JSONB NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  expires_at TIMESTAMPTZ
+);
+
+ALTER TABLE share_links ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "owner_select" ON share_links FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "owner_insert" ON share_links FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX idx_share_links_user_id ON share_links(user_id);


### PR DESCRIPTION
- Migration: share_links table with RLS (030_create_share_links.sql)
- Edge functions: share-create (JWT) and share-resolve (public)
- Modal to generate and copy share link from /bets page
- Public route /share/:token with KPI cards, bankroll chart, breakdown charts and paginated bets table
- CI/CD: add share-create and share-resolve to staging and production deploy workflows