### PR TITLE
feat: tela Oportunidades do Dia + insights Q/D + multi-teammate filter + plus_minus B2B

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Landing from "./pages/Landing";
 import Auth from "./pages/Auth";
 import Home from "./pages/Home";
+import Picks from "./pages/Picks";
 import NBADashboard from "./pages/NBADashboard";
 import ProtectedRoute from "./components/ProtectedRoute";
 import PremiumRoute from "./components/PremiumRoute";
@@ -55,6 +56,7 @@ const App = () => (
           <Routes>
             <Route path="/" element={<Landing />} />
             <Route path="/home-players" element={<Home />} />
+            <Route path="/oportunidades" element={<Picks />} />
             <Route path="/betinho" element={<Betinho />} />
             <Route path="/auth" element={
               <ProtectedRoute requireAuth={false}>

--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -12,7 +12,8 @@ import {
   ChevronLeft,
   ChevronDown,
   Target,
-  FileText
+  FileText,
+  TrendingUp
 } from 'lucide-react';
 import { useAuth } from '../hooks/use-auth';
 import { useSubscription } from '@/hooks/use-subscription';
@@ -42,6 +43,7 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
 
   const analysisItems = [
     { name: 'Home NBA', href: '/home-players', icon: BarChart3 },
+    { name: 'Oportunidades do Dia', href: '/oportunidades', icon: TrendingUp },
     { name: 'Jogos', href: '/home-games', icon: Calendar },
     { name: 'Jogadores', href: '/nba-players', icon: Users },
     { name: 'Relatório', href: '/report', icon: FileText },

--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -34,6 +34,7 @@ export default function MainNav({ className }: MainNavProps) {
 
   const analysisItems = [
     { name: 'Home NBA', href: '/home-players', icon: BarChart3 },
+    { name: 'Oportunidades do Dia', href: '/oportunidades', icon: TrendingUp },
     { name: 'Jogos', href: '/home-games', icon: TrendingUp },
     { name: 'Jogadores', href: '/nba-players', icon: Users },
     { name: 'Relatório', href: '/report', icon: FileText },

--- a/src/components/nba/GameChart.tsx
+++ b/src/components/nba/GameChart.tsx
@@ -489,11 +489,21 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
                     </div>
                   </div>
                   <div className="flex gap-1.5 shrink-0">
-                    <button onClick={() => { onTeammateFilterChange({ playerId: t.player_id, playerName: t.player_name, mode: 'with' }); setTeammateOpen(false); }}
+                    <button onClick={() => {
+                      const entry = { playerId: t.player_id, playerName: t.player_name, mode: 'with' as const };
+                      const current = teammateFilter ?? [];
+                      const filtered = current.filter(f => f.playerId !== t.player_id);
+                      onTeammateFilterChange([...filtered, entry]);
+                    }}
                       className="px-2.5 py-1 text-[11px] rounded border border-terminal-green/40 text-terminal-green hover:bg-terminal-green/15 transition-colors">
                       COM
                     </button>
-                    <button onClick={() => { onTeammateFilterChange({ playerId: t.player_id, playerName: t.player_name, mode: 'without' }); setTeammateOpen(false); }}
+                    <button onClick={() => {
+                      const entry = { playerId: t.player_id, playerName: t.player_name, mode: 'without' as const };
+                      const current = teammateFilter ?? [];
+                      const filtered = current.filter(f => f.playerId !== t.player_id);
+                      onTeammateFilterChange([...filtered, entry]);
+                    }}
                       className="px-2.5 py-1 text-[11px] rounded border border-terminal-red/40 text-terminal-red hover:bg-terminal-red/15 transition-colors">
                       SEM
                     </button>
@@ -504,29 +514,33 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
 
             return (
               <div className="relative" ref={teammateDropdownRef}>
-                {/* Button / active badge */}
-                {teammateFilter ? (
-                  <div className="flex items-center gap-1">
-                    <span className={`text-[10px] px-2 py-0.5 rounded border font-medium ${
-                      teammateFilter.mode === 'with'
-                        ? 'bg-terminal-green/15 border-terminal-green/50 text-terminal-green'
-                        : 'bg-terminal-red/15 border-terminal-red/50 text-terminal-red'
-                    }`}>
-                      {teammateFilter.mode === 'with' ? 'COM' : 'SEM'} {teammateFilter.playerName.split(' ').pop()}
-                    </span>
-                    <button onClick={() => onTeammateFilterChange(null)}
-                      className="w-5 h-5 flex items-center justify-center rounded border border-white/20 text-white/40 hover:text-white/80 hover:border-white/40 transition-colors">
-                      <X className="w-3 h-3" />
-                    </button>
-                  </div>
-                ) : (
+                {/* Active filter badges + add button */}
+                <div className="flex items-center gap-1 flex-wrap">
+                  {teammateFilter && teammateFilter.length > 0 && teammateFilter.map(f => (
+                    <div key={f.playerId} className="flex items-center gap-0.5">
+                      <span className={`text-[10px] px-2 py-0.5 rounded border font-medium ${
+                        f.mode === 'with'
+                          ? 'bg-terminal-green/15 border-terminal-green/50 text-terminal-green'
+                          : 'bg-terminal-red/15 border-terminal-red/50 text-terminal-red'
+                      }`}>
+                        {f.mode === 'with' ? 'COM' : 'SEM'} {f.playerName.split(' ').pop()}
+                      </span>
+                      <button onClick={() => {
+                        const updated = teammateFilter.filter(tf => tf.playerId !== f.playerId);
+                        onTeammateFilterChange(updated.length > 0 ? updated : null);
+                      }}
+                        className="w-4 h-4 flex items-center justify-center rounded border border-white/20 text-white/40 hover:text-white/80 hover:border-white/40 transition-colors">
+                        <X className="w-2.5 h-2.5" />
+                      </button>
+                    </div>
+                  ))}
                   <button onClick={() => setTeammateOpen(v => !v)} disabled={teammateFilterLoading}
                     className="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border border-terminal-green/30 text-terminal-text hover:border-terminal-green/50 hover:bg-terminal-green/5 transition-all disabled:opacity-40">
                     <Users className="w-3 h-3" />
-                    <span>Companheiro</span>
+                    <span>{teammateFilter && teammateFilter.length > 0 ? '+' : 'Companheiro'}</span>
                     <ChevronDown className={`w-3 h-3 transition-transform ${teammateOpen ? 'rotate-180' : ''}`} />
                   </button>
-                )}
+                </div>
 
                 {teammateOpen && (
                   <>
@@ -587,9 +601,17 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
         )}
       </div>
 
+      <div className="relative">
+      {teammateFilterLoading && (
+        <div className="absolute inset-0 z-20 flex items-center justify-center pointer-events-none">
+          <span className="text-sm font-semibold text-terminal-text bg-terminal-dark-gray px-4 py-2 rounded-lg border border-terminal-border-subtle animate-pulse shadow-lg">
+            Recalculando...
+          </span>
+        </div>
+      )}
       <div
         ref={chartContainerRef}
-        className={`h-72 ${isDragging ? 'cursor-grabbing' : adjustedLine !== null ? 'cursor-grab' : ''}`}
+        className={`h-72 ${isDragging ? 'cursor-grabbing' : adjustedLine !== null ? 'cursor-grab' : ''} ${teammateFilterLoading ? 'opacity-30' : ''} transition-opacity duration-200`}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
@@ -599,8 +621,8 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
         style={{ userSelect: 'none', touchAction: 'pan-x' }}
       >
         <ResponsiveContainer width="100%" height="100%">
-          <BarChart 
-            data={chartData} 
+          <BarChart
+            data={chartData}
             margin={{
               top: 5,
               right: 30,
@@ -662,7 +684,8 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
           </BarChart>
         </ResponsiveContainer>
       </div>
-      
+      </div>
+
       {/* Footer */}
       <div className="mt-3 pt-2.5 border-t border-white/10 flex items-center justify-between text-[10px]">
         {/* Legenda */}

--- a/src/components/nba/PropInsightsCard.tsx
+++ b/src/components/nba/PropInsightsCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { PropPlayer } from '@/services/nba-data.service';
-import { Lightbulb, Star, ChevronRight } from 'lucide-react';
+import { Lightbulb, AlertTriangle, Star, ChevronRight } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 
 const STAT_LABELS: Record<string, string> = {
@@ -18,20 +18,33 @@ const STAT_LABELS: Record<string, string> = {
   player_double_double: 'Double-Double',
 };
 
-const STAT_LABELS_SHORT: Record<string, string> = {
-  player_points: 'pontos',
-  player_assists: 'assistências',
-  player_rebounds: 'rebotes',
-  player_threes: '3 pontos',
-  player_steals: 'roubos',
-  player_blocks: 'bloqueios',
-  player_turnovers: 'turnovers',
-  player_points_assists: 'pts + ast',
-  player_points_rebounds: 'pts + reb',
-  player_rebounds_assists: 'reb + ast',
-  player_points_rebounds_assists: 'PRA',
-  player_double_double: 'double-doubles',
+const STAT_LABELS_SHORT: Record<string, { article: string; name: string }> = {
+  player_points: { article: 'os', name: 'pontos' },
+  player_assists: { article: 'as', name: 'assistências' },
+  player_rebounds: { article: 'os', name: 'rebotes' },
+  player_threes: { article: 'os', name: '3 pontos' },
+  player_steals: { article: 'os', name: 'roubos' },
+  player_blocks: { article: 'os', name: 'bloqueios' },
+  player_turnovers: { article: 'os', name: 'turnovers' },
+  player_points_assists: { article: 'os', name: 'pts + ast' },
+  player_points_rebounds: { article: 'os', name: 'pts + reb' },
+  player_rebounds_assists: { article: 'os', name: 'reb + ast' },
+  player_points_rebounds_assists: { article: 'o', name: 'PRA' },
+  player_double_double: { article: 'os', name: 'double-doubles' },
 };
+
+const STATUS_CONFIG: Record<string, { badge: string; badgeClass: string; color: string }> = {
+  out: { badge: 'OUT', badgeClass: 'bg-terminal-red/20 text-terminal-red', color: 'text-terminal-red' },
+  'out for season': { badge: 'OFS', badgeClass: 'bg-terminal-red/20 text-terminal-red', color: 'text-terminal-red' },
+  doubtful: { badge: 'DTD', badgeClass: 'bg-orange-400/20 text-orange-400', color: 'text-orange-400' },
+  questionable: { badge: 'Q', badgeClass: 'bg-yellow-400/20 text-yellow-400', color: 'text-yellow-400' },
+};
+
+function isConfirmedOut(status: string | null): boolean {
+  if (!status) return false;
+  const s = status.toLowerCase();
+  return s === 'out' || s === 'out for season';
+}
 
 interface PropInsightsCardProps {
   propPlayers: PropPlayer[];
@@ -56,7 +69,7 @@ export const PropInsightsCard: React.FC<PropInsightsCardProps> = ({ propPlayers,
     );
   }
 
-  // Apenas props com gatilho ativo
+  // Apenas props com gatilho ativo e impacto positivo
   const backupProps = propPlayers.filter(
     p => p.is_available_backup &&
       p.next_available_player_name?.trim() &&
@@ -64,107 +77,156 @@ export const PropInsightsCard: React.FC<PropInsightsCardProps> = ({ propPlayers,
       p.next_player_stats_when_leader_out > p.next_player_stats_normal
   );
 
-  // Sem gatilho → sem card
   if (backupProps.length === 0) return null;
 
-  // Trigger name: pega do primeiro (todos compartilham o mesmo gatilho no contexto do time)
-  const triggerName = backupProps[0].next_available_player_name;
-  const triggerLastName = triggerName.split(' ').pop();
   const playerLastName = playerName.split(' ').pop() || playerName;
+
+  // Agrupar por gatilho (pode ter mais de um líder lesionado)
+  const byTrigger = new Map<string, PropPlayer[]>();
+  backupProps.forEach(p => {
+    const key = p.next_available_player_name;
+    if (!byTrigger.has(key)) byTrigger.set(key, []);
+    byTrigger.get(key)!.push(p);
+  });
+
+  // Ordenar: Out primeiro, depois Doubtful, depois Questionable
+  const statusOrder = (s: string | null) => {
+    if (!s) return 99;
+    const l = s.toLowerCase();
+    if (l === 'out' || l === 'out for season') return 0;
+    if (l === 'doubtful') return 1;
+    return 2;
+  };
+
+  const triggerGroups = Array.from(byTrigger.entries())
+    .map(([name, props]) => ({ name, props, status: props[0].leader_injury_status }))
+    .sort((a, b) => statusOrder(a.status) - statusOrder(b.status));
 
   return (
     <div className="terminal-container p-4">
-      {/* Header — INSIGHT label */}
-      <div className="flex items-center gap-2 mb-1">
-        <Lightbulb className="w-3.5 h-3.5 text-terminal-yellow shrink-0" />
-        <span className="text-[10px] font-bold text-terminal-yellow uppercase tracking-widest">
-          Insight
-        </span>
-      </div>
-
-      {/* Storytelling — narrative sentence */}
-      <p className="text-xs text-terminal-text opacity-80 mb-3 leading-relaxed">
-        Com <span className="font-bold text-terminal-red">{triggerLastName}</span> fora,{' '}
-        {backupProps.length === 1 ? (
-          <>
-            os <span className="font-bold text-terminal-green">
-              {STAT_LABELS_SHORT[backupProps[0].stat_type] ?? backupProps[0].stat_type.replace('player_', '').replace(/_/g, ' ')}
-            </span> de {playerLastName} sobem{' '}
-            <span className="font-bold text-terminal-green">
-              +{backupProps[0].next_player_stats_normal > 0
-                ? Math.round(((backupProps[0].next_player_stats_when_leader_out - backupProps[0].next_player_stats_normal) / backupProps[0].next_player_stats_normal) * 100)
-                : 0}%
-            </span>
-          </>
-        ) : (
-          <>
-            as médias de {playerLastName} sobem em{' '}
-            <span className="font-bold text-terminal-green">
-              {backupProps.length} categorias
-            </span>
-          </>
-        )}
-      </p>
-
-      {/* Oportunidades — clickable */}
-      <div className="space-y-2">
-        {backupProps.map((prop, i) => {
-          const normal = prop.next_player_stats_normal;
-          const semEle = prop.next_player_stats_when_leader_out;
-          const gap = semEle - normal;
-          const gapPct = normal > 0 ? Math.round((gap / normal) * 100) : 0;
-          const statLabel = STAT_LABELS[prop.stat_type] ?? prop.stat_type.replace('player_', '').replace(/_/g, ' ');
-          const isClickable = !!onInsightClick;
+      <div className="space-y-4">
+        {triggerGroups.map((group) => {
+          const triggerLastName = group.name.split(' ').pop();
+          const status = group.status?.toLowerCase() || 'out';
+          const config = STATUS_CONFIG[status] || STATUS_CONFIG['out'];
+          const confirmed = isConfirmedOut(group.status);
 
           return (
-            <button
-              key={i}
-              className={`w-full text-left bg-terminal-dark-gray rounded border border-terminal-yellow/20 p-3 transition-all ${
-                isClickable ? 'hover:border-terminal-yellow/50 hover:bg-terminal-yellow/5 cursor-pointer' : 'cursor-default'
-              }`}
-              onClick={() => onInsightClick?.(prop.stat_type, triggerName)}
-            >
-              {/* Stat + estrelas */}
-              <div className="flex items-center justify-between mb-2">
-                <span className="text-xs font-bold text-terminal-text uppercase">{statLabel}</span>
-                <div className="flex items-center gap-1.5">
-                  {prop.rating_stars > 0 && (
-                    <div className="flex items-center gap-0.5">
-                      {Array.from({ length: prop.rating_stars }).map((_, j) => (
-                        <Star key={j} className="w-3 h-3 fill-terminal-yellow text-terminal-yellow" />
-                      ))}
-                    </div>
-                  )}
-                  {isClickable && (
-                    <ChevronRight className="w-4 h-4 text-terminal-yellow" />
-                  )}
-                </div>
-              </div>
-
-              {/* Números */}
-              <div className="flex items-center gap-2">
-                {normal > 0 && (
-                  <span className="text-sm opacity-50">{normal.toFixed(1)}</span>
+            <div key={group.name}>
+              {/* Header */}
+              <div className="flex items-center gap-2 mb-1">
+                {confirmed ? (
+                  <Lightbulb className="w-3.5 h-3.5 text-terminal-yellow shrink-0" />
+                ) : (
+                  <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
                 )}
-                {normal > 0 && (
-                  <span className="text-xs opacity-30">→</span>
-                )}
-                <span className="text-lg font-bold text-terminal-green leading-none">
-                  {semEle.toFixed(1)}
+                <span className="text-[10px] font-bold text-terminal-yellow uppercase tracking-widest">
+                  {confirmed ? 'Insight' : 'Alerta'}
                 </span>
-                {gapPct > 0 && (
-                  <span className="text-[11px] font-semibold text-terminal-green bg-terminal-green/10 px-1.5 py-0.5 rounded">
-                    +{gapPct}%
-                  </span>
-                )}
+                <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded ${config.badgeClass}`}>
+                  {config.badge}
+                </span>
               </div>
 
-              {normal > 0 && (
-                <div className="text-[9px] opacity-40 mt-1">
-                  média normal → sem {triggerLastName}
-                </div>
-              )}
-            </button>
+              {/* Storytelling */}
+              <p className="text-xs text-terminal-text opacity-80 mb-3 leading-relaxed">
+                {confirmed ? (
+                  <>
+                    Com <span className={`font-bold ${config.color}`}>{triggerLastName}</span> fora,{' '}
+                  </>
+                ) : (
+                  <>
+                    Se <span className={`font-bold ${config.color}`}>{triggerLastName}</span> for confirmado fora,{' '}
+                  </>
+                )}
+                {group.props.length === 1 ? (() => {
+                  const stat = STAT_LABELS_SHORT[group.props[0].stat_type];
+                  const article = stat?.article ?? 'os';
+                  const name = stat?.name ?? group.props[0].stat_type.replace('player_', '').replace(/_/g, ' ');
+                  const pct = group.props[0].next_player_stats_normal > 0
+                    ? Math.round(((group.props[0].next_player_stats_when_leader_out - group.props[0].next_player_stats_normal) / group.props[0].next_player_stats_normal) * 100)
+                    : 0;
+                  return (
+                    <>
+                      {article}{' '}
+                      <span className="font-bold text-terminal-green">{name}</span>
+                      {' '}de {playerLastName} {confirmed ? 'sobem' : 'podem subir'}{' '}
+                      <span className="font-bold text-terminal-green">+{pct}%</span>
+                    </>
+                  );
+                })() : (
+                  <>
+                    as médias de {playerLastName} {confirmed ? 'sobem' : 'podem subir'} em{' '}
+                    <span className="font-bold text-terminal-green">
+                      {group.props.length} categorias
+                    </span>
+                  </>
+                )}
+              </p>
+
+              {/* Oportunidades */}
+              <div className="space-y-2">
+                {group.props.map((prop, i) => {
+                  const normal = prop.next_player_stats_normal;
+                  const semEle = prop.next_player_stats_when_leader_out;
+                  const gap = semEle - normal;
+                  const gapPct = normal > 0 ? Math.round((gap / normal) * 100) : 0;
+                  const statLabel = STAT_LABELS[prop.stat_type] ?? prop.stat_type.replace('player_', '').replace(/_/g, ' ');
+                  const isClickable = !!onInsightClick;
+
+                  return (
+                    <button
+                      key={i}
+                      className={`w-full text-left bg-terminal-dark-gray rounded border p-3 transition-all ${
+                        confirmed ? 'border-terminal-yellow/20' : 'border-yellow-400/15'
+                      } ${isClickable ? 'hover:border-terminal-yellow/50 hover:bg-terminal-yellow/5 cursor-pointer' : 'cursor-default'}`}
+                      onClick={() => onInsightClick?.(prop.stat_type, group.name)}
+                    >
+                      {/* Stat + estrelas */}
+                      <div className="flex items-center justify-between mb-2">
+                        <span className="text-xs font-bold text-terminal-text uppercase">{statLabel}</span>
+                        <div className="flex items-center gap-1.5">
+                          {prop.rating_stars > 0 && (
+                            <div className="flex items-center gap-0.5">
+                              {Array.from({ length: prop.rating_stars }).map((_, j) => (
+                                <Star key={j} className="w-3 h-3 fill-terminal-yellow text-terminal-yellow" />
+                              ))}
+                            </div>
+                          )}
+                          {isClickable && (
+                            <ChevronRight className="w-4 h-4 text-terminal-yellow" />
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Números */}
+                      <div className="flex items-center gap-2">
+                        {normal > 0 && (
+                          <span className="text-sm opacity-50">{normal.toFixed(1)}</span>
+                        )}
+                        {normal > 0 && (
+                          <span className="text-xs opacity-30">→</span>
+                        )}
+                        <span className="text-lg font-bold text-terminal-green leading-none">
+                          {semEle.toFixed(1)}
+                        </span>
+                        {gapPct > 0 && (
+                          <span className="text-[11px] font-semibold text-terminal-green bg-terminal-green/10 px-1.5 py-0.5 rounded">
+                            +{gapPct}%
+                          </span>
+                        )}
+                      </div>
+
+                      {normal > 0 && (
+                        <div className="text-[9px] opacity-40 mt-1">
+                          média normal → sem {triggerLastName}
+                        </div>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
           );
         })}
       </div>

--- a/src/components/nba/TeammateFilterBar.tsx
+++ b/src/components/nba/TeammateFilterBar.tsx
@@ -3,11 +3,13 @@ import { Users, X, ChevronDown, Star } from 'lucide-react';
 import { TeamPlayer } from '@/services/nba-data.service';
 import { getPlayerPhotoUrl, tryNextPlayerPhotoUrl } from '@/utils/team-logos';
 
-type TeammateFilter = {
+type TeammateFilterEntry = {
   playerId: number;
   playerName: string;
   mode: 'with' | 'without';
-} | null;
+};
+
+type TeammateFilter = TeammateFilterEntry[] | null;
 
 interface TeammateFilterBarProps {
   teammates: TeamPlayer[];
@@ -32,12 +34,27 @@ export const TeammateFilterBar: React.FC<TeammateFilterBarProps> = ({
     t => Number(t.player_id) !== Number(currentPlayerId)
   );
 
+  const isSelected = (playerId: number) =>
+    teammateFilter?.some(f => f.playerId === playerId) ?? false;
+
   const handleSelect = (teammate: TeamPlayer, mode: 'with' | 'without') => {
-    onFilterChange({ playerId: teammate.player_id, playerName: teammate.player_name, mode });
-    setOpen(false);
+    const entry: TeammateFilterEntry = { playerId: teammate.player_id, playerName: teammate.player_name, mode };
+    if (!teammateFilter) {
+      onFilterChange([entry]);
+    } else {
+      // Remove if already selected, then add with new mode
+      const filtered = teammateFilter.filter(f => f.playerId !== teammate.player_id);
+      onFilterChange([...filtered, entry]);
+    }
   };
 
-  const handleClear = () => {
+  const handleRemove = (playerId: number) => {
+    if (!teammateFilter) return;
+    const filtered = teammateFilter.filter(f => f.playerId !== playerId);
+    onFilterChange(filtered.length > 0 ? filtered : null);
+  };
+
+  const handleClearAll = () => {
     onFilterChange(null);
     setOpen(false);
   };
@@ -47,118 +64,128 @@ export const TeammateFilterBar: React.FC<TeammateFilterBarProps> = ({
       <div className="flex items-center gap-3 flex-wrap">
         <span className="text-[10px] data-label opacity-50 shrink-0">TEAMMATE</span>
 
-        {/* Active filter badge */}
-        {teammateFilter ? (
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className={`text-[11px] px-2 py-0.5 rounded border font-medium ${
-              teammateFilter.mode === 'with'
-                ? 'bg-terminal-green/15 border-terminal-green/50 text-terminal-green'
-                : 'bg-terminal-red/15 border-terminal-red/50 text-terminal-red'
-            }`}>
-              {teammateFilter.mode === 'with' ? 'COM' : 'SEM'} {teammateFilter.playerName.split(' ').pop()}
-            </span>
-            <button
-              onClick={handleClear}
-              className="w-5 h-5 flex items-center justify-center rounded border border-white/20 text-white/40 hover:text-white/80 hover:border-white/40 transition-colors"
-              title="Remover filtro"
-            >
-              <X className="w-3 h-3" />
-            </button>
-          </div>
-        ) : (
-          <div className="relative">
-            <button
-              onClick={() => setOpen(v => !v)}
-              disabled={isLoading || available.length === 0}
-              className="flex items-center gap-1.5 px-3 py-1 text-[11px] rounded border border-terminal-green/30 text-terminal-text hover:border-terminal-green/50 hover:bg-terminal-green/5 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
-            >
-              <Users className="w-3 h-3" />
-              <span>Selecionar companheiro</span>
-              <ChevronDown className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`} />
-            </button>
-
-            {open && (
-              <div
-                className="absolute top-full left-0 mt-1 z-50 bg-terminal-dark-gray border border-terminal-border-subtle rounded shadow-lg min-w-[280px] max-h-[280px] overflow-y-auto
-                  [&::-webkit-scrollbar]:w-1
-                  [&::-webkit-scrollbar-track]:bg-transparent
-                  [&::-webkit-scrollbar-thumb]:bg-white/20
-                  [&::-webkit-scrollbar-thumb]:rounded-full
-                  [&::-webkit-scrollbar-thumb:hover]:bg-white/40"
-              >
-                {available.map(t => {
-                  const photoUrl = getPlayerPhotoUrl(t.player_name, teamName);
-                  const initials = t.player_name.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase();
-                  return (
-                    <div
-                      key={t.player_id}
-                      className="flex items-center gap-2.5 px-3 py-2 hover:bg-terminal-gray/40 border-b border-terminal-border-subtle/30 last:border-0"
-                    >
-                      {/* Avatar */}
-                      <div className="w-7 h-7 rounded-full overflow-hidden bg-terminal-gray border border-terminal-border-subtle shrink-0 flex items-center justify-center">
-                        {photoUrl ? (
-                          <img
-                            src={photoUrl}
-                            alt={t.player_name}
-                            data-player-photo-index="0"
-                            className="w-full h-full object-cover object-top"
-                            onError={(e) => {
-                              const didTry = tryNextPlayerPhotoUrl(e.target as HTMLImageElement, t.player_name, teamName);
-                              if (!didTry) {
-                                const el = e.target as HTMLImageElement;
-                                el.style.display = 'none';
-                                const parent = el.parentElement;
-                                if (parent) parent.innerHTML = `<span class="text-[9px] font-bold text-terminal-text opacity-60">${initials}</span>`;
-                              }
-                            }}
-                          />
-                        ) : (
-                          <span className="text-[9px] font-bold text-terminal-text opacity-60">{initials}</span>
-                        )}
-                      </div>
-
-                      {/* Name + position + stars */}
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-1.5">
-                          <span className="text-xs font-medium text-terminal-text truncate">{t.player_name}</span>
-                          {t.rating_stars > 0 && (
-                            <div className="flex items-center gap-0.5 shrink-0">
-                              {Array.from({ length: t.rating_stars }).map((_, i) => (
-                                <Star key={i} className="w-2.5 h-2.5 fill-terminal-yellow text-terminal-yellow" />
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-1.5 text-[10px] opacity-50">
-                          <span>{t.position}</span>
-                          {t.current_status && t.current_status.toLowerCase() !== 'active' && (
-                            <span className="text-terminal-red">{t.current_status}</span>
-                          )}
-                        </div>
-                      </div>
-
-                      {/* COM / SEM */}
-                      <div className="flex gap-1 shrink-0">
-                        <button
-                          onClick={() => handleSelect(t, 'with')}
-                          className="px-2 py-0.5 text-[10px] rounded border border-terminal-green/40 text-terminal-green hover:bg-terminal-green/15 transition-colors"
-                        >
-                          COM
-                        </button>
-                        <button
-                          onClick={() => handleSelect(t, 'without')}
-                          className="px-2 py-0.5 text-[10px] rounded border border-terminal-red/40 text-terminal-red hover:bg-terminal-red/15 transition-colors"
-                        >
-                          SEM
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })}
+        {/* Active filter badges */}
+        {teammateFilter && teammateFilter.length > 0 && (
+          <div className="flex items-center gap-1.5 flex-wrap">
+            {teammateFilter.map(f => (
+              <div key={f.playerId} className="flex items-center gap-1">
+                <span className={`text-[11px] px-2 py-0.5 rounded border font-medium ${
+                  f.mode === 'with'
+                    ? 'bg-terminal-green/15 border-terminal-green/50 text-terminal-green'
+                    : 'bg-terminal-red/15 border-terminal-red/50 text-terminal-red'
+                }`}>
+                  {f.mode === 'with' ? 'COM' : 'SEM'} {f.playerName.split(' ').pop()}
+                </span>
+                <button
+                  onClick={() => handleRemove(f.playerId)}
+                  className="w-4 h-4 flex items-center justify-center rounded border border-white/20 text-white/40 hover:text-white/80 hover:border-white/40 transition-colors"
+                >
+                  <X className="w-2.5 h-2.5" />
+                </button>
               </div>
+            ))}
+            {teammateFilter.length > 1 && (
+              <button
+                onClick={handleClearAll}
+                className="text-[9px] text-white/40 hover:text-white/70 transition-colors"
+              >
+                limpar
+              </button>
             )}
           </div>
         )}
+
+        {/* Add button */}
+        <div className="relative">
+          <button
+            onClick={() => setOpen(v => !v)}
+            disabled={isLoading || available.length === 0}
+            className="flex items-center gap-1.5 px-3 py-1 text-[11px] rounded border border-terminal-green/30 text-terminal-text hover:border-terminal-green/50 hover:bg-terminal-green/5 transition-all disabled:opacity-30 disabled:cursor-not-allowed"
+          >
+            <Users className="w-3 h-3" />
+            <span>{teammateFilter && teammateFilter.length > 0 ? '+' : 'Selecionar companheiro'}</span>
+            <ChevronDown className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`} />
+          </button>
+
+          {open && (
+            <div
+              className="absolute top-full left-0 mt-1 z-50 bg-terminal-dark-gray border border-terminal-border-subtle rounded shadow-lg min-w-[280px] max-h-[280px] overflow-y-auto
+                [&::-webkit-scrollbar]:w-1
+                [&::-webkit-scrollbar-track]:bg-transparent
+                [&::-webkit-scrollbar-thumb]:bg-white/20
+                [&::-webkit-scrollbar-thumb]:rounded-full
+                [&::-webkit-scrollbar-thumb:hover]:bg-white/40"
+            >
+              {available.map(t => {
+                const photoUrl = getPlayerPhotoUrl(t.player_name, teamName);
+                const initials = t.player_name.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase();
+                const selected = isSelected(t.player_id);
+                return (
+                  <div
+                    key={t.player_id}
+                    className={`flex items-center gap-2.5 px-3 py-2 hover:bg-terminal-gray/40 border-b border-terminal-border-subtle/30 last:border-0 ${selected ? 'bg-terminal-gray/20' : ''}`}
+                  >
+                    <div className="w-7 h-7 rounded-full overflow-hidden bg-terminal-gray border border-terminal-border-subtle shrink-0 flex items-center justify-center">
+                      {photoUrl ? (
+                        <img
+                          src={photoUrl}
+                          alt={t.player_name}
+                          data-player-photo-index="0"
+                          className="w-full h-full object-cover object-top"
+                          onError={(e) => {
+                            const didTry = tryNextPlayerPhotoUrl(e.target as HTMLImageElement, t.player_name, teamName);
+                            if (!didTry) {
+                              const el = e.target as HTMLImageElement;
+                              el.style.display = 'none';
+                              const parent = el.parentElement;
+                              if (parent) parent.innerHTML = `<span class="text-[9px] font-bold text-terminal-text opacity-60">${initials}</span>`;
+                            }
+                          }}
+                        />
+                      ) : (
+                        <span className="text-[9px] font-bold text-terminal-text opacity-60">{initials}</span>
+                      )}
+                    </div>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-xs font-medium text-terminal-text truncate">{t.player_name}</span>
+                        {t.rating_stars > 0 && (
+                          <div className="flex items-center gap-0.5 shrink-0">
+                            {Array.from({ length: t.rating_stars }).map((_, i) => (
+                              <Star key={i} className="w-2.5 h-2.5 fill-terminal-yellow text-terminal-yellow" />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-1.5 text-[10px] opacity-50">
+                        <span>{t.position}</span>
+                        {t.current_status && t.current_status.toLowerCase() !== 'active' && (
+                          <span className="text-terminal-red">{t.current_status}</span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex gap-1 shrink-0">
+                      <button
+                        onClick={() => handleSelect(t, 'with')}
+                        className="px-2 py-0.5 text-[10px] rounded border border-terminal-green/40 text-terminal-green hover:bg-terminal-green/15 transition-colors"
+                      >
+                        COM
+                      </button>
+                      <button
+                        onClick={() => handleSelect(t, 'without')}
+                        className="px-2 py-0.5 text-[10px] rounded border border-terminal-red/40 text-terminal-red hover:bg-terminal-red/15 transition-colors"
+                      >
+                        SEM
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
 
         {isLoading && (
           <span className="text-[10px] opacity-40 animate-pulse">carregando...</span>
@@ -168,4 +195,4 @@ export const TeammateFilterBar: React.FC<TeammateFilterBarProps> = ({
   );
 };
 
-export type { TeammateFilter };
+export type { TeammateFilter, TeammateFilterEntry };

--- a/src/pages/GameDetail.tsx
+++ b/src/pages/GameDetail.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate, useLocation, Link, Navigate } from 'react-router-dom';
 import AnalyticsNav from '@/components/AnalyticsNav';
-import { nbaDataService, Game, TeamPlayer, Team } from '@/services/nba-data.service';
+import { nbaDataService, Game, TeamPlayer, Team, BoxScorePlayer, B2BBoxScorePlayer } from '@/services/nba-data.service';
 import { gamesCache } from '@/pages/Games';
 import { getTeamLogoUrl, getPlayerPhotoUrl, tryNextPlayerPhotoUrl } from '@/utils/team-logos';
 import { getInjuryStatusStyle, getInjuryStatusLabel } from '@/utils/injury-status';
@@ -10,6 +10,12 @@ import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/use-auth';
 
 const SAO_PAULO_TIMEZONE = 'America/Sao_Paulo';
+
+const formatPct = (val: number | null): string => {
+  if (val == null || val === 0) return '—';
+  const pct = val * 100;
+  return pct % 1 === 0 ? `${Math.round(pct)}%` : `${pct.toFixed(1)}%`;
+};
 
 const formatGameDateSaoPaulo = (dateString: string): string => {
   const date = /^\d{4}-\d{2}-\d{2}$/.test(dateString)
@@ -32,6 +38,7 @@ interface GameDetailCache {
   visitorPlayers: TeamPlayer[];
   homeTeam: Team | null;
   visitorTeam: Team | null;
+  b2bData?: { home: B2BBoxScorePlayer[]; visitor: B2BBoxScorePlayer[] };
 }
 const gameDetailCache = new Map<string, GameDetailCache>();
 
@@ -49,6 +56,15 @@ export default function GameDetail() {
   const [visitorTeam, setVisitorTeam] = useState<Team | null>(initCache?.visitorTeam ?? null);
   const [isLoadingGame, setIsLoadingGame] = useState(!initCache);
   const [isLoadingTeams, setIsLoadingTeams] = useState(!initCache);
+  const [boxScore, setBoxScore] = useState<BoxScorePlayer[]>([]);
+  const [isLoadingBoxScore, setIsLoadingBoxScore] = useState(false);
+  const [activeTab, setActiveTab] = useState<'lineups' | 'boxscore' | 'b2b'>(initCache?.game?.winner_team_id != null ? 'boxscore' : 'lineups');
+  const [sortConfig, setSortConfig] = useState<{ key: string; direction: 'desc' | 'asc' }>({ key: 'points', direction: 'desc' });
+  const [boxScoreView, setBoxScoreView] = useState<'all' | 'home' | 'visitor'>('all');
+  const [detailedView, setDetailedView] = useState(() => window.innerWidth >= 768);
+  const [b2bData, setB2bData] = useState<{ home: B2BBoxScorePlayer[]; visitor: B2BBoxScorePlayer[] }>(initCache?.b2bData ?? { home: [], visitor: [] });
+  const [isLoadingB2B, setIsLoadingB2B] = useState(false);
+  const [b2bLoaded, setB2bLoaded] = useState(!!initCache?.b2bData);
   const hasLoaded = React.useRef(false);
 
   useEffect(() => {
@@ -56,6 +72,83 @@ export default function GameDetail() {
       loadGameData();
     }
   }, [gameId, authLoading, user]);
+
+  // Load box score when tab is activated (fallback if preload didn't finish)
+  useEffect(() => {
+    if (activeTab === 'boxscore' && game && game.winner_team_id !== null && boxScore.length === 0 && !isLoadingBoxScore) {
+      setIsLoadingBoxScore(true);
+      nbaDataService.getGameBoxScore(game.game_id)
+        .then(data => { if (boxScore.length === 0) setBoxScore(data); })
+        .catch(err => console.error('Error loading box score:', err))
+        .finally(() => setIsLoadingBoxScore(false));
+    }
+  }, [activeTab, game]);
+
+  // Load B2B data when tab is activated (lazy loading with cache)
+  useEffect(() => {
+    if (activeTab === 'b2b' && game && !isLoadingB2B) {
+      const hasCache = b2bLoaded;
+      // Skip if already loaded and not a background refresh
+      if (hasCache) {
+        // Background refresh: reload silently without showing loading state
+        const freshData: { home: B2BBoxScorePlayer[]; visitor: B2BBoxScorePlayer[] } = { home: [], visitor: [] };
+        const promises: Promise<void>[] = [];
+        if (game.home_team_is_b2b_game) {
+          promises.push(
+            nbaDataService.getB2BPreviousGameBoxScore(game.game_id, game.home_team_id)
+              .then(data => { freshData.home = data; })
+              .catch(() => {})
+          );
+        }
+        if (game.visitor_team_is_b2b_game) {
+          promises.push(
+            nbaDataService.getB2BPreviousGameBoxScore(game.game_id, game.visitor_team_id)
+              .then(data => { freshData.visitor = data; })
+              .catch(() => {})
+          );
+        }
+        Promise.all(promises).then(() => {
+          setB2bData(freshData);
+          if (gameId) {
+            const cached = gameDetailCache.get(gameId);
+            if (cached) gameDetailCache.set(gameId, { ...cached, b2bData: freshData });
+          }
+        });
+        return;
+      }
+
+      // First load: show loading state
+      setIsLoadingB2B(true);
+      const newData: { home: B2BBoxScorePlayer[]; visitor: B2BBoxScorePlayer[] } = { home: [], visitor: [] };
+      const promises: Promise<void>[] = [];
+
+      if (game.home_team_is_b2b_game) {
+        promises.push(
+          nbaDataService.getB2BPreviousGameBoxScore(game.game_id, game.home_team_id)
+            .then(data => { newData.home = data; })
+            .catch(err => console.error('Error loading home B2B data:', err))
+        );
+      }
+      if (game.visitor_team_is_b2b_game) {
+        promises.push(
+          nbaDataService.getB2BPreviousGameBoxScore(game.game_id, game.visitor_team_id)
+            .then(data => { newData.visitor = data; })
+            .catch(err => console.error('Error loading visitor B2B data:', err))
+        );
+      }
+
+      Promise.all(promises).finally(() => {
+        setB2bData(newData);
+        setIsLoadingB2B(false);
+        setB2bLoaded(true);
+        // Save to cache
+        if (gameId) {
+          const cached = gameDetailCache.get(gameId);
+          if (cached) gameDetailCache.set(gameId, { ...cached, b2bData: newData });
+        }
+      });
+    }
+  }, [activeTab, game]);
 
   // PLG freemium: detalhe do jogo exige login (deslogado redireciona para /auth)
   if (authLoading) {
@@ -118,31 +211,26 @@ export default function GameDetail() {
       }
 
       setGame(foundGame);
+      if (foundGame.winner_team_id != null) setActiveTab('boxscore');
       setIsLoadingGame(false);
 
-      // 2. Home team data
+      // 2. Load BOTH teams in parallel (was sequential before)
       let loadedHomePlayers: TeamPlayer[] = [];
       let loadedHomeTeam: Team | null = null;
-      try {
-        const [hp, ht] = await Promise.allSettled([
-          nbaDataService.getTeamPlayers(foundGame.home_team_id),
-          nbaDataService.getTeamById(foundGame.home_team_id),
-        ]);
-        if (hp.status === 'fulfilled') { loadedHomePlayers = hp.value; setHomePlayers(hp.value); }
-        if (ht.status === 'fulfilled') { loadedHomeTeam = ht.value; setHomeTeam(ht.value); }
-      } catch (e) { console.error('Error loading home team:', e); }
-
-      // 3. Visitor team data
       let loadedVisitorPlayers: TeamPlayer[] = [];
       let loadedVisitorTeam: Team | null = null;
-      try {
-        const [vp, vt] = await Promise.allSettled([
-          nbaDataService.getTeamPlayers(foundGame.visitor_team_id),
-          nbaDataService.getTeamById(foundGame.visitor_team_id),
-        ]);
-        if (vp.status === 'fulfilled') { loadedVisitorPlayers = vp.value; setVisitorPlayers(vp.value); }
-        if (vt.status === 'fulfilled') { loadedVisitorTeam = vt.value; setVisitorTeam(vt.value); }
-      } catch (e) { console.error('Error loading visitor team:', e); }
+
+      const [hp, ht, vp, vt] = await Promise.allSettled([
+        nbaDataService.getTeamPlayers(foundGame.home_team_id),
+        nbaDataService.getTeamById(foundGame.home_team_id),
+        nbaDataService.getTeamPlayers(foundGame.visitor_team_id),
+        nbaDataService.getTeamById(foundGame.visitor_team_id),
+      ]);
+
+      if (hp.status === 'fulfilled') { loadedHomePlayers = hp.value; setHomePlayers(hp.value); }
+      if (ht.status === 'fulfilled') { loadedHomeTeam = ht.value; setHomeTeam(ht.value); }
+      if (vp.status === 'fulfilled') { loadedVisitorPlayers = vp.value; setVisitorPlayers(vp.value); }
+      if (vt.status === 'fulfilled') { loadedVisitorTeam = vt.value; setVisitorTeam(vt.value); }
 
       // Save to cache
       gameDetailCache.set(gameId, {
@@ -153,6 +241,44 @@ export default function GameDetail() {
         visitorTeam: loadedVisitorTeam,
       });
       hasLoaded.current = true;
+
+      // 3. Background preload: Box Score (finished games) and B2B data
+      const isB2BGame = foundGame.home_team_is_b2b_game || foundGame.visitor_team_is_b2b_game;
+      const isFinished = foundGame.winner_team_id != null;
+
+      if (isFinished) {
+        nbaDataService.getGameBoxScore(foundGame.game_id)
+          .then(data => {
+            setBoxScore(data);
+            setIsLoadingBoxScore(false);
+          })
+          .catch(err => console.error('Error preloading box score:', err));
+      }
+
+      if (isB2BGame && !isFinished) {
+        const b2b: { home: B2BBoxScorePlayer[]; visitor: B2BBoxScorePlayer[] } = { home: [], visitor: [] };
+        const b2bPromises: Promise<void>[] = [];
+        if (foundGame.home_team_is_b2b_game) {
+          b2bPromises.push(
+            nbaDataService.getB2BPreviousGameBoxScore(foundGame.game_id, foundGame.home_team_id)
+              .then(data => { b2b.home = data; })
+              .catch(err => console.error('Error preloading home B2B:', err))
+          );
+        }
+        if (foundGame.visitor_team_is_b2b_game) {
+          b2bPromises.push(
+            nbaDataService.getB2BPreviousGameBoxScore(foundGame.game_id, foundGame.visitor_team_id)
+              .then(data => { b2b.visitor = data; })
+              .catch(err => console.error('Error preloading visitor B2B:', err))
+          );
+        }
+        Promise.all(b2bPromises).then(() => {
+          setB2bData(b2b);
+          setB2bLoaded(true);
+          const c = gameDetailCache.get(gameId);
+          if (c) gameDetailCache.set(gameId, { ...c, b2bData: b2b });
+        });
+      }
     } catch (error) {
       console.error('Error loading game data:', error);
       toast({
@@ -241,6 +367,273 @@ export default function GameDetail() {
   const sortedHomePlayers = [...homePlayers].sort(sortPlayers);
   const sortedVisitorPlayers = [...visitorPlayers].sort(sortPlayers);
 
+  const renderLineupTable = (players: TeamPlayer[], teamAbbr: string, teamName: string) => (
+    <div className="border border-terminal-border-subtle rounded-lg overflow-hidden">
+      <div className="bg-terminal-gray/20 px-3 py-2 border-b border-terminal-border-subtle">
+        <span className="text-xs font-bold text-terminal-text">{teamAbbr}</span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-terminal-border-subtle">
+              <th className="text-left py-2 px-2 text-[10px] font-medium text-terminal-text opacity-60">Jogador</th>
+              <th className="text-center py-2 px-1 text-[10px] font-medium text-terminal-text opacity-60">POS</th>
+              <th className="text-center py-2 px-1 text-[10px] font-medium text-terminal-text opacity-60">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {players.map((player) => (
+              <tr key={player.player_id} className="border-b border-terminal-border-subtle/50 hover:bg-terminal-gray/10 transition-colors">
+                <td className="py-2 px-2">
+                  <Link
+                    to={getPlayerHref(player.player_name)}
+                    className="flex items-center gap-2 cursor-pointer hover:text-terminal-green transition-colors"
+                  >
+                    <div className="w-6 h-6 bg-terminal-gray rounded-full flex items-center justify-center border border-terminal-border-subtle flex-shrink-0 relative overflow-hidden">
+                      <img
+                        src={getPlayerPhotoUrl(player.player_name, teamName)}
+                        alt={player.player_name}
+                        className="w-full h-full object-cover"
+                        loading="lazy"
+                        data-player-photo-index="0"
+                        onError={(e) => {
+                          const target = e.target as HTMLImageElement;
+                          const hasNext = tryNextPlayerPhotoUrl(target, player.player_name, teamName);
+                          if (hasNext) return;
+                          target.style.display = 'none';
+                          const parent = target.parentElement;
+                          if (parent) {
+                            const initials = player.player_name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2);
+                            parent.innerHTML = `<span class="text-[8px] font-bold text-terminal-text">${initials}</span>`;
+                          }
+                        }}
+                      />
+                    </div>
+                    <div className="min-w-0">
+                      <div className="text-xs font-medium text-terminal-text truncate">{player.player_name}</div>
+                      {player.rating_stars > 0 && (
+                        <div className="text-[9px] text-terminal-yellow opacity-70">{'★'.repeat(Math.min(player.rating_stars, 5))}</div>
+                      )}
+                    </div>
+                  </Link>
+                </td>
+                <td className="py-2 px-1 text-center text-xs text-terminal-text opacity-60">{player.position || '—'}</td>
+                <td className="py-2 px-1 text-center">
+                  {(() => {
+                    const injuryStyle = getInjuryStatusStyle(player.current_status);
+                    return (
+                      <span className={`text-[9px] px-1 py-0.5 rounded border whitespace-nowrap ${injuryStyle.textClass} ${injuryStyle.borderClass} ${injuryStyle.bgClass}`}>
+                        {getInjuryStatusLabel(player.current_status)}
+                      </span>
+                    );
+                  })()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+
+  const handleSort = (key: string) => {
+    setSortConfig(prev =>
+      prev.key === key
+        ? { key, direction: prev.direction === 'desc' ? 'asc' : 'desc' }
+        : { key, direction: 'desc' }
+    );
+  };
+
+  const sortBoxScorePlayers = (players: BoxScorePlayer[]) => {
+    const { key, direction } = sortConfig;
+    const fieldMap: Record<string, keyof BoxScorePlayer> = {
+      points: 'points', rebounds: 'rebounds', assists: 'assists',
+      minutes: 'minutes', threes: 'threes', steals: 'steals',
+      blocks: 'blocks', turnovers: 'turnovers',
+      offensive_rebounds: 'offensive_rebounds', defensive_rebounds: 'defensive_rebounds',
+      fg_pct: 'fg_pct', ft_pct: 'ft_pct',
+    };
+    const field = fieldMap[key];
+    if (!field) return players;
+    return [...players].sort((a, b) => {
+      const va = (a[field] as number) ?? -1;
+      const vb = (b[field] as number) ?? -1;
+      return direction === 'desc' ? vb - va : va - vb;
+    });
+  };
+
+  const getPlayerTeamName = (player: BoxScorePlayer) =>
+    player.home_away === 'Casa' ? game?.home_team_name ?? '' : game?.visitor_team_name ?? '';
+
+  const compactColumns = [
+    { key: 'points', label: 'PTS', tooltip: 'Points' },
+    { key: 'rebounds', label: 'REB', tooltip: 'Total Rebounds' },
+    { key: 'assists', label: 'AST', tooltip: 'Assists' },
+  ];
+
+  const detailedColumns = [
+    { key: 'points', label: 'PTS', tooltip: 'Points' },
+    { key: 'rebounds', label: 'REB', tooltip: 'Total Rebounds' },
+    { key: 'offensive_rebounds', label: 'OREB', tooltip: 'Offensive Rebounds' },
+    { key: 'defensive_rebounds', label: 'DREB', tooltip: 'Defensive Rebounds' },
+    { key: 'assists', label: 'AST', tooltip: 'Assists' },
+    { key: 'fg_pct', label: 'FG%', tooltip: 'Field Goal Percentage' },
+    { key: 'ft_pct', label: 'FT%', tooltip: 'Free Throw Percentage' },
+    { key: 'minutes', label: 'MIN', tooltip: 'Minutes Played' },
+    { key: 'threes', label: '3PM', tooltip: '3-Point Field Goals Made' },
+    { key: 'steals', label: 'STL', tooltip: 'Steals' },
+    { key: 'blocks', label: 'BLK', tooltip: 'Blocks' },
+    { key: 'turnovers', label: 'TO', tooltip: 'Turnovers' },
+  ];
+
+  const activeColumns = detailedView ? detailedColumns : compactColumns;
+
+  const statWeightClass: Record<string, string> = {
+    points: 'font-bold',
+    rebounds: 'font-semibold',
+    assists: 'font-semibold',
+    offensive_rebounds: 'opacity-80',
+    defensive_rebounds: 'opacity-80',
+    fg_pct: 'opacity-80',
+    ft_pct: 'opacity-80',
+    minutes: 'opacity-60',
+    threes: 'opacity-80',
+    steals: 'opacity-80',
+    blocks: 'opacity-80',
+    turnovers: 'opacity-60',
+  };
+
+  const renderBoxScoreRow = (player: BoxScorePlayer, teamName: string, idx: number) => (
+    <tr
+      key={player.player_id}
+      className={`border-b border-terminal-border-subtle/30 hover:bg-terminal-gray/30 active:bg-terminal-gray/40 transition-colors ${idx % 2 === 1 ? 'bg-terminal-gray/10' : ''}`}
+    >
+      <td className={`py-2 px-1 text-center w-8 bg-terminal-dark-gray ${detailedView ? '' : 'sticky left-0 z-20'}`}>
+        <img
+          src={getTeamLogoUrl(teamName)}
+          alt=""
+          className="w-4 h-4 object-contain inline-block"
+          onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+        />
+      </td>
+      <td className={`py-2 px-2 bg-terminal-dark-gray ${detailedView ? '' : 'sticky left-8 z-20 after:absolute after:right-0 after:top-0 after:bottom-0 after:w-3 after:-mr-3 after:bg-gradient-to-r after:from-terminal-dark-gray/80 after:to-transparent after:pointer-events-none'}`}>
+        <Link
+          to={getPlayerHref(player.player_name)}
+          className="flex items-center gap-2 cursor-pointer hover:text-terminal-green transition-colors"
+        >
+          {!detailedView && (
+            <div className="w-6 h-6 bg-terminal-gray rounded-full flex items-center justify-center border border-terminal-border-subtle flex-shrink-0 relative overflow-hidden">
+              <img
+                src={getPlayerPhotoUrl(player.player_name, teamName)}
+                alt={player.player_name}
+                className="w-full h-full object-cover"
+                loading="lazy"
+                data-player-photo-index="0"
+                onError={(e) => {
+                  const target = e.target as HTMLImageElement;
+                  const hasNext = tryNextPlayerPhotoUrl(target, player.player_name, teamName);
+                  if (hasNext) return;
+                  target.style.display = 'none';
+                  const parent = target.parentElement;
+                  if (parent) {
+                    const initials = player.player_name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2);
+                    parent.innerHTML = `<span class="text-[8px] font-bold text-terminal-text">${initials}</span>`;
+                  }
+                }}
+              />
+            </div>
+          )}
+          <span className={`font-medium text-terminal-text truncate ${detailedView ? 'text-[11px]' : 'text-xs'}`}>{player.player_name}</span>
+        </Link>
+      </td>
+      {activeColumns.map(col => {
+        const val = (player as unknown as Record<string, number | null>)[col.key];
+        let display: string;
+        if (val == null) {
+          display = '—';
+        } else if (col.key === 'minutes') {
+          display = `${Math.round(val)}'`;
+        } else if (col.key === 'fg_pct' || col.key === 'ft_pct') {
+          display = formatPct(val);
+        } else {
+          display = String(val);
+        }
+        return (
+          <td key={col.key} className={`py-2 px-1 sm:px-2 text-center text-xs tabular-nums ${sortConfig.key === col.key ? 'text-terminal-green font-bold' : `text-terminal-text ${statWeightClass[col.key] || ''}`}`}>
+            {display}
+          </td>
+        );
+      })}
+      {detailedView && (
+        <td className="py-2 px-1 sm:px-2 text-center text-[11px] text-terminal-text opacity-50">
+          {player.player_position || '—'}
+        </td>
+      )}
+    </tr>
+  );
+
+  const renderBoxScoreTableHeader = () => (
+    <thead>
+      <tr className="border-b border-terminal-border-subtle bg-terminal-gray">
+        <th className={`w-8 bg-terminal-gray ${detailedView ? '' : 'sticky left-0 z-20'}`}></th>
+        <th className={`text-left py-3 px-2 text-[11px] font-medium text-terminal-text opacity-70 bg-terminal-gray ${detailedView ? 'min-w-[100px]' : 'sticky left-8 z-20 min-w-[140px] after:absolute after:right-0 after:top-0 after:bottom-0 after:w-3 after:-mr-3 after:bg-gradient-to-r after:from-terminal-gray after:to-transparent after:pointer-events-none'}`}>Jogador</th>
+        {activeColumns.map(col => {
+          const isActive = sortConfig.key === col.key;
+          return (
+            <th
+              key={col.key}
+              className={`text-center py-3 px-1 sm:px-2 text-[11px] font-medium min-w-[36px] sm:min-w-[40px] cursor-pointer select-none transition-colors active:bg-terminal-light-gray ${isActive ? 'text-terminal-green' : 'text-terminal-text opacity-70 hover:opacity-100'}`}
+              onClick={() => handleSort(col.key)}
+              aria-sort={isActive ? (sortConfig.direction === 'desc' ? 'descending' : 'ascending') : 'none'}
+              aria-label={`Ordenar por ${col.label}`}
+              title={col.tooltip}
+              role="columnheader"
+            >
+              {col.label}
+              {isActive && (
+                <span className="ml-0.5 text-[8px]">{sortConfig.direction === 'desc' ? '▼' : '▲'}</span>
+              )}
+            </th>
+          );
+        })}
+        {detailedView && (
+          <th className="text-center py-3 px-1 sm:px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]">POS</th>
+        )}
+      </tr>
+    </thead>
+  );
+
+
+  const renderTableWrapper = (children: React.ReactNode) => (
+    <div className="border border-terminal-border-subtle rounded-lg overflow-hidden relative">
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          {renderBoxScoreTableHeader()}
+          <tbody>{children}</tbody>
+        </table>
+      </div>
+      {detailedView && (
+        <div className="absolute right-0 top-0 bottom-0 w-6 bg-gradient-to-l from-terminal-dark-gray/90 to-transparent pointer-events-none flex items-center justify-center">
+          <span className="text-terminal-text opacity-40 text-xs">▸</span>
+        </div>
+      )}
+    </div>
+  );
+
+  const renderBoxScoreTable = (players: BoxScorePlayer[], teamName: string) => {
+    const sortedPlayers = sortBoxScorePlayers(players);
+    return renderTableWrapper(
+      sortedPlayers.map((player, idx) => renderBoxScoreRow(player, teamName, idx))
+    );
+  };
+
+  const renderCombinedBoxScore = () => {
+    const sortedPlayers = sortBoxScorePlayers(boxScore);
+    return renderTableWrapper(
+      sortedPlayers.map((player, idx) => renderBoxScoreRow(player, getPlayerTeamName(player), idx))
+    );
+  };
+
   if (isLoadingGame) {
     return (
       <div className="min-h-screen bg-terminal-black text-terminal-text">
@@ -266,7 +659,7 @@ export default function GameDetail() {
         {/* Layout: left = header + injury (compact), right = lineup */}
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
           {/* Left column: game header + injury report */}
-          <div className="lg:col-span-6 xl:col-span-5 space-y-4">
+          <div className="lg:col-span-5 xl:col-span-5 space-y-4">
         {/* Game Header - Compact */}
         <div className="terminal-container p-4 md:p-5">
           {/* Main Matchup Row */}
@@ -337,7 +730,7 @@ export default function GameDetail() {
               {game.home_team_is_b2b_game && game.visitor_team_is_b2b_game && (
                 <div className="mt-2">
                   <span className="text-[10px] bg-terminal-yellow/20 text-terminal-yellow px-2 py-1 rounded">
-                    Both B2B
+                    Ambos B2B
                   </span>
                 </div>
               )}
@@ -427,15 +820,15 @@ export default function GameDetail() {
                 <div className="flex justify-center">
                   {renderLastFiveWithColors(homeLastFive)}
                 </div>
-                <div className="text-[10px] text-terminal-text opacity-50 self-center">LAST 5</div>
+                <div className="text-[10px] text-terminal-text opacity-50 self-center">ÚLT. 5</div>
                 <div className="flex justify-center">
                   {renderLastFiveWithColors(visitorLastFive)}
                 </div>
               </div>
               {isB2B && injuryReportTime && (
-                <div className="mt-2 pt-2 border-t border-terminal-border-subtle/50 text-center">
-                  <div className="text-[10px] text-terminal-text opacity-60">INJURY REPORT (GMT-3)</div>
-                  <div className="text-xs text-terminal-yellow">{injuryReportTime}</div>
+                <div className="mt-2 pt-2 border-t border-terminal-border-subtle/50 text-center" title="Horário previsto para atualização do relatório de lesões da NBA. Fique atento para mudanças de status dos jogadores antes do jogo.">
+                  <div className="text-xs text-terminal-text opacity-70">Injury Report sai às</div>
+                  <div className="text-sm text-terminal-yellow font-semibold">{injuryReportTime} <span className="text-[11px] opacity-60 font-normal">(horário de Brasília)</span></div>
                 </div>
               )}
             </div>
@@ -505,180 +898,362 @@ export default function GameDetail() {
         )}
           </div>
 
-          {/* Right column: Lineups - two tables side by side */}
-          <div className="lg:col-span-6 xl:col-span-7">
-        <div className="terminal-container p-4">
-          <h3 className="text-sm font-bold text-terminal-text mb-4">Lineups</h3>
-          {isLoadingTeams ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {[0, 1].map((i) => (
-                <div key={i} className="border border-terminal-border-subtle rounded-lg overflow-hidden">
-                  <div className="bg-terminal-gray/20 px-3 py-2 border-b border-terminal-border-subtle">
-                    <Skeleton className="h-4 w-10 bg-terminal-gray" />
-                  </div>
-                  <div className="p-2 space-y-2">
-                    {Array.from({ length: 8 }).map((_, j) => (
-                      <Skeleton key={j} className="h-8 w-full bg-terminal-gray/60" />
-                    ))}
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* Home team lineup - sorted by position then rating */}
-            <div className="border border-terminal-border-subtle rounded-lg overflow-hidden">
-              <div className="bg-terminal-gray/20 px-3 py-2 border-b border-terminal-border-subtle">
-                <span className="text-xs font-bold text-terminal-text">{game.home_team_abbreviation}</span>
+          {/* Right column: Tabs (Lineups / Box Score) */}
+          <div className="lg:col-span-7 xl:col-span-7">
+            <div className="terminal-container p-4">
+              {/* Tabs */}
+              <div className="flex items-center gap-1 mb-4 border-b border-terminal-border-subtle pb-2">
+                <button
+                  onClick={() => setActiveTab('lineups')}
+                  className={`px-4 min-h-[44px] text-xs font-bold rounded-t transition-colors active:opacity-70 ${
+                    activeTab === 'lineups'
+                      ? 'text-terminal-green border-b-2 border-terminal-green'
+                      : 'text-terminal-text opacity-50 hover:opacity-80'
+                  }`}
+                >
+                  Escalações
+                </button>
+                {isGameFinished && (
+                  <button
+                    onClick={() => setActiveTab('boxscore')}
+                    className={`px-4 min-h-[44px] text-xs font-bold rounded-t transition-colors active:opacity-70 ${
+                      activeTab === 'boxscore'
+                        ? 'text-terminal-green border-b-2 border-terminal-green'
+                        : 'text-terminal-text opacity-50 hover:opacity-80'
+                    }`}
+                  >
+                    Estatísticas
+                  </button>
+                )}
+                {!isGameFinished && isB2B && (
+                  <button
+                    onClick={() => setActiveTab('b2b')}
+                    className={`px-4 min-h-[44px] text-xs font-bold rounded-t transition-colors active:opacity-70 ${
+                      activeTab === 'b2b'
+                        ? 'text-terminal-green border-b-2 border-terminal-green'
+                        : 'text-terminal-text opacity-50 hover:opacity-80'
+                    }`}
+                  >
+                    Performance B2B
+                  </button>
+                )}
               </div>
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead>
-                    <tr className="border-b border-terminal-border-subtle">
-                      <th className="text-left py-2 px-2 text-[10px] font-medium text-terminal-text opacity-60">Player</th>
-                      <th className="text-center py-2 px-1 text-[10px] font-medium text-terminal-text opacity-60">POS</th>
-                      <th className="text-center py-2 px-1 text-[10px] font-medium text-terminal-text opacity-60">Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedHomePlayers.map((homePlayer) => (
-                      <tr
-                        key={homePlayer.player_id}
-                        className="border-b border-terminal-border-subtle/50 hover:bg-terminal-gray/10 transition-colors"
+
+              {/* Tab: Lineups */}
+              {activeTab === 'lineups' && (
+                <>
+                  {isLoadingTeams ? (
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      {[0, 1].map((i) => (
+                        <div key={i} className="border border-terminal-border-subtle rounded-lg overflow-hidden">
+                          <div className="bg-terminal-gray/20 px-3 py-2 border-b border-terminal-border-subtle">
+                            <Skeleton className="h-4 w-10 bg-terminal-gray" />
+                          </div>
+                          <div className="p-2 space-y-2">
+                            {Array.from({ length: 8 }).map((_, j) => (
+                              <Skeleton key={j} className="h-8 w-full bg-terminal-gray/60" />
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      {/* Home team lineup */}
+                      {renderLineupTable(sortedHomePlayers, game.home_team_abbreviation, game.home_team_name)}
+                      {/* Visitor team lineup */}
+                      {renderLineupTable(sortedVisitorPlayers, game.visitor_team_abbreviation, game.visitor_team_name)}
+                    </div>
+                  )}
+                </>
+              )}
+
+              {/* Tab: Box Score */}
+              {activeTab === 'boxscore' && (
+                <>
+                  {isLoadingBoxScore ? (
+                    <div className="space-y-4">
+                      {[0, 1].map((i) => (
+                        <div key={i} className="border border-terminal-border-subtle rounded-lg overflow-hidden">
+                          <div className="bg-terminal-gray/20 px-3 py-2 border-b border-terminal-border-subtle">
+                            <Skeleton className="h-4 w-20 bg-terminal-gray" />
+                          </div>
+                          <div className="p-2 space-y-2">
+                            {Array.from({ length: 6 }).map((_, j) => (
+                              <Skeleton key={j} className="h-8 w-full bg-terminal-gray/60" />
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : boxScore.length === 0 ? (
+                    <div className="text-center py-8 text-terminal-text opacity-50 text-sm">
+                      Box score indisponivel para este jogo
+                    </div>
+                  ) : (
+                    <div className="space-y-4">
+                      {/* Controls: Team selector + Detailed view toggle */}
+                      <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-1 bg-terminal-dark-gray border border-terminal-border-subtle rounded-lg p-1 w-fit">
+                        <button
+                          onClick={() => setBoxScoreView('all')}
+                          aria-label={`Ver todos os jogadores (${game.home_team_abbreviation} + ${game.visitor_team_abbreviation})`}
+                          aria-pressed={boxScoreView === 'all'}
+                          className={`flex items-center justify-center gap-1.5 min-h-[44px] min-w-[44px] px-3 rounded-md text-xs font-medium transition-colors active:scale-95 motion-reduce:transform-none ${boxScoreView === 'all' ? 'bg-terminal-green/20 text-terminal-green border border-terminal-green/30' : 'bg-terminal-gray/40 border border-terminal-border-subtle text-terminal-text opacity-70 hover:opacity-100 hover:bg-terminal-gray/60 active:bg-terminal-gray/80'}`}
+                        >
+                          <img src={getTeamLogoUrl(game.home_team_name)} alt="" className="w-5 h-5 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                          <span>+</span>
+                          <img src={getTeamLogoUrl(game.visitor_team_name)} alt="" className="w-5 h-5 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                        </button>
+                        <button
+                          onClick={() => setBoxScoreView('home')}
+                          aria-label={`Ver jogadores do ${game.home_team_abbreviation}`}
+                          aria-pressed={boxScoreView === 'home'}
+                          className={`flex items-center justify-center min-h-[44px] min-w-[44px] px-3 rounded-md text-xs font-medium transition-colors active:scale-95 motion-reduce:transform-none ${boxScoreView === 'home' ? 'bg-terminal-green/20 text-terminal-green border border-terminal-green/30' : 'bg-terminal-gray/40 border border-terminal-border-subtle text-terminal-text opacity-70 hover:opacity-100 hover:bg-terminal-gray/60 active:bg-terminal-gray/80'}`}
+                        >
+                          <img src={getTeamLogoUrl(game.home_team_name)} alt="" className="w-5 h-5 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                        </button>
+                        <button
+                          onClick={() => setBoxScoreView('visitor')}
+                          aria-label={`Ver jogadores do ${game.visitor_team_abbreviation}`}
+                          aria-pressed={boxScoreView === 'visitor'}
+                          className={`flex items-center justify-center min-h-[44px] min-w-[44px] px-3 rounded-md text-xs font-medium transition-colors active:scale-95 motion-reduce:transform-none ${boxScoreView === 'visitor' ? 'bg-terminal-green/20 text-terminal-green border border-terminal-green/30' : 'bg-terminal-gray/40 border border-terminal-border-subtle text-terminal-text opacity-70 hover:opacity-100 hover:bg-terminal-gray/60 active:bg-terminal-gray/80'}`}
+                        >
+                          <img src={getTeamLogoUrl(game.visitor_team_name)} alt="" className="w-5 h-5 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                        </button>
+                      </div>
+
+                      {/* Detailed view toggle — mobile only */}
+                      <button
+                        onClick={() => setDetailedView(!detailedView)}
+                        className={`md:hidden flex items-center gap-2 min-h-[44px] px-2 rounded-lg border transition-colors ${detailedView ? 'bg-terminal-green/15 border-terminal-green/30' : 'bg-terminal-dark-gray border-terminal-border-subtle hover:bg-terminal-gray/30'}`}
+                        aria-label={detailedView ? 'Mudar para visão compacta' : 'Mudar para visão detalhada'}
                       >
-                        <td className="py-2 px-2">
-                          <Link
-                            to={getPlayerHref(homePlayer.player_name)}
-                            className="flex items-center gap-2 cursor-pointer hover:text-terminal-green transition-colors"
-                          >
-                            <div className="w-6 h-6 bg-terminal-gray rounded-full flex items-center justify-center border border-terminal-border-subtle flex-shrink-0 relative overflow-hidden">
-                              <img
-                                src={getPlayerPhotoUrl(homePlayer.player_name, game.home_team_name)}
-                                alt={homePlayer.player_name}
-                                className="w-full h-full object-cover"
-                                loading="lazy"
-                                data-player-photo-index="0"
-                                onError={(e) => {
-                                  const target = e.target as HTMLImageElement;
-                                  const hasNext = tryNextPlayerPhotoUrl(target, homePlayer.player_name, game.home_team_name);
-                                  if (hasNext) return;
-                                  target.style.display = 'none';
-                                  const parent = target.parentElement;
-                                  if (parent) {
-                                    const initials = homePlayer.player_name
-                                      .split(' ')
-                                      .map(n => n[0])
-                                      .join('')
-                                      .toUpperCase()
-                                      .slice(0, 2);
-                                    parent.innerHTML = `<span class="text-[8px] font-bold text-terminal-text">${initials}</span>`;
-                                  }
-                                }}
-                              />
+                        <span className={`text-[11px] ${detailedView ? 'text-terminal-green' : 'text-terminal-text opacity-60'}`}>Detalhado</span>
+                        <div className={`relative w-10 h-[22px] rounded-full transition-colors border ${detailedView ? 'bg-terminal-green border-terminal-green' : 'bg-terminal-gray border-terminal-border-subtle'}`}>
+                          <div className={`absolute top-[2px] w-4 h-4 rounded-full shadow-sm transition-transform ${detailedView ? 'translate-x-[22px]' : 'translate-x-[3px]'} bg-white`} />
+                        </div>
+                      </button>
+                      </div>
+
+                      {boxScoreView === 'all' ? (
+                        renderCombinedBoxScore()
+                      ) : boxScoreView === 'home' ? (
+                        renderBoxScoreTable(
+                          boxScore.filter(p => p.home_away === 'Casa'),
+                          game.home_team_name
+                        )
+                      ) : (
+                        renderBoxScoreTable(
+                          boxScore.filter(p => p.home_away === 'Fora'),
+                          game.visitor_team_name
+                        )
+                      )}
+                    </div>
+                  )}
+                </>
+              )}
+
+              {/* Tab: Performance B2B */}
+              {activeTab === 'b2b' && (
+                <>
+                  {isLoadingB2B ? (
+                    <div className="space-y-4">
+                      {[0, 1].map((i) => (
+                        <div key={i} className="border border-terminal-border-subtle rounded-lg overflow-hidden">
+                          <div className="bg-terminal-gray/20 px-3 py-2 border-b border-terminal-border-subtle">
+                            <Skeleton className="h-4 w-24 bg-terminal-gray" />
+                          </div>
+                          <div className="p-2 space-y-2">
+                            {Array.from({ length: 5 }).map((_, j) => (
+                              <Skeleton key={j} className="h-10 w-full bg-terminal-gray/60" />
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="space-y-4">
+                      {/* Context info icon */}
+                      <div className="flex justify-end">
+                        <span
+                          className="inline-flex items-center justify-center w-5 h-5 rounded-full border border-terminal-border-subtle text-[10px] text-terminal-text opacity-50 hover:opacity-100 hover:border-terminal-yellow hover:text-terminal-yellow cursor-help transition-all"
+                          title="Jogadores com rating ★★ ou superior que atuaram no jogo anterior. Fique atento a minutagens altas — fadiga impacta diretamente a performance em back-to-back."
+                        >
+                          i
+                        </span>
+                      </div>
+
+                      <div className="grid gap-4 grid-cols-1">
+                        {/* Home team B2B */}
+                        {game.home_team_is_b2b_game && (
+                          <div className="border border-terminal-border-subtle rounded-lg overflow-hidden">
+                            <div className="bg-terminal-gray px-3 py-2 border-b border-terminal-border-subtle flex items-center justify-between">
+                              <div className="flex items-center gap-2">
+                                <img src={getTeamLogoUrl(game.home_team_name)} alt="" className="w-5 h-5 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                                <span className="text-xs font-bold text-terminal-text">{game.home_team_abbreviation}</span>
+                                <span className="text-[9px] bg-terminal-yellow/20 text-terminal-yellow px-1.5 py-0.5 rounded font-medium">B2B</span>
+                              </div>
+                              {b2bData.home.length > 0 && (() => {
+                                const p = b2bData.home[0];
+                                const won = (p.previous_team_score ?? 0) > (p.previous_opponent_score ?? 0);
+                                const location = p.previous_home_away === 'Casa' ? 'em casa' : 'fora de casa';
+                                const dateStr = new Date(p.previous_game_date + 'T12:00:00').toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
+                                return (
+                                  <span className={`text-[10px] ${won ? 'text-green-400' : 'text-terminal-red'}`}>
+                                    {won ? 'Venceu' : 'Perdeu'} {p.previous_opponent} {p.previous_team_score}-{p.previous_opponent_score} ({location}) • {dateStr}
+                                  </span>
+                                );
+                              })()}
                             </div>
-                            <div className="min-w-0">
-                              <div className="text-xs font-medium text-terminal-text truncate">{homePlayer.player_name}</div>
-                              {homePlayer.rating_stars > 0 && (
-                                <div className="text-[9px] text-terminal-yellow opacity-70">{'★'.repeat(Math.min(homePlayer.rating_stars, 5))}</div>
-                              )}
+                            {b2bData.home.length === 0 ? (
+                              <div className="text-center py-6 text-terminal-text opacity-50 text-xs">
+                                Dados do jogo anterior indisponíveis
+                              </div>
+                            ) : (
+                              <div className="overflow-x-auto">
+                                <table className="w-full">
+                                  <thead>
+                                    <tr className="border-b border-terminal-border-subtle bg-terminal-gray/50">
+                                      <th className="text-left py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[130px]">Jogador</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[40px]" title="Minutos jogados">MIN</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Pontos">PTS</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Rebotes totais">REB</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Assistências">AST</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Aproveitamento de arremessos de quadra">FG%</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Aproveitamento de lances livres">FT%</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                    {b2bData.home.map((player, idx) => {
+                                      const highMinutes = (player.minutes ?? 0) > 35;
+                                      const injured = homeInjuredPlayers.find(p => p.player_name === player.player_name);
+                                      return (
+                                        <tr key={player.player_id} className={`border-b border-terminal-border-subtle/30 ${idx % 2 === 1 ? 'bg-terminal-gray/10' : ''}`}>
+                                          <td className="py-2 px-2">
+                                            <div className="flex items-center gap-2">
+                                              <span className={`text-[10px] min-w-[24px] ${player.rating_stars > 0 ? 'text-terminal-yellow' : 'text-terminal-text opacity-20'}`} title={player.rating_stars > 0 ? `Rating: ${player.rating_stars} estrela${player.rating_stars > 1 ? 's' : ''} — potencial de impacto no prop` : 'Sem rating'}>
+                                                {player.rating_stars > 0 ? '★'.repeat(player.rating_stars) : '—'}
+                                              </span>
+                                              <Link to={getPlayerHref(player.player_name)} className="text-xs font-medium text-terminal-text hover:text-terminal-green transition-colors truncate">
+                                                {player.player_name}
+                                              </Link>
+                                              {injured && (() => {
+                                                const style = getInjuryStatusStyle(injured.current_status);
+                                                return (
+                                                  <span className={`text-[8px] px-1 py-0.5 rounded ${style.textClass} ${style.bgClass} whitespace-nowrap`}>
+                                                    {getInjuryStatusLabel(injured.current_status)}
+                                                  </span>
+                                                );
+                                              })()}
+                                            </div>
+                                          </td>
+                                          <td className={`py-2 px-2 text-center text-xs tabular-nums font-bold ${highMinutes ? 'text-terminal-red' : 'text-terminal-text'}`}>
+                                            {player.minutes != null ? Math.round(player.minutes) : '—'}
+                                            {highMinutes && <span className="ml-0.5 text-[8px]">⚠</span>}
+                                          </td>
+                                          <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text font-semibold">{player.points ?? '—'}</td>
+                                          <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text">{player.rebounds ?? '—'}</td>
+                                          <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text">{player.assists ?? '—'}</td>
+                                          <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text opacity-80">{formatPct(player.fg_pct)}</td>
+                                          <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text opacity-80">{formatPct(player.ft_pct)}</td>
+                                        </tr>
+                                      );
+                                    })}
+                                  </tbody>
+                                </table>
+                              </div>
+                            )}
+                          </div>
+                        )}
+
+                        {/* Visitor team B2B */}
+                        {game.visitor_team_is_b2b_game && (
+                          <div className="border border-terminal-border-subtle rounded-lg overflow-hidden">
+                            <div className="bg-terminal-gray px-3 py-2 border-b border-terminal-border-subtle flex items-center justify-between">
+                              <div className="flex items-center gap-2">
+                                <img src={getTeamLogoUrl(game.visitor_team_name)} alt="" className="w-5 h-5 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                                <span className="text-xs font-bold text-terminal-text">{game.visitor_team_abbreviation}</span>
+                                <span className="text-[9px] bg-terminal-yellow/20 text-terminal-yellow px-1.5 py-0.5 rounded font-medium">B2B</span>
+                              </div>
+                              {b2bData.visitor.length > 0 && (() => {
+                                const p = b2bData.visitor[0];
+                                const won = (p.previous_team_score ?? 0) > (p.previous_opponent_score ?? 0);
+                                const location = p.previous_home_away === 'Casa' ? 'em casa' : 'fora de casa';
+                                const dateStr = new Date(p.previous_game_date + 'T12:00:00').toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' });
+                                return (
+                                  <span className={`text-[10px] ${won ? 'text-green-400' : 'text-terminal-red'}`}>
+                                    {won ? 'Venceu' : 'Perdeu'} {p.previous_opponent} {p.previous_team_score}-{p.previous_opponent_score} ({location}) • {dateStr}
+                                  </span>
+                                );
+                              })()}
                             </div>
-                          </Link>
-                        </td>
-                        <td className="py-2 px-1 text-center text-xs text-terminal-text opacity-60">{homePlayer.position || '—'}</td>
-                        <td className="py-2 px-1 text-center">
-                          {(() => {
-                            const injuryStyle = getInjuryStatusStyle(homePlayer.current_status);
-                            return (
-                              <span className={`text-[9px] px-1 py-0.5 rounded border whitespace-nowrap ${injuryStyle.textClass} ${injuryStyle.borderClass} ${injuryStyle.bgClass}`}>
-                                {getInjuryStatusLabel(homePlayer.current_status)}
-                              </span>
-                            );
-                          })()}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
+                            {b2bData.visitor.length === 0 ? (
+                              <div className="text-center py-6 text-terminal-text opacity-50 text-xs">
+                                Dados do jogo anterior indisponíveis
+                              </div>
+                            ) : (
+                              <div className="overflow-x-auto">
+                                <table className="w-full">
+                                  <thead>
+                                    <tr className="border-b border-terminal-border-subtle bg-terminal-gray/50">
+                                      <th className="text-left py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[130px]">Jogador</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[40px]" title="Minutos jogados">MIN</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Pontos">PTS</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Rebotes totais">REB</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Assistências">AST</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Aproveitamento de arremessos de quadra">FG%</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Aproveitamento de lances livres">FT%</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                    {b2bData.visitor.map((player, idx) => {
+                                      const highMinutes = (player.minutes ?? 0) > 35;
+                                      const injured = visitorInjuredPlayers.find(p => p.player_name === player.player_name);
+                                      return (
+                                        <tr key={player.player_id} className={`border-b border-terminal-border-subtle/30 ${idx % 2 === 1 ? 'bg-terminal-gray/10' : ''}`}>
+                                          <td className="py-2 px-2">
+                                            <div className="flex items-center gap-2">
+                                              <span className={`text-[10px] min-w-[24px] ${player.rating_stars > 0 ? 'text-terminal-yellow' : 'text-terminal-text opacity-20'}`} title={player.rating_stars > 0 ? `Rating: ${player.rating_stars} estrela${player.rating_stars > 1 ? 's' : ''} — potencial de impacto no prop` : 'Sem rating'}>
+                                                {player.rating_stars > 0 ? '★'.repeat(player.rating_stars) : '—'}
+                                              </span>
+                                              <Link to={getPlayerHref(player.player_name)} className="text-xs font-medium text-terminal-text hover:text-terminal-green transition-colors truncate">
+                                                {player.player_name}
+                                              </Link>
+                                              {injured && (() => {
+                                                const style = getInjuryStatusStyle(injured.current_status);
+                                                return (
+                                                  <span className={`text-[8px] px-1 py-0.5 rounded ${style.textClass} ${style.bgClass} whitespace-nowrap`}>
+                                                    {getInjuryStatusLabel(injured.current_status)}
+                                                  </span>
+                                                );
+                                              })()}
+                                            </div>
+                                          </td>
+                                          <td className={`py-2 px-2 text-center text-xs tabular-nums font-bold ${highMinutes ? 'text-terminal-red' : 'text-terminal-text'}`}>
+                                            {player.minutes != null ? Math.round(player.minutes) : '—'}
+                                            {highMinutes && <span className="ml-0.5 text-[8px]">⚠</span>}
+                                          </td>
+                                          <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text font-semibold">{player.points ?? '—'}</td>
+                                          <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text">{player.rebounds ?? '—'}</td>
+                                          <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text">{player.assists ?? '—'}</td>
+                                          <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text opacity-80">{formatPct(player.fg_pct)}</td>
+                                          <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text opacity-80">{formatPct(player.ft_pct)}</td>
+                                        </tr>
+                                      );
+                                    })}
+                                  </tbody>
+                                </table>
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
             </div>
-            {/* Visitor team lineup */}
-            <div className="border border-terminal-border-subtle rounded-lg overflow-hidden">
-              <div className="bg-terminal-gray/20 px-3 py-2 border-b border-terminal-border-subtle">
-                <span className="text-xs font-bold text-terminal-text">{game.visitor_team_abbreviation}</span>
-              </div>
-              <div className="overflow-x-auto">
-                <table className="w-full">
-                  <thead>
-                    <tr className="border-b border-terminal-border-subtle">
-                      <th className="text-left py-2 px-2 text-[10px] font-medium text-terminal-text opacity-60">Player</th>
-                      <th className="text-center py-2 px-1 text-[10px] font-medium text-terminal-text opacity-60">POS</th>
-                      <th className="text-center py-2 px-1 text-[10px] font-medium text-terminal-text opacity-60">Status</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {sortedVisitorPlayers.map((visitorPlayer) => (
-                      <tr
-                        key={visitorPlayer.player_id}
-                        className="border-b border-terminal-border-subtle/50 hover:bg-terminal-gray/10 transition-colors"
-                      >
-                        <td className="py-2 px-2">
-                          <Link
-                            to={getPlayerHref(visitorPlayer.player_name)}
-                            className="flex items-center gap-2 cursor-pointer hover:text-terminal-green transition-colors"
-                          >
-                            <div className="w-6 h-6 bg-terminal-gray rounded-full flex items-center justify-center border border-terminal-border-subtle flex-shrink-0 relative overflow-hidden">
-                              <img
-                                src={getPlayerPhotoUrl(visitorPlayer.player_name, game.visitor_team_name)}
-                                alt={visitorPlayer.player_name}
-                                className="w-full h-full object-cover"
-                                loading="lazy"
-                                data-player-photo-index="0"
-                                onError={(e) => {
-                                  const target = e.target as HTMLImageElement;
-                                  const hasNext = tryNextPlayerPhotoUrl(target, visitorPlayer.player_name, game.visitor_team_name);
-                                  if (hasNext) return;
-                                  target.style.display = 'none';
-                                  const parent = target.parentElement;
-                                  if (parent) {
-                                    const initials = visitorPlayer.player_name
-                                      .split(' ')
-                                      .map(n => n[0])
-                                      .join('')
-                                      .toUpperCase()
-                                      .slice(0, 2);
-                                    parent.innerHTML = `<span class="text-[8px] font-bold text-terminal-text">${initials}</span>`;
-                                  }
-                                }}
-                              />
-                            </div>
-                            <div className="min-w-0">
-                              <div className="text-xs font-medium text-terminal-text truncate">{visitorPlayer.player_name}</div>
-                              {visitorPlayer.rating_stars > 0 && (
-                                <div className="text-[9px] text-terminal-yellow opacity-70">{'★'.repeat(Math.min(visitorPlayer.rating_stars, 5))}</div>
-                              )}
-                            </div>
-                          </Link>
-                        </td>
-                        <td className="py-2 px-1 text-center text-xs text-terminal-text opacity-60">{visitorPlayer.position || '—'}</td>
-                        <td className="py-2 px-1 text-center">
-                          {(() => {
-                            const injuryStyle = getInjuryStatusStyle(visitorPlayer.current_status);
-                            return (
-                              <span className={`text-[9px] px-1 py-0.5 rounded border whitespace-nowrap ${injuryStyle.textClass} ${injuryStyle.borderClass} ${injuryStyle.bgClass}`}>
-                                {getInjuryStatusLabel(visitorPlayer.current_status)}
-                              </span>
-                            );
-                          })()}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
-          )}
-        </div>
           </div>
         </div>
       </main>

--- a/src/pages/GameDetail.tsx
+++ b/src/pages/GameDetail.tsx
@@ -1122,6 +1122,7 @@ export default function GameDetail() {
                                       <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Assistências">AST</th>
                                       <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Aproveitamento de arremessos de quadra">FG%</th>
                                       <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Aproveitamento de lances livres">FT%</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Plus/Minus — impacto no placar quando em quadra">+/-</th>
                                     </tr>
                                   </thead>
                                   <tbody>
@@ -1157,6 +1158,9 @@ export default function GameDetail() {
                                           <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text">{player.assists ?? '—'}</td>
                                           <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text opacity-80">{formatPct(player.fg_pct)}</td>
                                           <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text opacity-80">{formatPct(player.ft_pct)}</td>
+                                          <td className={`py-2 px-2 text-center text-xs tabular-nums ${(player.plus_minus ?? 0) > 0 ? 'text-green-400' : (player.plus_minus ?? 0) < 0 ? 'text-terminal-red' : 'text-terminal-text opacity-50'}`}>
+                                            {player.plus_minus != null ? (player.plus_minus > 0 ? `+${player.plus_minus}` : player.plus_minus) : '—'}
+                                          </td>
                                         </tr>
                                       );
                                     })}
@@ -1204,6 +1208,7 @@ export default function GameDetail() {
                                       <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Assistências">AST</th>
                                       <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Aproveitamento de arremessos de quadra">FG%</th>
                                       <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Aproveitamento de lances livres">FT%</th>
+                                      <th className="text-center py-2 px-2 text-[11px] font-medium text-terminal-text opacity-70 min-w-[36px]" title="Plus/Minus — impacto no placar quando em quadra">+/-</th>
                                     </tr>
                                   </thead>
                                   <tbody>
@@ -1239,6 +1244,9 @@ export default function GameDetail() {
                                           <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text">{player.assists ?? '—'}</td>
                                           <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text opacity-80">{formatPct(player.fg_pct)}</td>
                                           <td className="py-2 px-2 text-center text-xs tabular-nums text-terminal-text opacity-80">{formatPct(player.ft_pct)}</td>
+                                          <td className={`py-2 px-2 text-center text-xs tabular-nums ${(player.plus_minus ?? 0) > 0 ? 'text-green-400' : (player.plus_minus ?? 0) < 0 ? 'text-terminal-red' : 'text-terminal-text opacity-50'}`}>
+                                            {player.plus_minus != null ? (player.plus_minus > 0 ? `+${player.plus_minus}` : player.plus_minus) : '—'}
+                                          </td>
                                         </tr>
                                       );
                                     })}

--- a/src/pages/NBADashboard.tsx
+++ b/src/pages/NBADashboard.tsx
@@ -78,12 +78,8 @@ export default function NBADashboard() {
 
   // PLG freemium: deslogado só acessa jogadores FREE_PLAYERS; outros → login
   const isFree = player ? isFreePlayer(player.player_name) : false;
-  if (!authLoading && !user && player && !isFree) {
-    return <Navigate to="/auth" state={{ from: location }} replace />;
-  }
 
   // Logado mas não premium: jogador não grátis → paywall
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     if (!subscriptionLoading && user && player && !isPremium && !isFree) {
       const playerFullName = player.player_name;
@@ -97,6 +93,96 @@ export default function NBADashboard() {
       }, 2000);
     }
   }, [player, user, isPremium, isFree, subscriptionLoading, navigate, toast]);
+
+  // Calculate season averages from all game stats
+  const seasonAverages = React.useMemo(() => {
+    const pointsGames = gameStats.filter(g => g.stat_type === 'player_points');
+    const assistsGames = gameStats.filter(g => g.stat_type === 'player_assists');
+    const reboundsGames = gameStats.filter(g => g.stat_type === 'player_rebounds');
+
+    return {
+      points: pointsGames.length > 0
+        ? pointsGames.reduce((sum, g) => sum + (g.stat_value ?? 0), 0) / pointsGames.length
+        : 0,
+      assists: assistsGames.length > 0
+        ? assistsGames.reduce((sum, g) => sum + (g.stat_value ?? 0), 0) / assistsGames.length
+        : 0,
+      rebounds: reboundsGames.length > 0
+        ? reboundsGames.reduce((sum, g) => sum + (g.stat_value ?? 0), 0) / reboundsGames.length
+        : 0,
+    };
+  }, [gameStats]);
+
+  // Ref to scroll chart into view when insight is clicked
+  const chartRef = React.useRef<HTMLDivElement>(null);
+
+  // Filter game stats based on selected filters
+  const filteredGameStats = useMemo(() => {
+    let filtered = gameStats.filter(g => g.stat_type === selectedStatType);
+
+    // Apply home/away filter
+    if (homeAway !== 'all') {
+      filtered = filtered.filter(g => {
+        const location = g.home_away?.toLowerCase();
+        if (homeAway === 'home') {
+          return location === 'home' || location === 'h' || location === 'casa';
+        }
+        return location === 'away' || location === 'a' || location === 'fora';
+      });
+    }
+
+    // Apply teammate filter (multi-select)
+    if (teammateFilter && teammateFilter.length > 0 && teammateGameIds) {
+      for (const tf of teammateFilter) {
+        const ids = teammateGameIds.get(tf.playerId);
+        if (!ids) continue;
+        filtered = filtered.filter(g =>
+          tf.mode === 'with'
+            ? ids.has(Number(g.game_id))
+            : !ids.has(Number(g.game_id))
+        );
+      }
+    }
+
+    // Apply B2B filter
+    if (b2bOnly) {
+      filtered = filtered.filter(g => g.is_b2b_game);
+    }
+
+    // Apply H2H filter (games against next opponent)
+    if (h2hOnly && teamData?.next_opponent_abbreviation) {
+      const opp = teamData.next_opponent_abbreviation.toUpperCase();
+      filtered = filtered.filter(g =>
+        g.played_against?.toUpperCase().replace('@', '').includes(opp)
+      );
+    }
+
+    // Apply last N games filter
+    if (lastNGames !== 'all') {
+      filtered = filtered.slice(0, lastNGames);
+    }
+
+    return filtered;
+  }, [gameStats, selectedStatType, homeAway, lastNGames, teammateFilter, teammateGameIds, b2bOnly, h2hOnly, teamData]);
+
+  // Get current betting line for selected stat type
+  const currentLine = useMemo(() => {
+    // Get the most recent game's line_most_recent for the selected stat type
+    const statsForType = gameStats.filter(g => g.stat_type === selectedStatType);
+    if (statsForType.length === 0) return null;
+
+    // Sort by date descending and get the first one's line_most_recent
+    const sortedStats = [...statsForType].sort((a, b) =>
+      new Date(b.game_date).getTime() - new Date(a.game_date).getTime()
+    );
+
+    return sortedStats[0]?.line_most_recent ?? null;
+  }, [gameStats, selectedStatType]);
+
+  // Early returns (after all hooks)
+  if (!authLoading && !user && player && !isFree) {
+    return <Navigate to="/auth" state={{ from: location }} replace />;
+  }
 
   const loadPlayer = async () => {
     if (!playerName) return;
@@ -285,30 +371,6 @@ export default function NBADashboard() {
     }
   };
 
-  // Calculate season averages from all game stats
-  // Must be before conditional returns to comply with Rules of Hooks
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const seasonAverages = React.useMemo(() => {
-    const pointsGames = gameStats.filter(g => g.stat_type === 'player_points');
-    const assistsGames = gameStats.filter(g => g.stat_type === 'player_assists');
-    const reboundsGames = gameStats.filter(g => g.stat_type === 'player_rebounds');
-
-    return {
-      points: pointsGames.length > 0 
-        ? pointsGames.reduce((sum, g) => sum + (g.stat_value ?? 0), 0) / pointsGames.length 
-        : 0,
-      assists: assistsGames.length > 0 
-        ? assistsGames.reduce((sum, g) => sum + (g.stat_value ?? 0), 0) / assistsGames.length 
-        : 0,
-      rebounds: reboundsGames.length > 0 
-        ? reboundsGames.reduce((sum, g) => sum + (g.stat_value ?? 0), 0) / reboundsGames.length 
-        : 0,
-    };
-  }, [gameStats]);
-
-  // Ref to scroll chart into view when insight is clicked
-  const chartRef = React.useRef<HTMLDivElement>(null);
-
   const handleInsightClick = (statType: string, triggerPlayerName: string) => {
     // 1. Switch stat type to the insight's stat
     setSelectedStatType(statType);
@@ -374,71 +436,6 @@ export default function NBADashboard() {
       setTeammateFilterLoading(false);
     }
   };
-
-  // Filter game stats based on selected filters
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const filteredGameStats = useMemo(() => {
-    let filtered = gameStats.filter(g => g.stat_type === selectedStatType);
-
-    // Apply home/away filter
-    if (homeAway !== 'all') {
-      filtered = filtered.filter(g => {
-        const location = g.home_away?.toLowerCase();
-        if (homeAway === 'home') {
-          return location === 'home' || location === 'h' || location === 'casa';
-        }
-        return location === 'away' || location === 'a' || location === 'fora';
-      });
-    }
-
-    // Apply teammate filter (multi-select)
-    if (teammateFilter && teammateFilter.length > 0 && teammateGameIds) {
-      for (const tf of teammateFilter) {
-        const ids = teammateGameIds.get(tf.playerId);
-        if (!ids) continue;
-        filtered = filtered.filter(g =>
-          tf.mode === 'with'
-            ? ids.has(Number(g.game_id))
-            : !ids.has(Number(g.game_id))
-        );
-      }
-    }
-
-    // Apply B2B filter
-    if (b2bOnly) {
-      filtered = filtered.filter(g => g.is_b2b_game);
-    }
-
-    // Apply H2H filter (games against next opponent)
-    if (h2hOnly && teamData?.next_opponent_abbreviation) {
-      const opp = teamData.next_opponent_abbreviation.toUpperCase();
-      filtered = filtered.filter(g =>
-        g.played_against?.toUpperCase().replace('@', '').includes(opp)
-      );
-    }
-
-    // Apply last N games filter
-    if (lastNGames !== 'all') {
-      filtered = filtered.slice(0, lastNGames);
-    }
-
-    return filtered;
-  }, [gameStats, selectedStatType, homeAway, lastNGames, teammateFilter, teammateGameIds, b2bOnly, h2hOnly, teamData]);
-
-  // Get current betting line for selected stat type
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const currentLine = useMemo(() => {
-    // Get the most recent game's line_most_recent for the selected stat type
-    const statsForType = gameStats.filter(g => g.stat_type === selectedStatType);
-    if (statsForType.length === 0) return null;
-    
-    // Sort by date descending and get the first one's line_most_recent
-    const sortedStats = [...statsForType].sort((a, b) => 
-      new Date(b.game_date).getTime() - new Date(a.game_date).getTime()
-    );
-    
-    return sortedStats[0]?.line_most_recent ?? null;
-  }, [gameStats, selectedStatType]);
 
   if (!player && playerLookupDone) {
     return (

--- a/src/pages/NBADashboard.tsx
+++ b/src/pages/NBADashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import { useParams, useNavigate, useSearchParams, useLocation, Navigate } from 'react-router-dom';
-import { nbaDataService, Player, GamePlayerStats, PropPlayer, TeamPlayer, Team, PlayerShootingZones } from '@/services/nba-data.service';
+import { nbaDataService, Player, GamePlayerStats, PropPlayer, TeamPlayer, Team, PlayerShootingZones, DailyOpportunity } from '@/services/nba-data.service';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { GameChart } from '@/components/nba/GameChart';
 import { ComparisonTable } from '@/components/nba/ComparisonTable';
@@ -54,17 +54,20 @@ export default function NBADashboard() {
   const [nextGameTime, setNextGameTime] = useState<string | null>(initCache?.nextGameTime ?? null);
   const [statsLoading, setStatsLoading] = useState(!initCache);
   const [propsLoading, setPropsLoading] = useState(!initCache);
+  const [dailyOpps, setDailyOpps] = useState<DailyOpportunity[]>([]);
   const [teammatesLoading, setTeammatesLoading] = useState(!initCache);
   const [teamLoading, setTeamLoading] = useState(!initCache);
   const [shootingZonesLoading, setShootingZonesLoading] = useState(!initCache);
   const [playerLookupDone, setPlayerLookupDone] = useState(!!initCache);
   const initialStat = searchParams.get('stat');
+  const initialTrigger = searchParams.get('trigger');
   const statFromUrl = initialStat && VALID_STAT_TYPES.includes(initialStat) ? initialStat : 'player_points';
   const [selectedStatType, setSelectedStatType] = useState<string>(statFromUrl);
+  const [pendingTriggerFilter, setPendingTriggerFilter] = useState<string | null>(initialTrigger);
   const [lastNGames, setLastNGames] = useState<number | 'all'>(15);
   const [homeAway, setHomeAway] = useState<'all' | 'home' | 'away'>('all');
   const [teammateFilter, setTeammateFilter] = useState<TeammateFilter>(null);
-  const [teammateGameIds, setTeammateGameIds] = useState<Set<number> | null>(null);
+  const [teammateGameIds, setTeammateGameIds] = useState<Map<number, Set<number>> | null>(null);
   const [teammateFilterLoading, setTeammateFilterLoading] = useState(false);
   const [b2bOnly, setB2bOnly] = useState(false);
   const [h2hOnly, setH2hOnly] = useState(false);
@@ -175,10 +178,33 @@ export default function NBADashboard() {
       } catch (e) { console.error('Error loading props:', e); }
       setPropsLoading(false);
 
+      // 3.5. Daily opportunities for this player (same data as Picks page)
+      try {
+        const allOpps = await nbaDataService.getDailyOpportunities();
+        const playerOpps = allOpps.filter(o => o.backup_player_name === playerData.player_name);
+        setDailyOpps(playerOpps);
+      } catch (e) { console.error('Error loading daily opportunities:', e); }
+
       // 4. Teammates
       try {
         loadedTeammates = await nbaDataService.getTeamPlayers(playerData.team_id);
         setTeammates(loadedTeammates);
+
+        // Auto-apply trigger filter from URL (e.g., from Picks page "Analisar" button)
+        if (pendingTriggerFilter) {
+          const triggerTeammate = loadedTeammates.find(
+            t => t.player_name.toLowerCase() === pendingTriggerFilter.toLowerCase()
+          );
+          if (triggerTeammate) {
+            handleTeammateFilterChange([{
+              playerId: triggerTeammate.player_id,
+              playerName: triggerTeammate.player_name,
+              mode: 'without',
+            }]);
+            setLastNGames('all');
+          }
+          setPendingTriggerFilter(null);
+        }
       } catch (e) { console.error('Error loading teammates:', e); }
       setTeammatesLoading(false);
 
@@ -292,15 +318,15 @@ export default function NBADashboard() {
       t => t.player_name.toLowerCase() === triggerPlayerName.toLowerCase()
     );
     if (triggerTeammate) {
-      handleTeammateFilterChange({
+      handleTeammateFilterChange([{
         playerId: triggerTeammate.player_id,
         playerName: triggerTeammate.player_name,
         mode: 'without',
-      });
+      }]);
     }
 
-    // 3. Reset other filters to show clean view
-    setLastNGames(15);
+    // 3. Reset other filters to show clean view (all games for full season comparison)
+    setLastNGames('all');
     setHomeAway('all');
     setB2bOnly(false);
     setH2hOnly(false);
@@ -310,14 +336,37 @@ export default function NBADashboard() {
 
   const handleTeammateFilterChange = async (filter: TeammateFilter) => {
     setTeammateFilter(filter);
-    if (!filter) {
+    if (!filter || filter.length === 0) {
       setTeammateGameIds(null);
       return;
     }
     setTeammateFilterLoading(true);
     try {
-      const stats = await nbaDataService.getPlayerGameStats(filter.playerId, 250);
-      setTeammateGameIds(new Set(stats.map(g => g.game_id)));
+      // Load game_ids for each teammate in parallel
+      const map = new Map<number, Set<number>>();
+      const existing = teammateGameIds ?? new Map<number, Set<number>>();
+
+      // Only load data for new teammates (reuse cached)
+      const toLoad = filter.filter(f => !existing.has(f.playerId));
+      const results = await Promise.all(
+        toLoad.map(async f => {
+          const stats = await nbaDataService.getPlayerGameStats(f.playerId, 250);
+          return { playerId: f.playerId, gameIds: new Set(stats.map(g => Number(g.game_id))) };
+        })
+      );
+
+      // Build map: keep existing + add new
+      for (const f of filter) {
+        const cached = existing.get(f.playerId);
+        if (cached) {
+          map.set(f.playerId, cached);
+        }
+      }
+      for (const r of results) {
+        map.set(r.playerId, r.gameIds);
+      }
+
+      setTeammateGameIds(map);
     } catch (e) {
       console.error('Error loading teammate stats:', e);
       setTeammateGameIds(null);
@@ -342,13 +391,17 @@ export default function NBADashboard() {
       });
     }
 
-    // Apply teammate filter
-    if (teammateFilter && teammateGameIds) {
-      filtered = filtered.filter(g =>
-        teammateFilter.mode === 'with'
-          ? teammateGameIds.has(g.game_id)
-          : !teammateGameIds.has(g.game_id)
-      );
+    // Apply teammate filter (multi-select)
+    if (teammateFilter && teammateFilter.length > 0 && teammateGameIds) {
+      for (const tf of teammateFilter) {
+        const ids = teammateGameIds.get(tf.playerId);
+        if (!ids) continue;
+        filtered = filtered.filter(g =>
+          tf.mode === 'with'
+            ? ids.has(Number(g.game_id))
+            : !ids.has(Number(g.game_id))
+        );
+      }
     }
 
     // Apply B2B filter
@@ -425,13 +478,78 @@ export default function NBADashboard() {
               nextGameTime={nextGameTime}
             />
 
-            {/* Prop Insights */}
-            <PropInsightsCard
-              propPlayers={propPlayers}
-              playerName={player?.player_name || ''}
-              isLoading={propsLoading}
-              onInsightClick={handleInsightClick}
-            />
+            {/* Oportunidades do Dia (mesma fonte dos Picks) ou fallback para Insights */}
+            {dailyOpps.length > 0 ? (
+              <div className="terminal-container p-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <span className="text-[10px] font-bold text-terminal-green uppercase tracking-widest">
+                    Oportunidades do Dia
+                  </span>
+                  <span className="text-[9px] opacity-40">mesma análise da tela de Picks</span>
+                </div>
+                <div className="space-y-2">
+                  {dailyOpps.map((opp, i) => {
+                    const triggerLastName = opp.trigger_name.split(' ').pop();
+                    const statusBadge = opp.trigger_status.toLowerCase().includes('out') ? { text: 'OUT', cls: 'bg-terminal-red/20 text-terminal-red border-terminal-red/30' }
+                      : opp.trigger_status.toLowerCase().includes('doubtful') ? { text: 'DTD', cls: 'bg-orange-400/20 text-orange-400 border-orange-400/30' }
+                      : { text: 'Q', cls: 'bg-yellow-400/20 text-yellow-400 border-yellow-400/30' };
+                    const statLabel = { player_points: 'Pontos', player_assists: 'Assistências', player_rebounds: 'Rebotes', player_points_rebounds_assists: 'PRA', player_threes: '3 Pontos', player_steals: 'Roubos', player_blocks: 'Bloqueios' }[opp.stat_type] || opp.stat_type;
+                    const isClickable = !!handleInsightClick;
+
+                    return (
+                      <button
+                        key={i}
+                        className={`w-full text-left bg-terminal-dark-gray rounded border border-terminal-green/20 p-3 transition-all ${
+                          isClickable ? 'hover:border-terminal-green/50 hover:bg-terminal-green/5 cursor-pointer' : 'cursor-default'
+                        }`}
+                        onClick={() => handleInsightClick?.(opp.stat_type, opp.trigger_name)}
+                      >
+                        {/* Header: stat + trigger + score */}
+                        <div className="flex items-center justify-between mb-2">
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs font-bold text-terminal-text uppercase">{statLabel}</span>
+                            <span className={`text-[9px] px-1.5 py-0.5 rounded border ${statusBadge.cls}`}>
+                              SEM {triggerLastName} ({statusBadge.text})
+                            </span>
+                          </div>
+                          <span className={`text-sm font-black tabular-nums ${
+                            (opp.score ?? 0) >= 80 ? 'text-terminal-green' : (opp.score ?? 0) >= 70 ? 'text-terminal-yellow' : 'text-orange-400'
+                          }`}>
+                            {opp.score}
+                          </span>
+                        </div>
+
+                        {/* Numbers */}
+                        <div className="flex items-center gap-2">
+                          <span className="text-sm opacity-50">{opp.avg_com?.toFixed(1)}</span>
+                          <span className="text-xs opacity-30">→</span>
+                          <span className="text-lg font-bold text-terminal-green leading-none">{opp.avg_sem?.toFixed(1)}</span>
+                          {opp.gap_pct > 0 && (
+                            <span className="text-[11px] font-semibold text-terminal-green bg-terminal-green/10 px-1.5 py-0.5 rounded">
+                              +{opp.gap_pct?.toFixed(1)}%
+                            </span>
+                          )}
+                          {opp.line_value && (
+                            <span className="text-[11px] opacity-40 ml-auto">Linha: {opp.line_value?.toFixed(1)}</span>
+                          )}
+                        </div>
+
+                        <div className="text-[9px] opacity-40 mt-1">
+                          com {triggerLastName} → sem {triggerLastName} • Clique para filtrar o gráfico
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : (
+              <PropInsightsCard
+                propPlayers={propPlayers}
+                playerName={player?.player_name || ''}
+                isLoading={propsLoading}
+                onInsightClick={handleInsightClick}
+              />
+            )}
 
             {/* Teammates */}
             <TeammatesCard

--- a/src/pages/Picks.tsx
+++ b/src/pages/Picks.tsx
@@ -1,0 +1,744 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  AlertTriangle,
+  ArrowUpDown,
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+  Filter,
+  LayoutList,
+  Loader2,
+  Shield,
+  TrendingUp,
+} from 'lucide-react';
+import { nbaDataService, DailyOpportunity } from '@/services/nba-data.service';
+import { getTeamLogoUrl, getPlayerPhotoUrl, tryNextPlayerPhotoUrl } from '@/utils/team-logos';
+import AnalyticsNav from '@/components/AnalyticsNav';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useSubscription } from '@/hooks/use-subscription';
+
+const STAT_LABELS: Record<string, string> = {
+  player_points: 'Pontos',
+  player_assists: 'Assistências',
+  player_rebounds: 'Rebotes',
+  player_threes: '3 Pontos',
+  player_steals: 'Roubos',
+  player_blocks: 'Bloqueios',
+  player_turnovers: 'Turnovers',
+  player_minutes: 'Minutos',
+  player_points_assists: 'Pts + Ast',
+  player_points_rebounds: 'Pts + Reb',
+  player_rebounds_assists: 'Reb + Ast',
+  player_points_rebounds_assists: 'PRA',
+  player_blocks_steals: 'Blk + Stl',
+};
+
+function getTriggerStatusBadge(status: string): { text: string; cls: string } {
+  const s = status.toLowerCase();
+  if (s.includes('out for season')) return { text: 'OFS', cls: 'bg-terminal-red/20 text-terminal-red border-terminal-red/30' };
+  if (s === 'out' || s.includes('out')) return { text: 'OUT', cls: 'bg-terminal-red/20 text-terminal-red border-terminal-red/30' };
+  if (s.includes('doubtful')) return { text: 'DTD', cls: 'bg-orange-400/20 text-orange-400 border-orange-400/30' };
+  return { text: 'Q', cls: 'bg-yellow-400/20 text-yellow-400 border-yellow-400/30' };
+}
+
+function getTriggerStatusColor(status: string): string {
+  const s = status.toLowerCase();
+  if (s === 'out' || s.includes('out')) return 'text-terminal-red';
+  if (s.includes('doubtful')) return 'text-orange-400';
+  return 'text-yellow-400';
+}
+
+function getScoreColor(score: number | null): string {
+  if (!score) return 'opacity-50';
+  if (score >= 80) return 'text-terminal-green';
+  if (score >= 70) return 'text-terminal-yellow';
+  return 'text-orange-400';
+}
+
+function PlayerPhoto({ name, teamAbbr }: { name: string; teamAbbr: string }) {
+  const initials = name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2);
+  return (
+    <div className="w-7 h-7 rounded-full overflow-hidden bg-terminal-gray border border-terminal-border-subtle shrink-0 flex items-center justify-center">
+      <img
+        src={getPlayerPhotoUrl(name, teamAbbr)}
+        alt={name}
+        className="w-full h-full object-cover object-top"
+        data-player-photo-index="0"
+        onError={(e) => {
+          const didTry = tryNextPlayerPhotoUrl(e.target as HTMLImageElement, name, teamAbbr);
+          if (!didTry) {
+            const el = e.target as HTMLImageElement;
+            el.style.display = 'none';
+            const parent = el.parentElement;
+            if (parent) parent.innerHTML = `<span class="text-[9px] font-bold text-terminal-text opacity-60">${initials}</span>`;
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+type SortField = 'score' | 'gap_pct' | 'gap_vs_line_pct' | 'rating_stars';
+type SortDir = 'asc' | 'desc';
+type ViewMode = 'score' | 'game';
+
+export default function Picks() {
+  const navigate = useNavigate();
+  const { isPremium } = useSubscription();
+  const [opportunities, setOpportunities] = useState<DailyOpportunity[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Free users see blurred data
+  const blur = !isPremium ? 'blur-sm select-none pointer-events-none' : '';
+
+  // View mode
+  const [viewMode, setViewMode] = useState<ViewMode>('score');
+
+  // Filters
+  const [statFilter, setStatFilter] = useState<string>('all');
+  const [gameFilter, setGameFilter] = useState<string>('all');
+  const [minScore, setMinScore] = useState<number>(0);
+
+  // Sort
+  const [sortField, setSortField] = useState<SortField>('score');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  // Mobile expand
+  const [expandedRow, setExpandedRow] = useState<number | null>(null);
+
+  // Game group collapse (Por Jogo view)
+  const [collapsedGames, setCollapsedGames] = useState<Set<number>>(new Set());
+  const toggleGameCollapse = (gameId: number) => {
+    setCollapsedGames(prev => {
+      const next = new Set(prev);
+      if (next.has(gameId)) next.delete(gameId); else next.add(gameId);
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const data = await nbaDataService.getDailyOpportunities();
+        setOpportunities(data);
+      } catch (err) {
+        console.error('Error loading opportunities:', err);
+        setError('Falha ao carregar oportunidades');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const uniqueGames = useMemo(() => {
+    const seen = new Map<number, { id: number; label: string }>();
+    opportunities.forEach(o => {
+      if (!seen.has(o.game_id)) {
+        seen.set(o.game_id, { id: o.game_id, label: `${o.home_team_abbr} vs ${o.visitor_team_abbr}` });
+      }
+    });
+    return Array.from(seen.values());
+  }, [opportunities]);
+
+  const availableStats = useMemo(() => {
+    const set = new Set(opportunities.map(o => o.stat_type));
+    return Array.from(set).sort();
+  }, [opportunities]);
+
+  const filtered = useMemo(() => {
+    let result = [...opportunities];
+
+    if (statFilter !== 'all') result = result.filter(o => o.stat_type === statFilter);
+    if (gameFilter !== 'all') result = result.filter(o => o.game_id === Number(gameFilter));
+    if (minScore > 0) result = result.filter(o => (o.score ?? 0) >= minScore);
+
+    result.sort((a, b) => {
+      let cmp = 0;
+      switch (sortField) {
+        case 'score': cmp = (a.score ?? 0) - (b.score ?? 0); break;
+        case 'gap_pct': cmp = a.gap_pct - b.gap_pct; break;
+        case 'gap_vs_line_pct': cmp = (a.gap_vs_line_pct ?? -999) - (b.gap_vs_line_pct ?? -999); break;
+        case 'rating_stars': cmp = a.rating_stars - b.rating_stars; break;
+      }
+      return sortDir === 'desc' ? -cmp : cmp;
+    });
+
+    return result;
+  }, [opportunities, statFilter, gameFilter, minScore, sortField, sortDir]);
+
+  // Group by game for "Por Jogo" view
+  const groupedByGame = useMemo(() => {
+    const map = new Map<number, { label: string; time: string | null; is_b2b_home: boolean; is_b2b_visitor: boolean; opps: DailyOpportunity[] }>();
+    filtered.forEach(o => {
+      if (!map.has(o.game_id)) {
+        map.set(o.game_id, {
+          label: `${o.home_team_abbr} vs ${o.visitor_team_abbr}`,
+          time: o.game_time,
+          is_b2b_home: false,
+          is_b2b_visitor: false,
+          opps: [],
+        });
+      }
+      const group = map.get(o.game_id)!;
+      group.opps.push(o);
+      if (o.is_b2b && o.is_home) group.is_b2b_home = true;
+      if (o.is_b2b && !o.is_home) group.is_b2b_visitor = true;
+    });
+    return Array.from(map.entries()).sort((a, b) => {
+      const maxA = Math.max(...a[1].opps.map(o => o.score ?? 0));
+      const maxB = Math.max(...b[1].opps.map(o => o.score ?? 0));
+      return maxB - maxA;
+    });
+  }, [filtered]);
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(d => d === 'desc' ? 'asc' : 'desc');
+    } else {
+      setSortField(field);
+      setSortDir('desc');
+    }
+  };
+
+
+  const SortIcon = ({ field }: { field: SortField }) => {
+    if (sortField !== field) return <ArrowUpDown className="w-3 h-3 opacity-30" />;
+    return sortDir === 'desc'
+      ? <ChevronDown className="w-3 h-3 text-terminal-green" />
+      : <ChevronUp className="w-3 h-3 text-terminal-green" />;
+  };
+
+  // Summary
+  const totalOpps = filtered.length;
+  const highConfidence = filtered.filter(o => (o.score ?? 0) >= 80).length;
+  const gamesCount = new Set(filtered.map(o => o.game_id)).size;
+
+  const InfoTip = ({ text }: { text: string }) => (
+    <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-terminal-gray border border-terminal-border-subtle text-[9px] font-bold text-terminal-text opacity-60 hover:opacity-100 hover:bg-terminal-green/20 hover:border-terminal-green hover:text-terminal-green cursor-help transition-all ml-1 shrink-0" title={text}>i</span>
+  );
+
+  // Render a table row — column order: SCORE, JOGO, GATILHO, JOGADOR, STAT, COM, SEM, GAP%, LINHA, vs LINHA, AÇÃO
+  const renderRow = (opp: DailyOpportunity, idx: number, showGame: boolean) => {
+    const statusBadge = getTriggerStatusBadge(opp.trigger_status);
+    const triggerLastName = opp.trigger_name.split(' ').pop();
+    const isHighConf = (opp.score ?? 0) >= 80;
+
+    return (
+      <tr key={`${opp.trigger_player_id}-${opp.backup_player_id}-${opp.stat_type}-${idx}`}
+        className={`border-b border-terminal-border-subtle hover:bg-terminal-light-gray/50 transition-colors ${isHighConf ? 'border-l-2 border-l-terminal-green bg-white/[0.02]' : ''}`}>
+        {/* SCORE */}
+        <td className="text-center py-2 px-3">
+          <span className={blur}>
+          {isHighConf ? (
+            <span className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-terminal-green/15 border border-terminal-green/40 text-base font-black tabular-nums text-terminal-green">
+              {opp.score}
+            </span>
+          ) : (
+            <span className={`text-sm font-bold tabular-nums ${getScoreColor(opp.score)}`}>
+              {opp.score ?? '—'}
+            </span>
+          )}
+          </span>
+        </td>
+        {/* JOGO */}
+        {showGame && (
+          <td className="py-2 px-3">
+            <div className="flex items-center gap-1.5">
+              <span className="font-medium">{opp.trigger_team_abbr}</span>
+              <span className="opacity-30">vs</span>
+              <span className="opacity-60">{opp.opponent_abbr}</span>
+              {opp.is_b2b && <span className="text-[8px] bg-terminal-yellow/20 text-terminal-yellow px-1 rounded">B2B</span>}
+            </div>
+            {opp.game_time && (
+              <div className="text-[9px] opacity-40 mt-0.5">
+                {opp.game_date ? new Date(opp.game_date + 'T12:00:00').toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' }) : ''} • {opp.game_time}
+              </div>
+            )}
+          </td>
+        )}
+        {/* GATILHO */}
+        <td className="py-2 px-3">
+          <div className="flex items-center gap-1.5">
+            <span className={`text-[9px] px-1.5 py-0.5 rounded border ${statusBadge.cls}`}>{statusBadge.text}</span>
+            <span className={`font-medium ${getTriggerStatusColor(opp.trigger_status)}`}>{triggerLastName}</span>
+            {opp.trigger_days_out != null && <span className="text-[9px] opacity-40">{opp.trigger_days_out}d</span>}
+          </div>
+        </td>
+        {/* JOGADOR */}
+        <td className="py-2 px-3">
+          <div className="flex items-center gap-2">
+            <PlayerPhoto name={opp.backup_player_name} teamAbbr={opp.trigger_team_abbr} />
+            <span className="font-bold text-terminal-green">{opp.backup_player_name}</span>
+          </div>
+        </td>
+        {/* STAT */}
+        <td className="py-2 px-3">
+          <span className="text-[10px] bg-terminal-gray border border-terminal-border-subtle px-1.5 py-0.5 rounded cursor-help"
+            title={{
+              player_points_rebounds_assists: 'Pontos + Rebotes + Assistências',
+              player_points_assists: 'Pontos + Assistências',
+              player_points_rebounds: 'Pontos + Rebotes',
+              player_rebounds_assists: 'Rebotes + Assistências',
+              player_blocks_steals: 'Bloqueios + Roubos',
+            }[opp.stat_type] || undefined}>
+            {STAT_LABELS[opp.stat_type] || opp.stat_type}
+          </span>
+        </td>
+        {/* COM */}
+        <td className={`text-right py-2 px-3 opacity-50 tabular-nums ${blur}`}>{opp.avg_com?.toFixed(1) ?? '—'}</td>
+        {/* SEM */}
+        <td className={`text-right py-2 px-3 font-bold text-terminal-green tabular-nums ${blur}`}>{opp.avg_sem?.toFixed(1) ?? '—'}</td>
+        {/* GAP% */}
+        <td className={`text-right py-2 px-3 ${blur}`}>
+          <span className={`font-bold tabular-nums ${(opp.gap_pct ?? 0) >= 30 ? 'text-orange-400' : (opp.gap_pct ?? 0) >= 15 ? 'text-terminal-green' : 'text-terminal-blue'}`}>
+            +{opp.gap_pct?.toFixed(1) ?? '—'}%
+          </span>
+        </td>
+        {/* LINHA */}
+        <td className="text-right py-2 px-3 tabular-nums">
+          {opp.line_value ? <span className="font-medium">{opp.line_value?.toFixed(1) ?? '—'}</span> : <span className="opacity-30">—</span>}
+        </td>
+        {/* vs LINHA */}
+        <td className={`text-right py-2 px-3 tabular-nums ${blur}`}>
+          {opp.gap_vs_line_pct != null ? (
+            <span className={`font-bold ${opp.gap_vs_line_pct > 10 ? 'text-terminal-green' : opp.gap_vs_line_pct > 0 ? 'text-terminal-blue' : 'text-terminal-red'}`}>
+              {opp.gap_vs_line_pct > 0 ? '+' : ''}{opp.gap_vs_line_pct?.toFixed(1) ?? '—'}%
+            </span>
+          ) : <span className="opacity-30">—</span>}
+        </td>
+        {/* AÇÃO */}
+        <td className="text-center py-2 px-3">
+          {(() => {
+            const slug = opp.backup_player_name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '-');
+            const params = new URLSearchParams({ stat: opp.stat_type, trigger: opp.trigger_name });
+            const dashboardHref = `/nba-dashboard/${slug}?${params.toString()}`;
+            const href = isPremium ? dashboardHref : '/paywall-platform';
+            return (
+              <a href={href}
+                onClick={(e) => {
+                  e.preventDefault();
+                  navigate(isPremium ? dashboardHref : '/paywall-platform');
+                }}
+                title={isPremium ? `Ver ${opp.backup_player_name} — ${STAT_LABELS[opp.stat_type] || opp.stat_type} sem ${opp.trigger_name}` : 'Recurso exclusivo Premium'}
+                className="inline-flex items-center gap-1 px-2 py-1 text-[9px] rounded border border-terminal-green/30 text-terminal-green hover:bg-terminal-green/10 hover:border-terminal-green/60 transition-all">
+                <ExternalLink className="w-3 h-3" /> {isPremium ? 'Analisar' : 'Premium'}
+              </a>
+            );
+          })()}
+        </td>
+      </tr>
+    );
+  };
+
+  const tableHeaders = (showGame: boolean) => (
+    <thead>
+      <tr className="border-b border-terminal-border-subtle bg-terminal-dark-gray/50">
+        <th className="text-center py-2.5 px-3 data-label whitespace-nowrap">
+          <div className="flex items-center justify-center gap-0.5">
+            <button onClick={() => handleSort('score')} className="flex items-center gap-1 hover:text-terminal-green">
+              SCORE <SortIcon field="score" />
+            </button>
+            <InfoTip text="Score de 0-100 baseado em gap vs linha, amostra de jogos, dias fora do gatilho, matchup defensivo, ambiente de jogo e consistência" />
+          </div>
+        </th>
+        {showGame && <th className="text-left py-2.5 px-3 data-label">JOGO</th>}
+        <th className="text-left py-2.5 px-3 data-label whitespace-nowrap">
+          <div className="flex items-center gap-0.5">
+            GATILHO
+            <InfoTip text="Jogador lesionado ou ausente que gera a oportunidade. OUT = confirmado fora. Q = Questionable (~50%). DTD = Doubtful (~75% fora)." />
+          </div>
+        </th>
+        <th className="text-left py-2.5 px-3 data-label">JOGADOR</th>
+        <th className="text-left py-2.5 px-3 data-label">STAT</th>
+        <th className="text-right py-2.5 px-3 data-label whitespace-nowrap">
+          <div className="flex items-center justify-end gap-0.5">
+            COM
+            <InfoTip text="Média do jogador nos jogos em que o gatilho estava em quadra" />
+          </div>
+        </th>
+        <th className="text-right py-2.5 px-3 data-label whitespace-nowrap">
+          <div className="flex items-center justify-end gap-0.5">
+            SEM
+            <InfoTip text="Média do jogador nos jogos em que o gatilho NÃO jogou — este é o cenário esperado para o jogo de hoje" />
+          </div>
+        </th>
+        <th className="text-right py-2.5 px-3 data-label whitespace-nowrap">
+          <div className="flex items-center justify-end gap-0.5">
+            <button onClick={() => handleSort('gap_pct')} className="flex items-center gap-1 hover:text-terminal-green">
+              GAP% <SortIcon field="gap_pct" />
+            </button>
+            <InfoTip text="Percentual de aumento: quanto o jogador performa a mais SEM o gatilho comparado a COM" />
+          </div>
+        </th>
+        <th className="text-right py-2.5 px-3 data-label">LINHA</th>
+        <th className="text-right py-2.5 px-3 data-label whitespace-nowrap">
+          <button onClick={() => handleSort('gap_vs_line_pct')} className="flex items-center gap-1 ml-auto hover:text-terminal-green">
+            vs LINHA <SortIcon field="gap_vs_line_pct" />
+          </button>
+        </th>
+        <th className="text-center py-2.5 px-3 data-label"></th>
+      </tr>
+    </thead>
+  );
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
+        <AnalyticsNav />
+        <div className="flex items-center justify-center py-20">
+          <div className="text-center">
+            <AlertTriangle className="w-8 h-8 text-terminal-red mx-auto mb-4" />
+            <p className="text-terminal-red text-sm mb-4">{error}</p>
+            <button onClick={() => window.location.reload()} className="terminal-button px-4 py-2 rounded text-xs">
+              TENTAR NOVAMENTE
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
+      <AnalyticsNav />
+
+      <div className="container mx-auto px-4 py-6 max-w-7xl">
+        {/* Header */}
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="w-10 h-10 bg-terminal-green/20 border border-terminal-green rounded-lg flex items-center justify-center">
+              <TrendingUp className="w-5 h-5 text-terminal-green" />
+            </div>
+            <div>
+              <h1 className="text-xl md:text-2xl font-bold tracking-wider text-terminal-green">
+                OPORTUNIDADES DO DIA
+              </h1>
+              <p className="text-[10px] md:text-xs text-terminal-text opacity-50">
+                Quem se beneficia quando um titular não joga — ranqueado por score de confiança
+              </p>
+            </div>
+          </div>
+
+          {!isLoading && (
+            <div className="flex flex-wrap items-center gap-2 mt-3">
+              <span className="text-[10px] bg-terminal-gray border border-terminal-border-subtle px-2 py-1 rounded">
+                {gamesCount} jogos • {totalOpps} oportunidades
+              </span>
+              {highConfidence > 0 && (
+                <button
+                  onClick={() => setMinScore(prev => prev === 80 ? 0 : 80)}
+                  className={`text-[10px] px-2 py-1 rounded flex items-center gap-1 transition-all ${
+                    minScore === 80
+                      ? 'bg-terminal-green/20 text-terminal-green border border-terminal-green'
+                      : 'bg-terminal-green/10 text-terminal-green border border-terminal-green/30 hover:border-terminal-green/60'
+                  }`}>
+                  <Shield className="w-3 h-3" /> {highConfidence} alta confiança
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Premium upsell banner */}
+        {!isPremium && !isLoading && (
+          <div className="bg-terminal-yellow/10 border border-terminal-yellow/30 rounded-lg px-4 py-3 mb-4 flex items-center justify-between">
+            <p className="text-xs text-terminal-yellow">
+              Dados de score, médias e gaps são exclusivos para assinantes Premium.
+            </p>
+            <a href="/paywall-platform" className="text-xs font-bold text-terminal-yellow hover:text-white transition-colors shrink-0 ml-4">
+              ASSINAR →
+            </a>
+          </div>
+        )}
+
+        {/* Filters bar */}
+        <div className="terminal-container p-3 mb-4">
+          <div className="flex items-center gap-2">
+            <Filter className="w-3.5 h-3.5 opacity-40 shrink-0 hidden md:block" />
+            <select value={statFilter} onChange={e => setStatFilter(e.target.value)}
+              className="bg-terminal-dark-gray border border-terminal-border-subtle rounded px-2 py-1.5 text-xs focus:outline-none focus:border-terminal-green/50 min-w-0 flex-1 md:flex-none">
+              <option value="all">Todas stats</option>
+              <option value="player_points">Pontos</option>
+              <option value="player_rebounds">Rebotes</option>
+              <option value="player_assists">Assistências</option>
+              <option value="player_points_rebounds_assists">PRA</option>
+              {availableStats.filter(st => !['player_points', 'player_rebounds', 'player_assists', 'player_points_rebounds_assists'].includes(st)).map(st => (
+                <option key={st} value={st}>{STAT_LABELS[st] || st}</option>
+              ))}
+            </select>
+            <select value={gameFilter} onChange={e => setGameFilter(e.target.value)}
+              className="bg-terminal-dark-gray border border-terminal-border-subtle rounded px-2 py-1.5 text-xs focus:outline-none focus:border-terminal-green/50 min-w-0 flex-1 md:flex-none">
+              <option value="all">Todos jogos</option>
+              {uniqueGames.map(g => <option key={g.id} value={g.id}>{g.label}</option>)}
+            </select>
+            <select value={minScore} onChange={e => setMinScore(Number(e.target.value))}
+              className="bg-terminal-dark-gray border border-terminal-border-subtle rounded px-2 py-1.5 text-xs focus:outline-none focus:border-terminal-green/50 min-w-0 flex-1 md:flex-none">
+              <option value={0}>Score: 0+</option>
+              <option value={70}>Score: 70+</option>
+              <option value={80}>Score: 80+</option>
+            </select>
+
+            {/* View mode toggle — same line on desktop, new line on mobile */}
+            <div className="hidden md:flex gap-1 ml-auto">
+              <button onClick={() => setViewMode('score')}
+                className={`px-2 py-1 text-[10px] rounded border transition-all ${viewMode === 'score' ? 'bg-terminal-green/20 border-terminal-green text-terminal-green' : 'border-terminal-border-subtle text-terminal-text opacity-50 hover:opacity-80'}`}>
+                Por Score
+              </button>
+              <button onClick={() => setViewMode('game')}
+                className={`px-2 py-1 text-[10px] rounded border transition-all flex items-center gap-1 ${viewMode === 'game' ? 'bg-terminal-green/20 border-terminal-green text-terminal-green' : 'border-terminal-border-subtle text-terminal-text opacity-50 hover:opacity-80'}`}>
+                <LayoutList className="w-3 h-3" /> Por Jogo
+              </button>
+            </div>
+          </div>
+          {/* Mobile: view mode toggle on separate line */}
+          <div className="flex gap-1 mt-2 md:hidden">
+            <button onClick={() => setViewMode('score')}
+              className={`flex-1 py-1.5 text-[10px] rounded border transition-all text-center ${viewMode === 'score' ? 'bg-terminal-green/20 border-terminal-green text-terminal-green' : 'border-terminal-border-subtle text-terminal-text opacity-50'}`}>
+              Por Score
+            </button>
+            <button onClick={() => setViewMode('game')}
+              className={`flex-1 py-1.5 text-[10px] rounded border transition-all text-center flex items-center justify-center gap-1 ${viewMode === 'game' ? 'bg-terminal-green/20 border-terminal-green text-terminal-green' : 'border-terminal-border-subtle text-terminal-text opacity-50'}`}>
+              <LayoutList className="w-3 h-3" /> Por Jogo
+            </button>
+          </div>
+        </div>
+
+        {/* Loading */}
+        {isLoading && (
+          <div className="terminal-container p-4">
+            <div className="flex items-center gap-3 mb-4">
+              <Loader2 className="w-5 h-5 text-terminal-green animate-spin" />
+              <span className="text-xs opacity-60">Carregando oportunidades...</span>
+            </div>
+            <div className="space-y-2">
+              {Array.from({ length: 8 }).map((_, i) => <Skeleton key={i} className="h-12 w-full bg-terminal-gray" />)}
+            </div>
+          </div>
+        )}
+
+        {/* Desktop — Por Score (flat table) */}
+        {!isLoading && filtered.length > 0 && viewMode === 'score' && (
+          <div className="hidden md:block terminal-container overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-xs">
+                {tableHeaders(true)}
+                <tbody>
+                  {filtered.map((opp, idx) => renderRow(opp, idx, true))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {/* Desktop — Por Jogo (grouped) */}
+        {!isLoading && filtered.length > 0 && viewMode === 'game' && (
+          <div className="hidden md:block space-y-4">
+            {groupedByGame.map(([gameId, group]) => (
+              <div key={gameId} className="terminal-container overflow-hidden">
+                <button onClick={() => toggleGameCollapse(gameId)}
+                  className="w-full bg-terminal-gray px-3 py-2 border-b border-terminal-border-subtle flex items-center gap-3 hover:bg-terminal-gray/80 transition-colors text-left">
+                  <div className="flex items-center gap-2">
+                    <img src={getTeamLogoUrl(group.label.split(' vs ')[0])} alt="" className="w-5 h-5 object-contain" onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                    <span className="text-xs font-bold">{group.label}</span>
+                  </div>
+                  {group.time && <span className="text-[10px] opacity-40">{group.time}</span>}
+                  {(group.is_b2b_home || group.is_b2b_visitor) && (
+                    <span className="text-[8px] bg-terminal-yellow/20 text-terminal-yellow px-1.5 py-0.5 rounded">B2B</span>
+                  )}
+                  <span className="text-[10px] opacity-40 ml-auto">{group.opps.length} oportunidades</span>
+                  <ChevronDown className={`w-4 h-4 opacity-40 shrink-0 transition-transform ${collapsedGames.has(gameId) ? '-rotate-90' : ''}`} />
+                </button>
+                {!collapsedGames.has(gameId) && (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-xs">
+                      {tableHeaders(false)}
+                      <tbody>
+                        {group.opps.map((opp, idx) => renderRow(opp, idx, false))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Mobile — Por Jogo (grouped) */}
+        {!isLoading && filtered.length > 0 && viewMode === 'game' && (
+          <div className="md:hidden space-y-4">
+            {groupedByGame.map(([gameId, group]) => (
+              <div key={gameId}>
+                <button onClick={() => toggleGameCollapse(gameId)}
+                  className="flex items-center gap-2 px-1 mb-2 w-full text-left">
+                  <img src={getTeamLogoUrl(group.label.split(' vs ')[0])} alt="" className="w-4 h-4 object-contain" onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                  <span className="text-xs font-bold">{group.label}</span>
+                  {group.time && <span className="text-[10px] opacity-40">{group.time}</span>}
+                  {(group.is_b2b_home || group.is_b2b_visitor) && (
+                    <span className="text-[8px] bg-terminal-yellow/20 text-terminal-yellow px-1 py-0.5 rounded">B2B</span>
+                  )}
+                  <span className="text-[10px] opacity-30 ml-auto">{group.opps.length}</span>
+                  <ChevronDown className={`w-4 h-4 opacity-40 shrink-0 transition-transform ${collapsedGames.has(gameId) ? '-rotate-90' : ''}`} />
+                </button>
+                {!collapsedGames.has(gameId) && <div className="space-y-2">
+                  {group.opps.map((opp, idx) => {
+                    const statusBadge = getTriggerStatusBadge(opp.trigger_status);
+                    const triggerLastName = opp.trigger_name.split(' ').pop();
+                    const isHighConf = (opp.score ?? 0) >= 80;
+                    const statLabel = STAT_LABELS[opp.stat_type] || opp.stat_type;
+                    const slug = opp.backup_player_name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '-');
+                    const analyzeHref = `/nba-dashboard/${slug}?stat=${opp.stat_type}&trigger=${encodeURIComponent(opp.trigger_name)}`;
+
+                    return (
+                      <a key={idx} href={analyzeHref} onClick={(e) => { if (!e.ctrlKey && !e.metaKey) { e.preventDefault(); navigate(analyzeHref); } }}
+                        className={`block terminal-container p-3 ${isHighConf ? 'border-terminal-green/30' : ''}`}>
+                        <div className="flex items-center gap-3">
+                          <PlayerPhoto name={opp.backup_player_name} teamAbbr={opp.trigger_team_abbr} />
+                          <div className="flex-1 min-w-0">
+                            <span className="font-bold text-terminal-green text-sm truncate block">{opp.backup_player_name}</span>
+                            <div className="flex items-center gap-1.5 mt-0.5">
+                              <span className="text-xs font-bold bg-terminal-green/10 text-terminal-green border border-terminal-green/30 px-1.5 py-0.5 rounded">{statLabel}</span>
+                              <span className={`text-[9px] px-1.5 py-0.5 rounded border ${statusBadge.cls}`}>SEM {triggerLastName} ({statusBadge.text})</span>
+                            </div>
+                          </div>
+                          {isHighConf ? (
+                            <span className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-terminal-green/15 border border-terminal-green/40 text-base font-black tabular-nums text-terminal-green shrink-0">{opp.score}</span>
+                          ) : (
+                            <span className={`text-lg font-bold tabular-nums shrink-0 ${getScoreColor(opp.score)}`}>{opp.score ?? '—'}</span>
+                          )}
+                        </div>
+                        <div className="mt-2 text-[11px] text-terminal-text opacity-80">
+                          Com {triggerLastName}: <span className="opacity-60">{opp.avg_com?.toFixed(1) ?? '—'}</span>
+                          <span className="mx-1.5 opacity-30">→</span>
+                          Sem: <span className="font-bold text-terminal-green">{opp.avg_sem?.toFixed(1) ?? '—'}</span>
+                          <span className={`ml-1.5 font-bold ${(opp.gap_pct ?? 0) >= 30 ? 'text-orange-400' : 'text-terminal-green'}`}>(+{opp.gap_pct?.toFixed(1) ?? '—'}%)</span>
+                        </div>
+                      </a>
+                    );
+                  })}
+                </div>}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Mobile — Por Score (flat cards) */}
+        {!isLoading && filtered.length > 0 && viewMode === 'score' && (
+          <div className="md:hidden space-y-2">
+            {filtered.map((opp, idx) => {
+              const statusBadge = getTriggerStatusBadge(opp.trigger_status);
+              const triggerLastName = opp.trigger_name.split(' ').pop();
+              const isExpanded = expandedRow === idx;
+              const isHighConf = (opp.score ?? 0) >= 80;
+              const statLabel = STAT_LABELS[opp.stat_type] || opp.stat_type;
+              const slug = opp.backup_player_name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '-');
+              const analyzeHref = `/nba-dashboard/${slug}?stat=${opp.stat_type}&trigger=${encodeURIComponent(opp.trigger_name)}`;
+
+              return (
+                <div key={idx} className={`terminal-container overflow-hidden ${isHighConf ? 'border-terminal-green/30' : ''}`}>
+                  <button className="w-full p-3 text-left" onClick={() => setExpandedRow(isExpanded ? null : idx)}>
+                    {/* Row 1: Player + Score */}
+                    <div className="flex items-center gap-3">
+                      <PlayerPhoto name={opp.backup_player_name} teamAbbr={opp.trigger_team_abbr} />
+                      <div className="flex-1 min-w-0">
+                        <span className="font-bold text-terminal-green text-sm truncate block">{opp.backup_player_name}</span>
+                        <div className="flex items-center gap-1.5 mt-0.5">
+                          <span className="text-[10px] opacity-50">{opp.trigger_team_abbr} vs {opp.opponent_abbr}</span>
+                          {opp.is_b2b && <span className="text-[8px] bg-terminal-yellow/20 text-terminal-yellow px-1 rounded">B2B</span>}
+                        </div>
+                      </div>
+                      <span className={blur}>
+                      {isHighConf ? (
+                        <span className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-terminal-green/15 border border-terminal-green/40 text-lg font-black tabular-nums text-terminal-green shrink-0">
+                          {opp.score}
+                        </span>
+                      ) : (
+                        <span className={`text-lg font-bold tabular-nums shrink-0 ${getScoreColor(opp.score)}`}>{opp.score ?? '—'}</span>
+                      )}
+                      </span>
+                      <ChevronDown className={`w-4 h-4 opacity-30 shrink-0 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
+                    </div>
+
+                    {/* Row 2: Stat + Trigger context */}
+                    <div className="flex items-center gap-2 mt-2">
+                      <span className="text-xs font-bold bg-terminal-green/10 text-terminal-green border border-terminal-green/30 px-2 py-0.5 rounded">
+                        {statLabel}
+                      </span>
+                      <span className={`text-[9px] px-1.5 py-0.5 rounded border ${statusBadge.cls}`}>
+                        SEM {triggerLastName} ({statusBadge.text})
+                      </span>
+                    </div>
+
+                    {/* Row 3: Storytelling — readable numbers */}
+                    <div className={`mt-2 text-[11px] text-terminal-text opacity-80 ${blur}`}>
+                      <span>Com {triggerLastName}: </span>
+                      <span className="opacity-60">{opp.avg_com?.toFixed(1) ?? '—'}</span>
+                      <span className="mx-1.5 opacity-30">→</span>
+                      <span>Sem: </span>
+                      <span className="font-bold text-terminal-green">{opp.avg_sem?.toFixed(1) ?? '—'}</span>
+                      <span className={`ml-1.5 font-bold ${(opp.gap_pct ?? 0) >= 30 ? 'text-orange-400' : 'text-terminal-green'}`}>
+                        (+{opp.gap_pct?.toFixed(1) ?? '—'}%)
+                      </span>
+                    </div>
+                    {opp.line_value && (
+                      <div className={`mt-1 text-[11px] opacity-60 ${blur}`}>
+                        Linha atual: <span className="font-medium text-terminal-text">{opp.line_value?.toFixed(1) ?? '—'}</span>
+                        {opp.gap_vs_line_pct != null && (
+                          <span className={`ml-1.5 font-bold ${opp.gap_vs_line_pct > 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
+                            ({opp.gap_vs_line_pct > 0 ? '+' : ''}{opp.gap_vs_line_pct?.toFixed(1) ?? '—'}% vs linha)
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </button>
+
+                  {isExpanded && (
+                    <div className="px-3 pb-3 border-t border-terminal-border-subtle pt-2 space-y-2">
+                      {opp.gap_vs_line_pct != null && opp.line_value && (
+                        <div className={`text-[11px] text-center py-1.5 rounded border ${
+                          opp.gap_vs_line_pct > 0
+                            ? 'bg-terminal-green/10 text-terminal-green border-terminal-green/30'
+                            : 'bg-terminal-red/10 text-terminal-red border-terminal-red/30'
+                        }`}>
+                          Média SEM ({opp.avg_sem?.toFixed(1) ?? '—'}) {opp.gap_vs_line_pct > 0 ? '>' : '<'} Linha ({opp.line_value?.toFixed(1) ?? '—'}) — {opp.gap_vs_line_pct > 0 ? 'OVER favorável' : 'UNDER favorável'}
+                        </div>
+                      )}
+
+                      <a href={analyzeHref}
+                        onClick={(e) => { if (!e.ctrlKey && !e.metaKey && e.button === 0) { e.preventDefault(); e.stopPropagation(); navigate(analyzeHref); } }}
+                        className="flex items-center justify-center gap-1.5 w-full py-2 text-xs font-bold text-terminal-green border border-terminal-green/30 rounded hover:bg-terminal-green/10 transition-all">
+                        <ExternalLink className="w-3.5 h-3.5" /> VER ANÁLISE COMPLETA
+                      </a>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!isLoading && filtered.length === 0 && (
+          <div className="terminal-container p-8 text-center">
+            <AlertTriangle className="w-8 h-8 text-terminal-yellow mx-auto mb-3 opacity-50" />
+            <p className="text-sm opacity-60 mb-1">Nenhuma oportunidade encontrada</p>
+            <p className="text-[10px] opacity-40">
+              {opportunities.length > 0 ? 'Tente ajustar os filtros' : 'Não há jogos com injury report disponível para hoje'}
+            </p>
+          </div>
+        )}
+
+        {/* Footer */}
+        {!isLoading && filtered.length > 0 && (
+          <div className="mt-3 text-center text-[9px] opacity-30">
+            Metodologia: análise 360° COM vs SEM • Score automático (gap + amostra + freshness + matchup)
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/services/nba-data.service.ts
+++ b/src/services/nba-data.service.ts
@@ -189,6 +189,75 @@ export interface PlayerDashboardBundle {
   shooting_zones: PlayerShootingZones | null;
 }
 
+export interface BoxScorePlayer {
+  player_id: number;
+  player_name: string;
+  player_position: string;
+  home_away: string;
+  minutes: number | null;
+  points: number | null;
+  rebounds: number | null;
+  assists: number | null;
+  blocks: number | null;
+  steals: number | null;
+  threes: number | null;
+  turnovers: number | null;
+  offensive_rebounds: number | null;
+  defensive_rebounds: number | null;
+  fg_pct: number | null;
+  ft_pct: number | null;
+}
+
+export interface B2BBoxScorePlayer {
+  player_id: number;
+  player_name: string;
+  player_position: string;
+  rating_stars: number;
+  minutes: number | null;
+  points: number | null;
+  rebounds: number | null;
+  assists: number | null;
+  fg_pct: number | null;
+  ft_pct: number | null;
+  previous_game_id: number;
+  previous_game_date: string;
+  previous_opponent: string;
+  previous_team_score: number | null;
+  previous_opponent_score: number | null;
+  previous_home_away: string;
+}
+
+export interface DailyOpportunity {
+  game_id: number;
+  game_date: string;
+  game_time: string | null;
+  home_team: string;
+  visitor_team: string;
+  home_team_abbr: string;
+  visitor_team_abbr: string;
+  is_home_b2b: boolean;
+  is_visitor_b2b: boolean;
+  trigger_player_id: number;
+  trigger_name: string;
+  trigger_status: string;
+  trigger_team_abbr: string;
+  trigger_team_id: number;
+  trigger_days_out: number | null;
+  backup_player_name: string;
+  backup_player_id: number | null;
+  stat_type: string;
+  avg_normal: number;
+  avg_sem: number;
+  gap: number;
+  gap_pct: number;
+  rating_stars: number;
+  line_value: number | null;
+  is_home: boolean;
+  opponent_abbr: string;
+  opponent_def_rank: number | null;
+  opponent_off_rank: number | null;
+}
+
 export const nbaDataService = {
   async getAllPlayers(): Promise<Player[]> {
     if (allPlayersCache && Date.now() < allPlayersCache.expiresAt) {
@@ -366,6 +435,38 @@ export const nbaDataService = {
         teammates: (payload.teammates ?? []) as TeamPlayer[],
         shooting_zones: (payload.shooting_zones ?? null) as PlayerShootingZones | null,
       };
+    });
+  },
+
+  async getGameBoxScore(gameId: number): Promise<BoxScorePlayer[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_game_box_score', {
+        p_game_id: gameId,
+      });
+      if (error) throw error;
+      return (data || []) as BoxScorePlayer[];
+    });
+  },
+
+  async getB2BPreviousGameBoxScore(gameId: number, teamId: number): Promise<B2BBoxScorePlayer[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_b2b_previous_game_box_score', {
+        p_game_id: gameId,
+        p_team_id: teamId,
+      });
+      if (error) throw error;
+      return (data || []) as B2BBoxScorePlayer[];
+    });
+  },
+
+  async getDailyOpportunities(gameDate?: string): Promise<DailyOpportunity[]> {
+    return withRetry(async () => {
+      const params: Record<string, string> = {};
+      if (gameDate) params.p_game_date = gameDate;
+
+      const { data, error } = await supabaseClient.rpc('get_daily_opportunities', params);
+      if (error) throw error;
+      return (data || []) as DailyOpportunity[];
     });
   },
 };

--- a/src/services/nba-data.service.ts
+++ b/src/services/nba-data.service.ts
@@ -68,6 +68,7 @@ export interface PropPlayer {
   next_player_stats_when_leader_out: number;
   next_player_stats_normal: number;
   loaded_at: string;
+  leader_injury_status: string | null;
 }
 
 export interface Team {
@@ -206,6 +207,7 @@ export interface BoxScorePlayer {
   defensive_rebounds: number | null;
   fg_pct: number | null;
   ft_pct: number | null;
+  plus_minus: number | null;
 }
 
 export interface B2BBoxScorePlayer {
@@ -219,6 +221,7 @@ export interface B2BBoxScorePlayer {
   assists: number | null;
   fg_pct: number | null;
   ft_pct: number | null;
+  plus_minus: number | null;
   previous_game_id: number;
   previous_game_date: string;
   previous_opponent: string;
@@ -231,31 +234,43 @@ export interface DailyOpportunity {
   game_id: number;
   game_date: string;
   game_time: string | null;
-  home_team: string;
-  visitor_team: string;
   home_team_abbr: string;
   visitor_team_abbr: string;
-  is_home_b2b: boolean;
-  is_visitor_b2b: boolean;
   trigger_player_id: number;
   trigger_name: string;
   trigger_status: string;
   trigger_team_abbr: string;
   trigger_team_id: number;
   trigger_days_out: number | null;
-  backup_player_name: string;
+  trigger_freshness: string | null;
+  trigger_participation_pct: number | null;
+  is_b2b: boolean;
+  fatigue_level: string | null;
   backup_player_id: number | null;
+  backup_player_name: string;
   stat_type: string;
-  avg_normal: number;
+  avg_com: number;
   avg_sem: number;
+  stddev_sem: number | null;
+  cv_sem: number | null;
   gap: number;
   gap_pct: number;
-  rating_stars: number;
+  jogos_com: number | null;
+  jogos_sem: number | null;
   line_value: number | null;
-  is_home: boolean;
-  opponent_abbr: string;
+  gap_vs_line: number | null;
+  gap_vs_line_pct: number | null;
+  signal: string | null;
+  score: number | null;
+  score_base: number | null;
+  score_label: string | null;
+  opponent_abbr: string | null;
   opponent_def_rank: number | null;
   opponent_off_rank: number | null;
+  is_home: boolean;
+  rating_stars: number;
+  spread: number | null;
+  blowout_deflator: number | null;
 }
 
 export const nbaDataService = {
@@ -352,11 +367,11 @@ export const nbaDataService = {
   async getPlayerGameStats(playerId: number, limit = 15): Promise<GamePlayerStats[]> {
     return withRetry(async () => {
       const { data, error } = await supabaseClient
-        .rpc('get_player_game_stats', { 
+        .rpc('get_player_game_stats', {
           p_player_id: playerId,
-          p_limit: limit 
+          p_limit: limit
         });
-      
+
       if (error) throw error;
       return (data || []) as GamePlayerStats[];
     });

--- a/supabase/migrations/036_get_b2b_previous_game_box_score.sql
+++ b/supabase/migrations/036_get_b2b_previous_game_box_score.sql
@@ -1,0 +1,87 @@
+-- Returns box score from the previous game for a team playing B2B.
+-- Reuses get_game_box_score() to avoid dim_players JOIN issues,
+-- then enriches with rating_stars and plus_minus.
+-- Uses UNION ALL instead of OR for FDW pushdown compatibility.
+
+DROP FUNCTION IF EXISTS public.get_b2b_previous_game_box_score(bigint, bigint);
+
+CREATE FUNCTION public.get_b2b_previous_game_box_score(
+  p_game_id bigint,
+  p_team_id bigint
+)
+RETURNS TABLE (
+  player_id bigint,
+  player_name text,
+  player_position text,
+  rating_stars bigint,
+  minutes float8,
+  points float8,
+  rebounds float8,
+  assists float8,
+  plus_minus float8,
+  previous_game_id bigint,
+  previous_game_date date,
+  previous_opponent text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_previous_game_id bigint;
+  v_previous_game_date date;
+  v_previous_opponent text;
+  v_current_game_date date;
+  v_team_was_home boolean;
+  v_team_home_away text;
+BEGIN
+  -- Step 1: Get current game date
+  SELECT g.game_date INTO v_current_game_date
+  FROM bigquery.ft_games g WHERE g.game_id = p_game_id LIMIT 1;
+
+  IF v_current_game_date IS NULL THEN RETURN; END IF;
+
+  -- Step 2: Find previous game using UNION ALL (FDW OR pushdown workaround)
+  SELECT sub.game_id, sub.game_date, sub.opponent, sub.was_home
+  INTO v_previous_game_id, v_previous_game_date, v_previous_opponent, v_team_was_home
+  FROM (
+    SELECT * FROM (
+      (SELECT g.game_id, g.game_date, g.visitor_team_abbreviation AS opponent, true AS was_home
+       FROM bigquery.ft_games g
+       WHERE g.home_team_id = p_team_id AND g.game_date < v_current_game_date AND g.winner_team_id IS NOT NULL
+       ORDER BY g.game_date DESC LIMIT 1)
+      UNION ALL
+      (SELECT g.game_id, g.game_date, g.home_team_abbreviation AS opponent, false AS was_home
+       FROM bigquery.ft_games g
+       WHERE g.visitor_team_id = p_team_id AND g.game_date < v_current_game_date AND g.winner_team_id IS NOT NULL
+       ORDER BY g.game_date DESC LIMIT 1)
+    ) combined ORDER BY game_date DESC LIMIT 1
+  ) sub;
+
+  IF v_previous_game_id IS NULL THEN RETURN; END IF;
+
+  v_team_home_away := CASE WHEN v_team_was_home THEN 'Casa' ELSE 'Fora' END;
+
+  -- Step 3: Get box score from existing function, enrich with rating_stars + plus_minus
+  RETURN QUERY
+  SELECT
+    bs.player_id, bs.player_name,
+    COALESCE(dp."position", '') AS player_position,
+    COALESCE(pr.max_stars, 0) AS rating_stars,
+    bs.minutes::float8, bs.points::float8, bs.rebounds::float8, bs.assists::float8,
+    MAX(CASE WHEN s.stat_type = 'player_plus_minus' THEN s.stat_value END) AS plus_minus,
+    v_previous_game_id, v_previous_game_date, v_previous_opponent
+  FROM get_game_box_score(v_previous_game_id) bs
+  LEFT JOIN bigquery.dim_players dp ON bs.player_id = dp.player_id
+  LEFT JOIN (
+    SELECT sp.player_id, MAX(sp.rating_stars) AS max_stars
+    FROM bigquery.dim_stat_player sp GROUP BY sp.player_id
+  ) pr ON bs.player_id = pr.player_id
+  LEFT JOIN bigquery.ft_game_player_stats s
+    ON s.player_id = bs.player_id AND s.game_id = v_previous_game_id AND s.stat_type = 'player_plus_minus'
+  WHERE bs.home_away = v_team_home_away
+  GROUP BY bs.player_id, bs.player_name, dp."position", pr.max_stars, bs.minutes, bs.points, bs.rebounds, bs.assists
+  ORDER BY bs.minutes DESC NULLS LAST;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_b2b_previous_game_box_score(bigint, bigint) TO authenticated, anon;


### PR DESCRIPTION
## Summary

- **Nova tela Oportunidades do Dia** (`/oportunidades`) — ranking de jogadores que se beneficiam de lesões, com score automático 0-100
- **Insights Q/D no dashboard** — alertas preventivos para jogadores Questionable/Doubtful
- **Multi-teammate filter** — filtrar gráfico por múltiplos companheiros simultaneamente
- **Plus/minus na Performance B2B** — nova coluna +/- com dados coletados
- **Paywall** — dados sensíveis com blur para free users
- **Rating stars fix** — classificação agora considera apenas PTS/AST/REB

## Tela Oportunidades do Dia

- Consome `dim_daily_opportunities` do BigQuery via nova RPC
- Filtros da skill nba-analisador: score >= 60, rating >= 1, gap >= 1.0, days_out <= 7, participação >= 50%
- Duas visualizações: Por Score (flat) e Por Jogo (agrupado, recolhível)
- Tooltips explicativos nos headers para novos usuários
- Botão "Analisar" navega ao dashboard com `?stat=&trigger=` pré-aplicados
- Free users: blur em score/COM/SEM/GAP% + banner upsell

## Insights Questionable/Doubtful

- PropInsightsCard suporta Q/D com storytelling condicional
- "Se Quickley for confirmado fora, as assistências podem subir +66%"
- Dashboard unificado: mostra oportunidades dos Picks quando existem, fallback para insights antigos

## Multi-Teammate Filter

- Selecionar múltiplos: "SEM Quickley" + "SEM Ingram"
- Cache de game_ids por jogador
- Loading visual: gráfico com opacity + "Recalculando..."

## Performance B2B

- Coluna +/- adicionada (verde/vermelho/cinza)
- RPCs atualizadas: get_game_box_score e get_b2b_previous_game_box_score

## Supabase (staging)

- FDW: dim_daily_opportunities, dim_stat_player (leader_injury_status)
- RPCs: get_daily_opportunities, get_player_trigger_insights, get_game_box_score, get_b2b_previous_game_box_score, get_all_players, get_team_players
- PostgREST db_max_rows: 1000 → 5000

## Test plan

- [ ] Abrir /oportunidades — tabela com ~50 oportunidades ordenadas por score
- [ ] Filtrar por stat (Pontos), jogo, score min 80
- [ ] Clicar badge "alta confiança" — toggle filtro score >= 80
- [ ] Toggle "Por Jogo" — cards agrupados e recolhíveis
- [ ] Clicar "Analisar" — abre dashboard com stat e trigger pré-filtrados
- [ ] Middle-click "Analisar" — abre em nova aba
- [ ] Hover nos (i) — tooltips explicativos aparecem
- [ ] Mobile: cards com storytelling, filtros em linha, vista Por Jogo
- [ ] Free user: blur nos dados + botão "Premium" leva ao paywall
- [ ] Dashboard jogador: mostra oportunidades dos Picks (ex: Deandre Ayton)
- [ ] PropInsightsCard: alerta Q/D (ex: Scottie Barnes com Quickley Q)
- [ ] Multi-teammate: SEM Quickley + SEM Ingram no gráfico
- [ ] Performance B2B: coluna +/- com cores (verde/vermelho)
- [ ] Rating stars: verificar que combos (P+A, STL) não inflam classificação

🤖 Generated with [Claude Code](https://claude.com/claude-code)