### PR TITLE
feat: v2 redesign tela Betinho

### DIFF
--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -78,7 +78,7 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                 variant="ghost"
                 size="sm"
                 onClick={() => navigate(backTo || '/home-players')}
-                className="text-terminal-text hover:text-terminal-green hover:bg-terminal-dark-gray -ml-2"
+                className="text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray -ml-2"
               >
                 <ChevronLeft className="w-4 h-4 mr-1" />
                 <span className="text-xs">Voltar</span>
@@ -88,11 +88,11 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                 className="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
                 onClick={() => navigate('/home-players')}
               >
-                <div className="w-8 h-8 bg-terminal-green/20 border border-terminal-green/50 rounded flex items-center justify-center">
-                  <BarChart3 className="w-4 h-4 text-terminal-green" />
+                <div className="w-8 h-8 bg-terminal-blue/20 border border-terminal-blue/50 rounded flex items-center justify-center">
+                  <BarChart3 className="w-4 h-4 text-terminal-blue" />
                 </div>
                 <div className="hidden sm:block">
-                  <span className="text-sm font-bold text-terminal-green tracking-wide">Smartbetting</span>
+                  <span className="text-sm font-bold text-terminal-blue tracking-wide">Smartbetting</span>
                 </div>
               </div>
             )}
@@ -113,7 +113,7 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="flex items-center gap-2 px-4 h-9 text-terminal-text hover:text-terminal-green hover:bg-terminal-dark-gray"
+                  className="flex items-center gap-2 px-4 h-9 text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray"
                 >
                   <span className="text-xs font-semibold uppercase tracking-wide">Análises</span>
                   <ChevronDown className="w-3 h-3 opacity-70" />
@@ -130,8 +130,8 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                     <DropdownMenuItem
                       key={item.href}
                       onClick={() => handleNavigation(item.href)}
