### PR TITLE
refactor: rename weekly-report to report

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ const ComoUsar = React.lazy(() => import("./pages/ComoUsar"));
 const Games = React.lazy(() => import("./pages/Games"));
 const GameDetail = React.lazy(() => import("./pages/GameDetail"));
 const Settings = React.lazy(() => import("./pages/Settings"));
-const WeeklyReport = React.lazy(() => import("./pages/WeeklyReport"));
+const Report = React.lazy(() => import("./pages/Report"));
 const SharePage = React.lazy(() => import("./pages/SharePage"));
 
 const queryClient = new QueryClient();
@@ -106,9 +106,9 @@ const App = () => (
             <Route path="/paywall-dashboard" element={<PaywallDashboard />} />
             <Route path="/paywall-platform" element={<PaywallPlatform />} />
             <Route path="/como-usar" element={<ComoUsar />} />
-            <Route path="/weekly-report" element={
+            <Route path="/report" element={
               <ProtectedRoute>
-                <WeeklyReport />
+                <Report />
               </ProtectedRoute>
             } />
             <Route path="/share/:token" element={<SharePage />} />

--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -44,7 +44,7 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
     { name: 'Home NBA', href: '/home-players', icon: BarChart3 },
     { name: 'Jogos', href: '/home-games', icon: Calendar },
     { name: 'Jogadores', href: '/nba-players', icon: Users },
-    { name: 'Relatório', href: '/weekly-report', icon: FileText },
+    { name: 'Relatório', href: '/report', icon: FileText },
   ];
 
   const betinhoModuleItems = [

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -36,7 +36,7 @@ export default function MainNav({ className }: MainNavProps) {
     { name: 'Home NBA', href: '/home-players', icon: BarChart3 },
     { name: 'Jogos', href: '/home-games', icon: TrendingUp },
     { name: 'Jogadores', href: '/nba-players', icon: Users },
-    { name: 'Relatório', href: '/weekly-report', icon: FileText },
+    { name: 'Relatório', href: '/report', icon: FileText },
   ];
 
   const betinhoModuleItems = [

--- a/src/pages/Report.tsx
+++ b/src/pages/Report.tsx
@@ -5,7 +5,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
 
 const BUCKET = 'reports';
-const FILE_PATH = 'weekly-report.pdf';
+const FILE_PATH = 'report.pdf';
 // Signed URL valid for 1 hour
 const SIGNED_URL_EXPIRY = 3600;
 
@@ -45,7 +45,7 @@ export default function WeeklyReport() {
         <div className="flex items-center gap-2 sm:gap-3 mb-4 sm:mb-6">
           <FileText className="w-5 h-5 sm:w-6 sm:h-6 text-primary shrink-0" />
           <div>
-            <h1 className="text-lg sm:text-2xl font-bold text-foreground">Relatório Semanal</h1>
+            <h1 className="text-lg sm:text-2xl font-bold text-foreground">Relatório</h1>
             <p className="text-xs sm:text-sm text-muted-foreground">
               Atualizado periodicamente pela equipe Smartbetting
             </p>
@@ -78,7 +78,7 @@ export default function WeeklyReport() {
           <div className="rounded-lg border border-border overflow-hidden bg-white">
             <iframe
               src={pdfUrl}
-              title="Relatório Semanal"
+              title="Relatório"
               className="w-full"
               style={{ height: 'calc(100vh - 160px)', minHeight: '400px' }}
             />


### PR DESCRIPTION
## Summary
- Renomeia rota de `/weekly-report` para `/report`
- Renomeia componente de `WeeklyReport` para `Report`
- Título da página de "Relatório Semanal" para "Relatório"
- Arquivo no storage de `weekly-report.pdf` para `report.pdf`

## Ação necessária
- Renomear o arquivo no Supabase Storage de `weekly-report.pdf` para `report.pdf`

## Test plan
- [ ] Acessar `/report` → deve carregar o PDF
- [ ] Links no menu "Análises" apontam para `/report`

🤖 Generated with [Claude Code](https://claude.com/claude-code)