### PR TITLE
feat: restrict report access to premium, trial, and flagged users

### DIFF
--- a/src/hooks/use-report-access.ts
+++ b/src/hooks/use-report-access.ts
@@ -1,0 +1,72 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '@/hooks/use-auth';
+import { createClient } from '@/integrations/supabase/client';
+
+const QUERY_KEY = ['report_access'] as const;
+const TRIAL_DAYS = 7;
+
+interface ReportAccessData {
+  created_at: string | null;
+  analytics_subscription_status: string | null;
+  betinho_subscription_status: string | null;
+  has_report_access: boolean | null;
+}
+
+function checkAccess(data: ReportAccessData): { hasAccess: boolean; reason: 'trial' | 'premium' | 'manual' | null } {
+  // 1. Manual flag
+  if (data.has_report_access) {
+    return { hasAccess: true, reason: 'manual' };
+  }
+
+  // 2. Premium (any subscription)
+  if (data.analytics_subscription_status === 'premium' || data.betinho_subscription_status === 'premium') {
+    return { hasAccess: true, reason: 'premium' };
+  }
+
+  // 3. Trial (signed up in the last N days)
+  if (data.created_at) {
+    const createdAt = new Date(data.created_at);
+    const now = new Date();
+    const diffMs = now.getTime() - createdAt.getTime();
+    const diffDays = diffMs / (1000 * 60 * 60 * 24);
+    if (diffDays <= TRIAL_DAYS) {
+      return { hasAccess: true, reason: 'trial' };
+    }
+  }
+
+  return { hasAccess: false, reason: null };
+}
+
+async function fetchReportAccess(userId: string) {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('users')
+    .select('created_at, analytics_subscription_status, betinho_subscription_status, has_report_access')
+    .eq('id', userId)
+    .single();
+
+  if (error) {
+    console.error('Error fetching report access:', error);
+    return { hasAccess: false, reason: null } as const;
+  }
+
+  return checkAccess(data as ReportAccessData);
+}
+
+export function useReportAccess() {
+  const { user } = useAuth();
+
+  const query = useQuery({
+    queryKey: [...QUERY_KEY, user?.id ?? ''],
+    queryFn: () => fetchReportAccess(user!.id),
+    enabled: !!user?.id,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+
+  return {
+    hasAccess: query.data?.hasAccess ?? false,
+    reason: query.data?.reason ?? null,
+    isLoading: query.isLoading,
+  };
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -505,6 +505,7 @@ export type Database = {
           conversation_id: string | null
           created_at: string | null
           email: string
+          has_report_access: boolean | null
           id: string
           name: string | null
           referral_code: string | null
@@ -543,6 +544,7 @@ export type Database = {
           conversation_id?: string | null
           created_at?: string | null
           email: string
+          has_report_access?: boolean | null
           id?: string
           name?: string | null
           referral_code?: string | null
@@ -581,6 +583,7 @@ export type Database = {
           conversation_id?: string | null
           created_at?: string | null
           email?: string
+          has_report_access?: boolean | null
           id?: string
           name?: string | null
           referral_code?: string | null

--- a/src/pages/Report.tsx
+++ b/src/pages/Report.tsx
@@ -1,10 +1,12 @@
 import { useState, useEffect, useMemo } from 'react';
-import { FileText, Loader2, AlertCircle, Calendar as CalendarIcon } from 'lucide-react';
+import { FileText, Loader2, AlertCircle, Calendar as CalendarIcon, Lock } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Calendar } from '@/components/ui/calendar';
+import { useReportAccess } from '@/hooks/use-report-access';
 
 const BUCKET = 'reports';
 const SIGNED_URL_EXPIRY = 3600;
@@ -41,6 +43,8 @@ interface ReportEntry {
 }
 
 export default function WeeklyReport() {
+  const { hasAccess, isLoading: accessLoading } = useReportAccess();
+  const navigate = useNavigate();
   const [reports, setReports] = useState<ReportEntry[]>([]);
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
@@ -153,6 +157,42 @@ export default function WeeklyReport() {
   };
 
   const isLoading = loading || loadingPdf;
+
+  if (accessLoading) {
+    return (
+      <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
+        <AnalyticsNav />
+        <div className="flex flex-col items-center justify-center py-20 gap-3">
+          <Loader2 className="w-8 h-8 animate-spin text-terminal-green" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!hasAccess) {
+    return (
+      <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
+        <AnalyticsNav />
+        <div className="flex flex-col items-center justify-center py-20 gap-4 text-center px-4">
+          <div className="w-16 h-16 bg-terminal-yellow/10 border border-terminal-yellow/30 rounded-full flex items-center justify-center">
+            <Lock className="w-8 h-8 text-terminal-yellow" />
+          </div>
+          <h2 className="text-lg font-bold text-terminal-yellow tracking-wider">
+            ACESSO RESTRITO
+          </h2>
+          <p className="text-terminal-text opacity-60 text-sm max-w-md">
+            Os relatórios estão disponíveis para assinantes premium e novos usuários em período de teste.
+          </p>
+          <Button
+            onClick={() => navigate('/paywall')}
+            className="mt-2 bg-terminal-green text-terminal-black hover:bg-terminal-green/90 font-bold tracking-wider"
+          >
+            VER PLANOS
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">

--- a/supabase/migrations/032_add_has_report_access.sql
+++ b/supabase/migrations/032_add_has_report_access.sql
@@ -1,0 +1,6 @@
+-- Add manual flag for report access
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS has_report_access boolean DEFAULT false;
+
+-- Allow RLS reads (users already have SELECT on their own row)
+COMMENT ON COLUMN public.users.has_report_access IS 'Manual flag to grant report access — set via Supabase dashboard';


### PR DESCRIPTION
## Summary
- Reports now require one of 3 conditions to access: premium subscription (analytics or betinho), account created within last 7 days (trial), or manual `has_report_access` flag set in Supabase
- Blocked users see a styled "ACESSO RESTRITO" screen with paywall redirect
- New `useReportAccess` hook handles the access check with React Query caching
- New migration adds `has_report_access` boolean column to `users` table

## Files changed
- `src/hooks/use-report-access.ts` — new hook
- `src/pages/Report.tsx` — access gate + blocked UI
- `src/integrations/supabase/types.ts` — new column type
- `supabase/migrations/032_add_has_report_access.sql` — DB migration

## How to manually grant access
```sql
UPDATE users SET has_report_access = true WHERE email = 'user@example.com';
```

## Test plan
- [ ] Premium user can access reports normally
- [ ] New user (< 7 days) can access reports
- [ ] Free user (> 7 days) sees "ACESSO RESTRITO" screen
- [ ] User with `has_report_access = true` can access regardless of subscription
- [ ] "VER PLANOS" button redirects to /paywall
- [ ] Run migration on staging and verify column exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)