-                      className={`cursor-pointer focus:bg-terminal-gray/40 focus:text-terminal-green ${
-                        isActive(item.href) ? 'text-terminal-green' : ''
+                      className={`cursor-pointer focus:bg-terminal-gray/40 focus:text-terminal-blue ${
+                        isActive(item.href) ? 'text-terminal-blue' : ''
                       }`}
                     >
                       <Icon className="w-4 h-4 mr-2" />
@@ -147,7 +147,7 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="flex items-center gap-2 px-4 h-9 text-terminal-text hover:text-terminal-green hover:bg-terminal-dark-gray"
+                  className="flex items-center gap-2 px-4 h-9 text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray"
                 >
                   <span className="text-xs font-semibold uppercase tracking-wide">Betinho</span>
                   <ChevronDown className="w-3 h-3 opacity-70" />
@@ -164,8 +164,8 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                     <DropdownMenuItem
                       key={item.href}
                       onClick={() => handleNavigation(item.href)}
-                      className={`cursor-pointer focus:bg-terminal-gray/40 focus:text-terminal-green ${
-                        isActive(item.href) ? 'text-terminal-green' : ''
+                      className={`cursor-pointer focus:bg-terminal-gray/40 focus:text-terminal-blue ${
+                        isActive(item.href) ? 'text-terminal-blue' : ''
                       }`}
                     >
                       <Icon className="w-4 h-4 mr-2" />
@@ -181,9 +181,9 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
           <div className="flex items-center gap-2">
             {/* Premium Badge */}
             {user && isPremium && (
-              <div className="hidden sm:flex items-center gap-1 bg-terminal-green/10 border border-terminal-green/30 px-2 py-1 rounded">
-                <Zap className="w-3 h-3 text-terminal-green" />
-                <span className="text-[10px] text-terminal-green font-bold">PREMIUM</span>
+              <div className="hidden sm:flex items-center gap-1 bg-terminal-blue/10 border border-terminal-blue/30 px-2 py-1 rounded">
+                <Zap className="w-3 h-3 text-terminal-blue" />
+                <span className="text-[10px] text-terminal-blue font-bold">PREMIUM</span>
               </div>
             )}
 
@@ -196,7 +196,7 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                   variant="ghost"
                   size="sm"
                   onClick={() => navigate('/auth')}
-                  className="text-terminal-text hover:text-terminal-green text-xs h-8"
+                  className="text-terminal-text hover:text-terminal-blue text-xs h-8"
                 >
                   <LogIn className="w-3 h-3 mr-1" />
                   Entrar
@@ -214,7 +214,7 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
 
             {/* Mobile menu button */}
             <button
-              className="md:hidden flex items-center gap-1.5 px-2 py-1.5 rounded hover:bg-terminal-dark-gray transition-colors text-terminal-text hover:text-terminal-green"
+              className="md:hidden flex items-center gap-1.5 px-2 py-1.5 rounded hover:bg-terminal-dark-gray transition-colors text-terminal-text hover:text-terminal-blue"
               onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
             >
               {activeModuleName && !isMobileMenuOpen && (
@@ -252,8 +252,8 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                         onClick={() => handleNavigation(item.href)}
                         className={`w-full justify-start h-10 ${
                           active
-                            ? 'bg-terminal-green/10 text-terminal-green'
-                            : 'text-terminal-text hover:text-terminal-green hover:bg-terminal-dark-gray'
+                            ? 'bg-terminal-blue/10 text-terminal-blue'
+                            : 'text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray'
                         }`}
                       >
                         <Icon className="w-4 h-4 mr-3" />
@@ -283,8 +283,8 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                         onClick={() => handleNavigation(item.href)}
                         className={`w-full justify-start h-10 ${
                           active
-                            ? 'bg-terminal-green/10 text-terminal-green'
-                            : 'text-terminal-text hover:text-terminal-green hover:bg-terminal-dark-gray'
+                            ? 'bg-terminal-blue/10 text-terminal-blue'
+                            : 'text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray'
                         }`}
                       >
                         <Icon className="w-4 h-4 mr-3" />

--- a/src/components/PremiumOverlay.tsx
+++ b/src/components/PremiumOverlay.tsx
@@ -32,11 +32,11 @@ export function PremiumOverlay({ onUnlock, className = '' }: PremiumOverlayProps
       onClick={(e) => e.stopPropagation()}
     >
       <div className="text-center p-4 space-y-4">
-        <div className="w-16 h-16 bg-terminal-green/20 border-2 border-terminal-green rounded-full flex items-center justify-center mx-auto">
-          <Lock className="w-8 h-8 text-terminal-green" />
+        <div className="w-16 h-16 bg-terminal-blue/20 border-2 border-terminal-blue rounded-full flex items-center justify-center mx-auto">
+          <Lock className="w-8 h-8 text-terminal-blue" />
         </div>
         <div>
-          <h3 className="text-lg font-bold text-terminal-green mb-2">CONTEÚDO PREMIUM</h3>
+          <h3 className="text-lg font-bold text-terminal-blue mb-2">CONTEÚDO PREMIUM</h3>
           <p className="text-sm text-terminal-text opacity-70 mb-4">
             Assine o plano premium para acessar análises completas deste jogador
           </p>

--- a/src/components/ReferralModal.tsx
+++ b/src/components/ReferralModal.tsx
@@ -120,7 +120,7 @@ export const ReferralModal: React.FC<ReferralModalProps> = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="bg-terminal-dark-gray border-terminal-border text-terminal-text sm:max-w-lg max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2 text-terminal-green">
+          <DialogTitle className="flex items-center gap-2 text-terminal-blue">
             <Users className="w-5 h-5" />
             Indique um amigo
           </DialogTitle>

--- a/src/components/bets/BankrollEvolutionChart.tsx
+++ b/src/components/bets/BankrollEvolutionChart.tsx
@@ -1,19 +1,14 @@
 import React, { useState, useMemo, useEffect } from 'react';
-import { 
-  LineChart, 
-  Line, 
-  XAxis, 
-  YAxis, 
-  CartesianGrid, 
-  Tooltip, 
+import {
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
   ResponsiveContainer,
   AreaChart,
   Area
 } from 'recharts';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { TrendingUp, Save, Edit2 } from 'lucide-react';
+import { TrendingUp, Save, Edit2, ChevronRight, BarChart3, DollarSign } from 'lucide-react';
 import { Bet } from '@/hooks/use-bets';
 import type { CapitalMovement } from '@/hooks/use-capital-movements';
 
@@ -21,12 +16,13 @@ interface BankrollEvolutionChartProps {
   bets: Bet[];
   initialBankroll: number | null;
   onUpdateBankroll: (amount: number) => Promise<boolean>;
-  /** Capital movements (aportes/resgates) to include in timeline. Only affects_balance=true are applied to balance. */
   capitalMovements?: CapitalMovement[];
-  /** When true, hide initial bankroll edit and show as "Lucro acumulado no período" (e.g. for dashboard period view). */
   readOnly?: boolean;
-  /** Optional: chart container height (responsive). */
   chartHeight?: number;
+  onAporte?: () => void;
+  onResgate?: () => void;
+  onNavigateCashFlow?: () => void;
+  onNavigateDashboard?: () => void;
 }
 
 export const BankrollEvolutionChart: React.FC<BankrollEvolutionChartProps> = ({
@@ -36,6 +32,10 @@ export const BankrollEvolutionChart: React.FC<BankrollEvolutionChartProps> = ({
   capitalMovements = [],
   readOnly = false,
   chartHeight = 300,
+  onAporte,
+  onResgate,
+  onNavigateCashFlow,
+  onNavigateDashboard,
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [tempBankroll, setTempBankroll] = useState<string>('');
@@ -112,133 +112,225 @@ export const BankrollEvolutionChart: React.FC<BankrollEvolutionChartProps> = ({
   const formatBRL = (value: number) =>
     value.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 
+  const lineColor = totalProfit >= 0 ? '#4ade80' : '#e57373';
+
   return (
     <div className="terminal-container p-4 mb-6">
-      <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6 gap-4">
-        <div>
-          <h3 className="section-title flex items-center gap-2">
+      <div className="flex flex-col md:flex-row gap-4">
+        {/* Chart - left */}
+        <div className="md:w-3/4 min-w-0 pb-4 border-b border-terminal-border-subtle md:pb-0 md:border-b-0">
+          <h3 className="section-title flex items-center gap-2 mb-4">
             <TrendingUp className="w-4 h-4 text-terminal-green" />
             {readOnly ? 'LUCRO ACUMULADO NO PERÍODO' : 'EVOLUÇÃO DA BANCA'}
           </h3>
-          <p className="text-xs opacity-60 mt-1">
-            {readOnly ? 'Evolução do lucro no intervalo selecionado' : 'Acompanhe o crescimento do seu capital'}
-          </p>
+
+          <div style={{ height: chartHeight }} className="w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={chartData}>
+                <defs>
+                  <linearGradient id="colorBankroll" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor={lineColor} stopOpacity={0.15}/>
+                    <stop offset="95%" stopColor={lineColor} stopOpacity={0}/>
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="#333" vertical={false} />
+                <XAxis
+                  dataKey="date"
+                  stroke="#666"
+                  tick={{ fill: 'var(--terminal-text)', fontSize: 10 }}
+                  tickLine={false}
+                  axisLine={false}
+                  minTickGap={30}
+                />
+                <YAxis
+                  stroke="#666"
+                  tick={{ fill: 'var(--terminal-text)', fontSize: 10 }}
+                  tickLine={false}
+                  axisLine={false}
+                  tickFormatter={(value) => `R$${formatBRL(value)}`}
+                  domain={[0, (dataMax: number) => Math.ceil(dataMax * 1.05)]}
+                  allowDataOverflow={false}
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: '#0a0a0a',
+                    border: '1px solid #333',
+                    borderRadius: '4px',
+                    color: '#fff'
+                  }}
+                  itemStyle={{ color: lineColor }}
+                  formatter={(value: number) => [`R$ ${formatBRL(value)}`, 'Banca']}
+                  labelFormatter={(label, payload) => {
+                    if (payload && payload.length > 0) {
+                      return payload[0].payload.fullDate;
+                    }
+                    return label;
+                  }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="bankroll"
+                  stroke={lineColor}
+                  strokeWidth={2}
+                  fillOpacity={1}
+                  fill="url(#colorBankroll)"
+                  animationDuration={500}
+                  animationEasing="ease-in-out"
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
         </div>
 
-        <div className="flex items-center gap-4 bg-terminal-dark-gray/50 p-2 rounded border border-terminal-border-subtle">
-          {!readOnly && (
-            <>
-              <div className="flex flex-col">
-                <span className="text-[10px] uppercase opacity-50">Banca Inicial</span>
-                {isEditing ? (
-                  <div className="flex items-center gap-2">
-                    <input
-                      type="number"
-                      value={tempBankroll}
-                      onChange={(e) => setTempBankroll(e.target.value)}
-                      className="w-24 bg-terminal-black border border-terminal-border text-xs p-1 rounded text-terminal-text"
-                      placeholder="0.00"
-                    />
-                    <button
-                      type="button"
-                      onClick={handleSave}
-                      disabled={isUpdating}
-                      className="p-1 hover:text-terminal-green transition-colors"
-                    >
-                      <Save className="w-4 h-4" />
-                    </button>
-                  </div>
-                ) : (
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono font-bold text-terminal-text">
-                      R$ {initialBankroll != null ? formatBRL(initialBankroll) : '0,00'}
-                    </span>
-                    <button
-                      type="button"
-                      onClick={() => setIsEditing(true)}
-                      className="p-1 opacity-50 hover:opacity-100 hover:text-terminal-blue transition-opacity"
-                    >
-                      <Edit2 className="w-3 h-3" />
-                    </button>
-                  </div>
+        {/* Side panel - right */}
+        {!readOnly && (
+          <div className="md:w-1/4 flex flex-col justify-between bg-terminal-dark-gray rounded-md p-4 md:border-l md:border-terminal-border-subtle">
+            {/* Top section: title + banca info */}
+            <div>
+              {/* Panel title */}
+              <h3 className="section-title flex items-center gap-2 mb-4">
+                GESTÃO DA BANCA
+              </h3>
+
+              {/* Banca info - vertical rows */}
+              <div className="flex flex-col gap-3">
+                {/* Banca Inicial */}
+                <div className="flex items-center justify-between">
+                  <span className="text-[10px] uppercase opacity-50">Banca Inicial</span>
+                  {isEditing ? (
+                    <div className="flex items-center gap-1">
+                      <input
+                        type="number"
+                        value={tempBankroll}
+                        onChange={(e) => setTempBankroll(e.target.value)}
+                        className="w-24 bg-terminal-black border border-terminal-border text-sm p-1 rounded text-terminal-text text-right"
+                        placeholder="0.00"
+                      />
+                      <button
+                        type="button"
+                        onClick={handleSave}
+                        disabled={isUpdating}
+                        className="p-1 hover:text-terminal-green transition-colors"
+                      >
+                        <Save className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex items-center gap-1">
+                      <span className="font-bold text-terminal-text text-sm whitespace-nowrap">
+                        R$ {initialBankroll != null ? formatBRL(initialBankroll) : '0,00'}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => setIsEditing(true)}
+                        className="p-0.5 opacity-40 hover:opacity-100 hover:text-terminal-blue transition-all"
+                      >
+                        <Edit2 className="w-3 h-3" />
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                {/* Banca Atual */}
+                <div className="flex items-center justify-between">
+                  <span className="text-[10px] uppercase opacity-50">Banca Atual</span>
+                  <span className={`font-bold text-sm whitespace-nowrap ${totalProfit >= 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
+                    R$ {formatBRL(currentBankroll)}
+                  </span>
+                </div>
+
+                {/* Lucro */}
+                <div className="flex items-center justify-between">
+                  <span className="text-[10px] uppercase opacity-50">Lucro</span>
+                  <span className={`font-bold text-sm whitespace-nowrap ${totalProfit >= 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
+                    {totalProfit >= 0 ? '+' : '-'}R$ {formatBRL(Math.abs(totalProfit))}
+                    {initialBankroll ? ` (${profitPercentage >= 0 ? '+' : ''}${profitPercentage.toFixed(1)}%)` : ''}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Middle section: Aporte / Resgate buttons */}
+            {(onAporte || onResgate) && (
+              <div className="grid grid-cols-2 gap-2 mt-4">
+                {onAporte && (
+                  <button
+                    type="button"
+                    onClick={onAporte}
+                    className="py-2 px-3 text-xs font-bold text-terminal-green bg-terminal-light-gray border border-terminal-green/60 rounded hover:bg-terminal-green/20 hover:border-terminal-green/90 hover:brightness-125 active:scale-95 transition-all text-center"
+                  >
+                    + Aporte
+                  </button>
+                )}
+                {onResgate && (
+                  <button
+                    type="button"
+                    onClick={onResgate}
+                    className="py-2 px-3 text-xs font-bold text-terminal-red bg-terminal-light-gray border border-terminal-red/60 rounded hover:bg-terminal-red/20 hover:border-terminal-red/90 hover:brightness-125 active:scale-95 transition-all text-center"
+                  >
+                    − Resgate
+                  </button>
                 )}
               </div>
-              <div className="h-8 w-px bg-terminal-border-subtle mx-2" />
-            </>
-          )}
+            )}
 
-          <div className="flex flex-col">
-            <span className="text-[10px] uppercase opacity-50">{readOnly ? 'Lucro no período' : 'Banca Atual'}</span>
-            <span className={`font-mono font-bold ${totalProfit >= 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
-              R$ {formatBRL(currentBankroll)}
-            </span>
+            {/* Bottom section: Navigation */}
+            {(onNavigateCashFlow || onNavigateDashboard) && (
+              <div className="flex flex-col gap-1.5 border-t border-terminal-border-subtle mt-4 pt-4">
+                {onNavigateCashFlow && (
+                  <button
+                    type="button"
+                    onClick={onNavigateCashFlow}
+                    className="flex items-center justify-between py-2 px-2.5 text-xs text-terminal-text/70 hover:text-terminal-text transition-colors group rounded bg-terminal-gray border border-terminal-border-subtle hover:border-terminal-border"
+                  >
+                    <div className="flex items-center gap-2">
+                      <DollarSign className="w-3.5 h-3.5 opacity-50 group-hover:opacity-90 transition-opacity" />
+                      <div className="text-left">
+                        <div className="font-semibold text-sm">Fluxo de Caixa</div>
+                        <div className="text-[10px] opacity-60">Histórico detalhado de transações</div>
+                      </div>
+                    </div>
+                    <ChevronRight className="w-3.5 h-3.5 opacity-40 group-hover:opacity-80 transition-opacity" />
+                  </button>
+                )}
+                {onNavigateDashboard && (
+                  <button
+                    type="button"
+                    onClick={onNavigateDashboard}
+                    className="flex items-center justify-between py-2 px-2.5 text-xs text-terminal-text/70 hover:text-terminal-text transition-colors group rounded bg-terminal-gray border border-terminal-border-subtle hover:border-terminal-border"
+                  >
+                    <div className="flex items-center gap-2">
+                      <BarChart3 className="w-3.5 h-3.5 opacity-50 group-hover:opacity-90 transition-opacity" />
+                      <div className="text-left">
+                        <div className="font-semibold text-sm">Dashboard</div>
+                        <div className="text-[10px] opacity-60">KPIs e gráficos por período</div>
+                      </div>
+                    </div>
+                    <ChevronRight className="w-3.5 h-3.5 opacity-30 group-hover:opacity-60 transition-opacity" />
+                  </button>
+                )}
+              </div>
+            )}
           </div>
+        )}
 
-          <div className="flex flex-col text-right">
-            <span className="text-[10px] uppercase opacity-50">Lucro</span>
-            <span className={`font-mono text-xs ${totalProfit >= 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
-              {totalProfit >= 0 ? '+' : ''}{formatBRL(totalProfit)}
-              {!readOnly && initialBankroll ? ` (${profitPercentage >= 0 ? '+' : ''}${profitPercentage.toFixed(1)}%)` : ''}
-            </span>
+        {/* Read-only mode info */}
+        {readOnly && (
+          <div className="md:w-48 flex flex-col justify-center gap-2 md:border-l md:border-terminal-border-subtle md:pl-4">
+            <div>
+              <span className="text-[10px] uppercase opacity-50 block mb-0.5">Lucro no período</span>
+              <span className={`font-mono font-bold ${totalProfit >= 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
+                R$ {formatBRL(currentBankroll)}
+              </span>
+            </div>
+            <div>
+              <span className="text-[10px] uppercase opacity-50 block mb-0.5">Lucro</span>
+              <span className={`font-mono text-xs ${totalProfit >= 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
+                {totalProfit >= 0 ? '+' : ''}{formatBRL(totalProfit)}
+              </span>
+            </div>
           </div>
-        </div>
-      </div>
-
-      <div style={{ height: chartHeight }} className="w-full">
-        <ResponsiveContainer width="100%" height="100%">
-          <AreaChart data={chartData}>
-            <defs>
-              <linearGradient id="colorBankroll" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#00d4ff" stopOpacity={0.1}/>
-                <stop offset="95%" stopColor="#00d4ff" stopOpacity={0}/>
-              </linearGradient>
-            </defs>
-            <CartesianGrid strokeDasharray="3 3" stroke="#333" vertical={false} />
-            <XAxis
-              dataKey="date"
-              stroke="#666"
-              tick={{ fill: 'var(--terminal-text)', fontSize: 10 }}
-              tickLine={false}
-              axisLine={false}
-              minTickGap={30}
-            />
-            <YAxis
-              stroke="#666"
-              tick={{ fill: 'var(--terminal-text)', fontSize: 10 }}
-              tickLine={false}
-              axisLine={false}
-              tickFormatter={(value) => `R$${formatBRL(value)}`}
-              domain={[0, (dataMax: number) => Math.ceil(dataMax * 1.05)]}
-              allowDataOverflow={false}
-            />
-            <Tooltip 
-              contentStyle={{ 
-                backgroundColor: '#0a0a0a', 
-                border: '1px solid #333',
-                borderRadius: '4px',
-                color: '#fff'
-              }}
-              itemStyle={{ color: '#00d4ff' }}
-              formatter={(value: number) => [`R$ ${formatBRL(value)}`, 'Banca']}
-              labelFormatter={(label, payload) => {
-                if (payload && payload.length > 0) {
-                  return payload[0].payload.fullDate;
-                }
-                return label;
-              }}
-            />
-            <Area
-              type="monotone"
-              dataKey="bankroll"
-              stroke="#00d4ff"
-              strokeWidth={2}
-              fillOpacity={1}
-              fill="url(#colorBankroll)"
-              animationDuration={500}
-              animationEasing="ease-in-out"
-            />
-          </AreaChart>
-        </ResponsiveContainer>
+        )}
       </div>
     </div>
   );

--- a/src/components/bets/BetsHeader.tsx
+++ b/src/components/bets/BetsHeader.tsx
@@ -1,12 +1,29 @@
-import React from 'react';
-import { UserIcon, ArrowLeft, Users, LogOut, Settings, BarChart3, Send, Share2 } from 'lucide-react';
-import { telegramBotUrl } from '@/config/environment';
-import { useNavigate, useLocation } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../hooks/use-auth';
+import { telegramBotUrl } from '@/config/environment';
+import { Button } from '../ui/button';
+import {
+  BarChart3,
+  Calendar,
+  Users,
+  Menu,
+  X,
+  ChevronDown,
+  Target,
+  FileText,
+  Share2,
+  Settings,
+  LogOut,
+  Send,
+  Users as UsersIcon,
+  UserIcon,
+} from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
@@ -24,7 +41,6 @@ interface BetsHeaderProps {
 }
 
 export const BetsHeader: React.FC<BetsHeaderProps> = ({
-  title = "STATIX BETS",
   onShareClick,
   onReferralClick,
   showUnitsView = false,
@@ -32,10 +48,35 @@ export const BetsHeader: React.FC<BetsHeaderProps> = ({
   onUnitConfigClick,
   unitsConfigured = true,
 }) => {
-  const navigate = useNavigate();
   const location = useLocation();
+  const navigate = useNavigate();
   const { user, signOut } = useAuth();
-  const isDashboard = location.pathname === '/betting-dashboard';
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  const analysisItems = [
+    { name: 'Home NBA', href: '/home-players', icon: BarChart3 },
+    { name: 'Jogos', href: '/home-games', icon: Calendar },
+    { name: 'Jogadores', href: '/nba-players', icon: Users },
+    { name: 'Relatório', href: '/report', icon: FileText },
+  ];
+
+  const betinhoModuleItems = [
+    { name: 'Dashboard', href: '/betting-dashboard', icon: BarChart3 },
+    { name: 'Apostas', href: '/bets', icon: Target },
+  ];
+
+  const isActive = (path: string) => location.pathname === path;
+
+  const activeModuleName = analysisItems.some((i) => isActive(i.href))
+    ? 'Análises'
+    : betinhoModuleItems.some((i) => isActive(i.href))
+    ? 'Betinho'
+    : null;
+
+  const handleNavigation = (href: string) => {
+    navigate(href);
+    setIsMobileMenuOpen(false);
+  };
 
   const handleSignOut = async () => {
     await signOut();
@@ -43,120 +84,284 @@ export const BetsHeader: React.FC<BetsHeaderProps> = ({
   };
 
   return (
-    <div className="terminal-header w-full max-w-full overflow-x-hidden py-2 px-2 md:p-3 min-h-12 md:min-h-0">
-      <div className="w-full min-w-0 flex justify-between items-center gap-1">
-        <div className="flex items-center min-w-0">
-        <button
-          type="button"
-          onClick={() => navigate('/bets')}
-          className="terminal-button px-1.5 sm:px-2 md:px-3 py-1.5 md:py-2 text-xs md:text-sm font-medium mr-1 sm:mr-1.5 md:mr-4 flex items-center border-terminal-border hover:border-terminal-green transition-colors"
-        >
-          <ArrowLeft size={16} className="sm:mr-1.5 md:mr-2" />
-          <span className="hidden sm:inline">INÍCIO</span>
-        </button>
-        {!isDashboard && (
-          <button
-            type="button"
-            onClick={() => navigate('/betting-dashboard')}
-            className="terminal-button px-1.5 sm:px-2 md:px-3 py-1.5 md:py-2 text-xs md:text-sm font-medium mr-1 sm:mr-1.5 md:mr-4 flex items-center border-terminal-border hover:border-terminal-green transition-colors"
+    <nav className="bg-terminal-black border-b border-terminal-border-subtle sticky top-0 z-50">
+      <div className="max-w-7xl mx-auto px-4">
+        <div className="flex justify-between items-center h-14">
+
+          {/* Left - Logo */}
+          <div
+            className="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
+            onClick={() => navigate('/home-players')}
           >
-            <BarChart3 size={16} className="sm:mr-1.5 md:mr-2" />
-            <span className="hidden sm:inline">DASHBOARD</span>
-          </button>
-        )}
-        <span className="text-xs sm:text-sm md:text-base font-semibold mr-1 sm:mr-2 md:mr-6 text-terminal-green tracking-wide truncate">
-          Betinho
-        </span>
-      </div>
-      <div className="flex items-center shrink-0 space-x-1 md:space-x-2 ml-1 md:ml-0">
-        {onShowUnitsViewChange !== undefined && (
-          <div className="flex items-center gap-1 md:gap-2 mr-0.5 md:mr-2">
-            <Label htmlFor="header-show-units" className="hidden sm:inline text-xs whitespace-nowrap text-terminal-text opacity-80 cursor-pointer">
-              Unidades
-            </Label>
-            <Switch
-              id="header-show-units"
-              checked={showUnitsView}
-              onCheckedChange={onShowUnitsViewChange}
-              disabled={!unitsConfigured}
-              className="scale-75 sm:scale-90 md:scale-100 origin-right data-[state=unchecked]:bg-white/80 data-[state=checked]:bg-[var(--terminal-green)]"
-            />
+            <div className="w-8 h-8 bg-terminal-blue/20 border border-terminal-blue/50 rounded flex items-center justify-center">
+              <BarChart3 className="w-4 h-4 text-terminal-blue" />
+            </div>
+            <div className="hidden sm:block">
+              <span className="text-sm font-bold text-terminal-blue tracking-wide">Smartbetting</span>
+            </div>
+          </div>
+
+          {/* Center - Desktop dropdowns */}
+          <div className="hidden md:flex items-center gap-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="flex items-center gap-2 px-4 h-9 text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray"
+                >
+                  <span className="text-xs font-semibold uppercase tracking-wide">Análises</span>
+                  <ChevronDown className="w-3 h-3 opacity-70" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="center"
+                className="w-56 bg-terminal-dark-gray border-terminal-border-subtle text-terminal-text"
+              >
+                <DropdownMenuLabel className="text-[10px] uppercase tracking-wide opacity-70">Módulo NBA</DropdownMenuLabel>
+                {analysisItems.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <DropdownMenuItem
+                      key={item.href}
+                      onClick={() => handleNavigation(item.href)}
+                      className={`cursor-pointer focus:bg-terminal-gray/40 focus:text-terminal-blue ${
+                        isActive(item.href) ? 'text-terminal-blue' : ''
+                      }`}
+                    >
+                      <Icon className="w-4 h-4 mr-2" />
+                      {item.name}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="flex items-center gap-2 px-4 h-9 text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray"
+                >
+                  <span className="text-xs font-semibold uppercase tracking-wide">Betinho</span>
+                  <ChevronDown className="w-3 h-3 opacity-70" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="center"
+                className="w-56 bg-terminal-dark-gray border-terminal-border-subtle text-terminal-text"
+              >
+                <DropdownMenuLabel className="text-[10px] uppercase tracking-wide opacity-70">Módulo Betinho</DropdownMenuLabel>
+                {betinhoModuleItems.map((item) => {
+                  const Icon = item.icon;
+                  return (
+                    <DropdownMenuItem
+                      key={item.href}
+                      onClick={() => handleNavigation(item.href)}
+                      className={`cursor-pointer focus:bg-terminal-gray/40 focus:text-terminal-blue ${
+                        isActive(item.href) ? 'text-terminal-blue' : ''
+                      }`}
+                    >
+                      <Icon className="w-4 h-4 mr-2" />
+                      {item.name}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+
+          {/* Right - Controls */}
+          <div className="flex items-center gap-1 md:gap-2">
+            {/* Units Toggle */}
+            {onShowUnitsViewChange !== undefined && (
+              <div className="flex items-center gap-1 md:gap-2">
+                <Label htmlFor="bets-header-units" className="hidden sm:inline text-xs whitespace-nowrap text-terminal-text opacity-80 cursor-pointer">
+                  Unidades
+                </Label>
+                <Switch
+                  id="bets-header-units"
+                  checked={showUnitsView}
+                  onCheckedChange={onShowUnitsViewChange}
+                  disabled={!unitsConfigured}
+                  className="scale-75 sm:scale-90 md:scale-100 origin-right data-[state=unchecked]:bg-white/80 data-[state=checked]:bg-[var(--terminal-green)]"
+                />
+              </div>
+            )}
+
+            {/* Units Config */}
+            {onUnitConfigClick && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onUnitConfigClick}
+                className="flex items-center gap-1.5 h-9 px-2 md:px-3 text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray"
+                title="Configurar unidades"
+              >
+                <Settings className="w-4 h-4" />
+                <span className="hidden sm:inline text-xs font-semibold uppercase tracking-wide">Unidades</span>
+              </Button>
+            )}
+
+            {/* Share */}
+            {onShareClick && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onShareClick}
+                className="flex items-center gap-1.5 h-9 px-2 md:px-3 text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray"
+                title="Compartilhar"
+              >
+                <Share2 className="w-4 h-4" />
+                <span className="hidden sm:inline text-xs font-semibold uppercase tracking-wide">Compartilhar</span>
+              </Button>
+            )}
+
+            {/* User Menu */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-9 w-9 rounded-full flex items-center justify-center text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray"
+                >
+                  <UserIcon className="w-4 h-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-48 bg-terminal-dark-gray border-terminal-border text-terminal-text"
+                align="end"
+              >
+                {user?.email && (
+                  <>
+                    <div className="px-2 py-1.5 text-xs opacity-70 border-b border-terminal-border-subtle">
+                      <p className="truncate">{user.email}</p>
+                    </div>
+                    <DropdownMenuSeparator className="bg-terminal-border-subtle" />
+                  </>
+                )}
+                <DropdownMenuItem
+                  onClick={() => navigate('/settings')}
+                  className="text-terminal-text hover:bg-terminal-gray focus:bg-terminal-gray cursor-pointer"
+                >
+                  <Settings className="mr-2 h-4 w-4" />
+                  <span>Configurações</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => window.open(telegramBotUrl, '_blank')}
+                  className="text-terminal-text hover:bg-terminal-gray focus:bg-terminal-gray cursor-pointer"
+                >
+                  <Send className="mr-2 h-4 w-4" />
+                  <span>Abrir Telegram</span>
+                </DropdownMenuItem>
+                {onReferralClick && (
+                  <DropdownMenuItem
+                    onClick={onReferralClick}
+                    className="text-terminal-text hover:bg-terminal-gray focus:bg-terminal-gray cursor-pointer"
+                  >
+                    <UsersIcon className="mr-2 h-4 w-4" />
+                    <span>Indique um amigo</span>
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuSeparator className="bg-terminal-border-subtle" />
+                <DropdownMenuItem
+                  onClick={handleSignOut}
+                  className="text-terminal-red hover:bg-terminal-red/10 focus:bg-terminal-red/10 cursor-pointer"
+                >
+                  <LogOut className="mr-2 h-4 w-4" />
+                  <span>Sair</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* Mobile menu button */}
+            <button
+              className="md:hidden flex items-center gap-1.5 px-2 py-1.5 rounded hover:bg-terminal-dark-gray transition-colors text-terminal-text hover:text-terminal-blue"
+              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+            >
+              {activeModuleName && !isMobileMenuOpen && (
+                <span className="text-[10px] font-semibold uppercase tracking-wide opacity-70">
+                  {activeModuleName}
+                </span>
+              )}
+              {isMobileMenuOpen ? (
+                <X className="w-4 h-4" />
+              ) : (
+                <Menu className="w-4 h-4" />
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Mobile Navigation Menu */}
+        {isMobileMenuOpen && (
+          <div className="md:hidden border-t border-terminal-border-subtle py-3">
+            <div className="flex flex-col gap-4">
+
+              {/* Seção Análises */}
+              <div>
+                <p className="px-3 mb-1 text-[10px] font-semibold uppercase tracking-wider text-terminal-text opacity-50">
+                  Análises
+                </p>
+                <div className="flex flex-col gap-1">
+                  {analysisItems.map((item) => {
+                    const Icon = item.icon;
+                    const active = isActive(item.href);
+                    return (
+                      <Button
+                        key={item.name}
+                        variant="ghost"
+                        onClick={() => handleNavigation(item.href)}
+                        className={`w-full justify-start h-10 ${
+                          active
+                            ? 'bg-terminal-blue/10 text-terminal-blue'
+                            : 'text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray'
+                        }`}
+                      >
+                        <Icon className="w-4 h-4 mr-3" />
+                        <span className="text-sm">{item.name}</span>
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Divisor */}
+              <div className="border-t border-terminal-border-subtle" />
+
+              {/* Seção Betinho */}
+              <div>
+                <p className="px-3 mb-1 text-[10px] font-semibold uppercase tracking-wider text-terminal-text opacity-50">
+                  Betinho
+                </p>
+                <div className="flex flex-col gap-1">
+                  {betinhoModuleItems.map((item) => {
+                    const Icon = item.icon;
+                    const active = isActive(item.href);
+                    return (
+                      <Button
+                        key={item.name}
+                        variant="ghost"
+                        onClick={() => handleNavigation(item.href)}
+                        className={`w-full justify-start h-10 ${
+                          active
+                            ? 'bg-terminal-blue/10 text-terminal-blue'
+                            : 'text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray'
+                        }`}
+                      >
+                        <Icon className="w-4 h-4 mr-3" />
+                        <span className="text-sm">{item.name}</span>
+                      </Button>
+                    );
+                  })}
+                </div>
+              </div>
+
+            </div>
           </div>
         )}
-        {onUnitConfigClick && (
-          <button
-            type="button"
-            onClick={onUnitConfigClick}
-            className="terminal-button px-1.5 md:px-3 py-1.5 md:py-2 text-xs md:text-sm font-medium flex items-center gap-1.5 md:gap-2 border-terminal-border hover:border-terminal-green transition-colors mr-0.5 md:mr-2"
-          >
-            <Settings size={16} className="shrink-0" />
-            <span className="hidden sm:inline">UNIDADES</span>
-          </button>
-        )}
-        {onShareClick && (
-          <button
-            type="button"
-            onClick={onShareClick}
-            className="terminal-button px-1.5 md:px-3 py-1.5 md:py-2 text-xs md:text-sm font-medium flex items-center border-terminal-border hover:border-terminal-green transition-colors"
-            title="Compartilhar"
-          >
-            <Share2 size={16} className="mr-1.5 md:mr-2" />
-            <span className="hidden sm:inline">COMPARTILHAR</span>
-          </button>
-        )}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button className="terminal-button p-1 md:p-1.5 hover:border-terminal-green transition-colors">
-              <UserIcon size={16} />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent 
-            className="bg-terminal-dark-gray border-terminal-border text-terminal-text w-48" 
-            align="end"
-          >
-            {user?.email && (
-              <>
-                <div className="px-2 py-1.5 text-xs opacity-70 border-b border-terminal-border-subtle">
-                  <p className="truncate">{user.email}</p>
-                </div>
-                <DropdownMenuSeparator className="bg-terminal-border-subtle" />
-              </>
-            )}
-            <DropdownMenuItem 
-              onClick={() => navigate('/settings')}
-              className="text-terminal-text hover:bg-terminal-gray focus:bg-terminal-gray cursor-pointer"
-            >
-              <Settings className="mr-2 h-4 w-4" />
-              <span>Configurações</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => window.open(telegramBotUrl, '_blank')}
-              className="text-terminal-text hover:bg-terminal-gray focus:bg-terminal-gray cursor-pointer"
-            >
-              <Send className="mr-2 h-4 w-4" />
-              <span>Abrir Telegram</span>
-            </DropdownMenuItem>
-            {onReferralClick && (
-              <DropdownMenuItem
-                onClick={onReferralClick}
-                className="text-terminal-text hover:bg-terminal-gray focus:bg-terminal-gray cursor-pointer"
-              >
-                <Users className="mr-2 h-4 w-4" />
-                <span>Indique um amigo</span>
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuSeparator className="bg-terminal-border-subtle" />
-            <DropdownMenuItem 
-              onClick={handleSignOut}
-              className="text-terminal-red hover:bg-terminal-red/10 focus:bg-terminal-red/10 cursor-pointer"
-            >
-              <LogOut className="mr-2 h-4 w-4" />
-              <span>Sair</span>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </div>
-      </div>
-    </div>
+    </nav>
   );
 };

--- a/src/components/bets/CreateBetModal.tsx
+++ b/src/components/bets/CreateBetModal.tsx
@@ -27,6 +27,7 @@ export interface CreateBetFormData {
   bet_date: string;
   match_date: string;
   selectedTagIds: string[];
+  is_credit_bet: boolean;
 }
 
 interface CreateBetModalProps {
@@ -51,6 +52,7 @@ const getDefaultFormData = (): CreateBetFormData => ({
   bet_date: new Date().toISOString().split('T')[0],
   match_date: '',
   selectedTagIds: [],
+  is_credit_bet: false,
 });
 
 const parseDateString = (dateString: string): Date | undefined => {
@@ -64,11 +66,11 @@ const formatDateToString = (date: Date | undefined): string => {
   return format(date, 'yyyy-MM-dd');
 };
 
-type CreateBetFormState = Omit<CreateBetFormData, 'selectedTagIds'> & { selectedTags: CreateBetTag[] };
+type CreateBetFormState = Omit<CreateBetFormData, 'selectedTagIds'> & { selectedTags: CreateBetTag[]; is_credit_bet: boolean };
 
 const getDefaultFormState = (): CreateBetFormState => {
   const { selectedTagIds: _, ...rest } = getDefaultFormData();
-  return { ...rest, selectedTags: [] };
+  return { ...rest, selectedTags: [], is_credit_bet: false };
 };
 
 export const CreateBetModal: React.FC<CreateBetModalProps> = ({
@@ -234,7 +236,7 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="bg-terminal-dark-gray border-terminal-border text-terminal-text sm:max-w-lg max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2 text-terminal-green">
+          <DialogTitle className="flex items-center gap-2 text-terminal-blue">
             <Plus className="w-4 h-4" />
             NOVA APOSTA
           </DialogTitle>
@@ -600,6 +602,33 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
               />
             </div>
           </div>
+
+          {/* Credit bet toggle + return preview */}
+          <div className="flex items-center gap-3">
+            <p className="text-xs uppercase opacity-70 tracking-wide">Crédito de apostas</p>
+            <button
+              type="button"
+              onClick={() => setFormData(prev => ({ ...prev, is_credit_bet: !prev.is_credit_bet }))}
+              style={{ backgroundColor: formData.is_credit_bet ? 'var(--terminal-green)' : '#3d4a5c' }}
+              className="relative w-10 h-5 rounded-full transition-colors flex-shrink-0"
+            >
+              <span style={{ transform: formData.is_credit_bet ? 'translateX(22px)' : 'translateX(2px)' }} className="absolute top-0.5 left-0 w-4 h-4 bg-white rounded-full shadow transition-transform" />
+            </button>
+          </div>
+          {formData.odds && formData.stake_amount && (
+            <p className="text-xs text-terminal-text/60">
+              Retorno potencial:{' '}
+              <span className="text-terminal-green font-bold">
+                {(() => {
+                  const odds = parseFloat(formData.odds);
+                  const stake = parseFloat(formData.stake_amount);
+                  if (isNaN(odds) || isNaN(stake)) return '—';
+                  const ret = formData.is_credit_bet ? stake * (odds - 1) : stake * odds;
+                  return `R$ ${ret.toFixed(2)}`;
+                })()}
+              </span>
+            </p>
+          )}
 
           <div className="space-y-2">
             <Label className="text-xs uppercase opacity-70">Data da Aposta</Label>

--- a/src/components/bets/ShareLinkModal.tsx
+++ b/src/components/bets/ShareLinkModal.tsx
@@ -117,7 +117,7 @@ export const ShareLinkModal: React.FC<ShareLinkModalProps> = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="bg-terminal-dark-gray border-terminal-border text-terminal-text max-w-md">
         <DialogHeader>
-          <DialogTitle className="text-terminal-green flex items-center gap-2">
+          <DialogTitle className="text-terminal-blue flex items-center gap-2">
             <Link2 className="w-5 h-5" />
             Compartilhar apostas
           </DialogTitle>

--- a/src/components/bets/TagSelector.tsx
+++ b/src/components/bets/TagSelector.tsx
@@ -151,11 +151,11 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
   return (
     <div className={`relative ${className}`}>
       {/* Selected Tags Display */}
-      <div className="flex flex-wrap gap-2 mb-2">
+      <div className="flex flex-wrap gap-1 items-center">
         {selectedTags.map(tag => (
           <Popover key={tag.id}>
             <span
-              className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium"
+              className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium"
               style={{
                 backgroundColor: `${tag.color}20`,
                 color: tag.color,
@@ -218,10 +218,10 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
             <PopoverTrigger asChild>
               <button
                 type="button"
-                className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs border border-terminal-border hover:border-terminal-blue transition-colors"
+                className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] border border-terminal-border hover:border-terminal-blue transition-colors opacity-60 hover:opacity-100"
               >
-                <Plus className="w-3 h-3" />
-                <span>Adicionar Tag</span>
+                <Plus className="w-2.5 h-2.5" />
+                <span>Tag</span>
               </button>
             </PopoverTrigger>
             <PopoverContent

--- a/src/components/nba/NBAHeader.tsx
+++ b/src/components/nba/NBAHeader.tsx
@@ -21,7 +21,7 @@ export const NBAHeader: React.FC<NBAHeaderProps> = ({ playerName }) => {
             BACK
           </button>
         )}
-        <span className="text-base font-semibold mr-6 text-terminal-green tracking-wide">
+        <span className="text-base font-semibold mr-6 text-terminal-blue tracking-wide">
           Smartbetting
         </span>
         <div className="hidden sm:flex space-x-2">

--- a/src/components/nba/PlayerHeader.tsx
+++ b/src/components/nba/PlayerHeader.tsx
@@ -58,7 +58,7 @@ export const PlayerHeader: React.FC<PlayerHeaderProps> = ({ player, seasonAverag
       <div className="flex items-start gap-4">
         {/* Player Avatar */}
         <div className="flex-shrink-0">
-          <div className="w-20 h-20 rounded-lg bg-terminal-gray border-2 border-terminal-green flex items-center justify-center overflow-hidden">
+          <div className="w-20 h-20 rounded-lg bg-terminal-gray border-2 border-terminal-blue flex items-center justify-center overflow-hidden">
             <img 
               src={getPlayerPhotoUrl(player.player_name, player.team_name)}
               alt={player.player_name}
@@ -74,7 +74,7 @@ export const PlayerHeader: React.FC<PlayerHeaderProps> = ({ player, seasonAverag
                 target.style.display = 'none';
                 const parent = target.parentElement;
                 if (parent) {
-                  parent.innerHTML = `<span class="text-2xl font-bold text-terminal-green">${initials}</span>`;
+                  parent.innerHTML = `<span class="text-2xl font-bold text-terminal-blue">${initials}</span>`;
                 }
               }}
             />
@@ -85,7 +85,7 @@ export const PlayerHeader: React.FC<PlayerHeaderProps> = ({ player, seasonAverag
         <div className="flex-1">
           <div className="flex items-start justify-between mb-2">
             <div>
-              <h2 className="text-2xl font-bold text-terminal-green mb-1">
+              <h2 className="text-2xl font-bold text-terminal-blue mb-1">
                 {player.player_name}
               </h2>
               <div className="flex items-center gap-3 text-sm">
@@ -117,7 +117,7 @@ export const PlayerHeader: React.FC<PlayerHeaderProps> = ({ player, seasonAverag
             {player.rating_stars > 0 && (
               <div className="flex items-center gap-1 bg-terminal-dark-gray px-3 py-1.5 rounded border border-terminal-border-subtle">
                 <Star className="w-4 h-4 text-terminal-yellow fill-current" />
-                <span className="text-sm font-bold text-terminal-green">
+                <span className="text-sm font-bold text-terminal-blue">
                   {player.rating_stars}
                 </span>
               </div>

--- a/src/components/nba/TeammatesCard.tsx
+++ b/src/components/nba/TeammatesCard.tsx
@@ -57,11 +57,11 @@ export const TeammatesCard: React.FC<TeammatesCardProps> = ({
             <button
               key={player.player_id}
               onClick={() => handlePlayerClick(player.player_name)}
-              className="w-full text-left p-2 rounded border border-terminal-green/20 hover:border-terminal-green/50 hover:bg-terminal-green/5 transition-all group"
+              className="w-full text-left p-2 rounded border border-terminal-blue/20 hover:border-terminal-blue/50 hover:bg-terminal-blue/5 transition-all group"
             >
               <div className="flex items-start justify-between gap-2">
                 <div className="flex-1 min-w-0">
-                  <div className="text-sm font-medium text-terminal-green group-hover:text-terminal-green-bright truncate">
+                  <div className="text-sm font-medium text-terminal-blue group-hover:text-terminal-blue truncate">
                     {player.player_name}
                   </div>
                   <div className="text-xs opacity-70 flex items-center gap-2">

--- a/src/components/share/ShareBankrollChart.tsx
+++ b/src/components/share/ShareBankrollChart.tsx
@@ -62,7 +62,7 @@ export const ShareBankrollChart: React.FC<ShareBankrollChartProps> = ({ bets }) 
   return (
     <Card className="bg-terminal-dark-gray border-terminal-border">
       <CardHeader>
-        <CardTitle className="text-sm font-medium text-terminal-green">
+        <CardTitle className="text-sm font-medium text-terminal-blue">
           Evolução do saldo acumulado
         </CardTitle>
       </CardHeader>

--- a/src/components/share/ShareBetsTable.tsx
+++ b/src/components/share/ShareBetsTable.tsx
@@ -82,7 +82,7 @@ export const ShareBetsTable: React.FC<ShareBetsTableProps> = ({ bets }) => {
 
   return (
     <div className="space-y-4">
-      <h2 className="text-sm font-semibold text-terminal-green">Apostas</h2>
+      <h2 className="text-sm font-semibold text-terminal-blue">Apostas</h2>
       <div className="rounded-md border border-terminal-border overflow-hidden">
         <Table>
           <TableHeader>

--- a/src/components/share/ShareBreakdownCharts.tsx
+++ b/src/components/share/ShareBreakdownCharts.tsx
@@ -99,7 +99,7 @@ export const ShareBreakdownCharts: React.FC<ShareBreakdownChartsProps> = ({ bets
       {charts.map(({ data, title }) => (
         <Card key={title} className="bg-terminal-dark-gray border-terminal-border">
           <CardHeader>
-            <CardTitle className="text-sm font-medium text-terminal-green">
+            <CardTitle className="text-sm font-medium text-terminal-blue">
               {title}
             </CardTitle>
           </CardHeader>

--- a/src/index.css
+++ b/src/index.css
@@ -105,9 +105,9 @@ All colors MUST be HSL.
     --terminal-light-gray: #2d3541;
     --terminal-border: #3d4a5c;
     --terminal-border-subtle: #252d38;
-    --terminal-green: #5b9bd5;  /* Changed from green to blue */
-    --terminal-green-bright: #7a9bb5; /* Lighter blue */
-    --terminal-blue: #5b9bd5;
+    --terminal-green: #4ade80;  /* Green → positive result */
+    --terminal-green-bright: #86efac; /* Light green */
+    --terminal-blue: #5b9bd5;   /* Blue → neutral info */
     --terminal-yellow: #e5c07b; /* Gold/Yellow for stars */
     --terminal-text: #d4dce6;
     --terminal-red: #e57373;

--- a/src/pages/Bets.tsx
+++ b/src/pages/Bets.tsx
@@ -97,6 +97,7 @@ interface Bet {
   odds: number;
   stake_amount: number;
   potential_return: number;
+  is_credit_bet?: boolean;
   status: 'pending' | 'won' | 'lost' | 'void' | 'cashout' | 'half_won' | 'half_lost';
   bet_date: string;
   match_date?: string;
@@ -271,15 +272,9 @@ const BetRow = React.memo(function BetRow({
           availableTags={availableTags}
         />
       </td>
-      <td className="py-1.5 px-1.5 opacity-70">{bet.sport}</td>
-      <td className="py-1.5 px-1.5 opacity-70">{bet.league || '-'}</td>
-      <td className="py-1.5 px-1.5 opacity-70">{bet.betting_market || '-'}</td>
       <td className="text-right py-1.5 px-1.5">{formatValue(bet.stake_amount)}</td>
       <td className="text-right py-1.5 px-1.5 text-terminal-blue">{bet.odds.toFixed(2)}</td>
-      <td className={`text-right py-1.5 px-1.5 min-w-[5.5rem] overflow-hidden text-ellipsis whitespace-nowrap ${
-        bet.status === 'won' || bet.status === 'half_won' ? 'text-terminal-green' :
-        bet.status === 'lost' || bet.status === 'half_lost' ? 'text-terminal-red' : 'opacity-70'
-      }`}>
+      <td className="text-right py-1.5 px-1.5 min-w-[5.5rem] overflow-hidden text-ellipsis whitespace-nowrap opacity-70">
         {bet.is_cashout && bet.cashout_amount
           ? formatValue(bet.cashout_amount)
           : bet.status === 'half_won'
@@ -289,6 +284,24 @@ const BetRow = React.memo(function BetRow({
               : bet.status === 'void'
                 ? formatValue(bet.stake_amount)
                 : formatValue(bet.potential_return)}
+      </td>
+      <td className={`text-right py-1.5 px-1.5 min-w-[5.5rem] font-medium ${
+        bet.status === 'won' || bet.status === 'half_won' || (bet.is_cashout && bet.cashout_amount && bet.cashout_amount > bet.stake_amount) ? 'text-terminal-green' :
+        bet.status === 'lost' || bet.status === 'half_lost' ? 'text-terminal-red' : 'opacity-40'
+      }`}>
+        {bet.status === 'pending'
+          ? '—'
+          : bet.is_cashout && bet.cashout_amount
+            ? formatValue(bet.cashout_amount - bet.stake_amount)
+            : bet.status === 'won'
+              ? formatValue(bet.potential_return - bet.stake_amount)
+              : bet.status === 'lost'
+                ? formatValue(-bet.stake_amount)
+                : bet.status === 'half_won'
+                  ? formatValue((bet.potential_return - bet.stake_amount) / 2)
+                  : bet.status === 'half_lost'
+                    ? formatValue(-bet.stake_amount / 2)
+                    : '—'}
       </td>
       <td className="text-center py-1.5 px-1.5 whitespace-nowrap min-w-[5rem]">
         <span className={`inline-block px-1.5 py-0.5 text-[10px] uppercase font-bold whitespace-nowrap ${
@@ -303,6 +316,9 @@ const BetRow = React.memo(function BetRow({
           {translateStatus(bet.status)}
         </span>
       </td>
+      <td className="py-1.5 px-1.5 opacity-70">{bet.sport}</td>
+      <td className="py-1.5 px-1.5 opacity-70">{bet.league || '-'}</td>
+      <td className="py-1.5 px-1.5 opacity-70">{bet.betting_market || '-'}</td>
       <td className="py-1.5 px-1.5 min-w-[11rem]">
         <div className="flex flex-row items-center gap-1.5 justify-end flex-nowrap">
           {bet.status === 'pending' && (
@@ -466,23 +482,32 @@ const BetCard = React.memo(function BetCard({
           <div className="text-[10px] opacity-50 uppercase mb-0.5">Odds</div>
           <div className="text-sm text-terminal-blue">{bet.odds.toFixed(2)}</div>
         </div>
-        <div className="text-center border-l border-terminal-border-subtle">
-          <div className="text-[10px] opacity-50 uppercase mb-0.5">Retorno</div>
-          <div className={`text-sm ${
-            bet.status === 'won' || bet.status === 'half_won' ? 'text-terminal-green' :
-            bet.status === 'lost' || bet.status === 'half_lost' ? 'text-terminal-red' : 'opacity-70'
-          }`}>
-            {bet.is_cashout && bet.cashout_amount
-              ? formatValue(bet.cashout_amount)
-              : bet.status === 'half_won'
-                ? formatValue((bet.stake_amount + bet.potential_return) / 2)
-                : bet.status === 'half_lost'
-                  ? formatValue(bet.stake_amount / 2)
-                  : bet.status === 'void'
-                    ? formatValue(bet.stake_amount)
-                    : formatValue(bet.potential_return)}
+        {bet.status === 'pending' ? (
+          <div className="text-center border-l border-terminal-border-subtle">
+            <div className="text-[10px] opacity-50 uppercase mb-0.5">Retorno</div>
+            <div className="text-sm opacity-70">{formatValue(bet.potential_return)}</div>
           </div>
-        </div>
+        ) : (
+          <div className="text-center border-l border-terminal-border-subtle">
+            <div className="text-[10px] opacity-50 uppercase mb-0.5">Lucro</div>
+            <div className={`text-sm font-medium ${
+              bet.status === 'won' || bet.status === 'half_won' || (bet.is_cashout && bet.cashout_amount && bet.cashout_amount > bet.stake_amount) ? 'text-terminal-green' :
+              bet.status === 'lost' || bet.status === 'half_lost' ? 'text-terminal-red' : 'opacity-50'
+            }`}>
+              {bet.is_cashout && bet.cashout_amount
+                ? formatValue(bet.cashout_amount - bet.stake_amount)
+                : bet.status === 'won'
+                  ? formatValue(bet.potential_return - bet.stake_amount)
+                  : bet.status === 'lost'
+                    ? formatValue(-bet.stake_amount)
+                    : bet.status === 'half_won'
+                      ? formatValue((bet.potential_return - bet.stake_amount) / 2)
+                      : bet.status === 'half_lost'
+                        ? formatValue(-bet.stake_amount / 2)
+                        : '—'}
+            </div>
+          </div>
+        )}
       </div>
       <div className="pt-2">
         {bet.status === 'pending' ? (
@@ -558,7 +583,7 @@ export default function Bets() {
   const { user, isLoading: authLoading } = useAuth();
   const { isPremium: isBetinhoPremium, isFree: isBetinhoFree } = useBetinhoPremium();
   const { isConfigured, toUnits, formatUnits, config, updateConfig, formatCurrency, refetchConfig } = useUserUnit();
-  const { movements: capitalMovements } = useCapitalMovements(user?.id);
+  const { movements: capitalMovements, addMovement } = useCapitalMovements(user?.id);
   const { toast } = useToast();
   const navigate = useNavigate();
   const [bets, setBets] = useState<Bet[]>([]);
@@ -588,6 +613,10 @@ export default function Bets() {
   });
   
   // Modals state
+  const [capitalModal, setCapitalModal] = useState<{ isOpen: boolean; type: 'deposit' | 'withdrawal'; amount: string; description: string }>({
+    isOpen: false, type: 'deposit', amount: '', description: ''
+  });
+
   const [cashoutModal, setCashoutModal] = useState<{
     isOpen: boolean;
     bet: Bet | null;
@@ -614,6 +643,7 @@ export default function Bets() {
       bet_date: string;
       match_date: string;
       status: 'pending' | 'won' | 'lost' | 'void' | 'cashout' | 'half_won' | 'half_lost';
+      is_credit_bet: boolean;
     };
   }>({
     isOpen: false,
@@ -628,7 +658,8 @@ export default function Bets() {
       stake_amount: '',
       bet_date: '',
       match_date: '',
-      status: 'pending'
+      status: 'pending',
+      is_credit_bet: false
     }
   });
   const [isEditDatePopoverOpen, setIsEditDatePopoverOpen] = useState(false);
@@ -667,7 +698,7 @@ export default function Bets() {
 
   // Sort state
   type SortDirection = 'asc' | 'desc';
-  type SortColumn = 'bet_date' | 'sport' | 'league' | 'betting_market' | 'stake_amount' | 'odds' | 'return' | 'status' | null;
+  type SortColumn = 'bet_date' | 'sport' | 'league' | 'betting_market' | 'stake_amount' | 'odds' | 'return' | 'profit' | 'status' | null;
   
   const [sortConfig, setSortConfig] = useState<{
     column: SortColumn;
@@ -930,7 +961,8 @@ export default function Bets() {
 
     const odds = parseFloat(editModal.formData.odds);
     const stakeAmount = parseFloat(editModal.formData.stake_amount);
-    const potentialReturn = stakeAmount * odds;
+    const isCreditBet = editModal.formData.is_credit_bet;
+    const potentialReturn = isCreditBet ? stakeAmount * (odds - 1) : stakeAmount * odds;
     const updatedAt = new Date().toISOString();
 
     // Convert yyyy-MM-dd to local midnight ISO so the calendar day is preserved in all timezones
@@ -955,6 +987,7 @@ export default function Bets() {
       odds: odds,
       stake_amount: stakeAmount,
       potential_return: potentialReturn,
+      is_credit_bet: isCreditBet,
       bet_date: betDateISO,
       match_date: matchDateISO,
       status: editModal.formData.status,
@@ -1011,7 +1044,8 @@ export default function Bets() {
       if (isNaN(odds) || isNaN(stakeAmount)) {
         throw new Error('Valores inválidos');
       }
-      const potentialReturn = stakeAmount * odds;
+      const isCreditBet = data.is_credit_bet ?? false;
+      const potentialReturn = isCreditBet ? stakeAmount * (odds - 1) : stakeAmount * odds;
 
       const { data: newBet, error } = await supabase
         .from('bets')
@@ -1026,6 +1060,7 @@ export default function Bets() {
           odds: odds,
           stake_amount: stakeAmount,
           potential_return: potentialReturn,
+          is_credit_bet: isCreditBet,
           bet_date: data.bet_date || new Date().toISOString(),
           match_date: data.match_date || null,
           status: 'pending',
@@ -1085,7 +1120,8 @@ export default function Bets() {
         stake_amount: bet.stake_amount?.toString() || '',
         bet_date: bet.bet_date ? String(bet.bet_date).split('T')[0] : '',
         match_date: bet.match_date ? String(bet.match_date).split('T')[0] : '',
-        status: bet.status || 'pending'
+        status: bet.status || 'pending',
+        is_credit_bet: bet.is_credit_bet ?? false
       }
     });
     setIsSportDropdownOpen(false);
@@ -1377,6 +1413,20 @@ export default function Bets() {
                 ? b.stake_amount / 2 
                 : (b.potential_return || 0);
           break;
+        case 'profit': {
+          const getProfit = (bet: Bet) => {
+            if (bet.status === 'pending') return 0;
+            if (bet.is_cashout && bet.cashout_amount) return bet.cashout_amount - bet.stake_amount;
+            if (bet.status === 'won') return bet.potential_return - bet.stake_amount;
+            if (bet.status === 'lost') return -bet.stake_amount;
+            if (bet.status === 'half_won') return (bet.potential_return - bet.stake_amount) / 2;
+            if (bet.status === 'half_lost') return -bet.stake_amount / 2;
+            return 0;
+          };
+          aValue = getProfit(a);
+          bValue = getProfit(b);
+          break;
+        }
         case 'status':
           // Ordem customizada: pending, won, lost, half_won, half_lost, cashout, void
           const statusOrder: Record<string, number> = {
@@ -1766,67 +1816,62 @@ export default function Bets() {
       
       <main className="container mx-auto px-3 py-4">
         {/* Stats Grid */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-          <BetStatsCard 
-            label="TOTAL APOSTAS" 
-            value={stats.totalBets}
-            valueColor="text-terminal-text"
-          />
-          <BetStatsCard 
-            label="TAXA DE ACERTO" 
-            value={`${stats.winRate.toFixed(1)}%`}
-            trend={
-              stats.winRate > 50
-                ? 'up'
-                : stats.winRate < 50
-                  ? 'down'
-                  : undefined
-            }
-          />
-          <BetStatsCard 
-            label="LUCRO" 
-            value={formatValue(stats.profit)}
-            valueColor={stats.profit >= 0 ? 'text-terminal-green' : 'text-terminal-red'}
-            trend={
-              stats.profit > 0
-                ? 'up'
-                : stats.profit < 0
-                  ? 'down'
-                  : undefined
-            }
-          />
-          <BetStatsCard 
-            label="ROI" 
-            value={`${stats.roi.toFixed(1)}%`}
-            valueColor={stats.roi >= 0 ? 'text-terminal-green' : 'text-terminal-red'}
-            trend={
-              stats.roi > 0
-                ? 'up'
-                : stats.roi < 0
-                  ? 'down'
-                  : undefined
-            }
-          />
-          <BetStatsCard 
-            label="TOTAL APOSTADO" 
-            value={formatValue(stats.totalStaked)}
-            valueColor="text-terminal-text"
-          />
-          <BetStatsCard 
-            label="RETORNO TOTAL" 
-            value={formatValue(stats.totalReturn)}
-            valueColor="text-terminal-green"
-          />
-          <BetStatsCard 
-            label="MÉDIA APOSTA" 
-            value={formatValue(stats.averageStake)}
-            valueColor="text-terminal-text"
-          />
-          <BetStatsCard 
-            label="MÉDIA ODDS" 
-            value={stats.averageOdd.toFixed(2)}
-            valueColor="text-terminal-blue"
-          />
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-6">
+          {/* ROI - card grande */}
+          <div className="terminal-container p-4 md:p-5 flex flex-col items-center justify-center">
+            <div className="data-label text-[10px] md:text-xs mb-2 text-center">ROI</div>
+            <div className={`text-2xl md:text-4xl font-bold ${stats.roi >= 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
+              {stats.roi.toFixed(1)}%
+            </div>
+          </div>
+
+          {/* Lucro Líquido - card grande */}
+          <div className="terminal-container p-4 md:p-5 flex flex-col items-center justify-center">
+            <div className="data-label text-[10px] md:text-xs mb-2 text-center">Lucro Líquido</div>
+            <div className={`text-2xl md:text-4xl font-bold ${stats.profit >= 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
+              {formatValue(stats.profit)}
+            </div>
+          </div>
+
+          {/* Total Apostado + Retorno Bruto */}
+          <div className="terminal-container p-3 md:p-4 flex flex-col justify-center gap-0">
+            <div className="pb-2.5 text-center">
+              <div className="data-label text-[10px] mb-1">Total Apostado</div>
+              <div className="text-base md:text-lg font-bold text-terminal-text">{formatValue(stats.totalStaked)}</div>
+            </div>
+            <div className="border-t border-terminal-border pt-2.5 text-center">
+              <div className="data-label text-[10px] mb-1">Retorno Bruto</div>
+              <div className="text-base md:text-lg font-bold text-terminal-text">{formatValue(stats.totalReturn)}</div>
+            </div>
+          </div>
+
+          {/* Total Apostas + Taxa de Acerto */}
+          <div className="terminal-container p-3 md:p-4 flex flex-col justify-center gap-0">
+            <div className="pb-2.5 text-center">
+              <div className="data-label text-[10px] mb-1">Total Apostas</div>
+              <div className="text-base md:text-lg font-bold text-terminal-text">{stats.totalBets}</div>
+            </div>
+            <div className="border-t border-terminal-border pt-2.5 text-center">
+              <div className="data-label text-[10px] mb-1">Taxa de Acerto</div>
+              <div className={`text-base md:text-lg font-bold ${stats.winRate >= 50 ? 'text-terminal-green' : 'text-terminal-red'}`}>
+                {stats.winRate.toFixed(1)}%
+              </div>
+            </div>
+          </div>
+
+          {/* Valor Médio + Odd Média */}
+          <div className="terminal-container p-3 md:p-4 flex flex-row md:flex-col items-stretch justify-center gap-0 col-span-2 md:col-span-1">
+            <div className="flex-1 text-center flex flex-col justify-center md:pb-2.5">
+              <div className="data-label text-[10px] mb-1">Valor Médio das Apostas</div>
+              <div className="text-base md:text-lg font-bold text-terminal-text">{formatValue(stats.averageStake)}</div>
+            </div>
+            <div className="w-px self-stretch md:hidden mx-3" style={{ backgroundColor: 'var(--terminal-border)' }} />
+            <div className="hidden md:block border-t border-terminal-border my-0 md:pt-2.5" />
+            <div className="flex-1 text-center flex flex-col justify-center md:pt-2.5">
+              <div className="data-label text-[10px] mb-1">Odd Média</div>
+              <div className="text-base md:text-lg font-bold text-terminal-text">{stats.averageOdd.toFixed(2)}</div>
+            </div>
+          </div>
         </div>
 
         <BankrollEvolutionChart 
@@ -1850,60 +1895,15 @@ export default function Bets() {
               divisor: currentDivisor
             });
           }}
+          onAporte={() => setCapitalModal({ isOpen: true, type: 'deposit', amount: '', description: '' })}
+          onResgate={() => setCapitalModal({ isOpen: true, type: 'withdrawal', amount: '', description: '' })}
+          onNavigateCashFlow={() => navigate('/bankroll')}
+          onNavigateDashboard={() => navigate('/betting-dashboard')}
         />
 
-        {/* Dashboard + Cash Flow Buttons */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-          <button
-            type="button"
-            onClick={() => navigate('/betting-dashboard')}
-            className="w-full terminal-container p-4 flex items-center justify-between hover:bg-terminal-dark-gray/50 transition-all group"
-          >
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded bg-terminal-green/10 flex items-center justify-center group-hover:bg-terminal-green/20 transition-colors">
-                <BarChart3 className="w-5 h-5 text-terminal-green" />
-              </div>
-              <div className="text-left">
-                <div className="font-bold text-sm text-terminal-green">DASHBOARD</div>
-                <div className="text-xs opacity-60">KPIs e gráficos por período</div>
-              </div>
-            </div>
-            <ChevronRight className="w-5 h-5 text-terminal-green opacity-50 group-hover:opacity-100 group-hover:translate-x-1 transition-all" />
-          </button>
-          <button
-            type="button"
-            onClick={() => navigate('/bankroll')}
-            className="w-full terminal-container p-4 flex items-center justify-between hover:bg-terminal-dark-gray/50 transition-all group"
-          >
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded bg-blue-500/10 flex items-center justify-center group-hover:bg-blue-500/20 transition-colors">
-                <DollarSign className="w-5 h-5 text-blue-400" />
-              </div>
-              <div className="text-left">
-                <div className="font-bold text-sm text-blue-400">FLUXO DE CAIXA</div>
-                <div className="text-xs opacity-60">Histórico detalhado de transações</div>
-              </div>
-            </div>
-            <ChevronRight className="w-5 h-5 text-blue-400 opacity-50 group-hover:opacity-100 group-hover:translate-x-1 transition-all" />
-          </button>
-        </div>
-
         {/* Filters Bar */}
-        <div className="terminal-container p-3 mb-4 flex flex-col md:flex-row gap-3 items-center justify-between">
-          <div className="flex flex-col gap-3 w-full">
-            {/* Primeira linha: Filtros principais */}
-            <div className="grid grid-cols-2 md:flex md:flex-wrap gap-3 w-full">
-              <div className="relative col-span-2 md:w-auto md:min-w-[200px]">
-                <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 w-4 h-4 text-terminal-text opacity-50" />
-                <input 
-                  type="text" 
-                  placeholder="BUSCAR APOSTAS..." 
-                  className="terminal-input w-full pl-8 pr-3 py-1.5 text-xs rounded-sm"
-                  value={filters.searchQuery}
-                  onChange={(e) => setFilters(prev => ({ ...prev, searchQuery: e.target.value }))}
-                />
-              </div>
-              
+        <div className="terminal-container p-3 mb-4">
+          <div className="grid grid-cols-2 md:flex md:flex-wrap gap-2 items-center">
               <MultiSelectFilter
                 label="STATUS"
                 placeholder="TODOS STATUS"
@@ -1934,48 +1934,6 @@ export default function Bets() {
                 onChange={(values) => setFilters(prev => ({ ...prev, sport: values }))}
               />
 
-              <MultiSelectFilter
-                label="LIGAS"
-                placeholder="TODAS LIGAS"
-                options={[
-                  ...uniqueLeagues.map(league => ({
-                    value: league,
-                    label: league.toUpperCase()
-                  })),
-                  { value: '__empty__', label: 'SEM CLASSIFICAÇÃO' }
-                ]}
-                selected={filters.league}
-                onChange={(values) => setFilters(prev => ({ ...prev, league: values }))}
-              />
-
-              <MultiSelectFilter
-                label="MERCADOS"
-                placeholder="TODOS MERCADOS"
-                options={[
-                  ...uniqueBettingMarkets.map(market => ({
-                    value: market,
-                    label: market.toUpperCase()
-                  })),
-                  { value: '__empty__', label: 'SEM CLASSIFICAÇÃO' }
-                ]}
-                selected={filters.betting_market}
-                onChange={(values) => setFilters(prev => ({ ...prev, betting_market: values }))}
-              />
-
-              <MultiSelectFilter
-                label="TAGS"
-                placeholder="TODAS AS TAGS"
-                options={userTags.map(tag => ({
-                  value: tag.id,
-                  label: tag.name.toUpperCase()
-                }))}
-                selected={filters.selectedTags}
-                onChange={(values) => setFilters(prev => ({ ...prev, selectedTags: values }))}
-              />
-            </div>
-
-            {/* Segunda linha: Filtros de data */}
-            <div className="flex gap-3">
               <Popover open={isFilterDateFromOpen} onOpenChange={setIsFilterDateFromOpen}>
                 <PopoverTrigger asChild>
                   <Button
@@ -2039,9 +1997,9 @@ export default function Bets() {
                       if (fromDate && date && isBefore(date, fromDate)) {
                         return;
                       }
-                      setFilters(prev => ({ 
-                        ...prev, 
-                        dateTo: formatDateToString(date) 
+                      setFilters(prev => ({
+                        ...prev,
+                        dateTo: formatDateToString(date)
                       }));
                       setIsFilterDateToOpen(false);
                     }}
@@ -2050,26 +2008,65 @@ export default function Bets() {
                   />
                 </PopoverContent>
               </Popover>
-            </div>
-          </div>
 
-          <div className="flex flex-wrap items-center gap-2">
-            <button 
-              type="button"
-              onClick={clearAllFilters}
-              className="terminal-button px-4 py-2.5 text-sm flex items-center justify-center gap-2 border-terminal-border hover:border-terminal-red hover:text-terminal-red transition-colors min-h-[40px]"
-            >
-              <X className="w-4 h-4 shrink-0" />
-              <span>LIMPAR FILTROS</span>
-            </button>
-            <button 
-              type="button"
-              onClick={fetchBets}
-              className="terminal-button px-4 py-2.5 text-sm flex items-center justify-center gap-2 border-terminal-border hover:border-terminal-green transition-colors min-h-[40px]"
-            >
-              <RefreshCw className={`w-4 h-4 shrink-0 ${isLoading ? 'animate-spin' : ''}`} />
-              <span>ATUALIZAR</span>
-            </button>
+              <MultiSelectFilter
+                label="LIGAS"
+                placeholder="TODAS LIGAS"
+                options={[
+                  ...uniqueLeagues.map(league => ({
+                    value: league,
+                    label: league.toUpperCase()
+                  })),
+                  { value: '__empty__', label: 'SEM CLASSIFICAÇÃO' }
+                ]}
+                selected={filters.league}
+                onChange={(values) => setFilters(prev => ({ ...prev, league: values }))}
+              />
+
+              <MultiSelectFilter
+                label="MERCADOS"
+                placeholder="TODOS MERCADOS"
+                options={[
+                  ...uniqueBettingMarkets.map(market => ({
+                    value: market,
+                    label: market.toUpperCase()
+                  })),
+                  { value: '__empty__', label: 'SEM CLASSIFICAÇÃO' }
+                ]}
+                selected={filters.betting_market}
+                onChange={(values) => setFilters(prev => ({ ...prev, betting_market: values }))}
+              />
+
+              <MultiSelectFilter
+                label="TAGS"
+                placeholder="TODAS AS TAGS"
+                options={userTags.map(tag => ({
+                  value: tag.id,
+                  label: tag.name.toUpperCase()
+                }))}
+                selected={filters.selectedTags}
+                onChange={(values) => setFilters(prev => ({ ...prev, selectedTags: values }))}
+              />
+
+              <button
+                type="button"
+                onClick={clearAllFilters}
+                className="terminal-input px-3 py-1.5 text-xs flex items-center justify-center gap-1.5 border border-terminal-border hover:border-terminal-red hover:text-terminal-red transition-colors rounded-sm whitespace-nowrap"
+              >
+                <X className="w-3.5 h-3.5 shrink-0" />
+                <span>Limpar Filtros</span>
+              </button>
+
+              <div className="relative col-span-2 md:w-auto md:min-w-[120px] md:max-w-[140px]">
+                <Search className="absolute left-2 top-1/2 transform -translate-y-1/2 w-4 h-4 text-terminal-text opacity-50" />
+                <input
+                  type="text"
+                  placeholder="Buscar aposta..."
+                  className="terminal-input w-full pl-8 pr-3 py-1.5 text-xs rounded-sm"
+                  value={filters.searchQuery}
+                  onChange={(e) => setFilters(prev => ({ ...prev, searchQuery: e.target.value }))}
+                />
+              </div>
           </div>
         </div>
 
@@ -2090,6 +2087,13 @@ export default function Bets() {
               </label>
             </div>
             <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={fetchBets}
+                className="terminal-button px-3 py-2 text-sm flex items-center justify-center gap-1.5 border-terminal-border hover:border-terminal-green transition-colors"
+              >
+                <RefreshCw className={`w-4 h-4 shrink-0 ${isLoading ? 'animate-spin' : ''}`} />
+              </button>
             <button
               type="button"
               onClick={() => {
@@ -2142,13 +2146,14 @@ export default function Bets() {
                       <SortableHeader column="bet_date" label="DATA" />
                       <th className="text-left py-1.5 px-1.5 data-label">DESCRIÇÃO</th>
                       <th className="text-left py-1.5 px-1.5 data-label">TAGS</th>
-                      <SortableHeader column="sport" label="ESPORTE" />
-                      <SortableHeader column="league" label="LIGA" />
-                      <SortableHeader column="betting_market" label="MERCADO" />
                       <SortableHeader column="stake_amount" label="VALOR" align="right" />
                       <SortableHeader column="odds" label="ODDS" align="right" />
                       <SortableHeader column="return" label="RETORNO" align="right" className="min-w-[5.5rem]" />
+                      <SortableHeader column="profit" label="LUCRO" align="right" className="min-w-[5.5rem]" />
                       <SortableHeader column="status" label="STATUS" align="center" className="min-w-[5rem]" />
+                      <SortableHeader column="sport" label="ESPORTE" />
+                      <SortableHeader column="league" label="LIGA" />
+                      <SortableHeader column="betting_market" label="MERCADO" />
                       <th className="text-right py-1.5 px-1.5 data-label min-w-[11rem]">AÇÕES</th>
                     </tr>
                   </thead>
@@ -2215,19 +2220,15 @@ export default function Bets() {
       {selectedBetIds.size > 0 && (
         <div className="fixed bottom-0 left-0 right-0 z-50 flex justify-center px-3 pb-3 pointer-events-none">
           <div className="container flex items-center gap-2 px-4 py-3 bg-terminal-dark-gray border border-white/10 rounded-lg shadow-lg pointer-events-auto">
-            <span className="text-xs text-terminal-green font-bold whitespace-nowrap">
-              {selectedBetIds.size} Aposta{selectedBetIds.size !== 1 ? 's' : ''} selecionada{selectedBetIds.size !== 1 ? 's' : ''}
-            </span>
-            <button type="button" onClick={clearSelection}
-              className="text-xs text-terminal-text/50 hover:text-terminal-text transition-colors">
-              ×
-            </button>
-            {filteredBets.length > paginatedBets.length && (
-              <button type="button" onClick={selectAllFiltered}
-                className="hidden md:inline text-xs text-terminal-blue underline hover:no-underline whitespace-nowrap">
-                Selecionar todas as {filteredBets.length}
+            <div className="flex items-center gap-1.5 border border-white/15 rounded px-2 py-1">
+              <span className="text-xs text-terminal-green font-bold whitespace-nowrap">
+                {selectedBetIds.size} Aposta{selectedBetIds.size !== 1 ? 's' : ''} selecionada{selectedBetIds.size !== 1 ? 's' : ''}
+              </span>
+              <button type="button" onClick={clearSelection}
+                className="text-xs text-terminal-text/50 hover:text-terminal-text transition-colors leading-none">
+                ×
               </button>
-            )}
+            </div>
             <div className="flex-1" />
 
             {/* Mobile: single "Ações" button opening a bottom sheet */}
@@ -2240,17 +2241,9 @@ export default function Bets() {
                   </button>
                 </SheetTrigger>
                 <SheetContent side="bottom" className="bg-terminal-dark-gray border-t border-white/10 px-4 pb-8 pt-4 rounded-t-xl">
-                  <div className="flex items-center justify-between mb-3">
-                    <p className="text-xs text-terminal-text/50">
-                      {selectedBetIds.size} Aposta{selectedBetIds.size !== 1 ? 's' : ''} selecionada{selectedBetIds.size !== 1 ? 's' : ''}
-                    </p>
-                    {filteredBets.length > paginatedBets.length && (
-                      <button type="button" onClick={selectAllFiltered}
-                        className="text-xs text-terminal-blue underline hover:no-underline">
-                        Selecionar todas as {filteredBets.length}
-                      </button>
-                    )}
-                  </div>
+                  <p className="text-xs text-terminal-text/50 mb-3 pr-8">
+                    {selectedBetIds.size} Aposta{selectedBetIds.size !== 1 ? 's' : ''} selecionada{selectedBetIds.size !== 1 ? 's' : ''}
+                  </p>
                   <div className="grid grid-cols-2 gap-2">
                     <button type="button" onClick={() => bulkUpdateStatus('won')}
                       className="py-3 text-xs font-bold border border-terminal-green text-terminal-green hover:bg-terminal-green hover:text-terminal-black rounded transition-colors flex items-center justify-center gap-2">
@@ -2406,6 +2399,65 @@ export default function Bets() {
               </div>
             </div>
           )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Capital Movement Modal (Aporte/Resgate) */}
+      <Dialog open={capitalModal.isOpen} onOpenChange={(open) => setCapitalModal(prev => ({ ...prev, isOpen: open }))}>
+        <DialogContent className="bg-terminal-dark-gray border-terminal-border text-terminal-text sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="text-terminal-blue">
+              {capitalModal.type === 'deposit' ? 'APORTE' : 'RESGATE'}
+            </DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label className="text-xs uppercase opacity-70">Valor</Label>
+              <Input
+                type="number"
+                value={capitalModal.amount}
+                onChange={(e) => setCapitalModal(prev => ({ ...prev, amount: e.target.value }))}
+                placeholder="0.00"
+                className="bg-terminal-black border-terminal-border text-terminal-text"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label className="text-xs uppercase opacity-70">Descrição (opcional)</Label>
+              <Input
+                value={capitalModal.description}
+                onChange={(e) => setCapitalModal(prev => ({ ...prev, description: e.target.value }))}
+                placeholder="Ex: Depósito via PIX"
+                className="bg-terminal-black border-terminal-border text-terminal-text"
+              />
+            </div>
+            <div className="flex gap-2 pt-2">
+              <Button
+                onClick={() => setCapitalModal(prev => ({ ...prev, isOpen: false }))}
+                variant="outline"
+                className="flex-1 border-terminal-border hover:bg-terminal-gray text-terminal-text"
+              >
+                CANCELAR
+              </Button>
+              <Button
+                onClick={async () => {
+                  const amount = parseFloat(capitalModal.amount);
+                  if (isNaN(amount) || amount <= 0) return;
+                  await addMovement({
+                    type: capitalModal.type,
+                    amount,
+                    description: capitalModal.description || undefined,
+                    affects_balance: true,
+                  });
+                  setCapitalModal({ isOpen: false, type: 'deposit', amount: '', description: '' });
+                  toast({ title: 'Sucesso', description: capitalModal.type === 'deposit' ? 'Aporte registrado' : 'Resgate registrado' });
+                }}
+                disabled={!capitalModal.amount || parseFloat(capitalModal.amount) <= 0}
+                className="flex-1 bg-terminal-blue hover:bg-blue-600 text-white"
+              >
+                CONFIRMAR
+              </Button>
+            </div>
+          </div>
         </DialogContent>
       </Dialog>
 
@@ -2789,6 +2841,18 @@ export default function Bets() {
                 </div>
               </div>
 
+              <div className="flex items-center gap-3">
+                <Label className="text-xs uppercase opacity-70">Crédito de apostas</Label>
+                <button
+                  type="button"
+                  onClick={() => setEditModal(prev => ({ ...prev, formData: { ...prev.formData, is_credit_bet: !prev.formData.is_credit_bet } }))}
+                  style={{ backgroundColor: editModal.formData.is_credit_bet ? 'var(--terminal-green)' : '#3d4a5c' }}
+                  className="relative w-10 h-5 rounded-full transition-colors flex-shrink-0"
+                >
+                  <span style={{ transform: editModal.formData.is_credit_bet ? 'translateX(22px)' : 'translateX(2px)' }} className="absolute top-0.5 left-0 w-4 h-4 bg-white rounded-full shadow transition-transform" />
+                </button>
+              </div>
+
               <div className="space-y-2">
                 <Label className="text-xs uppercase opacity-70">Data da Aposta</Label>
                 <Popover open={isEditDatePopoverOpen} onOpenChange={setIsEditDatePopoverOpen} modal>
@@ -2809,12 +2873,12 @@ export default function Bets() {
                       mode="single"
                       selected={parseDateString(editModal.formData.bet_date) || undefined}
                       onSelect={(date) => {
-                        setEditModal(prev => ({ 
-                          ...prev, 
-                          formData: { 
-                            ...prev.formData, 
-                            bet_date: formatDateToString(date) 
-                          } 
+                        setEditModal(prev => ({
+                          ...prev,
+                          formData: {
+                            ...prev.formData,
+                            bet_date: formatDateToString(date)
+                          }
                         }));
                         setIsEditDatePopoverOpen(false);
                       }}
@@ -2827,8 +2891,8 @@ export default function Bets() {
 
               <div className="space-y-2">
                 <Label className="text-xs uppercase opacity-70">Status</Label>
-                <Select 
-                  value={editModal.formData.status} 
+                <Select
+                  value={editModal.formData.status}
                   onValueChange={(value: any) => setEditModal(prev => ({ ...prev, formData: { ...prev.formData, status: value } }))}
                 >
                   <SelectTrigger className="bg-terminal-black border-terminal-border text-terminal-text">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -109,11 +109,11 @@ export default function Home() {
           <div className="max-w-4xl mx-auto">
             {/* Title and Badge */}
             <div className="flex items-center justify-center gap-3 mb-6">
-              <div className="w-12 h-12 bg-terminal-green/20 border border-terminal-green rounded-lg flex items-center justify-center">
-                <Trophy className="w-6 h-6 text-terminal-green" />
+              <div className="w-12 h-12 bg-terminal-blue/20 border border-terminal-blue rounded-lg flex items-center justify-center">
+                <Trophy className="w-6 h-6 text-terminal-blue" />
               </div>
               <div className="text-center">
-                <h1 className="text-2xl md:text-3xl font-bold tracking-wider text-terminal-green mb-1">
+                <h1 className="text-2xl md:text-3xl font-bold tracking-wider text-terminal-blue mb-1">
                   NBA ANALYTICS
                 </h1>
                 <div className="flex items-center justify-center gap-2">
@@ -132,7 +132,7 @@ export default function Home() {
             {/* Value Proposition */}
             <p className="text-center text-sm md:text-base text-terminal-text opacity-80 mb-6 max-w-2xl mx-auto">
               Análises avançadas de dados para suas apostas na NBA. 
-              <span className="text-terminal-green font-semibold"> Baseado em evidências, não em palpites.</span>
+              <span className="text-terminal-blue font-semibold"> Baseado em evidências, não em palpites.</span>
             </p>
           </div>
         </div>
@@ -225,10 +225,10 @@ export default function Home() {
           <section className="bg-terminal-dark-gray border border-terminal-border-subtle rounded-lg p-6 md:p-8">
             <div className="max-w-3xl mx-auto">
               <div className="text-center mb-6">
-                <div className="inline-flex items-center justify-center w-16 h-16 bg-terminal-green/20 border-2 border-terminal-green rounded-full mb-4">
-                  <Zap className="w-8 h-8 text-terminal-green" />
+                <div className="inline-flex items-center justify-center w-16 h-16 bg-terminal-blue/20 border-2 border-terminal-blue rounded-full mb-4">
+                  <Zap className="w-8 h-8 text-terminal-blue" />
                 </div>
-                <h2 className="text-xl md:text-2xl font-bold text-terminal-green mb-2">
+                <h2 className="text-xl md:text-2xl font-bold text-terminal-blue mb-2">
                   Desbloqueie Análises Avançadas
                 </h2>
                 <p className="text-sm text-terminal-text opacity-70">

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -300,7 +300,7 @@ const Landing = () => {
                     { title: 'Backcourt', fga: '0.1', fgm: '0.0', pct: '0.0%' },
                   ].map((z) => (
                     <div key={z.title} className="p-3 bg-terminal-dark-gray border border-terminal-border-subtle rounded-sm">
-                      <div className="text-xs font-bold text-terminal-green mb-2">{z.title}</div>
+                      <div className="text-xs font-bold text-terminal-blue mb-2">{z.title}</div>
                       <div className="flex items-center justify-between text-xs">
                         <div className="flex flex-col">
                           <span className="opacity-60">FGA</span>

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -145,7 +145,7 @@ export default function Onboarding() {
   const renderStep0 = () => (
     <div className="max-w-md mx-auto">
       <div className="terminal-container p-6 rounded-lg">
-        <h2 className="section-title text-base md:text-lg text-center mb-2 text-terminal-green">
+        <h2 className="section-title text-base md:text-lg text-center mb-2 text-terminal-blue">
           O que você quer fazer primeiro?
         </h2>
         <p className="text-center text-sm text-terminal-text opacity-70 mb-6">

--- a/src/pages/PlayerSelection.tsx
+++ b/src/pages/PlayerSelection.tsx
@@ -216,11 +216,11 @@ export default function PlayerSelection() {
         <header className="terminal-header p-4 sticky top-0 z-10">
           <div className="container mx-auto flex items-center justify-between">
             <div className="flex items-center space-x-3">
-              <div className="w-8 h-8 bg-terminal-green/20 border border-terminal-green rounded flex items-center justify-center">
-                <Trophy className="w-4 h-4 text-terminal-green" />
+              <div className="w-8 h-8 bg-terminal-blue/20 border border-terminal-blue rounded flex items-center justify-center">
+                <Trophy className="w-4 h-4 text-terminal-blue" />
               </div>
               <div>
-                <h1 className="text-lg font-bold tracking-wider text-terminal-green">PLAYER DATABASE</h1>
+                <h1 className="text-lg font-bold tracking-wider text-terminal-blue">PLAYER DATABASE</h1>
                 <p className="text-[10px] text-terminal-text opacity-60">SECURE CONNECTION ESTABLISHED</p>
               </div>
             </div>

--- a/supabase/migrations/031_add_is_credit_bet.sql
+++ b/supabase/migrations/031_add_is_credit_bet.sql
@@ -1,0 +1,4 @@
+-- Add is_credit_bet field to bets table
+-- Credit bets return only the profit (stake x (odds - 1)) instead of full return (stake x odds)
+ALTER TABLE public.bets
+ADD COLUMN IF NOT EXISTS is_credit_bet boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
- BankrollEvolutionChart: layout 75/25, painel lateral com gestão da banca, botões Aporte/Resgate com background, navegação padronizada
- BetsHeader: unificado com AnalyticsNav (logo Smartbetting, menus Análises/Betinho, controles à direita)
- Filtros reordenados e padronizados (Status > Esporte > Data > Ligas > Mercados > Tags > Buscar > Limpar)
- Tabela: coluna Tags entre Descrição e Valor, Retorno neutro, Lucro condicional no mobile
- Mobile: último card de stats lado a lado com separador vertical, col-span-2
- TagSelector compactado (badges menores, layout inline)
- Auditoria de cores: revert text-terminal-green → text-terminal-blue em headers, modais, nav e componentes share
- Fix: --terminal-green corrigido para #4ade80 (era #5b9bd5 idêntico ao blue)
- Migração: 031_add_is_credit_bet.sql