### PR TITLE
fix: team logo click works across pagination pages

### DIFF
--- a/src/pages/PlayerSelection.tsx
+++ b/src/pages/PlayerSelection.tsx
@@ -169,13 +169,25 @@ export default function PlayerSelection() {
   }, [totalPages]);
 
   const scrollToTeam = (teamName: string) => {
-    const element = document.getElementById(`team-${teamName}`);
-    if (element) {
-      element.scrollIntoView({ behavior: 'smooth' });
-      if (!expandedTeams.has(teamName)) {
-        toggleTeam(teamName);
+    // Find which page the team is on and navigate there first
+    const teamIndex = sortedTeams.indexOf(teamName);
+    if (teamIndex !== -1) {
+      const targetPage = Math.floor(teamIndex / pageSize) + 1;
+      if (targetPage !== currentPage) {
+        setCurrentPage(targetPage);
       }
     }
+
+    // Wait for re-render then scroll
+    setTimeout(() => {
+      const element = document.getElementById(`team-${teamName}`);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth' });
+        if (!expandedTeams.has(teamName)) {
+          toggleTeam(teamName);
+        }
+      }
+    }, 50);
   };
 
   if (error) {


### PR DESCRIPTION
## Summary
- Corrige clique no logo do time na página de jogadores quando o time está em outra página da paginação
- Agora calcula a página correta, navega até ela e faz scroll até o time

## Arquivos alterados
- `src/pages/PlayerSelection.tsx`

## Test plan
- [ ] Ir para página de jogadores → clicar em logo de time que está na página 2+ → deve mudar de página e scrollar até o time

🤖 Generated with [Claude Code](https://claude.com/claude-code)