### PR TITLE
fix(cd): deploy share-create with --no-verify-jwt

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,7 +35,7 @@ jobs:
           supabase functions deploy stripe-webhook
           supabase functions deploy telegram-webhook --no-verify-jwt
           supabase functions deploy whatsapp-webhook --no-verify-jwt
-          supabase functions deploy share-create
+          supabase functions deploy share-create --no-verify-jwt
           supabase functions deploy share-resolve --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -35,7 +35,7 @@ jobs:
           supabase functions deploy stripe-webhook
           supabase functions deploy telegram-webhook --no-verify-jwt
           supabase functions deploy whatsapp-webhook --no-verify-jwt
-          supabase functions deploy share-create
+          supabase functions deploy share-create --no-verify-jwt
           supabase functions deploy share-resolve --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
Supabase gateway rejects ES256 JWTs before function runs when JWT verification is enabled. The function handles its own auth via JWT payload decode.