### PR TITLE
feat: standardize nav + calendar reports + mobile PDF fix

### DIFF
--- a/src/pages/PlayerSelection.tsx
+++ b/src/pages/PlayerSelection.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import AuthenticatedLayout from '../components/AuthenticatedLayout';
+import AnalyticsNav from '@/components/AnalyticsNav';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
@@ -192,12 +192,13 @@ export default function PlayerSelection() {
 
   if (error) {
     return (
-      <AuthenticatedLayout>
-        <div className="min-h-screen bg-terminal-black flex items-center justify-center">
+      <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
+        <AnalyticsNav />
+        <div className="flex items-center justify-center" style={{ minHeight: 'calc(100vh - 56px)' }}>
           <div className="text-center">
             <div className="text-terminal-red text-xl mb-4">⚠️ SYSTEM ERROR</div>
             <p className="text-terminal-text mb-4 font-mono">{error}</p>
-            <button 
+            <button
               onClick={() => window.location.reload()}
               className="terminal-button px-4 py-2 rounded"
             >
@@ -205,40 +206,26 @@ export default function PlayerSelection() {
             </button>
           </div>
         </div>
-      </AuthenticatedLayout>
+      </div>
     );
   }
 
   return (
-    <AuthenticatedLayout>
-      <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
-        {/* Header */}
-        <header className="terminal-header p-4 sticky top-0 z-10">
-          <div className="container mx-auto flex items-center justify-between">
-            <div className="flex items-center space-x-3">
-              <div className="w-8 h-8 bg-terminal-green/20 border border-terminal-green rounded flex items-center justify-center">
-                <Trophy className="w-4 h-4 text-terminal-green" />
-              </div>
-              <div>
-                <h1 className="text-lg font-bold tracking-wider text-terminal-green">PLAYER DATABASE</h1>
-                <p className="text-[10px] text-terminal-text opacity-60">SECURE CONNECTION ESTABLISHED</p>
-              </div>
-            </div>
-            
-            <div className="relative w-64">
-              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-terminal-text opacity-50 h-4 w-4" />
-              <Input
-                placeholder="SEARCH DATABASE..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="terminal-input pl-10 h-9 text-xs w-full"
-              />
-            </div>
-          </div>
-        </header>
+    <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
+      <AnalyticsNav />
 
-        <div className="container mx-auto px-4 py-6 space-y-8">
-          
+      <div className="container mx-auto px-4 py-6 space-y-8">
+          {/* Search Bar */}
+          <div className="relative max-w-md w-full">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-terminal-text opacity-50 h-4 w-4" />
+            <Input
+              placeholder="BUSCAR JOGADORES..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="terminal-input pl-10 h-10 text-sm w-full"
+            />
+          </div>
+
           {/* Best Players Section */}
           {!searchTerm && !teamFilter && (bestPlayers.length > 0 || isLoading) && (
             <section>
@@ -460,6 +447,6 @@ export default function PlayerSelection() {
           </section>
         </div>
       </div>
-    </AuthenticatedLayout>
   );
 }
+

--- a/src/pages/Report.tsx
+++ b/src/pages/Report.tsx
@@ -1,15 +1,10 @@
-import { useState, useEffect } from 'react';
-import { FileText, Loader2, AlertCircle, ChevronDown, Calendar } from 'lucide-react';
-import MainNav from '@/components/MainNav';
+import { useState, useEffect, useMemo } from 'react';
+import { FileText, Loader2, AlertCircle, Calendar as CalendarIcon } from 'lucide-react';
+import AnalyticsNav from '@/components/AnalyticsNav';
 import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Calendar } from '@/components/ui/calendar';
 
 const BUCKET = 'reports';
 const SIGNED_URL_EXPIRY = 3600;
@@ -22,17 +17,21 @@ function parseReportDate(filename: string): Date | null {
   return new Date(Number(year), Number(month) - 1, Number(day));
 }
 
-/** Format Date to DD/MM/YYYY for display */
-function formatDateDisplay(date: Date): string {
+/** Build DD-MM-YYYY filename from a Date */
+function toReportFilename(date: Date): string {
   const day = String(date.getDate()).padStart(2, '0');
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const year = date.getFullYear();
-  return `${day}/${month}/${year}`;
+  return `${day}-${month}-${year}.pdf`;
 }
 
-/** Format Date to weekday label */
-function formatWeekday(date: Date): string {
-  return date.toLocaleDateString('pt-BR', { weekday: 'short' }).replace('.', '');
+/** Format Date to a short display label  */
+function formatDateLabel(date: Date): string {
+  const weekday = date.toLocaleDateString('pt-BR', { weekday: 'short' }).replace('.', '');
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const year = date.getFullYear();
+  return `${weekday}, ${day}/${month}/${year}`;
 }
 
 interface ReportEntry {
@@ -43,11 +42,23 @@ interface ReportEntry {
 
 export default function WeeklyReport() {
   const [reports, setReports] = useState<ReportEntry[]>([]);
-  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [loadingPdf, setLoadingPdf] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [noReportForDate, setNoReportForDate] = useState(false);
+  const [calendarOpen, setCalendarOpen] = useState(false);
+
+  // Set of date-strings (YYYY-MM-DD) that have reports — used to highlight calendar days
+  const availableDateSet = useMemo(() => {
+    const set = new Set<string>();
+    reports.forEach((r) => {
+      const key = `${r.date.getFullYear()}-${String(r.date.getMonth() + 1).padStart(2, '0')}-${String(r.date.getDate()).padStart(2, '0')}`;
+      set.add(key);
+    });
+    return set;
+  }, [reports]);
 
   // Fetch available reports from the bucket
   useEffect(() => {
@@ -72,7 +83,7 @@ export default function WeeklyReport() {
           return {
             filename: file.name,
             date,
-            label: `${formatWeekday(date)}, ${formatDateDisplay(date)}`,
+            label: formatDateLabel(date),
           };
         })
         .filter((entry): entry is ReportEntry => entry !== null)
@@ -80,8 +91,9 @@ export default function WeeklyReport() {
 
       setReports(entries);
 
+      // Auto-select the most recent report
       if (entries.length > 0) {
-        setSelectedFile(entries[0].filename);
+        setSelectedDate(entries[0].date);
       }
 
       setLoading(false);
@@ -90,9 +102,21 @@ export default function WeeklyReport() {
     fetchReports();
   }, []);
 
-  // Fetch signed URL when selected file changes
+  // Fetch signed URL when selected date changes
   useEffect(() => {
-    if (!selectedFile) return;
+    if (!selectedDate) return;
+
+    const filename = toReportFilename(selectedDate);
+    const match = reports.find((r) => r.filename === filename);
+
+    if (!match) {
+      // No report exists for this date
+      setPdfUrl(null);
+      setNoReportForDate(true);
+      return;
+    }
+
+    setNoReportForDate(false);
 
     async function fetchPdfUrl() {
       setLoadingPdf(true);
@@ -100,7 +124,7 @@ export default function WeeklyReport() {
 
       const { data, error: storageError } = await supabase.storage
         .from(BUCKET)
-        .createSignedUrl(selectedFile!, SIGNED_URL_EXPIRY);
+        .createSignedUrl(filename, SIGNED_URL_EXPIRY);
 
       if (storageError || !data?.signedUrl) {
         setError('Não foi possível carregar o relatório. Tente novamente mais tarde.');
@@ -114,66 +138,117 @@ export default function WeeklyReport() {
     }
 
     fetchPdfUrl();
-  }, [selectedFile]);
+  }, [selectedDate, reports]);
+
+  const handleDateSelect = (date: Date | undefined) => {
+    if (!date) return;
+    setSelectedDate(date);
+    setCalendarOpen(false);
+  };
+
+  // Modifier to add a dot indicator on days that have reports
+  const reportDayModifier = (date: Date) => {
+    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+    return availableDateSet.has(key);
+  };
 
   const isLoading = loading || loadingPdf;
 
   return (
-    <div className="min-h-screen bg-background">
-      <MainNav />
+    <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
+      <AnalyticsNav />
 
       <div className="max-w-5xl mx-auto px-3 sm:px-4 py-4 sm:py-6">
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4 mb-4 sm:mb-6">
           <div className="flex items-center gap-2 sm:gap-3">
-            <FileText className="w-5 h-5 sm:w-6 sm:h-6 text-primary shrink-0" />
+            <div className="w-8 h-8 bg-terminal-green/20 border border-terminal-green/50 rounded flex items-center justify-center">
+              <FileText className="w-4 h-4 text-terminal-green" />
+            </div>
             <div>
-              <h1 className="text-lg sm:text-2xl font-bold text-foreground">Relatório</h1>
-              <p className="text-xs sm:text-sm text-muted-foreground">
+              <h1 className="text-lg sm:text-xl font-bold tracking-wider text-terminal-green">
+                RELATÓRIO
+              </h1>
+              <p className="text-[10px] sm:text-xs text-terminal-text opacity-60">
                 Atualizado periodicamente pela equipe Smartbetting
               </p>
             </div>
           </div>
 
-          {/* Date selector */}
+          {/* Calendar date picker */}
           {reports.length > 0 && (
-            <Select
-              value={selectedFile || undefined}
-              onValueChange={(value) => setSelectedFile(value)}
-            >
-              <SelectTrigger className="w-full sm:w-[220px]">
-                <div className="flex items-center gap-2">
-                  <Calendar className="w-4 h-4 text-muted-foreground" />
-                  <SelectValue placeholder="Selecione a data" />
-                </div>
-              </SelectTrigger>
-              <SelectContent>
-                {reports.map((report) => (
-                  <SelectItem key={report.filename} value={report.filename}>
-                    {report.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="terminal-input h-9 text-sm w-full sm:w-[240px] justify-start border-terminal-border-subtle bg-terminal-gray/30 hover:bg-terminal-gray/40"
+                >
+                  <CalendarIcon className="w-4 h-4 mr-2 opacity-70" />
+                  {selectedDate ? formatDateLabel(selectedDate) : 'Selecione a data'}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="w-auto p-0 bg-terminal-dark-gray border-terminal-border-subtle"
+                align="end"
+              >
+                <Calendar
+                  mode="single"
+                  selected={selectedDate || undefined}
+                  onSelect={handleDateSelect}
+                  initialFocus
+                  modifiers={{ hasReport: reportDayModifier }}
+                  modifiersClassNames={{
+                    hasReport: 'report-day-dot',
+                  }}
+                  className="bg-terminal-dark-gray text-terminal-text"
+                  classNames={{
+                    caption_label: 'text-sm font-semibold text-terminal-text',
+                    head_cell: 'text-terminal-text/60 rounded-md w-9 font-medium text-[0.75rem]',
+                    day: 'h-9 w-9 p-0 font-normal text-terminal-text hover:bg-terminal-gray/40 relative',
+                    day_selected: 'bg-terminal-green text-terminal-black hover:bg-terminal-green/90',
+                    day_today: 'bg-terminal-gray text-terminal-text',
+                    nav_button:
+                      'h-7 w-7 bg-transparent p-0 opacity-70 hover:opacity-100 border border-terminal-border-subtle',
+                  }}
+                />
+                <style>{`
+                  .report-day-dot::after {
+                    content: '';
+                    position: absolute;
+                    bottom: 2px;
+                    left: 50%;
+                    transform: translateX(-50%);
+                    width: 4px;
+                    height: 4px;
+                    border-radius: 50%;
+                    background-color: #00ff88;
+                  }
+                  .report-day-dot[aria-selected="true"]::after {
+                    background-color: #000;
+                  }
+                `}</style>
+              </PopoverContent>
+            </Popover>
           )}
         </div>
 
         {/* Content */}
         {isLoading && (
           <div className="flex flex-col items-center justify-center py-20 gap-3">
-            <Loader2 className="w-8 h-8 animate-spin text-primary" />
-            <p className="text-muted-foreground">Carregando relatório...</p>
+            <Loader2 className="w-8 h-8 animate-spin text-terminal-green" />
+            <p className="text-terminal-text opacity-60">Carregando relatório...</p>
           </div>
         )}
 
         {error && !isLoading && (
           <div className="flex flex-col items-center justify-center py-20 gap-3 text-center">
-            <AlertCircle className="w-10 h-10 text-destructive" />
-            <p className="text-destructive font-medium">{error}</p>
+            <AlertCircle className="w-10 h-10 text-terminal-red" />
+            <p className="text-terminal-red font-medium">{error}</p>
             <Button
               variant="outline"
               size="sm"
               onClick={() => window.location.reload()}
+              className="terminal-button"
             >
               Tentar novamente
             </Button>
@@ -182,19 +257,65 @@ export default function WeeklyReport() {
 
         {!loading && !error && reports.length === 0 && (
           <div className="flex flex-col items-center justify-center py-20 gap-3 text-center">
-            <FileText className="w-10 h-10 text-muted-foreground" />
-            <p className="text-muted-foreground font-medium">Nenhum relatório disponível</p>
+            <FileText className="w-10 h-10 text-terminal-text opacity-40" />
+            <p className="text-terminal-text opacity-60 font-medium">Nenhum relatório disponível</p>
           </div>
         )}
 
-        {pdfUrl && !isLoading && !error && (
-          <div className="rounded-lg border border-border overflow-hidden bg-white">
-            <iframe
-              src={pdfUrl}
-              title="Relatório"
-              className="w-full"
-              style={{ height: 'calc(100vh - 200px)', minHeight: '400px' }}
-            />
+        {!isLoading && !error && noReportForDate && (
+          <div className="flex flex-col items-center justify-center py-20 gap-3 text-center">
+            <CalendarIcon className="w-10 h-10 text-terminal-yellow opacity-70" />
+            <p className="text-terminal-yellow font-medium">
+              Não há relatório para esse dia
+            </p>
+            <p className="text-terminal-text opacity-50 text-xs">
+              Selecione uma data com o indicador verde no calendário
+            </p>
+          </div>
+        )}
+
+        {pdfUrl && !isLoading && !error && !noReportForDate && (
+          <div>
+            {/* Mobile fallback: direct link to open PDF in native viewer */}
+            <div className="sm:hidden mb-3">
+              <a
+                href={pdfUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center gap-2 w-full py-3 rounded-lg border border-terminal-green bg-terminal-green/10 text-terminal-green text-sm font-semibold hover:bg-terminal-green/20 transition-colors"
+              >
+                <FileText className="w-4 h-4" />
+                Abrir PDF em tela cheia
+              </a>
+            </div>
+
+            {/*
+              iOS Safari expands iframes to their content height, ignoring CSS height.
+              Fix: position the iframe absolutely inside a fixed-height container.
+              The wrapper clips overflow so the PDF scrolls inside, not the page.
+            */}
+            <div
+              className="rounded-lg border border-terminal-border-subtle overflow-hidden bg-white relative"
+              style={{
+                height: 'calc(100vh - 220px)',
+                minHeight: '400px',
+                WebkitOverflowScrolling: 'touch',
+                overflow: 'auto',
+              }}
+            >
+              <iframe
+                src={pdfUrl}
+                title="Relatório"
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  height: '100%',
+                  border: 'none',
+                }}
+              />
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- **PlayerSelection**: removido header duplo (MainNav + header custom) → agora usa `AnalyticsNav` como as demais páginas
- **Report**: trocado `MainNav` por `AnalyticsNav` (tema terminal), substituído `Select` dropdown por **Calendar date picker** com indicadores verdes nos dias com relatório
- **Report mobile**: fix do bug de PDF travado no iOS (iframe não respeitava altura) + botão "Abrir PDF em tela cheia" como fallback no mobile

## Test plan
- [ ] Verificar que `/nba-players` mostra apenas um header (AnalyticsNav)
- [ ] Verificar que `/report` usa tema terminal com AnalyticsNav
- [ ] Testar o calendário: dias com relatório devem ter bolinha verde
- [ ] Selecionar um dia sem relatório → deve mostrar mensagem "Não há relatório para esse dia"
- [ ] Testar PDF no mobile (iOS Safari) → deve rolar dentro do container
- [ ] Testar botão "Abrir PDF em tela cheia" no mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)