### PR TITLE
fix: apostas pendentes não devem impactar lucro/ROI exibido

### DIFF
--- a/src/hooks/use-bets.ts
+++ b/src/hooks/use-bets.ts
@@ -53,6 +53,13 @@ export function useBets(userId: string) {
     const cashoutBets = betsData.filter(bet => bet.status === 'cashout');
     const halfWonBets = betsData.filter(bet => bet.status === 'half_won');
     const halfLostBets = betsData.filter(bet => bet.status === 'half_lost');
+
+    const settledStaked =
+      wonBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
+      lostBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
+      cashoutBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
+      halfWonBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
+      halfLostBets.reduce((sum, bet) => sum + bet.stake_amount, 0);
     
     const totalReturn = wonBets.reduce((sum, bet) => sum + bet.potential_return, 0);
     const totalCashout = cashoutBets.reduce((sum, bet) => sum + (bet.cashout_amount || 0), 0);
@@ -65,8 +72,8 @@ export function useBets(userId: string) {
     const lossEquiv = lostBets.length + halfLostBets.length * 0.5;
     const settledCount = winEquiv + lossEquiv;
     const winRate = settledCount > 0 ? (winEquiv / settledCount) * 100 : 0;
-    const profit = totalEarnings - totalStaked;
-    const roi = totalStaked > 0 ? (profit / totalStaked) * 100 : 0;
+    const profit = totalEarnings - settledStaked;
+    const roi = settledStaked > 0 ? (profit / settledStaked) * 100 : 0;
 
     setStats({
       totalBets,

--- a/src/pages/Bets.tsx
+++ b/src/pages/Bets.tsx
@@ -755,6 +755,13 @@ export default function Bets() {
     const cashoutBets = betsData.filter(bet => bet.status === 'cashout');
     const halfWonBets = betsData.filter(bet => bet.status === 'half_won');
     const halfLostBets = betsData.filter(bet => bet.status === 'half_lost');
+
+    const settledStaked =
+      wonBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
+      lostBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
+      cashoutBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
+      halfWonBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
+      halfLostBets.reduce((sum, bet) => sum + bet.stake_amount, 0);
     
     const totalReturn = wonBets.reduce((sum, bet) => sum + bet.potential_return, 0);
     const totalCashout = cashoutBets.reduce((sum, bet) => sum + (bet.cashout_amount || 0), 0);
@@ -766,13 +773,13 @@ export default function Bets() {
     const winEquiv = wonBets.length + cashoutBets.length + halfWonBets.length * 0.5;
     const lossEquiv = lostBets.length + halfLostBets.length * 0.5;
     const winRate = settledCount > 0 ? (winEquiv / (winEquiv + lossEquiv)) * 100 : 0;
-    const profit = totalEarnings - totalStaked;
+    const profit = totalEarnings - settledStaked;
     const averageStake = totalBets > 0 ? totalStaked / totalBets : 0;
     
     const totalOdds = betsData.reduce((sum, bet) => sum + bet.odds, 0);
     const averageOdd = totalBets > 0 ? totalOdds / totalBets : 0;
     
-    const roi = totalStaked > 0 ? (profit / totalStaked) * 100 : 0;
+    const roi = settledStaked > 0 ? (profit / settledStaked) * 100 : 0;
 
     if (isMountedRef.current) {
       setStats({

--- a/src/utils/bettingStats.ts
+++ b/src/utils/bettingStats.ts
@@ -94,6 +94,13 @@ export function statsForDateRange(bets: Bet[]): PeriodStats {
   const halfWonBets = bets.filter((b) => b.status === 'half_won');
   const halfLostBets = bets.filter((b) => b.status === 'half_lost');
 
+  const settledStaked =
+    wonBets.reduce((s, b) => s + b.stake_amount, 0) +
+    lostBets.reduce((s, b) => s + b.stake_amount, 0) +
+    cashoutBets.reduce((s, b) => s + b.stake_amount, 0) +
+    halfWonBets.reduce((s, b) => s + b.stake_amount, 0) +
+    halfLostBets.reduce((s, b) => s + b.stake_amount, 0);
+
   const totalReturn =
     wonBets.reduce((s, b) => s + b.potential_return, 0) +
     cashoutBets.reduce((s, b) => s + (b.cashout_amount ?? 0), 0) +
@@ -104,8 +111,8 @@ export function statsForDateRange(bets: Bet[]): PeriodStats {
   const lossEquiv = lostBets.length + halfLostBets.length * 0.5;
   const settledCount = winEquiv + lossEquiv;
   const winRate = settledCount > 0 ? (winEquiv / settledCount) * 100 : 0;
-  const profit = totalReturn - totalStaked;
-  const roi = totalStaked > 0 ? (profit / totalStaked) * 100 : 0;
+  const profit = totalReturn - settledStaked;
+  const roi = settledStaked > 0 ? (profit / settledStaked) * 100 : 0;
   const averageStake = totalBets > 0 ? totalStaked / totalBets : 0;
   const totalOdds = bets.reduce((s, b) => s + b.odds, 0);
   const averageOdd = totalBets > 0 ? totalOdds / totalBets : 0;


### PR DESCRIPTION
- Adiciona settledStaked (soma apenas apostas com resultado) em statsForDateRange, calculateStats do use-bets e Bets.tsx
- Profit e ROI passam a usar settledStaked em vez de totalStaked
- Apostas pendentes deixam de ser tratadas como perda no cálculo

Made-with: Cursor