### PR TITLE
fix: add --no-verify-jwt to Stripe edge functions deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Deploy Edge Functions (production)
         run: |
           supabase functions deploy injury-insights
-          supabase functions deploy stripe-create-checkout
-          supabase functions deploy stripe-customer-portal
-          supabase functions deploy stripe-verify-session
-          supabase functions deploy stripe-webhook
+          supabase functions deploy stripe-create-checkout --no-verify-jwt
+          supabase functions deploy stripe-customer-portal --no-verify-jwt
+          supabase functions deploy stripe-verify-session --no-verify-jwt
+          supabase functions deploy stripe-webhook --no-verify-jwt
           supabase functions deploy telegram-webhook --no-verify-jwt
           supabase functions deploy whatsapp-webhook --no-verify-jwt
           supabase functions deploy share-create --no-verify-jwt

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Deploy Edge Functions (staging)
         run: |
           supabase functions deploy injury-insights
-          supabase functions deploy stripe-create-checkout
-          supabase functions deploy stripe-customer-portal
-          supabase functions deploy stripe-verify-session
-          supabase functions deploy stripe-webhook
+          supabase functions deploy stripe-create-checkout --no-verify-jwt
+          supabase functions deploy stripe-customer-portal --no-verify-jwt
+          supabase functions deploy stripe-verify-session --no-verify-jwt
+          supabase functions deploy stripe-webhook --no-verify-jwt
           supabase functions deploy telegram-webhook --no-verify-jwt
           supabase functions deploy whatsapp-webhook --no-verify-jwt
           supabase functions deploy share-create --no-verify-jwt

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -4,6 +4,16 @@ project_id = "lavclmlvvfzkblrstojd"
 # Expose both public and bigquery schemas via PostgREST
 schemas = ["public", "graphql_public", "bigquery"]
 
+[functions.stripe-create-checkout]
+# Função faz sua própria validação de JWT via supabase.auth.getUser()
+verify_jwt = false
+
+[functions.stripe-verify-session]
+verify_jwt = false
+
+[functions.stripe-customer-portal]
+verify_jwt = false
+
 [functions.stripe-webhook]
 # Desabilita verificação JWT para webhooks do Stripe
 # Webhooks do Stripe usam assinatura própria (stripe-signature) ao invés de JWT


### PR DESCRIPTION
Stripe edge functions (create-checkout, verify-session, customer-portal, webhook) do their own JWT validation internally, so the Supabase gateway check was causing 'Invalid JWT' 401 errors.