### PR TITLE
fix: use APP_BASE_URL fallback for Stripe redirect URLs

### DIFF
--- a/supabase/functions/stripe-create-checkout/index.ts
+++ b/supabase/functions/stripe-create-checkout/index.ts
@@ -106,7 +106,7 @@ serve(async (req) => {
     console.log('Product Type resolved:', finalProductType);
 
     // Use SITE_URL for frontend redirects, fallback to SUPABASE_URL for local dev
-    const SITE_URL = Deno.env.get('SITE_URL') || Deno.env.get('SUPABASE_URL') || 'http://localhost:8080';
+    const SITE_URL = Deno.env.get('SITE_URL') || Deno.env.get('APP_BASE_URL') || 'http://localhost:8080';
     console.log('Using SITE_URL:', SITE_URL);
 
     // Criar ou buscar customer no Stripe (necessário para Accounts V2)


### PR DESCRIPTION
SITE_URL was falling back to SUPABASE_URL, causing Stripe to redirect users to the Supabase API domain instead of the frontend after checkout.