### PR TITLE
feat: UX polish — navegação, sistema de cores semântico, middle-click e HomeNBA

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,6 @@
 # Development environment (Supabase Docker local)
 # Secrets ficam em .env.local (não commitado)
 VITE_APP_NAME=Smartbetting [DEV]
-VITE_SUPABASE_URL=http://127.0.0.1:54321
+VITE_SUPABASE_URL=https://kpbjuplcwiyrymafhehz.supabase.co
 VITE_ENABLE_ANALYTICS=false
 VITE_TELEGRAM_BOT_USERNAME=betinho_assistente_dev_bot

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,8 @@ const GameDetail = React.lazy(() => import("./pages/GameDetail"));
 const Settings = React.lazy(() => import("./pages/Settings"));
 const Report = React.lazy(() => import("./pages/Report"));
 const SharePage = React.lazy(() => import("./pages/SharePage"));
+const Analise360List = React.lazy(() => import("./pages/Analise360List"));
+const Analise360Detail = React.lazy(() => import("./pages/Analise360Detail"));
 
 const queryClient = new QueryClient();
 
@@ -111,6 +113,20 @@ const App = () => (
             <Route path="/report" element={
               <ProtectedRoute>
                 <Report />
+              </ProtectedRoute>
+            } />
+            <Route path="/analise-360" element={
+              <ProtectedRoute>
+                <PremiumRoute redirectTo="/paywall-platform">
+                  <Analise360List />
+                </PremiumRoute>
+              </ProtectedRoute>
+            } />
+            <Route path="/analise-360/:triggerPlayerId" element={
+              <ProtectedRoute>
+                <PremiumRoute redirectTo="/paywall-platform">
+                  <Analise360Detail />
+                </PremiumRoute>
               </ProtectedRoute>
             } />
             <Route path="/share/:token" element={<SharePage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ const Report = React.lazy(() => import("./pages/Report"));
 const SharePage = React.lazy(() => import("./pages/SharePage"));
 const Analise360List = React.lazy(() => import("./pages/Analise360List"));
 const Analise360Detail = React.lazy(() => import("./pages/Analise360Detail"));
+const HomeNBA = React.lazy(() => import("./pages/HomeNBA"));
 
 const queryClient = new QueryClient();
 
@@ -57,6 +58,7 @@ const App = () => (
         <Suspense fallback={<LazyFallback />}>
           <Routes>
             <Route path="/" element={<Landing />} />
+            <Route path="/home-nba" element={<HomeNBA />} />
             <Route path="/home-players" element={<Home />} />
             <Route path="/oportunidades" element={<Picks />} />
             <Route path="/betinho" element={<Betinho />} />

--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -43,17 +43,16 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const analysisItems = [
-    { name: 'Home NBA', href: '/home-players', icon: BarChart3 },
-    { name: 'Oportunidades do Dia', href: '/oportunidades', icon: TrendingUp },
-    { name: 'Jogos', href: '/home-games', icon: Calendar },
-    { name: 'Jogadores', href: '/nba-players', icon: Users },
+    { name: 'Hoje', href: '/home-nba', icon: BarChart3 },
+    { name: 'Oportunidades', href: '/oportunidades', icon: TrendingUp },
     { name: 'Análise 360', href: '/analise-360', icon: Radar },
+    { name: 'Jogos', href: '/home-games', icon: Calendar },
     { name: 'Relatório', href: '/report', icon: FileText },
   ];
 
   const betinhoModuleItems = [
-    { name: 'Dashboard', href: '/betting-dashboard', icon: BarChart3 },
     { name: 'Apostas', href: '/bets', icon: Target },
+    { name: 'Dashboard', href: '/betting-dashboard', icon: BarChart3 },
   ];
 
   const isActive = (path: string) => {
@@ -79,7 +78,7 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
           <div className="flex items-center gap-3">
             <div
               className="flex items-center cursor-pointer hover:opacity-80 transition-opacity"
-              onClick={() => navigate('/home-players')}
+              onClick={() => navigate('/home-nba')}
             >
               <img src="/logo.png" alt="Smartbetting" className="h-8 w-auto" />
             </div>
@@ -87,7 +86,7 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => navigate(backTo || '/home-players')}
+                onClick={() => backTo ? navigate(backTo) : navigate(-1)}
                 className="text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray -ml-2"
               >
                 <ChevronLeft className="w-4 h-4 mr-1" />

--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -13,7 +13,8 @@ import {
   ChevronDown,
   Target,
   FileText,
-  TrendingUp
+  TrendingUp,
+  Radar
 } from 'lucide-react';
 import { useAuth } from '../hooks/use-auth';
 import { useSubscription } from '@/hooks/use-subscription';
@@ -46,6 +47,7 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
     { name: 'Oportunidades do Dia', href: '/oportunidades', icon: TrendingUp },
     { name: 'Jogos', href: '/home-games', icon: Calendar },
     { name: 'Jogadores', href: '/nba-players', icon: Users },
+    { name: 'Análise 360', href: '/analise-360', icon: Radar },
     { name: 'Relatório', href: '/report', icon: FileText },
   ];
 

--- a/src/components/bets/BetsHeader.tsx
+++ b/src/components/bets/BetsHeader.tsx
@@ -6,7 +6,9 @@ import { Button } from '../ui/button';
 import {
   BarChart3,
   Calendar,
-  Users,
+  Radar,
+  TrendingUp,
+  ChevronLeft,
   Menu,
   X,
   ChevronDown,
@@ -32,6 +34,7 @@ import { Switch } from '../ui/switch';
 
 interface BetsHeaderProps {
   title?: string;
+  showBack?: boolean;
   onShareClick?: () => void;
   onReferralClick?: () => void;
   showUnitsView?: boolean;
@@ -41,6 +44,7 @@ interface BetsHeaderProps {
 }
 
 export const BetsHeader: React.FC<BetsHeaderProps> = ({
+  showBack,
   onShareClick,
   onReferralClick,
   showUnitsView = false,
@@ -54,15 +58,16 @@ export const BetsHeader: React.FC<BetsHeaderProps> = ({
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const analysisItems = [
-    { name: 'Home NBA', href: '/home-players', icon: BarChart3 },
+    { name: 'Hoje', href: '/home-nba', icon: BarChart3 },
+    { name: 'Oportunidades', href: '/oportunidades', icon: TrendingUp },
+    { name: 'Análise 360', href: '/analise-360', icon: Radar },
     { name: 'Jogos', href: '/home-games', icon: Calendar },
-    { name: 'Jogadores', href: '/nba-players', icon: Users },
     { name: 'Relatório', href: '/report', icon: FileText },
   ];
 
   const betinhoModuleItems = [
-    { name: 'Dashboard', href: '/betting-dashboard', icon: BarChart3 },
     { name: 'Apostas', href: '/bets', icon: Target },
+    { name: 'Dashboard', href: '/betting-dashboard', icon: BarChart3 },
   ];
 
   const isActive = (path: string) => location.pathname === path;
@@ -88,17 +93,25 @@ export const BetsHeader: React.FC<BetsHeaderProps> = ({
       <div className="max-w-7xl mx-auto px-4">
         <div className="flex justify-between items-center h-14">
 
-          {/* Left - Logo */}
-          <div
-            className="flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
-            onClick={() => navigate('/home-players')}
-          >
-            <div className="w-8 h-8 bg-terminal-blue/20 border border-terminal-blue/50 rounded flex items-center justify-center">
-              <BarChart3 className="w-4 h-4 text-terminal-blue" />
+          {/* Left - Logo + Back */}
+          <div className="flex items-center gap-3">
+            <div
+              className="flex items-center cursor-pointer hover:opacity-80 transition-opacity"
+              onClick={() => navigate('/home-nba')}
+            >
+              <img src="/logo.png" alt="Smartbetting" className="h-8 w-auto" />
             </div>
-            <div className="hidden sm:block">
-              <span className="text-sm font-bold text-terminal-blue tracking-wide">Smartbetting</span>
-            </div>
+            {showBack && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => navigate(-1)}
+                className="text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray -ml-2"
+              >
+                <ChevronLeft className="w-4 h-4 mr-1" />
+                <span className="text-xs">Voltar</span>
+              </Button>
+            )}
           </div>
 
           {/* Center - Desktop dropdowns */}

--- a/src/components/nba/FreePropCard.tsx
+++ b/src/components/nba/FreePropCard.tsx
@@ -1,59 +1,47 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Star, ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react';
-import { nbaDataService, Player, PropPlayer } from '@/services/nba-data.service';
-import { isFreePlayer } from '@/config/freemium';
+import { ArrowRight, ChevronLeft, ChevronRight } from 'lucide-react';
+import { nbaDataService, DailyOpportunity } from '@/services/nba-data.service';
+import { getPlayerPhotoUrl, tryNextPlayerPhotoUrl } from '@/utils/team-logos';
+
+const STAT_LABELS: Record<string, string> = {
+  player_points: 'PONTOS',
+  player_assists: 'ASSISTÊNCIAS',
+  player_rebounds: 'REBOTES',
+  player_threes: '3 PONTOS',
+  player_steals: 'ROUBOS',
+  player_blocks: 'BLOQUEIOS',
+  player_points_rebounds_assists: 'PRA',
+  player_points_assists: 'PTS + AST',
+  player_points_rebounds: 'PTS + REB',
+  player_rebounds_assists: 'REB + AST',
+  player_blocks_steals: 'BLK + STL',
+};
 
 interface FreePropCardProps {
-  /** 'vertical' = sidebar single-prop (default), 'horizontal' = hero row for Games page */
   layout?: 'vertical' | 'horizontal';
 }
 
 export function FreePropCard({ layout = 'vertical' }: FreePropCardProps) {
   const navigate = useNavigate();
-  const [freeProps, setFreeProps] = useState<Array<{ player: Player; prop: PropPlayer }>>([]);
+  const [topOpps, setTopOpps] = useState<DailyOpportunity[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [activeIndex, setActiveIndex] = useState(0);
 
   useEffect(() => {
-    const loadFreeProps = async () => {
+    const load = async () => {
       try {
         setIsLoading(true);
-        const players = await nbaDataService.getAllPlayers();
-        const uniquePlayers = players.filter(
-          (player, index, self) =>
-            index === self.findIndex((p) => p.player_id === player.player_id)
-        );
-        const freePlayers = uniquePlayers
-          .filter((p) => isFreePlayer(p.player_name))
-          .sort((a, b) => (b.rating_stars || 0) - (a.rating_stars || 0));
-
-        if (freePlayers.length === 0) {
-          setIsLoading(false);
-          return;
-        }
-
-        const results: Array<{ player: Player; prop: PropPlayer }> = [];
-        for (const freePlayer of freePlayers) {
-          const props = await nbaDataService.getPlayerProps(freePlayer.player_id);
-          const threeStarProp = props.find((p) => p.rating_stars === 3);
-          const topProp =
-            threeStarProp ||
-            [...props].sort((a, b) => (b.rating_stars || 0) - (a.rating_stars || 0))[0] ||
-            props[0];
-          if (topProp) {
-            results.push({ player: freePlayer, prop: topProp });
-          }
-        }
-        setFreeProps(results);
+        const opps = await nbaDataService.getDailyOpportunities();
+        // Top 2 by score
+        setTopOpps(opps.slice(0, 2));
       } catch (error) {
-        console.error('Error loading free props:', error);
+        console.error('Error loading daily opportunities:', error);
       } finally {
         setIsLoading(false);
       }
     };
-
-    loadFreeProps();
+    load();
   }, []);
 
   const isHorizontal = layout === 'horizontal';
@@ -61,8 +49,7 @@ export function FreePropCard({ layout = 'vertical' }: FreePropCardProps) {
   if (isLoading) {
     return (
       <div className={isHorizontal ? 'terminal-container p-6' : 'terminal-container p-4'}>
-        <h3 className="section-title mb-3">PROP GRÁTIS DO DIA</h3>
-        {isHorizontal && <p className="text-xs text-terminal-text opacity-70 mb-4">Análises gratuitas — sem login necessário</p>}
+        <h3 className="section-title mb-3">OPORTUNIDADE GRÁTIS DO DIA</h3>
         <div className="animate-pulse space-y-2">
           <div className="h-4 bg-terminal-gray rounded w-3/4"></div>
           <div className="h-4 bg-terminal-gray rounded w-1/2"></div>
@@ -71,140 +58,134 @@ export function FreePropCard({ layout = 'vertical' }: FreePropCardProps) {
     );
   }
 
-  if (freeProps.length === 0) {
-    return null;
-  }
+  if (topOpps.length === 0) return null;
 
-  // Horizontal layout: show all props in a grid (mobile hero / Games page top)
+  const renderOppCard = (opp: DailyOpportunity, compact: boolean) => {
+    const statLabel = STAT_LABELS[opp.stat_type] || opp.stat_type.replace('player_', '').replace(/_/g, ' ').toUpperCase();
+    const triggerLastName = opp.trigger_name.split(' ').pop();
+    const statusColor = opp.trigger_status.toLowerCase().includes('out') ? 'bg-terminal-red/20 text-terminal-red border-terminal-red/30'
+      : opp.trigger_status.toLowerCase().includes('doubtful') ? 'bg-orange-400/20 text-orange-400 border-orange-400/30'
+      : 'bg-yellow-400/20 text-yellow-400 border-yellow-400/30';
+    const triggerTextColor = opp.trigger_status.toLowerCase().includes('out') ? 'text-terminal-red'
+      : opp.trigger_status.toLowerCase().includes('doubtful') ? 'text-orange-400' : 'text-yellow-400';
+    const slug = opp.backup_player_name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '-');
+    const href = `/nba-dashboard/${slug}?stat=${opp.stat_type}&trigger=${encodeURIComponent(opp.trigger_name)}`;
+    const initials = opp.backup_player_name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2);
+
+    const handleClick = () => navigate(href);
+
+    return (
+      <div
+        key={`${opp.trigger_player_id}-${opp.backup_player_id}-${opp.stat_type}`}
+        onClick={handleClick}
+        className="bg-terminal-gray rounded border border-terminal-green/30 hover:border-terminal-green transition-colors cursor-pointer p-3"
+      >
+        {/* Row 1: Photo + Name + Score */}
+        <div className="flex items-center gap-2.5 mb-2">
+          <div className="w-8 h-8 rounded-full overflow-hidden bg-terminal-dark-gray border border-terminal-border-subtle shrink-0 flex items-center justify-center">
+            <img
+              src={getPlayerPhotoUrl(opp.backup_player_name, opp.trigger_team_abbr)}
+              alt={opp.backup_player_name}
+              className="w-full h-full object-cover object-top"
+              data-player-photo-index="0"
+              onError={(e) => {
+                const didTry = tryNextPlayerPhotoUrl(e.target as HTMLImageElement, opp.backup_player_name, opp.trigger_team_abbr);
+                if (!didTry) {
+                  const el = e.target as HTMLImageElement;
+                  el.style.display = 'none';
+                  const parent = el.parentElement;
+                  if (parent) parent.innerHTML = `<span class="text-[9px] font-bold text-terminal-text opacity-60">${initials}</span>`;
+                }
+              }}
+            />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className={`font-bold text-terminal-green truncate ${compact ? 'text-xs' : 'text-sm'}`}>
+              {opp.backup_player_name}
+            </div>
+            <div className={`opacity-50 ${compact ? 'text-[10px]' : 'text-xs'}`}>
+              {opp.trigger_team_abbr} vs {opp.opponent_abbr}
+            </div>
+          </div>
+          <div className={`flex items-center gap-1 px-2.5 py-1.5 rounded-lg border shrink-0 ${
+            (opp.score ?? 0) >= 80 ? 'bg-terminal-green/15 text-terminal-green border-terminal-green/40' : (opp.score ?? 0) >= 70 ? 'bg-terminal-yellow/15 text-terminal-yellow border-terminal-yellow/40' : 'bg-orange-400/15 text-orange-400 border-orange-400/40'
+          }`}>
+            <span className="text-[9px] opacity-60">Score</span>
+            <span className="text-sm font-black tabular-nums">{opp.score}</span>
+          </div>
+        </div>
+
+        {/* Row 2: Stat + Trigger badge */}
+        <div className="flex items-center gap-2 mb-2">
+          <span className={`font-bold bg-terminal-green/10 text-terminal-green border border-terminal-green/30 px-1.5 py-0.5 rounded ${compact ? 'text-[10px]' : 'text-xs'}`}>
+            {statLabel}
+          </span>
+          <span className={`text-[9px] px-1.5 py-0.5 rounded border ${statusColor}`}>
+            SEM <span className={`font-medium ${triggerTextColor}`}>{triggerLastName}</span>
+          </span>
+        </div>
+
+        {/* Row 3: Numbers with labels */}
+        <div className={`${compact ? 'text-[10px]' : 'text-xs'} text-terminal-text`}>
+          <span className="opacity-50">Com {triggerLastName}: </span>
+          <span className="opacity-60">{opp.avg_com?.toFixed(1)}</span>
+          <span className="mx-1 opacity-30">→</span>
+          <span className="opacity-50">Sem: </span>
+          <span className="font-bold text-terminal-green">{opp.avg_sem?.toFixed(1)}</span>
+          <span className="ml-1 font-bold text-terminal-green">(+{opp.gap_pct?.toFixed(1)}%)</span>
+        </div>
+        {opp.line_value && (
+          <div className={`${compact ? 'text-[10px]' : 'text-xs'} opacity-50 mt-0.5`}>
+            Linha: {opp.line_value?.toFixed(1)}
+          </div>
+        )}
+
+        {/* CTA */}
+        <div className="mt-3 pt-0">
+          <div className="flex items-center justify-center gap-1.5 w-full py-2 text-xs font-bold text-terminal-black bg-terminal-green rounded hover:bg-terminal-green/90 transition-all">
+            Ver Análise Completa <ArrowRight className="w-3.5 h-3.5" />
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  // Horizontal: show both in grid
   if (isHorizontal) {
     return (
       <div className="terminal-container p-6">
-        <h3 className="section-title mb-3">PROP GRÁTIS DO DIA</h3>
-        <p className="text-xs text-terminal-text opacity-70 mb-4">Análises gratuitas — sem login necessário</p>
+        <h3 className="section-title mb-3">OPORTUNIDADE GRÁTIS DO DIA</h3>
+        <p className="text-xs text-terminal-text opacity-70 mb-4">Top oportunidades do dia — acesso gratuito</p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {freeProps.map((freeProp) => {
-            const statTypeDisplay = freeProp.prop.stat_type
-              .replace('player_', '')
-              .replace(/_/g, ' ')
-              .toUpperCase();
-            const handleClick = () => {
-              const slug = freeProp.player.player_name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '-');
-              navigate(`/nba-dashboard/${slug}?stat=${encodeURIComponent(freeProp.prop.stat_type)}`);
-            };
-            const backupName = freeProp.prop.next_available_player_name?.trim();
-            const showBackup = Boolean(backupName && backupName.toLowerCase() !== freeProp.player.player_name.toLowerCase());
-            return (
-              <div
-                key={freeProp.player.player_id}
-                onClick={handleClick}
-                className="bg-terminal-gray rounded border border-terminal-green/30 hover:border-terminal-green transition-colors cursor-pointer p-4 flex flex-col"
-              >
-                <div className="flex items-start justify-between mb-2">
-                  <div className="flex-1">
-                    <div className="text-sm font-medium text-terminal-green mb-1">{freeProp.player.player_name}</div>
-                    <div className="text-sm font-bold text-terminal-text mb-1">{statTypeDisplay}</div>
-                    <div className="flex items-center gap-2 opacity-60 text-xs">
-                      <span>{freeProp.player.team_abbreviation}</span>
-                      <span>•</span>
-                      <span>RANK #{freeProp.prop.stat_rank}</span>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-1 bg-terminal-dark-gray px-2 py-1 rounded">
-                    <Star className="w-3 h-3 text-terminal-green fill-current" />
-                    <span className="text-xs font-bold text-terminal-green">{freeProp.prop.rating_stars}</span>
-                  </div>
-                </div>
-                {showBackup && (
-                  <div className="mt-2 pt-2 border-t border-terminal-border-subtle text-xs">
-                    <span className="opacity-60">BACKUP: </span>
-                    <span className="text-terminal-text">{backupName}</span>
-                  </div>
-                )}
-                <div className="mt-auto pt-2">
-                  <span className="inline-flex items-center gap-1 text-xs text-terminal-green opacity-70 hover:opacity-100 transition-opacity font-mono">
-                    Ver Análise Completa <ArrowRight className="w-3 h-3" />
-                  </span>
-                </div>
-              </div>
-            );
-          })}
+          {topOpps.map(opp => renderOppCard(opp, false))}
         </div>
       </div>
     );
   }
 
-  // Vertical (sidebar): show one prop at a time with pagination
-  const current = freeProps[activeIndex];
-  const total = freeProps.length;
-  const statTypeDisplay = current.prop.stat_type
-    .replace('player_', '')
-    .replace(/_/g, ' ')
-    .toUpperCase();
-  const handleClick = () => {
-    const slug = current.player.player_name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '-');
-    navigate(`/nba-dashboard/${slug}?stat=${encodeURIComponent(current.prop.stat_type)}`);
-  };
-  const backupName = current.prop.next_available_player_name?.trim();
-  const showBackup = Boolean(backupName && backupName.toLowerCase() !== current.player.player_name.toLowerCase());
+  // Vertical (sidebar): paginate
+  const current = topOpps[activeIndex];
+  const total = topOpps.length;
 
   return (
     <div className="terminal-container p-4">
-      {/* Header with title + pagination */}
       <div className="flex items-center justify-between mb-3">
-        <h3 className="section-title">PROP GRÁTIS DO DIA</h3>
+        <h3 className="section-title">OPORTUNIDADE DO DIA</h3>
         {total > 1 && (
           <div className="flex items-center gap-1">
-            <button
-              onClick={(e) => { e.stopPropagation(); setActiveIndex((i) => (i - 1 + total) % total); }}
-              className="w-5 h-5 flex items-center justify-center rounded hover:bg-terminal-gray/50 text-terminal-text/50 hover:text-terminal-text transition-colors"
-            >
+            <button onClick={(e) => { e.stopPropagation(); setActiveIndex((i) => (i - 1 + total) % total); }}
+              className="w-5 h-5 flex items-center justify-center rounded hover:bg-terminal-gray/50 text-terminal-text/50 hover:text-terminal-text transition-colors">
               <ChevronLeft className="w-3 h-3" />
             </button>
             <span className="text-[10px] text-terminal-text/40 font-mono tabular-nums">{activeIndex + 1}/{total}</span>
-            <button
-              onClick={(e) => { e.stopPropagation(); setActiveIndex((i) => (i + 1) % total); }}
-              className="w-5 h-5 flex items-center justify-center rounded hover:bg-terminal-gray/50 text-terminal-text/50 hover:text-terminal-text transition-colors"
-            >
+            <button onClick={(e) => { e.stopPropagation(); setActiveIndex((i) => (i + 1) % total); }}
+              className="w-5 h-5 flex items-center justify-center rounded hover:bg-terminal-gray/50 text-terminal-text/50 hover:text-terminal-text transition-colors">
               <ChevronRight className="w-3 h-3" />
             </button>
           </div>
         )}
       </div>
-
-      {/* Single prop card */}
-      <div
-        onClick={handleClick}
-        className="bg-terminal-gray rounded border border-terminal-green/30 hover:border-terminal-green transition-colors cursor-pointer p-3 flex flex-col"
-      >
-        <div className="flex items-start justify-between mb-2">
-          <div className="flex-1">
-            <div className="text-xs font-medium text-terminal-green mb-1">{current.player.player_name}</div>
-            <div className="text-xs font-bold text-terminal-text mb-1">{statTypeDisplay}</div>
-            <div className="flex items-center gap-2 opacity-60 text-[10px]">
-              <span>{current.player.team_abbreviation}</span>
-              <span>•</span>
-              <span>RANK #{current.prop.stat_rank}</span>
-            </div>
-          </div>
-          <div className="flex items-center gap-1 bg-terminal-dark-gray px-2 py-1 rounded flex-shrink-0">
-            <Star className="w-3 h-3 text-terminal-green fill-current" />
-            <span className="text-xs font-bold text-terminal-green">{current.prop.rating_stars}</span>
-          </div>
-        </div>
-
-        {showBackup && (
-          <div className="mt-2 pt-2 border-t border-terminal-border-subtle text-[10px]">
-            <span className="opacity-60">BACKUP: </span>
-            <span className="text-terminal-text">{backupName}</span>
-          </div>
-        )}
-
-        <div className="mt-2 pt-2 border-t border-terminal-border">
-          <span className="inline-flex items-center gap-1 text-xs text-terminal-green opacity-70 hover:opacity-100 transition-opacity font-mono">
-            Ver Análise Completa <ArrowRight className="w-3 h-3" />
-          </span>
-        </div>
-      </div>
+      {renderOppCard(current, true)}
     </div>
   );
 }

--- a/src/components/nba/FreePropCard.tsx
+++ b/src/components/nba/FreePropCard.tsx
@@ -100,7 +100,7 @@ export function FreePropCard({ layout = 'vertical' }: FreePropCardProps) {
             />
           </div>
           <div className="flex-1 min-w-0">
-            <div className={`font-bold text-terminal-green truncate ${compact ? 'text-xs' : 'text-sm'}`}>
+            <div className={`font-bold text-terminal-text truncate ${compact ? 'text-xs' : 'text-sm'}`}>
               {opp.backup_player_name}
             </div>
             <div className={`opacity-50 ${compact ? 'text-[10px]' : 'text-xs'}`}>
@@ -117,7 +117,7 @@ export function FreePropCard({ layout = 'vertical' }: FreePropCardProps) {
 
         {/* Row 2: Stat + Trigger badge */}
         <div className="flex items-center gap-2 mb-2">
-          <span className={`font-bold bg-terminal-green/10 text-terminal-green border border-terminal-green/30 px-1.5 py-0.5 rounded ${compact ? 'text-[10px]' : 'text-xs'}`}>
+          <span className={`font-bold bg-terminal-blue/10 text-terminal-blue border border-terminal-blue/30 px-1.5 py-0.5 rounded ${compact ? 'text-[10px]' : 'text-xs'}`}>
             {statLabel}
           </span>
           <span className={`text-[9px] px-1.5 py-0.5 rounded border ${statusColor}`}>
@@ -131,8 +131,8 @@ export function FreePropCard({ layout = 'vertical' }: FreePropCardProps) {
           <span className="opacity-60">{opp.avg_com?.toFixed(1)}</span>
           <span className="mx-1 opacity-30">→</span>
           <span className="opacity-50">Sem: </span>
-          <span className="font-bold text-terminal-green">{opp.avg_sem?.toFixed(1)}</span>
-          <span className="ml-1 font-bold text-terminal-green">(+{opp.gap_pct?.toFixed(1)}%)</span>
+          <span className="font-bold text-terminal-text">{opp.avg_sem?.toFixed(1)}</span>
+          <span className="ml-1 font-bold text-terminal-text">(+{opp.gap_pct?.toFixed(1)}%)</span>
         </div>
         {opp.line_value && (
           <div className={`${compact ? 'text-[10px]' : 'text-xs'} opacity-50 mt-0.5`}>

--- a/src/components/nba/GameChart.tsx
+++ b/src/components/nba/GameChart.tsx
@@ -382,10 +382,10 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
                   disabled={isDisabled}
                   className={`px-2 py-0.5 text-[11px] font-medium rounded border transition-all whitespace-nowrap ${
                     isActive
-                      ? 'bg-terminal-green/20 border-terminal-green text-terminal-green'
+                      ? 'bg-terminal-blue/20 border-terminal-blue text-terminal-blue'
                       : isDisabled
-                      ? 'border-terminal-green/10 text-terminal-text/30 cursor-not-allowed'
-                      : 'border-terminal-green/30 text-terminal-text hover:border-terminal-green/50 hover:bg-terminal-green/5'
+                      ? 'border-terminal-blue/10 text-terminal-text/30 cursor-not-allowed'
+                      : 'border-terminal-blue/30 text-terminal-text hover:border-terminal-blue/50 hover:bg-terminal-blue/5'
                   }`}
                 >
                   {opt.label}
@@ -394,7 +394,7 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
             })}
           </div>
 
-          <div className="h-4 w-px bg-terminal-green/20" />
+          <div className="h-4 w-px bg-terminal-blue/20" />
 
           {/* Home/Away */}
           <div className="flex gap-1">
@@ -407,8 +407,8 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
                   title={opt.value === 'all' ? 'Todos' : opt.value === 'home' ? 'Casa' : 'Fora'}
                   className={`w-6 h-6 flex items-center justify-center rounded border transition-all ${
                     isActive
-                      ? 'bg-terminal-green/20 border-terminal-green text-terminal-green'
-                      : 'border-terminal-green/30 text-terminal-text hover:border-terminal-green/50 hover:bg-terminal-green/5'
+                      ? 'bg-terminal-blue/20 border-terminal-blue text-terminal-blue'
+                      : 'border-terminal-blue/30 text-terminal-text hover:border-terminal-blue/50 hover:bg-terminal-blue/5'
                   }`}
                 >
                   {opt.icon}
@@ -417,7 +417,7 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
             })}
           </div>
 
-          <div className="h-4 w-px bg-terminal-green/20" />
+          <div className="h-4 w-px bg-terminal-blue/20" />
 
           {/* B2B */}
           <button
@@ -426,7 +426,7 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
             className={`px-2 py-0.5 text-[11px] font-medium rounded border transition-all ${
               b2bOnly
                 ? 'bg-terminal-yellow/20 border-terminal-yellow text-terminal-yellow'
-                : 'border-terminal-green/30 text-terminal-text hover:border-terminal-green/50 hover:bg-terminal-green/5'
+                : 'border-terminal-blue/30 text-terminal-text hover:border-terminal-blue/50 hover:bg-terminal-blue/5'
             }`}
           >
             B2B
@@ -440,14 +440,14 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
               className={`px-2 py-0.5 text-[11px] font-medium rounded border transition-all ${
                 h2hOnly
                   ? 'bg-terminal-blue/20 border-terminal-blue text-terminal-blue'
-                  : 'border-terminal-green/30 text-terminal-text hover:border-terminal-green/50 hover:bg-terminal-green/5'
+                  : 'border-terminal-blue/30 text-terminal-text hover:border-terminal-blue/50 hover:bg-terminal-blue/5'
               }`}
             >
               vs {nextOpponent}
             </button>
           )}
 
-          <div className="h-4 w-px bg-terminal-green/20" />
+          <div className="h-4 w-px bg-terminal-blue/20" />
 
           {/* Teammate filter */}
           {availableTeammates.length > 0 && (() => {
@@ -495,7 +495,7 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
                       const filtered = current.filter(f => f.playerId !== t.player_id);
                       onTeammateFilterChange([...filtered, entry]);
                     }}
-                      className="px-2.5 py-1 text-[11px] rounded border border-terminal-green/40 text-terminal-green hover:bg-terminal-green/15 transition-colors">
+                      className="px-2.5 py-1 text-[11px] rounded border border-terminal-blue/40 text-terminal-blue hover:bg-terminal-blue/15 transition-colors">
                       COM
                     </button>
                     <button onClick={() => {
@@ -535,7 +535,7 @@ export const GameChart: React.FC<GameChartProps> = ({ gameStats, currentLine, se
                     </div>
                   ))}
                   <button onClick={() => setTeammateOpen(v => !v)} disabled={teammateFilterLoading}
-                    className="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border border-terminal-green/30 text-terminal-text hover:border-terminal-green/50 hover:bg-terminal-green/5 transition-all disabled:opacity-40">
+                    className="flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border border-terminal-blue/30 text-terminal-text hover:border-terminal-blue/50 hover:bg-terminal-blue/5 transition-all disabled:opacity-40">
                     <Users className="w-3 h-3" />
                     <span>{teammateFilter && teammateFilter.length > 0 ? '+' : 'Companheiro'}</span>
                     <ChevronDown className={`w-3 h-3 transition-transform ${teammateOpen ? 'rotate-180' : ''}`} />

--- a/src/components/nba/InjuryReportModal.tsx
+++ b/src/components/nba/InjuryReportModal.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { nbaDataService, Game, Player } from '@/services/nba-data.service';
 import { getTeamLogoUrl } from '@/utils/team-logos';
-import { Loader2, Star, Radar } from 'lucide-react';
+import { Loader2, Star } from 'lucide-react';
 
 const INJURY_STATUSES = ['Probable', 'Questionable', 'Doubtful', 'Out'] as const;
 type InjuryStatus = (typeof INJURY_STATUSES)[number];
@@ -36,7 +35,6 @@ interface Props {
 }
 
 export function InjuryReportModal({ open, onClose, games }: Props) {
-  const navigate = useNavigate();
   const [players, setPlayers] = useState<Player[]>(playersCache ?? []);
   const [isLoading, setIsLoading] = useState(!playersCache);
 
@@ -170,15 +168,6 @@ export function InjuryReportModal({ open, onClose, games }: Props) {
                                             {player.stars >= 3 && (
                                               <Star className="w-2.5 h-2.5 text-terminal-yellow fill-terminal-yellow inline flex-shrink-0" />
                                             )}
-                                            {player.stars >= 3 && (status === 'Out' || status === 'Doubtful') && (
-                                              <button
-                                                onClick={(e) => { e.stopPropagation(); onClose(); navigate(`/analise-360/${player.playerId}`); }}
-                                                className="ml-0.5 text-terminal-blue/60 hover:text-terminal-blue transition-colors"
-                                                title="Ver Análise 360"
-                                              >
-                                                <Radar className="w-3 h-3" />
-                                              </button>
-                                            )}
                                           </span>
                                         ))}
                                     </div>
@@ -227,7 +216,7 @@ export function InjuryReportModal({ open, onClose, games }: Props) {
                     </tr>
 
                     {matchup.homeHasInjuries && (
-                      <TeamRow team={matchup.home} teamInjuryData={teamInjuryData} isHome bgClass="bg-[#242b35]" onNavigate360={(id) => { onClose(); navigate(`/analise-360/${id}`); }} />
+                      <TeamRow team={matchup.home} teamInjuryData={teamInjuryData} isHome bgClass="bg-[#242b35]" />
                     )}
 
                     {matchup.homeHasInjuries && matchup.visitorHasInjuries && (
@@ -235,7 +224,7 @@ export function InjuryReportModal({ open, onClose, games }: Props) {
                     )}
 
                     {matchup.visitorHasInjuries && (
-                      <TeamRow team={matchup.visitor} teamInjuryData={teamInjuryData} isHome={false} bgClass="bg-[#1e2630]" onNavigate360={(id) => { onClose(); navigate(`/analise-360/${id}`); }} />
+                      <TeamRow team={matchup.visitor} teamInjuryData={teamInjuryData} isHome={false} bgClass="bg-[#1e2630]" />
                     )}
                   </React.Fragment>
                 ))}
@@ -255,13 +244,11 @@ function TeamRow({
   teamInjuryData,
   isHome,
   bgClass,
-  onNavigate360,
 }: {
   team: { abbr: string; name: string };
   teamInjuryData: Map<string, Map<InjuryStatus, InjuredPlayer[]>>;
   isHome: boolean;
   bgClass: string;
-  onNavigate360: (playerId: number) => void;
 }) {
   const teamMap = teamInjuryData.get(team.abbr);
 
@@ -310,15 +297,6 @@ function TeamRow({
                       </span>
                       {player.stars >= 3 && (
                         <Star className="w-2.5 h-2.5 text-terminal-yellow fill-terminal-yellow flex-shrink-0" />
-                      )}
-                      {player.stars >= 3 && (status === 'Out' || status === 'Doubtful') && (
-                        <button
-                          onClick={(e) => { e.stopPropagation(); onNavigate360(player.playerId); }}
-                          className="text-terminal-blue/60 hover:text-terminal-blue transition-colors"
-                          title="Ver Análise 360"
-                        >
-                          <Radar className="w-3 h-3" />
-                        </button>
                       )}
                     </div>
                   ))}

--- a/src/components/nba/InjuryReportModal.tsx
+++ b/src/components/nba/InjuryReportModal.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { nbaDataService, Game, Player } from '@/services/nba-data.service';
 import { getTeamLogoUrl } from '@/utils/team-logos';
-import { Loader2, Star } from 'lucide-react';
+import { Loader2, Star, Radar } from 'lucide-react';
 
 const INJURY_STATUSES = ['Probable', 'Questionable', 'Doubtful', 'Out'] as const;
 type InjuryStatus = (typeof INJURY_STATUSES)[number];
@@ -14,7 +15,7 @@ const STATUS_STYLE: Record<InjuryStatus, { headerBg: string; headerText: string;
   Out:          { headerBg: 'bg-[#251515]', headerText: 'text-red-400',     playerText: 'text-red-400'    },
 };
 
-interface InjuredPlayer { name: string; stars: number }
+interface InjuredPlayer { name: string; stars: number; playerId: number }
 
 function normalizeStatus(status: string): InjuryStatus | null {
   const s = (status ?? '').toLowerCase().trim();
@@ -35,6 +36,7 @@ interface Props {
 }
 
 export function InjuryReportModal({ open, onClose, games }: Props) {
+  const navigate = useNavigate();
   const [players, setPlayers] = useState<Player[]>(playersCache ?? []);
   const [isLoading, setIsLoading] = useState(!playersCache);
 
@@ -65,7 +67,7 @@ export function InjuryReportModal({ open, onClose, games }: Props) {
     }
     const m = teamInjuryData.get(player.team_abbreviation)!;
     if (!m.has(status)) m.set(status, []);
-    m.get(status)!.push({ name: player.player_name, stars: player.rating_stars ?? 0 });
+    m.get(status)!.push({ name: player.player_name, stars: player.rating_stars ?? 0, playerId: player.player_id });
   });
 
   const matchups = games
@@ -168,6 +170,15 @@ export function InjuryReportModal({ open, onClose, games }: Props) {
                                             {player.stars >= 3 && (
                                               <Star className="w-2.5 h-2.5 text-terminal-yellow fill-terminal-yellow inline flex-shrink-0" />
                                             )}
+                                            {player.stars >= 3 && (status === 'Out' || status === 'Doubtful') && (
+                                              <button
+                                                onClick={(e) => { e.stopPropagation(); onClose(); navigate(`/analise-360/${player.playerId}`); }}
+                                                className="ml-0.5 text-terminal-blue/60 hover:text-terminal-blue transition-colors"
+                                                title="Ver Análise 360"
+                                              >
+                                                <Radar className="w-3 h-3" />
+                                              </button>
+                                            )}
                                           </span>
                                         ))}
                                     </div>
@@ -216,7 +227,7 @@ export function InjuryReportModal({ open, onClose, games }: Props) {
                     </tr>
 
                     {matchup.homeHasInjuries && (
-                      <TeamRow team={matchup.home} teamInjuryData={teamInjuryData} isHome bgClass="bg-[#242b35]" />
+                      <TeamRow team={matchup.home} teamInjuryData={teamInjuryData} isHome bgClass="bg-[#242b35]" onNavigate360={(id) => { onClose(); navigate(`/analise-360/${id}`); }} />
                     )}
 
                     {matchup.homeHasInjuries && matchup.visitorHasInjuries && (
@@ -224,7 +235,7 @@ export function InjuryReportModal({ open, onClose, games }: Props) {
                     )}
 
                     {matchup.visitorHasInjuries && (
-                      <TeamRow team={matchup.visitor} teamInjuryData={teamInjuryData} isHome={false} bgClass="bg-[#1e2630]" />
+                      <TeamRow team={matchup.visitor} teamInjuryData={teamInjuryData} isHome={false} bgClass="bg-[#1e2630]" onNavigate360={(id) => { onClose(); navigate(`/analise-360/${id}`); }} />
                     )}
                   </React.Fragment>
                 ))}
@@ -244,11 +255,13 @@ function TeamRow({
   teamInjuryData,
   isHome,
   bgClass,
+  onNavigate360,
 }: {
   team: { abbr: string; name: string };
   teamInjuryData: Map<string, Map<InjuryStatus, InjuredPlayer[]>>;
   isHome: boolean;
   bgClass: string;
+  onNavigate360: (playerId: number) => void;
 }) {
   const teamMap = teamInjuryData.get(team.abbr);
 
@@ -297,6 +310,15 @@ function TeamRow({
                       </span>
                       {player.stars >= 3 && (
                         <Star className="w-2.5 h-2.5 text-terminal-yellow fill-terminal-yellow flex-shrink-0" />
+                      )}
+                      {player.stars >= 3 && (status === 'Out' || status === 'Doubtful') && (
+                        <button
+                          onClick={(e) => { e.stopPropagation(); onNavigate360(player.playerId); }}
+                          className="text-terminal-blue/60 hover:text-terminal-blue transition-colors"
+                          title="Ver Análise 360"
+                        >
+                          <Radar className="w-3 h-3" />
+                        </button>
                       )}
                     </div>
                   ))}

--- a/src/components/nba/NextGamesCard.tsx
+++ b/src/components/nba/NextGamesCard.tsx
@@ -72,7 +72,7 @@ export const NextGamesCard: React.FC<NextGamesCardProps> = ({ team, isLoading, i
             </div>
             <div className="flex items-center gap-1.5">
               {nextGameTime && (
-                <span className="text-[10px] font-semibold text-terminal-green">{nextGameTime}</span>
+                <span className="text-[10px] font-semibold text-terminal-blue">{nextGameTime}</span>
               )}
               <Calendar className="w-3 h-3 opacity-40" />
             </div>

--- a/src/components/nba/TeammatesCard.tsx
+++ b/src/components/nba/TeammatesCard.tsx
@@ -73,11 +73,11 @@ export const TeammatesCard: React.FC<TeammatesCardProps> = ({
               <button
                 key={player.player_id}
                 onClick={() => handlePlayerClick(player.player_name)}
-                className="w-full text-left p-2 rounded border border-terminal-green/20 hover:border-terminal-green/50 hover:bg-terminal-green/5 transition-all group"
+                className="w-full text-left p-2 rounded border border-terminal-blue/20 hover:border-terminal-blue/50 hover:bg-terminal-blue/5 transition-all group"
               >
                 <div className="flex items-center gap-2">
                   {/* Avatar */}
-                  <div className="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-terminal-dark-gray border border-terminal-green/20">
+                  <div className="w-9 h-9 rounded-full overflow-hidden flex-shrink-0 bg-terminal-dark-gray border border-terminal-blue/20">
                     {photoUrl ? (
                       <img
                         src={photoUrl}
@@ -90,7 +90,7 @@ export const TeammatesCard: React.FC<TeammatesCardProps> = ({
                         }}
                       />
                     ) : (
-                      <div className="w-full h-full flex items-center justify-center text-[10px] font-bold text-terminal-green/60">
+                      <div className="w-full h-full flex items-center justify-center text-[10px] font-bold text-terminal-blue/60">
                         {initials}
                       </div>
                     )}
@@ -98,7 +98,7 @@ export const TeammatesCard: React.FC<TeammatesCardProps> = ({
 
                   {/* Info */}
                   <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium text-terminal-green group-hover:text-terminal-green-bright truncate">
+                    <div className="text-sm font-medium text-terminal-blue group-hover:text-terminal-blue truncate">
                       {player.player_name}
                     </div>
                     <div className="flex items-center gap-2">

--- a/src/hooks/use-analise360.ts
+++ b/src/hooks/use-analise360.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { nbaDataService, DailyOpportunity } from '@/services/nba-data.service';
+
+interface PlayerStarsMap {
+  map: Map<number, number>;
+}
+
+async function fetchAnalise360Data(): Promise<{
+  opportunities: DailyOpportunity[];
+  playerStarsMap: Map<number, number>;
+}> {
+  const [opportunities, players] = await Promise.all([
+    nbaDataService.getDailyOpportunities(),
+    nbaDataService.getAllPlayers(),
+  ]);
+  const playerStarsMap = new Map<number, number>();
+  players.forEach(p => playerStarsMap.set(p.player_id, p.rating_stars ?? 0));
+  return { opportunities, playerStarsMap };
+}
+
+export function useAnalise360Data() {
+  return useQuery({
+    queryKey: ['analise360', 'data'],
+    queryFn: fetchAnalise360Data,
+    staleTime: 2 * 60 * 1000,    // 2 min — data is fresh
+    gcTime: 10 * 60 * 1000,      // 10 min — keep in cache
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,16 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Mandala satellite entrance animation */
+@keyframes mandala-satellite-enter {
+  0% { opacity: 0; transform: translate(-50%, -50%) scale(0.6); filter: blur(4px); }
+  60% { opacity: 1; transform: translate(-50%, -50%) scale(1.03); filter: blur(0px); }
+  100% { opacity: 1; transform: translate(-50%, -50%) scale(1); filter: blur(0px); }
+}
+.mandala-satellite-enter {
+  animation: mandala-satellite-enter 0.5s cubic-bezier(0.16, 1, 0.3, 1) backwards;
+}
+
 /* Definition of the design system. All colors, gradients, fonts, etc should be defined here. 
 All colors MUST be HSL.
 */

--- a/src/pages/Analise360Detail.tsx
+++ b/src/pages/Analise360Detail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Loader2, Radar, Star, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
+import { Loader2, Radar, Star, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
 import { getPlayerPhotoUrl, tryNextPlayerPhotoUrl, getTeamLogoUrl, teamAbbrToName } from '@/utils/team-logos';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useAnalise360Data } from '@/hooks/use-analise360';
@@ -596,18 +596,9 @@ export default function Analise360Detail() {
 
   return (
     <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
-      <AnalyticsNav />
+      <AnalyticsNav showBack />
 
       <div className="max-w-6xl mx-auto px-4 py-6">
-        {/* Back */}
-        <button
-          onClick={() => navigate('/analise-360')}
-          className="flex items-center gap-1.5 text-xs text-terminal-text/40 hover:text-terminal-blue mb-5 transition-colors"
-        >
-          <ArrowLeft className="w-3.5 h-3.5" />
-          Voltar
-        </button>
-
         {isLoading ? (
           <div className="flex items-center justify-center py-20 gap-2">
             <Loader2 className="w-5 h-5 animate-spin text-terminal-green opacity-60" />

--- a/src/pages/Analise360Detail.tsx
+++ b/src/pages/Analise360Detail.tsx
@@ -1,0 +1,832 @@
+import { useState, useEffect, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { ArrowLeft, Loader2, Radar, Star, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
+import { getPlayerPhotoUrl, tryNextPlayerPhotoUrl, getTeamLogoUrl, teamAbbrToName } from '@/utils/team-logos';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { useAnalise360Data } from '@/hooks/use-analise360';
+import AnalyticsNav from '@/components/AnalyticsNav';
+
+// --- Types ---
+
+interface BackupSatellite {
+  backupPlayerId: number;
+  backupPlayerName: string;
+  avgCom: number;
+  avgSem: number;
+  gap: number;
+  gapPct: number;
+  score: number | null;
+  jogosCom: number | null;
+  jogosSem: number | null;
+  lineValue: number | null;
+  gapVsLine: number | null;
+  gapVsLinePct: number | null;
+  cvSem: number | null;
+  stddevSem: number | null;
+  ratingStars: number;
+  statType: string;
+  isFallback: boolean;
+}
+
+interface TriggerInfo {
+  triggerPlayerId: number;
+  triggerName: string;
+  triggerStatus: string;
+  triggerTeamAbbr: string;
+  triggerDaysOut: number | null;
+  ratingStars: number;
+  gameLabel: string;
+  gameDate: string;
+  homeTeamAbbr: string;
+  visitorTeamAbbr: string;
+  opponentAbbr: string | null;
+  opponentDefRank: number | null;
+  opponentOffRank: number | null;
+  isHome: boolean;
+  isB2b: boolean;
+  gameTime: string | null;
+}
+
+// --- Constants ---
+
+const STAT_TABS = [
+  { key: 'player_points', label: 'PTS' },
+  { key: 'player_assists', label: 'AST' },
+  { key: 'player_rebounds', label: 'REB' },
+] as const;
+
+const MAX_VISIBLE_SATELLITES = 8;
+
+const STAT_SHORT_LABEL: Record<string, string> = {
+  player_points: 'PTS',
+  player_assists: 'AST',
+  player_rebounds: 'REB',
+  player_points_rebounds_assists: 'PRA',
+  player_points_assists: 'P+A',
+  player_points_rebounds: 'P+R',
+  player_rebounds_assists: 'R+A',
+  player_blocks_steals: 'B+S',
+  player_threes: '3PT',
+  player_steals: 'STL',
+  player_blocks: 'BLK',
+};
+
+// --- Helpers ---
+
+function slugify(name: string) {
+  return name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '-');
+}
+
+function getGapColor(gapPct: number): string {
+  if (gapPct >= 20) return 'text-emerald-400';
+  if (gapPct >= 10) return 'text-terminal-green';
+  if (gapPct >= 5) return 'text-lime-400';
+  if (gapPct > -3) return 'text-terminal-text/50';
+  return 'text-terminal-red';
+}
+
+function getGapBgColor(gapPct: number): string {
+  if (gapPct >= 20) return 'bg-emerald-400';
+  if (gapPct >= 10) return 'bg-terminal-green';
+  if (gapPct >= 5) return 'bg-lime-400';
+  if (gapPct > -3) return 'bg-terminal-text/20';
+  return 'bg-terminal-red';
+}
+
+// Subtle, low-opacity lines — data nodes are the hero, not connections
+function getLineStroke(gapPct: number): string {
+  if (gapPct >= 20) return 'rgba(52, 211, 153, 0.35)';   // emerald
+  if (gapPct >= 10) return 'rgba(74, 222, 128, 0.25)';   // green
+  if (gapPct >= 5) return 'rgba(163, 230, 53, 0.20)';    // lime
+  if (gapPct > -3) return 'rgba(255, 255, 255, 0.06)';   // neutral
+  return 'rgba(239, 68, 68, 0.20)';                       // red
+}
+
+function getLineWidth(gapPct: number): number {
+  const absGap = Math.abs(gapPct);
+  return Math.max(0.3, Math.min(1.2, 0.3 + (absGap / 40) * 0.9));
+}
+
+// Glow color for satellite ring
+function getRingGlow(gapPct: number): string {
+  if (gapPct >= 20) return 'ring-emerald-400/40 shadow-[0_0_12px_rgba(52,211,153,0.25)]';
+  if (gapPct >= 10) return 'ring-terminal-green/30 shadow-[0_0_10px_rgba(74,222,128,0.20)]';
+  if (gapPct >= 5) return 'ring-lime-400/25 shadow-[0_0_8px_rgba(163,230,53,0.15)]';
+  if (gapPct > -3) return 'ring-terminal-border/30';
+  return 'ring-terminal-red/30 shadow-[0_0_8px_rgba(239,68,68,0.15)]';
+}
+
+function getTriggerStatusBadge(status: string): { text: string; cls: string } {
+  const s = status.toLowerCase();
+  if (s === 'out' || s.includes('out')) return { text: 'OUT', cls: 'bg-terminal-red/15 text-terminal-red border-terminal-red/25' };
+  if (s.includes('doubtful')) return { text: 'DTD', cls: 'bg-orange-400/15 text-orange-400 border-orange-400/25' };
+  return { text: 'Q', cls: 'bg-yellow-400/15 text-yellow-400 border-yellow-400/25' };
+}
+
+// --- Player Photo Component ---
+
+function PlayerPhoto({ name, teamAbbr, size = 'md' }: { name: string; teamAbbr: string; size?: 'sm' | 'md' | 'lg' | 'xl' | 'center' }) {
+  const initials = name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2);
+  const sizeClass = {
+    center: 'w-[88px] h-[88px]',
+    xl: 'w-16 h-16',
+    lg: 'w-14 h-14',
+    md: 'w-14 h-14',
+    sm: 'w-9 h-9',
+  }[size];
+  const textClass = {
+    center: 'text-2xl',
+    xl: 'text-base',
+    lg: 'text-sm',
+    md: 'text-sm',
+    sm: 'text-[10px]',
+  }[size];
+
+  return (
+    <div className={`${sizeClass} rounded-full overflow-hidden bg-terminal-gray shrink-0 flex items-center justify-center relative`}>
+      <img
+        src={getPlayerPhotoUrl(name, teamAbbr)}
+        alt={name}
+        className="w-[115%] h-[115%] object-cover object-top absolute top-0 left-1/2 -translate-x-1/2"
+        loading="lazy"
+        data-player-photo-index="0"
+        onError={(e) => {
+          const didTry = tryNextPlayerPhotoUrl(e.target as HTMLImageElement, name, teamAbbr);
+          if (!didTry) {
+            const el = e.target as HTMLImageElement;
+            el.style.display = 'none';
+            const parent = el.parentElement;
+            if (parent) parent.innerHTML = `<span class="${textClass} font-bold text-terminal-text opacity-50">${initials}</span>`;
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+// --- Mandala View (Desktop) ---
+
+function MandalaView({
+  satellites,
+  trigger,
+  onSatelliteClick,
+  selectedBackup,
+  onCloseTooltip,
+}: {
+  satellites: BackupSatellite[];
+  trigger: TriggerInfo;
+  onSatelliteClick: (sat: BackupSatellite) => void;
+  selectedBackup: number | null;
+  onCloseTooltip: () => void;
+}) {
+  const visible = satellites.slice(0, MAX_VISIBLE_SATELLITES);
+  const count = visible.length;
+  const radius = 36;
+
+  return (
+    <div className="relative w-full" style={{ paddingBottom: '95%', maxWidth: '750px', margin: '0 auto' }}>
+      <div className="absolute inset-0">
+
+        {/* Subtle orbit ring */}
+        <svg className="absolute inset-0 w-full h-full pointer-events-none" viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r="18" fill="none" stroke="rgba(255,255,255,0.03)" strokeWidth="0.2" />
+          <circle cx="50" cy="50" r={radius} fill="none" stroke="rgba(255,255,255,0.04)" strokeWidth="0.2" strokeDasharray="1.5 1.5" />
+        </svg>
+
+        {/* Connection lines */}
+        <svg className="absolute inset-0 w-full h-full pointer-events-none" viewBox="0 0 100 100">
+          {visible.map((sat, i) => {
+            const angle = (2 * Math.PI / count) * i - Math.PI / 2;
+            const x2 = 50 + radius * Math.cos(angle);
+            const y2 = 50 + radius * Math.sin(angle);
+            const isActive = selectedBackup === sat.backupPlayerId;
+            return (
+              <line
+                key={sat.backupPlayerId}
+                x1="50" y1="50"
+                x2={x2} y2={y2}
+                stroke={getLineStroke(sat.gapPct)}
+                strokeWidth={isActive ? getLineWidth(sat.gapPct) * 2 : getLineWidth(sat.gapPct)}
+                strokeOpacity={isActive ? 1 : (selectedBackup ? 0.3 : 1)}
+                className="transition-all duration-500 ease-out"
+                strokeLinecap="round"
+              />
+            );
+          })}
+        </svg>
+
+        {/* Center node */}
+        <div
+          className="absolute flex flex-col items-center z-10"
+          style={{ left: '50%', top: '50%', transform: 'translate(-50%, -50%)' }}
+        >
+          <div className="relative">
+            <div className="absolute inset-0 rounded-full bg-terminal-border/10 animate-pulse scale-[1.4]" />
+            <PlayerPhoto name={trigger.triggerName} teamAbbr={trigger.triggerTeamAbbr} size="center" />
+            <span className={`absolute -bottom-3.5 left-1/2 -translate-x-1/2 text-[10px] font-bold px-2.5 py-0.5 rounded-full border whitespace-nowrap bg-terminal-dark-gray/90 backdrop-blur-sm ${getTriggerStatusBadge(trigger.triggerStatus).cls}`}>
+              {getTriggerStatusBadge(trigger.triggerStatus).text}
+            </span>
+          </div>
+          <span className="text-sm font-semibold text-terminal-text/80 mt-5 text-center max-w-[130px] leading-tight">
+            {trigger.triggerName}
+          </span>
+          <span className="text-[9px] text-terminal-blue/40 mt-1">Clique nos jogadores para detalhes</span>
+        </div>
+
+        {/* Satellite nodes */}
+        {visible.map((sat, i) => {
+          const angle = (2 * Math.PI / count) * i - Math.PI / 2;
+          const x = 50 + radius * Math.cos(angle);
+          const y = 50 + radius * Math.sin(angle);
+          const isSelected = selectedBackup === sat.backupPlayerId;
+          const isPositive = sat.gapPct > 0;
+          const isDimmed = selectedBackup != null && !isSelected;
+
+          return (
+            <button
+              key={sat.backupPlayerId}
+              className={`absolute flex flex-col items-center cursor-pointer group mandala-satellite-enter ${isSelected ? 'z-20' : 'z-10'} transition-opacity duration-300 ${isDimmed ? 'opacity-40' : 'opacity-100'}`}
+              style={{
+                left: `${x}%`,
+                top: `${y}%`,
+                transform: 'translate(-50%, -50%)',
+                animationDelay: `${i * 60}ms`,
+              }}
+              onClick={() => onSatelliteClick(sat)}
+            >
+              <div className={`relative transition-all duration-200 ease-out ${isSelected ? 'scale-115' : 'group-hover:scale-105'} group-active:scale-95`}>
+                <div className={`rounded-full ring-2 ${getRingGlow(sat.gapPct)} ${sat.isFallback ? 'opacity-60' : ''}`}>
+                  <PlayerPhoto name={sat.backupPlayerName} teamAbbr={trigger.triggerTeamAbbr} size="md" />
+                </div>
+                {/* Gap badge */}
+                <span className={`absolute -bottom-1.5 left-1/2 -translate-x-1/2 text-[11px] font-bold px-2.5 py-0.5 rounded-full whitespace-nowrap backdrop-blur-sm ${
+                  isPositive
+                    ? 'bg-emerald-950/80 text-emerald-400 border border-emerald-400/20'
+                    : sat.gapPct <= -3
+                    ? 'bg-red-950/80 text-red-400 border border-red-400/20'
+                    : 'bg-terminal-dark-gray/80 text-terminal-text/50 border border-terminal-border-subtle'
+                }`}>
+                  {isPositive ? '+' : ''}{sat.gapPct.toFixed(0)}%
+                </span>
+              </div>
+
+              {/* Player name */}
+              <span className={`text-[13px] mt-2.5 text-center max-w-[110px] leading-tight transition-colors ${
+                isSelected ? 'text-terminal-text font-semibold' : 'text-terminal-text/60 group-hover:text-terminal-text/80'
+              }`}>
+                {sat.backupPlayerName.split(' ').length > 2
+                  ? sat.backupPlayerName.split(' ').slice(-2).join(' ')
+                  : sat.backupPlayerName}
+              </span>
+
+              {/* Fallback stat indicator */}
+              {sat.isFallback && (
+                <span className="text-[10px] text-terminal-text/30 uppercase tracking-wider">
+                  {STAT_SHORT_LABEL[sat.statType] ?? sat.statType}
+                </span>
+              )}
+            </button>
+          );
+        })}
+
+        {/* Click-outside backdrop */}
+        {selectedBackup && (
+          <div className="fixed inset-0 z-[5]" onClick={onCloseTooltip} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// --- Mobile Ranked List ---
+
+function MobileRankedList({
+  satellites,
+  trigger,
+  onSatelliteClick,
+}: {
+  satellites: BackupSatellite[];
+  trigger: TriggerInfo;
+  onSatelliteClick: (sat: BackupSatellite) => void;
+}) {
+  const [showAll, setShowAll] = useState(false);
+  const INITIAL_SHOW = 6;
+  const visible = showAll ? satellites : satellites.slice(0, INITIAL_SHOW);
+  const hasMore = satellites.length > INITIAL_SHOW;
+  const maxGapPct = Math.max(...satellites.map(s => Math.abs(s.gapPct)), 1);
+
+  return (
+    <div className="space-y-1.5">
+      {visible.map((sat, i) => {
+        const isPositive = sat.gapPct > 0;
+        const barWidth = Math.min(100, (Math.abs(sat.gapPct) / maxGapPct) * 100);
+
+        return (
+          <button
+            key={sat.backupPlayerId}
+            onClick={() => onSatelliteClick(sat)}
+            className="w-full bg-terminal-dark-gray/60 border border-terminal-border-subtle/50 rounded-lg p-3 hover:border-terminal-blue/30 active:scale-[0.99] transition-all text-left"
+          >
+            <div className="flex items-center gap-3">
+              <span className="text-[10px] text-terminal-text/20 w-4 text-right font-mono tabular-nums">{i + 1}</span>
+              <div className={`rounded-full ring-1 ${getRingGlow(sat.gapPct)}`}>
+                <PlayerPhoto name={sat.backupPlayerName} teamAbbr={trigger.triggerTeamAbbr} size="sm" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between mb-1.5">
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <span className={`text-xs font-medium truncate ${sat.isFallback ? 'text-terminal-text/50' : 'text-terminal-text/90'}`}>
+                      {sat.backupPlayerName}
+                    </span>
+                    {sat.isFallback && (
+                      <span className="text-[8px] text-terminal-text/25 bg-terminal-gray/40 px-1 py-0.5 rounded shrink-0 uppercase tracking-wider">
+                        {STAT_SHORT_LABEL[sat.statType] ?? sat.statType}
+                      </span>
+                    )}
+                  </div>
+                  <span className={`text-xs font-bold shrink-0 ml-2 tabular-nums ${getGapColor(sat.gapPct)}`}>
+                    {isPositive ? '+' : ''}{sat.gapPct.toFixed(1)}%
+                  </span>
+                </div>
+                {/* Progress bar */}
+                <div className="w-full h-1 bg-terminal-gray/40 rounded-full overflow-hidden">
+                  <div
+                    className={`h-full rounded-full transition-all duration-700 ease-out ${getGapBgColor(sat.gapPct)}`}
+                    style={{ width: `${barWidth}%`, opacity: 0.7 }}
+                  />
+                </div>
+                <div className="flex items-center justify-between mt-1">
+                  <span className="text-[10px] text-terminal-text/30 tabular-nums">
+                    com: {sat.avgCom.toFixed(1)} · sem: {sat.avgSem.toFixed(1)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </button>
+        );
+      })}
+
+      {hasMore && !showAll && (
+        <button
+          onClick={() => setShowAll(true)}
+          className="w-full py-2.5 text-[10px] text-terminal-blue/60 hover:text-terminal-blue flex items-center justify-center gap-1 transition-colors"
+        >
+          <ChevronDown className="w-3 h-3" />
+          Ver mais {satellites.length - INITIAL_SHOW} jogadores
+        </button>
+      )}
+      {hasMore && showAll && (
+        <button
+          onClick={() => setShowAll(false)}
+          className="w-full py-2.5 text-[10px] text-terminal-text/30 hover:text-terminal-text/50 flex items-center justify-center gap-1 transition-colors"
+        >
+          <ChevronUp className="w-3 h-3" />
+          Recolher
+        </button>
+      )}
+    </div>
+  );
+}
+
+// --- Satellite Detail Panel ---
+
+function SatelliteDetail({
+  satellite,
+  trigger,
+  onClose,
+}: {
+  satellite: BackupSatellite;
+  trigger: TriggerInfo;
+  onClose: () => void;
+}) {
+  const navigate = useNavigate();
+  const isPositive = satellite.gapPct > 0;
+  const slug = slugify(satellite.backupPlayerName);
+  const triggerLastName = trigger.triggerName.split(' ').pop();
+
+  return (
+    <div className="bg-terminal-dark-gray/80 backdrop-blur-sm border border-terminal-border-subtle/60 rounded-xl p-4 animate-in fade-in slide-in-from-bottom-2 duration-200">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2.5">
+          <div className={`rounded-full ring-1 ${getRingGlow(satellite.gapPct)}`}>
+            <PlayerPhoto name={satellite.backupPlayerName} teamAbbr={trigger.triggerTeamAbbr} size="sm" />
+          </div>
+          <div>
+            <span className="text-sm font-semibold text-terminal-text block">{satellite.backupPlayerName}</span>
+            <span className="text-[9px] text-terminal-text/30 uppercase tracking-wider">
+              {STAT_SHORT_LABEL[satellite.statType] ?? satellite.statType}
+            </span>
+          </div>
+        </div>
+        <button onClick={onClose} className="text-terminal-text/20 hover:text-terminal-text/50 transition-colors p-1">
+          <span className="text-sm">&#x2715;</span>
+        </button>
+      </div>
+
+      {/* Stats comparison */}
+      <div className="grid grid-cols-2 gap-3 mb-3">
+        <div className="bg-terminal-gray/30 rounded-lg p-2.5 text-center">
+          <span className="text-[9px] text-terminal-text/30 uppercase tracking-wider block mb-1">Com {triggerLastName}</span>
+          <span className="text-base font-bold text-terminal-text/70 tabular-nums">{satellite.avgCom.toFixed(1)}</span>
+        </div>
+        <div className="bg-terminal-gray/30 rounded-lg p-2.5 text-center">
+          <span className="text-[9px] text-terminal-text/30 uppercase tracking-wider block mb-1">Sem {triggerLastName}</span>
+          <span className="text-base font-bold text-terminal-text tabular-nums">{satellite.avgSem.toFixed(1)}</span>
+        </div>
+      </div>
+
+      {/* Gap + metadata */}
+      <div className="space-y-1.5 text-xs mb-3">
+        <div className="flex justify-between items-center">
+          <span className="text-terminal-text/35">Diferenca</span>
+          <span className={`font-bold tabular-nums ${getGapColor(satellite.gapPct)}`}>
+            {isPositive ? '+' : ''}{satellite.gap.toFixed(1)} ({isPositive ? '+' : ''}{satellite.gapPct.toFixed(1)}%)
+          </span>
+        </div>
+        {satellite.jogosSem != null && (
+          <div className="flex justify-between items-center">
+            <span className="text-terminal-text/35">Amostra</span>
+            <span className="text-terminal-text/60 tabular-nums">{satellite.jogosSem} jogos sem</span>
+          </div>
+        )}
+        {satellite.score != null && (
+          <div className="flex justify-between items-center">
+            <span className="text-terminal-text/35">Score</span>
+            <span className="text-terminal-text/60 tabular-nums">{satellite.score}/100</span>
+          </div>
+        )}
+        {satellite.cvSem != null && (
+          <div className="flex justify-between items-center">
+            <span className="text-terminal-text/35">Consistencia</span>
+            <span className={`tabular-nums font-medium ${
+              satellite.cvSem <= 30 ? 'text-terminal-green/70' : satellite.cvSem <= 50 ? 'text-terminal-yellow/70' : 'text-terminal-red/70'
+            }`}>
+              {satellite.cvSem <= 30 ? 'Alta' : satellite.cvSem <= 50 ? 'Media' : 'Baixa'}
+              <span className="text-terminal-text/25 ml-1">({satellite.cvSem.toFixed(0)}%)</span>
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Line + gap vs line */}
+      {satellite.lineValue != null && (
+        <div className="border-t border-terminal-border-subtle/30 pt-2.5 mb-3 space-y-1.5 text-xs">
+          <div className="flex justify-between items-center">
+            <span className="text-terminal-text/35">Linha</span>
+            <span className="text-terminal-text/60 tabular-nums">{satellite.lineValue.toFixed(1)}</span>
+          </div>
+          {satellite.gapVsLinePct != null && (
+            <div className="flex justify-between items-center">
+              <span className="text-terminal-text/35">Gap vs Linha</span>
+              <span className={`font-bold tabular-nums ${satellite.gapVsLinePct > 0 ? 'text-terminal-green/80' : 'text-terminal-red/70'}`}>
+                {satellite.gapVsLinePct > 0 ? '+' : ''}{satellite.gapVsLinePct.toFixed(1)}%
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+
+      <a
+        href={`/nba-dashboard/${slug}?stat=${satellite.statType}&trigger=${encodeURIComponent(trigger.triggerName)}`}
+        onClick={(e) => { if (!e.ctrlKey && !e.metaKey && e.button === 0) { e.preventDefault(); navigate(`/nba-dashboard/${slug}?stat=${satellite.statType}&trigger=${encodeURIComponent(trigger.triggerName)}`); } }}
+        className="w-full flex items-center justify-center gap-1.5 py-2 text-[10px] font-semibold text-terminal-blue/80 hover:text-terminal-blue bg-terminal-blue/5 hover:bg-terminal-blue/10 rounded-lg border border-terminal-blue/15 transition-all active:scale-[0.98] no-underline"
+      >
+        Ver Dashboard
+        <ExternalLink className="w-3 h-3" />
+      </a>
+    </div>
+  );
+}
+
+// --- Main Page ---
+
+export default function Analise360Detail() {
+  const { triggerPlayerId } = useParams<{ triggerPlayerId: string }>();
+  const navigate = useNavigate();
+  const isMobile = useIsMobile();
+
+  const { data, isLoading, error } = useAnalise360Data();
+  const opportunities = data?.opportunities ?? [];
+  const playerStarsMap = data?.playerStarsMap ?? new Map<number, number>();
+  const [selectedStat, setSelectedStat] = useState<string>('player_points');
+  const [selectedBackup, setSelectedBackup] = useState<BackupSatellite | null>(null);
+
+  const triggerIdNum = Number(triggerPlayerId);
+
+  const triggerOpps = useMemo(() => {
+    return opportunities.filter(o => o.trigger_player_id === triggerIdNum);
+  }, [opportunities, triggerIdNum]);
+
+  const triggerInfo = useMemo((): TriggerInfo | null => {
+    if (triggerOpps.length === 0) return null;
+    const first = triggerOpps[0];
+    return {
+      triggerPlayerId: first.trigger_player_id,
+      triggerName: first.trigger_name,
+      triggerStatus: first.trigger_status,
+      triggerTeamAbbr: first.trigger_team_abbr,
+      triggerDaysOut: first.trigger_days_out,
+      ratingStars: playerStarsMap.get(first.trigger_player_id) ?? 0,
+      gameLabel: `${first.home_team_abbr} vs ${first.visitor_team_abbr}`,
+      gameDate: first.game_date,
+      homeTeamAbbr: first.home_team_abbr,
+      visitorTeamAbbr: first.visitor_team_abbr,
+      opponentAbbr: first.opponent_abbr,
+      opponentDefRank: first.opponent_def_rank,
+      opponentOffRank: first.opponent_off_rank,
+      isHome: first.is_home,
+      isB2b: first.is_b2b,
+      gameTime: first.game_time,
+    };
+  }, [triggerOpps, playerStarsMap]);
+
+  const satellites = useMemo((): BackupSatellite[] => {
+    const byBackup = new Map<number, DailyOpportunity[]>();
+    triggerOpps.forEach(o => {
+      if (o.backup_player_id == null) return;
+      if (!byBackup.has(o.backup_player_id)) byBackup.set(o.backup_player_id, []);
+      byBackup.get(o.backup_player_id)!.push(o);
+    });
+
+    const sats: BackupSatellite[] = [];
+    byBackup.forEach((opps, backupId) => {
+      let pick = opps.find(o => o.stat_type === selectedStat);
+      const isFallback = !pick;
+      if (!pick) {
+        pick = opps.reduce((best, o) => (o.gap_pct > (best?.gap_pct ?? -Infinity) ? o : best), opps[0]);
+      }
+      sats.push({
+        backupPlayerId: backupId,
+        backupPlayerName: pick.backup_player_name,
+        avgCom: pick.avg_com,
+        avgSem: pick.avg_sem,
+        gap: pick.gap,
+        gapPct: pick.gap_pct,
+        score: pick.score,
+        jogosCom: pick.jogos_com,
+        jogosSem: pick.jogos_sem,
+        lineValue: pick.line_value,
+        gapVsLine: pick.gap_vs_line,
+        gapVsLinePct: pick.gap_vs_line_pct,
+        cvSem: pick.cv_sem,
+        stddevSem: pick.stddev_sem,
+        ratingStars: pick.rating_stars,
+        statType: pick.stat_type,
+        isFallback,
+      });
+    });
+
+    sats.sort((a, b) => b.gapPct - a.gapPct);
+    return sats;
+  }, [triggerOpps, selectedStat]);
+
+  const availableTabs = useMemo(() => {
+    const statTypes = new Set(triggerOpps.map(o => o.stat_type));
+    return STAT_TABS.filter(t => statTypes.has(t.key));
+  }, [triggerOpps]);
+
+  useEffect(() => {
+    setSelectedBackup(null);
+  }, [selectedStat]);
+
+  const handleSatelliteClick = (sat: BackupSatellite) => {
+    setSelectedBackup(prev => prev?.backupPlayerId === sat.backupPlayerId ? null : sat);
+  };
+
+
+  return (
+    <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
+      <AnalyticsNav />
+
+      <div className="max-w-6xl mx-auto px-4 py-6">
+        {/* Back */}
+        <button
+          onClick={() => navigate('/analise-360')}
+          className="flex items-center gap-1.5 text-xs text-terminal-text/40 hover:text-terminal-blue mb-5 transition-colors"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" />
+          Voltar
+        </button>
+
+        {isLoading ? (
+          <div className="flex items-center justify-center py-20 gap-2">
+            <Loader2 className="w-5 h-5 animate-spin text-terminal-green opacity-60" />
+            <span className="text-sm text-terminal-text/30">Carregando...</span>
+          </div>
+        ) : error ? (
+          <div className="text-center py-20 text-sm text-terminal-red/60">{error?.message ?? 'Falha ao carregar dados'}</div>
+        ) : !triggerInfo ? (
+          <div className="text-center py-20">
+            <Radar className="w-8 h-8 text-terminal-text/15 mx-auto mb-3" />
+            <p className="text-sm text-terminal-text/30">Nenhum dado encontrado para este jogador</p>
+          </div>
+        ) : (
+          <>
+            {/* Header */}
+            <div className="flex items-center gap-4 mb-4">
+              <PlayerPhoto name={triggerInfo.triggerName} teamAbbr={triggerInfo.triggerTeamAbbr} size="xl" />
+              <div>
+                <div className="flex items-center gap-2.5 mb-1">
+                  <h1 className="text-lg font-bold text-terminal-text">{triggerInfo.triggerName}</h1>
+                  <span className={`text-[8px] font-bold px-2 py-0.5 rounded-full border ${getTriggerStatusBadge(triggerInfo.triggerStatus).cls}`}>
+                    {getTriggerStatusBadge(triggerInfo.triggerStatus).text}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <img
+                    src={getTeamLogoUrl(teamAbbrToName(triggerInfo.triggerTeamAbbr))}
+                    alt={triggerInfo.triggerTeamAbbr}
+                    className="w-4 h-4 object-contain opacity-70"
+                    onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                  />
+                  <span className="text-[10px] text-terminal-text/40">{triggerInfo.triggerTeamAbbr}</span>
+                  <span className="text-[10px] text-terminal-text/15">·</span>
+                  <div className="flex items-center gap-0.5">
+                    {Array.from({ length: Math.min(triggerInfo.ratingStars, 5) }).map((_, i) => (
+                      <Star key={i} className="w-2.5 h-2.5 text-terminal-yellow fill-terminal-yellow" />
+                    ))}
+                  </div>
+                  {triggerInfo.triggerDaysOut != null && triggerInfo.triggerDaysOut > 0 && (
+                    <>
+                      <span className="text-[10px] text-terminal-text/15">·</span>
+                      <span className="text-[10px] text-terminal-red/60">Fora ha {triggerInfo.triggerDaysOut} {triggerInfo.triggerDaysOut === 1 ? 'dia' : 'dias'}</span>
+                    </>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {/* Stat tabs */}
+            <div className="flex items-center gap-0.5 mb-2 bg-terminal-dark-gray/60 rounded-lg p-1 w-fit border border-terminal-border-subtle/30">
+              {availableTabs.map(tab => (
+                <button
+                  key={tab.key}
+                  onClick={() => setSelectedStat(tab.key)}
+                  className={`px-5 py-1.5 text-[11px] font-bold rounded-md transition-all duration-200 ${
+                    selectedStat === tab.key
+                      ? 'bg-terminal-blue/90 text-white shadow-sm'
+                      : 'text-terminal-text/40 hover:text-terminal-text/70 hover:bg-terminal-gray/20'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            {satellites.length === 0 ? (
+              <div className="text-center py-16">
+                <p className="text-sm text-terminal-text/30">Sem dados para esta stat</p>
+              </div>
+            ) : isMobile ? (
+              <>
+                <MobileRankedList
+                  satellites={satellites}
+                  trigger={triggerInfo}
+                  onSatelliteClick={handleSatelliteClick}
+                />
+                {selectedBackup && triggerInfo && (
+                  <div className="mt-4">
+                    <SatelliteDetail
+                      satellite={selectedBackup}
+                      trigger={triggerInfo}
+                      onClose={() => setSelectedBackup(null)}
+                    />
+                  </div>
+                )}
+              </>
+            ) : (
+              /* Desktop: mandala + side panel */
+              <div className="flex gap-6 items-start">
+                {/* Left: Mandala */}
+                <div className="flex-1 min-w-0">
+                  <MandalaView
+                    satellites={satellites}
+                    trigger={triggerInfo}
+                    onSatelliteClick={handleSatelliteClick}
+                    selectedBackup={selectedBackup?.backupPlayerId ?? null}
+                    onCloseTooltip={() => setSelectedBackup(null)}
+                  />
+                </div>
+
+                {/* Right: Side Panel */}
+                <div className="w-[320px] shrink-0 space-y-4 relative z-10">
+                  {/* Game context card */}
+                  <div className="bg-terminal-dark-gray border border-terminal-border-subtle/50 rounded-xl p-3.5">
+                    <div className="flex items-center justify-between mb-3">
+                      <span className="text-[10px] text-terminal-text/30 uppercase tracking-wider font-semibold">Proximo Jogo</span>
+                      <span className="text-[10px] text-terminal-text/30 tabular-nums">
+                        {triggerInfo.gameDate}{triggerInfo.gameTime ? ` · ${triggerInfo.gameTime}` : ''}
+                      </span>
+                    </div>
+                    {/* Matchup with logos */}
+                    <div className="flex items-center justify-center gap-5 mb-3">
+                      <div className="flex flex-col items-center gap-1">
+                        <div className="w-12 h-12 rounded-xl bg-white/90 flex items-center justify-center p-1.5">
+                          <img
+                            src={getTeamLogoUrl(teamAbbrToName(triggerInfo.homeTeamAbbr))}
+                            alt={triggerInfo.homeTeamAbbr}
+                            className="w-full h-full object-contain"
+                            onError={(e) => { const el = e.target as HTMLImageElement; el.style.display = 'none'; el.parentElement!.innerHTML = `<span class="text-[10px] font-bold text-terminal-text/50">${triggerInfo.homeTeamAbbr}</span>`; }}
+                          />
+                        </div>
+                      </div>
+                      <span className="text-xs text-terminal-text/20 font-semibold">vs</span>
+                      <div className="flex flex-col items-center gap-1">
+                        <div className="w-12 h-12 rounded-xl bg-white/90 flex items-center justify-center p-1.5">
+                          <img
+                            src={getTeamLogoUrl(teamAbbrToName(triggerInfo.visitorTeamAbbr))}
+                            alt={triggerInfo.visitorTeamAbbr}
+                            className="w-full h-full object-contain"
+                            onError={(e) => { const el = e.target as HTMLImageElement; el.style.display = 'none'; el.parentElement!.innerHTML = `<span class="text-[10px] font-bold text-terminal-text/50">${triggerInfo.visitorTeamAbbr}</span>`; }}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                    {/* B2B flag only */}
+                    {triggerInfo.isB2b && (
+                      <div className="flex justify-center">
+                        <span className="text-[10px] px-2 py-0.5 rounded-full border text-orange-400/80 border-orange-400/20 bg-orange-400/5">
+                          Back-to-Back
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Summary cards */}
+                  <div className="grid grid-cols-3 gap-2">
+                    <div className="bg-terminal-dark-gray border border-terminal-border-subtle/50 rounded-lg p-3 text-center">
+                      <span className="text-lg font-bold text-terminal-text tabular-nums">{satellites.length}</span>
+                      <span className="text-[9px] text-terminal-text/30 uppercase tracking-wider block mt-0.5">Jogadores</span>
+                    </div>
+                    <div className="bg-terminal-dark-gray border border-terminal-border-subtle/50 rounded-lg p-3 text-center">
+                      <span className={`text-lg font-bold tabular-nums ${getGapColor(Math.round(satellites.reduce((s, sat) => s + sat.gapPct, 0) / satellites.length))}`}>
+                        +{Math.round(satellites.reduce((s, sat) => s + sat.gapPct, 0) / satellites.length)}%
+                      </span>
+                      <span className="text-[9px] text-terminal-text/30 uppercase tracking-wider block mt-0.5">Gap Medio</span>
+                    </div>
+                    <div className="bg-terminal-dark-gray border border-terminal-border-subtle/50 rounded-lg p-3 text-center">
+                      <span className={`text-lg font-bold tabular-nums ${getGapColor(satellites[0]?.gapPct ?? 0)}`}>
+                        +{satellites[0]?.gapPct.toFixed(0) ?? 0}%
+                      </span>
+                      <span className="text-[9px] text-terminal-text/30 uppercase tracking-wider block mt-0.5">Maior</span>
+                    </div>
+                  </div>
+
+                  {/* Selected player detail OR ranking */}
+                  {selectedBackup && triggerInfo ? (
+                    <SatelliteDetail
+                      satellite={selectedBackup}
+                      trigger={triggerInfo}
+                      onClose={() => setSelectedBackup(null)}
+                    />
+                  ) : (
+                    /* Ranking list */
+                    <div className="bg-terminal-dark-gray border border-terminal-border-subtle/50 rounded-xl p-3">
+                      <div className="flex items-center justify-between mb-3">
+                        <span className="text-[10px] text-terminal-text/30 uppercase tracking-wider font-semibold">Ranking de Impacto</span>
+                        <span className="text-[9px] text-terminal-blue/50">Clique para ver detalhes</span>
+                      </div>
+                      <div className="space-y-1">
+                        {satellites.map((sat, i) => {
+                          const isPositive = sat.gapPct > 0;
+                          const maxGap = Math.max(...satellites.map(s => Math.abs(s.gapPct)), 1);
+                          const barWidth = Math.min(100, (Math.abs(sat.gapPct) / maxGap) * 100);
+                          return (
+                            <button
+                              key={sat.backupPlayerId}
+                              onClick={() => handleSatelliteClick(sat)}
+                              className="w-full flex items-center gap-2.5 p-2 rounded-lg hover:bg-terminal-gray/20 active:scale-[0.99] transition-all text-left group"
+                            >
+                              <span className="text-[10px] text-terminal-text/20 w-4 text-right font-mono tabular-nums">{i + 1}</span>
+                              <PlayerPhoto name={sat.backupPlayerName} teamAbbr={triggerInfo.triggerTeamAbbr} size="sm" />
+                              <div className="flex-1 min-w-0">
+                                <div className="flex items-center justify-between mb-1">
+                                  <span className="text-[11px] text-terminal-text/70 truncate group-hover:text-terminal-text transition-colors">
+                                    {sat.backupPlayerName}
+                                  </span>
+                                  <span className={`text-[11px] font-bold tabular-nums shrink-0 ml-2 ${getGapColor(sat.gapPct)}`}>
+                                    {isPositive ? '+' : ''}{sat.gapPct.toFixed(0)}%
+                                  </span>
+                                </div>
+                                <div className="w-full h-1 bg-terminal-gray/30 rounded-full overflow-hidden">
+                                  <div
+                                    className={`h-full rounded-full ${getGapBgColor(sat.gapPct)}`}
+                                    style={{ width: `${barWidth}%`, opacity: 0.6 }}
+                                  />
+                                </div>
+                              </div>
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Analise360List.tsx
+++ b/src/pages/Analise360List.tsx
@@ -125,14 +125,14 @@ export default function Analise360List() {
 
   return (
     <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
-      <AnalyticsNav />
+      <AnalyticsNav showBack />
 
       <div className="max-w-5xl mx-auto px-4 py-6">
         {/* Header */}
         <div className="mb-6">
           <div className="flex items-center gap-3 mb-2">
             <Radar className="w-5 h-5 text-terminal-blue" />
-            <h1 className="text-lg font-bold text-terminal-text">Análise 360</h1>
+            <h1 className="text-lg font-bold text-terminal-blue">Análise 360</h1>
           </div>
           <p className="text-xs text-terminal-text/50">
             Veja como lesões reorganizam o time — selecione um jogador para ver o impacto nos companheiros

--- a/src/pages/Analise360List.tsx
+++ b/src/pages/Analise360List.tsx
@@ -1,0 +1,261 @@
+import { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Loader2, Star, Radar, ChevronRight, Users } from 'lucide-react';
+import { getPlayerPhotoUrl, tryNextPlayerPhotoUrl, getTeamLogoUrl, teamAbbrToName } from '@/utils/team-logos';
+import { useAnalise360Data } from '@/hooks/use-analise360';
+import AnalyticsNav from '@/components/AnalyticsNav';
+
+interface TriggerGroup {
+  triggerPlayerId: number;
+  triggerName: string;
+  triggerStatus: string;
+  triggerTeamAbbr: string;
+  triggerTeamId: number;
+  triggerDaysOut: number | null;
+  ratingStars: number;
+  backupCount: number;
+  gameLabel: string;
+}
+
+const STATUS_ORDER: Record<string, number> = { out: 0, doubtful: 1, questionable: 2, probable: 3 };
+
+function normalizeStatusGroup(status: string): string {
+  const s = status.toLowerCase();
+  if (s === 'out' || s.includes('out')) return 'out';
+  if (s.includes('doubtful')) return 'doubtful';
+  if (s.includes('questionable')) return 'questionable';
+  return 'probable';
+}
+
+const STATUS_BADGE: Record<string, { label: string; cls: string }> = {
+  out: { label: 'OUT', cls: 'bg-terminal-red/20 text-terminal-red border-terminal-red/30' },
+  doubtful: { label: 'DOUBTFUL', cls: 'bg-orange-400/20 text-orange-400 border-orange-400/30' },
+  questionable: { label: 'QUESTIONABLE', cls: 'bg-yellow-400/20 text-yellow-400 border-yellow-400/30' },
+  probable: { label: 'PROBABLE', cls: 'bg-lime-400/20 text-lime-400 border-lime-400/30' },
+};
+
+function PlayerPhoto({ name, teamAbbr, size = 'md' }: { name: string; teamAbbr: string; size?: 'sm' | 'md' | 'lg' }) {
+  const initials = name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2);
+  const sizeClass = size === 'lg' ? 'w-14 h-14' : size === 'md' ? 'w-10 h-10' : 'w-7 h-7';
+  const textClass = size === 'lg' ? 'text-sm' : size === 'md' ? 'text-[10px]' : 'text-[9px]';
+  return (
+    <div className={`${sizeClass} rounded-full overflow-hidden bg-terminal-gray border border-terminal-border-subtle shrink-0 flex items-center justify-center`}>
+      <img
+        src={getPlayerPhotoUrl(name, teamAbbr)}
+        alt={name}
+        className="w-full h-full object-cover object-top"
+        data-player-photo-index="0"
+        onError={(e) => {
+          const didTry = tryNextPlayerPhotoUrl(e.target as HTMLImageElement, name, teamAbbr);
+          if (!didTry) {
+            const el = e.target as HTMLImageElement;
+            el.style.display = 'none';
+            const parent = el.parentElement;
+            if (parent) parent.innerHTML = `<span class="${textClass} font-bold text-terminal-text opacity-60">${initials}</span>`;
+          }
+        }}
+      />
+    </div>
+  );
+}
+
+export default function Analise360List() {
+  const navigate = useNavigate();
+  const { data, isLoading, error } = useAnalise360Data();
+  const opportunities = data?.opportunities ?? [];
+  const playerStarsMap = data?.playerStarsMap ?? new Map<number, number>();
+  const [minStars, setMinStars] = useState<number>(0);
+
+  const triggerGroups = useMemo(() => {
+    const byTrigger = new Map<number, typeof opportunities>();
+    opportunities.forEach(o => {
+      if (!byTrigger.has(o.trigger_player_id)) byTrigger.set(o.trigger_player_id, []);
+      byTrigger.get(o.trigger_player_id)!.push(o);
+    });
+
+    const groups: TriggerGroup[] = [];
+    byTrigger.forEach((opps, triggerId) => {
+      const first = opps[0];
+      const uniqueBackups = new Set(opps.filter(o => o.backup_player_id).map(o => o.backup_player_id));
+      groups.push({
+        triggerPlayerId: triggerId,
+        triggerName: first.trigger_name,
+        triggerStatus: first.trigger_status,
+        triggerTeamAbbr: first.trigger_team_abbr,
+        triggerTeamId: first.trigger_team_id,
+        triggerDaysOut: first.trigger_days_out,
+        ratingStars: playerStarsMap.get(triggerId) ?? 0,
+        backupCount: uniqueBackups.size,
+        gameLabel: `${first.home_team_abbr} vs ${first.visitor_team_abbr}`,
+      });
+    });
+
+    // Sort by status severity, then by stars desc
+    groups.sort((a, b) => {
+      const sa = STATUS_ORDER[normalizeStatusGroup(a.triggerStatus)] ?? 99;
+      const sb = STATUS_ORDER[normalizeStatusGroup(b.triggerStatus)] ?? 99;
+      if (sa !== sb) return sa - sb;
+      return b.ratingStars - a.ratingStars;
+    });
+
+    return groups;
+  }, [opportunities]);
+
+  // Filter by min stars
+  const filteredGroups = useMemo(() => {
+    if (minStars === 0) return triggerGroups;
+    return triggerGroups.filter(g => g.ratingStars >= minStars);
+  }, [triggerGroups, minStars]);
+
+  // Group triggers by status
+  const groupedByStatus = useMemo(() => {
+    const map = new Map<string, TriggerGroup[]>();
+    filteredGroups.forEach(g => {
+      const key = normalizeStatusGroup(g.triggerStatus);
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(g);
+    });
+    return map;
+  }, [filteredGroups]);
+
+  const statusSections = useMemo(() => {
+    return Array.from(groupedByStatus.entries())
+      .sort(([a], [b]) => (STATUS_ORDER[a] ?? 99) - (STATUS_ORDER[b] ?? 99));
+  }, [groupedByStatus]);
+
+  return (
+    <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
+      <AnalyticsNav />
+
+      <div className="max-w-5xl mx-auto px-4 py-6">
+        {/* Header */}
+        <div className="mb-6">
+          <div className="flex items-center gap-3 mb-2">
+            <Radar className="w-5 h-5 text-terminal-blue" />
+            <h1 className="text-lg font-bold text-terminal-text">Análise 360</h1>
+          </div>
+          <p className="text-xs text-terminal-text/50">
+            Veja como lesões reorganizam o time — selecione um jogador para ver o impacto nos companheiros
+          </p>
+        </div>
+
+        {/* Stars filter */}
+        {!isLoading && triggerGroups.length > 0 && (
+          <div className="flex items-center gap-2 mb-5">
+            <span className="text-[10px] text-terminal-text/40 uppercase tracking-wider">Estrelas:</span>
+            {[0, 1, 2, 3].map(stars => (
+              <button
+                key={stars}
+                onClick={() => setMinStars(stars)}
+                className={`flex items-center gap-1 px-3 py-1 text-[11px] rounded-md border transition-all ${
+                  minStars === stars
+                    ? 'bg-terminal-blue/15 text-terminal-blue border-terminal-blue/30'
+                    : 'text-terminal-text/40 border-terminal-border-subtle/30 hover:text-terminal-text/60 hover:border-terminal-border-subtle/60'
+                }`}
+              >
+                {stars === 0 ? 'Todos' : (
+                  <>
+                    {stars}+ <Star className="w-3 h-3 text-terminal-yellow fill-terminal-yellow" />
+                  </>
+                )}
+              </button>
+            ))}
+            {minStars > 0 && (
+              <span className="text-[10px] text-terminal-text/30 ml-1">
+                {filteredGroups.length} de {triggerGroups.length}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Content */}
+        {isLoading ? (
+          <div className="flex items-center justify-center py-20 gap-2">
+            <Loader2 className="w-5 h-5 animate-spin text-terminal-green opacity-60" />
+            <span className="text-sm text-terminal-text/40">Carregando dados...</span>
+          </div>
+        ) : error ? (
+          <div className="text-center py-20 text-sm text-terminal-red/70">{error?.message ?? 'Falha ao carregar dados'}</div>
+        ) : filteredGroups.length === 0 ? (
+          <div className="text-center py-20">
+            <Radar className="w-8 h-8 text-terminal-text/20 mx-auto mb-3" />
+            <p className="text-sm text-terminal-text/40">
+              {minStars > 0 ? `Nenhum jogador com ${minStars}+ estrelas lesionado hoje` : 'Nenhum jogador com lesão impactante hoje'}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {statusSections.map(([statusKey, triggers]) => {
+              const badge = STATUS_BADGE[statusKey] || STATUS_BADGE.probable;
+              return (
+                <div key={statusKey}>
+                  {/* Status section header */}
+                  <div className="flex items-center gap-2 mb-3">
+                    <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded border ${badge.cls}`}>
+                      {badge.label}
+                    </span>
+                    <span className="text-[10px] text-terminal-text/30">
+                      {triggers.length} {triggers.length === 1 ? 'jogador' : 'jogadores'}
+                    </span>
+                  </div>
+
+                  {/* Trigger cards grid */}
+                  <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                    {triggers.map(trigger => (
+                      <button
+                        key={trigger.triggerPlayerId}
+                        onClick={() => navigate(`/analise-360/${trigger.triggerPlayerId}`)}
+                        className="bg-terminal-dark-gray border border-terminal-border-subtle rounded-lg p-4 hover:border-terminal-blue/50 hover:bg-terminal-dark-gray/80 transition-all text-left group cursor-pointer"
+                      >
+                        <div className="flex items-center gap-3">
+                          <PlayerPhoto name={trigger.triggerName} teamAbbr={trigger.triggerTeamAbbr} size="lg" />
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-1.5 mb-0.5">
+                              <span className="text-sm font-bold text-terminal-text truncate">
+                                {trigger.triggerName}
+                              </span>
+                              <ChevronRight className="w-3.5 h-3.5 text-terminal-text/30 group-hover:text-terminal-blue transition-colors shrink-0" />
+                            </div>
+                            <div className="flex items-center gap-2 mb-1.5">
+                              <img
+                                src={getTeamLogoUrl(teamAbbrToName(trigger.triggerTeamAbbr))}
+                                alt={trigger.triggerTeamAbbr}
+                                className="w-4 h-4 object-contain"
+                                onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                              />
+                              <span className="text-[10px] text-terminal-text/50">{trigger.triggerTeamAbbr}</span>
+                              <span className="text-[10px] text-terminal-text/30">·</span>
+                              <span className="text-[10px] text-terminal-text/40">{trigger.gameLabel}</span>
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <div className="flex items-center gap-0.5">
+                                {Array.from({ length: Math.min(trigger.ratingStars, 5) }).map((_, i) => (
+                                  <Star key={i} className="w-2.5 h-2.5 text-terminal-yellow fill-terminal-yellow" />
+                                ))}
+                              </div>
+                              <span className="text-[10px] text-terminal-text/30">·</span>
+                              <div className="flex items-center gap-1 text-[10px] text-terminal-blue/70">
+                                <Users className="w-3 h-3" />
+                                <span>{trigger.backupCount} impactados</span>
+                              </div>
+                              {trigger.triggerDaysOut != null && trigger.triggerDaysOut > 0 && (
+                                <>
+                                  <span className="text-[10px] text-terminal-text/30">·</span>
+                                  <span className="text-[10px] text-terminal-red/50">{trigger.triggerDaysOut}d fora</span>
+                                </>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Bankroll.tsx
+++ b/src/pages/Bankroll.tsx
@@ -191,7 +191,7 @@ export default function Bankroll() {
 
   return (
     <div className="min-h-screen bg-terminal-black text-terminal-text">
-      <BetsHeader />
+      <BetsHeader showBack />
 
       <div className="container mx-auto px-4 py-6 max-w-7xl">
         <div className="flex flex-wrap gap-2 mb-4">

--- a/src/pages/Bets.tsx
+++ b/src/pages/Bets.tsx
@@ -1806,6 +1806,7 @@ export default function Bets() {
   return (
     <div className="w-full min-h-screen bg-terminal-black text-terminal-text">
       <BetsHeader
+        showBack
         onShareClick={() => setIsShareModalOpen(true)}
         onReferralClick={() => setReferralModalOpen(true)}
         showUnitsView={showUnitsView}

--- a/src/pages/BettingDashboard.tsx
+++ b/src/pages/BettingDashboard.tsx
@@ -169,6 +169,7 @@ export default function BettingDashboard() {
   return (
     <div className="w-full min-h-screen bg-terminal-black text-terminal-text">
       <BetsHeader
+        showBack
         showUnitsView={showUnitsView}
         onShowUnitsViewChange={setShowUnitsView}
         onUnitConfigClick={() => setUnitConfigOpen(true)}

--- a/src/pages/GameDetail.tsx
+++ b/src/pages/GameDetail.tsx
@@ -154,7 +154,7 @@ export default function GameDetail() {
   if (authLoading) {
     return (
       <div className="min-h-screen bg-terminal-black flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-terminal-green" />
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-terminal-blue" />
       </div>
     );
   }
@@ -559,7 +559,7 @@ export default function GameDetail() {
           display = String(val);
         }
         return (
-          <td key={col.key} className={`py-2 px-1 sm:px-2 text-center text-xs tabular-nums ${sortConfig.key === col.key ? 'text-terminal-green font-bold' : `text-terminal-text ${statWeightClass[col.key] || ''}`}`}>
+          <td key={col.key} className={`py-2 px-1 sm:px-2 text-center text-xs tabular-nums ${sortConfig.key === col.key ? 'text-terminal-blue font-bold' : `text-terminal-text ${statWeightClass[col.key] || ''}`}`}>
             {display}
           </td>
         );
@@ -582,7 +582,7 @@ export default function GameDetail() {
           return (
             <th
               key={col.key}
-              className={`text-center py-3 px-1 sm:px-2 text-[11px] font-medium min-w-[36px] sm:min-w-[40px] cursor-pointer select-none transition-colors active:bg-terminal-light-gray ${isActive ? 'text-terminal-green' : 'text-terminal-text opacity-70 hover:opacity-100'}`}
+              className={`text-center py-3 px-1 sm:px-2 text-[11px] font-medium min-w-[36px] sm:min-w-[40px] cursor-pointer select-none transition-colors active:bg-terminal-light-gray ${isActive ? 'text-terminal-blue' : 'text-terminal-text opacity-70 hover:opacity-100'}`}
               onClick={() => handleSort(col.key)}
               aria-sort={isActive ? (sortConfig.direction === 'desc' ? 'descending' : 'ascending') : 'none'}
               aria-label={`Ordenar por ${col.label}`}
@@ -653,7 +653,7 @@ export default function GameDetail() {
 
   return (
     <div className="min-h-screen bg-terminal-black text-terminal-text">
-      <AnalyticsNav showBack backTo="/home-games" title="Game Details" />
+      <AnalyticsNav showBack title="Game Details" />
       
       <main className="container mx-auto px-4 py-4">
         {/* Layout: left = header + injury (compact), right = lineup */}
@@ -682,7 +682,7 @@ export default function GameDetail() {
                 />
               </div>
               <div className="flex-1">
-                <div className="text-lg font-bold text-terminal-green mb-1">
+                <div className="text-lg font-bold text-terminal-text mb-1">
                   {game.home_team_name}
                 </div>
                 {homeTeam && (
@@ -719,7 +719,7 @@ export default function GameDetail() {
                 {formatGameDateSaoPaulo(game.game_date)}
               </div>
               {game.game_datetime_brasilia && !isGameFinished && (
-                <div className="text-sm font-bold text-terminal-green mt-0.5">
+                <div className="text-sm font-bold text-terminal-blue mt-0.5">
                   {new Date(game.game_datetime_brasilia).toLocaleTimeString('pt-BR', {
                     timeZone: 'America/Sao_Paulo',
                     hour: '2-digit',
@@ -848,7 +848,7 @@ export default function GameDetail() {
               {/* Home injuries */}
               {homeInjuredPlayers.length > 0 && (
                 <div>
-                  <div className="text-[10px] text-terminal-green opacity-70 mb-1">{game.home_team_abbreviation}</div>
+                  <div className="text-[10px] text-terminal-blue opacity-70 mb-1">{game.home_team_abbreviation}</div>
                   <div className="flex flex-wrap gap-1">
                     {homeInjuredPlayers.map((player) => {
                       const injuryStyle = getInjuryStatusStyle(player.current_status);
@@ -907,7 +907,7 @@ export default function GameDetail() {
                   onClick={() => setActiveTab('lineups')}
                   className={`px-4 min-h-[44px] text-xs font-bold rounded-t transition-colors active:opacity-70 ${
                     activeTab === 'lineups'
-                      ? 'text-terminal-green border-b-2 border-terminal-green'
+                      ? 'text-terminal-blue border-b-2 border-terminal-blue'
                       : 'text-terminal-text opacity-50 hover:opacity-80'
                   }`}
                 >
@@ -918,7 +918,7 @@ export default function GameDetail() {
                     onClick={() => setActiveTab('boxscore')}
                     className={`px-4 min-h-[44px] text-xs font-bold rounded-t transition-colors active:opacity-70 ${
                       activeTab === 'boxscore'
-                        ? 'text-terminal-green border-b-2 border-terminal-green'
+                        ? 'text-terminal-blue border-b-2 border-terminal-blue'
                         : 'text-terminal-text opacity-50 hover:opacity-80'
                     }`}
                   >
@@ -930,7 +930,7 @@ export default function GameDetail() {
                     onClick={() => setActiveTab('b2b')}
                     className={`px-4 min-h-[44px] text-xs font-bold rounded-t transition-colors active:opacity-70 ${
                       activeTab === 'b2b'
-                        ? 'text-terminal-green border-b-2 border-terminal-green'
+                        ? 'text-terminal-blue border-b-2 border-terminal-blue'
                         : 'text-terminal-text opacity-50 hover:opacity-80'
                     }`}
                   >
@@ -999,7 +999,7 @@ export default function GameDetail() {
                           onClick={() => setBoxScoreView('all')}
                           aria-label={`Ver todos os jogadores (${game.home_team_abbreviation} + ${game.visitor_team_abbreviation})`}
                           aria-pressed={boxScoreView === 'all'}
-                          className={`flex items-center justify-center gap-1.5 min-h-[44px] min-w-[44px] px-3 rounded-md text-xs font-medium transition-colors active:scale-95 motion-reduce:transform-none ${boxScoreView === 'all' ? 'bg-terminal-green/20 text-terminal-green border border-terminal-green/30' : 'bg-terminal-gray/40 border border-terminal-border-subtle text-terminal-text opacity-70 hover:opacity-100 hover:bg-terminal-gray/60 active:bg-terminal-gray/80'}`}
+                          className={`flex items-center justify-center gap-1.5 min-h-[44px] min-w-[44px] px-3 rounded-md text-xs font-medium transition-colors active:scale-95 motion-reduce:transform-none ${boxScoreView === 'all' ? 'bg-terminal-blue/20 text-terminal-blue border border-terminal-blue/30' : 'bg-terminal-gray/40 border border-terminal-border-subtle text-terminal-text opacity-70 hover:opacity-100 hover:bg-terminal-gray/60 active:bg-terminal-gray/80'}`}
                         >
                           <img src={getTeamLogoUrl(game.home_team_name)} alt="" className="w-5 h-5 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
                           <span>+</span>
@@ -1009,7 +1009,7 @@ export default function GameDetail() {
                           onClick={() => setBoxScoreView('home')}
                           aria-label={`Ver jogadores do ${game.home_team_abbreviation}`}
                           aria-pressed={boxScoreView === 'home'}
-                          className={`flex items-center justify-center min-h-[44px] min-w-[44px] px-3 rounded-md text-xs font-medium transition-colors active:scale-95 motion-reduce:transform-none ${boxScoreView === 'home' ? 'bg-terminal-green/20 text-terminal-green border border-terminal-green/30' : 'bg-terminal-gray/40 border border-terminal-border-subtle text-terminal-text opacity-70 hover:opacity-100 hover:bg-terminal-gray/60 active:bg-terminal-gray/80'}`}
+                          className={`flex items-center justify-center min-h-[44px] min-w-[44px] px-3 rounded-md text-xs font-medium transition-colors active:scale-95 motion-reduce:transform-none ${boxScoreView === 'home' ? 'bg-terminal-blue/20 text-terminal-blue border border-terminal-blue/30' : 'bg-terminal-gray/40 border border-terminal-border-subtle text-terminal-text opacity-70 hover:opacity-100 hover:bg-terminal-gray/60 active:bg-terminal-gray/80'}`}
                         >
                           <img src={getTeamLogoUrl(game.home_team_name)} alt="" className="w-5 h-5 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
                         </button>
@@ -1017,7 +1017,7 @@ export default function GameDetail() {
                           onClick={() => setBoxScoreView('visitor')}
                           aria-label={`Ver jogadores do ${game.visitor_team_abbreviation}`}
                           aria-pressed={boxScoreView === 'visitor'}
-                          className={`flex items-center justify-center min-h-[44px] min-w-[44px] px-3 rounded-md text-xs font-medium transition-colors active:scale-95 motion-reduce:transform-none ${boxScoreView === 'visitor' ? 'bg-terminal-green/20 text-terminal-green border border-terminal-green/30' : 'bg-terminal-gray/40 border border-terminal-border-subtle text-terminal-text opacity-70 hover:opacity-100 hover:bg-terminal-gray/60 active:bg-terminal-gray/80'}`}
+                          className={`flex items-center justify-center min-h-[44px] min-w-[44px] px-3 rounded-md text-xs font-medium transition-colors active:scale-95 motion-reduce:transform-none ${boxScoreView === 'visitor' ? 'bg-terminal-blue/20 text-terminal-blue border border-terminal-blue/30' : 'bg-terminal-gray/40 border border-terminal-border-subtle text-terminal-text opacity-70 hover:opacity-100 hover:bg-terminal-gray/60 active:bg-terminal-gray/80'}`}
                         >
                           <img src={getTeamLogoUrl(game.visitor_team_name)} alt="" className="w-5 h-5 object-contain" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
                         </button>
@@ -1026,11 +1026,11 @@ export default function GameDetail() {
                       {/* Detailed view toggle — mobile only */}
                       <button
                         onClick={() => setDetailedView(!detailedView)}
-                        className={`md:hidden flex items-center gap-2 min-h-[44px] px-2 rounded-lg border transition-colors ${detailedView ? 'bg-terminal-green/15 border-terminal-green/30' : 'bg-terminal-dark-gray border-terminal-border-subtle hover:bg-terminal-gray/30'}`}
+                        className={`md:hidden flex items-center gap-2 min-h-[44px] px-2 rounded-lg border transition-colors ${detailedView ? 'bg-terminal-blue/15 border-terminal-blue/30' : 'bg-terminal-dark-gray border-terminal-border-subtle hover:bg-terminal-gray/30'}`}
                         aria-label={detailedView ? 'Mudar para visão compacta' : 'Mudar para visão detalhada'}
                       >
-                        <span className={`text-[11px] ${detailedView ? 'text-terminal-green' : 'text-terminal-text opacity-60'}`}>Detalhado</span>
-                        <div className={`relative w-10 h-[22px] rounded-full transition-colors border ${detailedView ? 'bg-terminal-green border-terminal-green' : 'bg-terminal-gray border-terminal-border-subtle'}`}>
+                        <span className={`text-[11px] ${detailedView ? 'text-terminal-blue' : 'text-terminal-text opacity-60'}`}>Detalhado</span>
+                        <div className={`relative w-10 h-[22px] rounded-full transition-colors border ${detailedView ? 'bg-terminal-blue border-terminal-blue' : 'bg-terminal-gray border-terminal-border-subtle'}`}>
                           <div className={`absolute top-[2px] w-4 h-4 rounded-full shadow-sm transition-transform ${detailedView ? 'translate-x-[22px]' : 'translate-x-[3px]'} bg-white`} />
                         </div>
                       </button>

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -271,7 +271,7 @@ export default function Games() {
 
   return (
     <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
-      <AnalyticsNav />
+      <AnalyticsNav showBack />
 
       <main className="container mx-auto px-4 py-4">
         {error && (
@@ -298,16 +298,16 @@ export default function Games() {
           </button>
           <button
             onClick={() => navigate('/report')}
-            className="w-full flex items-center justify-between gap-3 bg-terminal-dark-gray border border-terminal-border-subtle rounded-lg px-3 py-3 hover:border-terminal-green/40 transition-all group"
+            className="w-full flex items-center justify-between gap-3 bg-terminal-dark-gray border border-terminal-border-subtle rounded-lg px-3 py-3 hover:border-terminal-blue/40 transition-all group"
           >
             <div className="flex items-center gap-2.5">
-              <FileText className="w-4 h-4 text-terminal-green flex-shrink-0" />
+              <FileText className="w-4 h-4 text-terminal-blue flex-shrink-0" />
               <div className="flex flex-col items-start">
-                <span className="text-sm font-semibold text-terminal-green font-mono leading-tight">Relatório do Dia</span>
+                <span className="text-sm font-semibold text-terminal-blue font-mono leading-tight">Relatório do Dia</span>
                 <span className="text-[11px] text-terminal-text/40 font-mono leading-tight">veja as melhores props</span>
               </div>
             </div>
-            <span className="text-[10px] text-terminal-green/60 font-mono group-hover:text-terminal-green transition-colors">→</span>
+            <span className="text-[10px] text-terminal-blue/60 font-mono group-hover:text-terminal-blue transition-colors">→</span>
           </button>
         </div>
 
@@ -472,7 +472,7 @@ export default function Games() {
                               {dateDisplay}
                             </div>
                             {game.game_datetime_brasilia && !finished && (
-                              <div className="text-[11px] text-terminal-green opacity-100 whitespace-nowrap font-mono">
+                              <div className="text-[11px] text-terminal-blue opacity-100 whitespace-nowrap font-mono">
                                 {new Date(game.game_datetime_brasilia).toLocaleTimeString('pt-BR', {
                                   timeZone: SAO_PAULO_TIMEZONE,
                                   hour: '2-digit',
@@ -668,12 +668,12 @@ export default function Games() {
             {/* Reports button */}
             <button
               onClick={() => navigate('/report')}
-              className="w-full flex items-center justify-between gap-3 bg-terminal-dark-gray border border-terminal-border-subtle rounded-lg px-3 py-3 hover:border-terminal-green/40 transition-all group"
+              className="w-full flex items-center justify-between gap-3 bg-terminal-dark-gray border border-terminal-border-subtle rounded-lg px-3 py-3 hover:border-terminal-blue/40 transition-all group"
             >
               <div className="flex items-center gap-2.5">
-                <FileText className="w-4 h-4 text-terminal-green flex-shrink-0" />
+                <FileText className="w-4 h-4 text-terminal-blue flex-shrink-0" />
                 <div className="flex flex-col items-start">
-                  <span className="text-sm font-semibold text-terminal-green font-mono leading-tight">
+                  <span className="text-sm font-semibold text-terminal-blue font-mono leading-tight">
                     Relatório do Dia
                   </span>
                   <span className="text-[11px] text-terminal-text/40 font-mono leading-tight">
@@ -681,7 +681,7 @@ export default function Games() {
                   </span>
                 </div>
               </div>
-              <span className="text-[10px] text-terminal-green/60 font-mono group-hover:text-terminal-green transition-colors">→</span>
+              <span className="text-[10px] text-terminal-blue/60 font-mono group-hover:text-terminal-blue transition-colors">→</span>
             </button>
 
           </div>
@@ -693,11 +693,11 @@ export default function Games() {
           <section className="bg-terminal-dark-gray border border-terminal-border-subtle rounded-lg p-4 mt-4">
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
               <div className="flex items-center gap-3">
-                <div className="w-10 h-10 bg-terminal-green/20 border border-terminal-green rounded-full flex items-center justify-center">
-                  <BarChart3 className="w-5 h-5 text-terminal-green" />
+                <div className="w-10 h-10 bg-terminal-blue/20 border border-terminal-blue rounded-full flex items-center justify-center">
+                  <BarChart3 className="w-5 h-5 text-terminal-blue" />
                 </div>
                 <div>
-                  <h2 className="text-sm font-bold text-terminal-green">
+                  <h2 className="text-sm font-bold text-terminal-blue">
                     Desbloqueie Análises Completas
                   </h2>
                   <p className="text-[10px] text-terminal-text opacity-70">

--- a/src/pages/NBADashboard.tsx
+++ b/src/pages/NBADashboard.tsx
@@ -277,7 +277,7 @@ export default function NBADashboard() {
           description: `Could not find player "${playerName.replace(/-/g, ' ')}"`,
           variant: 'destructive',
         });
-        navigate('/home-players');
+        navigate('/home-nba');
         return;
       }
 
@@ -466,9 +466,9 @@ export default function NBADashboard() {
         <Button
           variant="outline"
           className="terminal-button"
-          onClick={() => navigate('/home-players')}
+          onClick={() => navigate(-1)}
         >
-          Voltar ao início
+          Voltar
         </Button>
       </div>
     );
@@ -476,7 +476,7 @@ export default function NBADashboard() {
 
   return (
     <div className="w-full min-h-screen bg-terminal-black text-terminal-text">
-      <AnalyticsNav showBack backTo="/home-players" title={player?.player_name} />
+      <AnalyticsNav showBack title={player?.player_name} />
       <main className="container mx-auto px-3 py-4">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
           {/* Left Sidebar */}
@@ -501,7 +501,7 @@ export default function NBADashboard() {
             {dailyOpps.length > 0 ? (
               <div className="terminal-container p-4">
                 <div className="flex items-center gap-2 mb-3">
-                  <span className="text-[10px] font-bold text-terminal-green uppercase tracking-widest">
+                  <span className="text-[10px] font-bold text-terminal-blue uppercase tracking-widest">
                     Oportunidades do Dia
                   </span>
                   <span className="text-[9px] opacity-40">mesma análise da tela de Picks</span>
@@ -518,8 +518,8 @@ export default function NBADashboard() {
                     return (
                       <button
                         key={i}
-                        className={`w-full text-left bg-terminal-dark-gray rounded border border-terminal-green/20 p-3 transition-all ${
-                          isClickable ? 'hover:border-terminal-green/50 hover:bg-terminal-green/5 cursor-pointer' : 'cursor-default'
+                        className={`w-full text-left bg-terminal-dark-gray rounded border border-terminal-blue/20 p-3 transition-all ${
+                          isClickable ? 'hover:border-terminal-blue/50 hover:bg-terminal-blue/5 cursor-pointer' : 'cursor-default'
                         }`}
                         onClick={() => handleInsightClick?.(opp.stat_type, opp.trigger_name)}
                       >
@@ -542,9 +542,9 @@ export default function NBADashboard() {
                         <div className="flex items-center gap-2">
                           <span className="text-sm opacity-50">{opp.avg_com?.toFixed(1)}</span>
                           <span className="text-xs opacity-30">→</span>
-                          <span className="text-lg font-bold text-terminal-green leading-none">{opp.avg_sem?.toFixed(1)}</span>
+                          <span className="text-lg font-bold text-terminal-text leading-none">{opp.avg_sem?.toFixed(1)}</span>
                           {opp.gap_pct > 0 && (
-                            <span className="text-[11px] font-semibold text-terminal-green bg-terminal-green/10 px-1.5 py-0.5 rounded">
+                            <span className="text-[11px] font-semibold text-terminal-text bg-terminal-text/10 px-1.5 py-0.5 rounded">
                               +{opp.gap_pct?.toFixed(1)}%
                             </span>
                           )}

--- a/src/pages/NBADashboard.tsx
+++ b/src/pages/NBADashboard.tsx
@@ -63,25 +63,66 @@ export default function NBADashboard() {
   const initialTrigger = searchParams.get('trigger');
   const statFromUrl = initialStat && VALID_STAT_TYPES.includes(initialStat) ? initialStat : 'player_points';
   const [selectedStatType, setSelectedStatType] = useState<string>(statFromUrl);
-  const [pendingTriggerFilter, setPendingTriggerFilter] = useState<string | null>(initialTrigger);
   const [lastNGames, setLastNGames] = useState<number | 'all'>(15);
   const [homeAway, setHomeAway] = useState<'all' | 'home' | 'away'>('all');
   const [teammateFilter, setTeammateFilter] = useState<TeammateFilter>(null);
   const [teammateGameIds, setTeammateGameIds] = useState<Map<number, Set<number>> | null>(null);
-  const [teammateFilterLoading, setTeammateFilterLoading] = useState(false);
+  const [teammateFilterLoading, setTeammateFilterLoading] = useState(!!initialTrigger);
   const [b2bOnly, setB2bOnly] = useState(false);
+
+  // React to URL param changes (stat type only — trigger handled below)
+  useEffect(() => {
+    const urlStat = searchParams.get('stat');
+    if (urlStat && VALID_STAT_TYPES.includes(urlStat)) {
+      setSelectedStatType(urlStat);
+    }
+  }, [searchParams.get('stat')]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Apply trigger filter when teammates are ready + URL has trigger param
+  useEffect(() => {
+    const urlTrigger = searchParams.get('trigger');
+    if (!urlTrigger || teammates.length === 0) return;
+
+    const triggerTeammate = teammates.find(
+      t => t.player_name.toLowerCase() === urlTrigger.toLowerCase()
+    );
+    if (triggerTeammate) {
+      // Only apply if not already filtering for this trigger
+      const alreadyFiltered = teammateFilter?.some(f => f.playerId === triggerTeammate.player_id && f.mode === 'without');
+      if (!alreadyFiltered) {
+        handleTeammateFilterChange([{
+          playerId: triggerTeammate.player_id,
+          playerName: triggerTeammate.player_name,
+          mode: 'without',
+        }]);
+      }
+    }
+  }, [teammates.length, searchParams.get('trigger')]); // eslint-disable-line react-hooks/exhaustive-deps
   const [h2hOnly, setH2hOnly] = useState(false);
 
   useEffect(() => {
     loadPlayer();
   }, [playerName]);
 
-  // PLG freemium: deslogado só acessa jogadores FREE_PLAYERS; outros → login
-  const isFree = player ? isFreePlayer(player.player_name) : false;
-
-  // Logado mas não premium: jogador não grátis → paywall
+  // Load daily opportunities whenever player is identified
   useEffect(() => {
-    if (!subscriptionLoading && user && player && !isPremium && !isFree) {
+    if (!player) return;
+    nbaDataService.getDailyOpportunities()
+      .then(allOpps => {
+        const playerOpps = allOpps.filter(o => o.backup_player_name === player.player_name);
+        setDailyOpps(playerOpps);
+      })
+      .catch(e => console.error('Error loading daily opportunities:', e));
+  }, [player?.player_name]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // PLG freemium: deslogado só acessa jogadores FREE_PLAYERS ou via Picks trial; outros → login
+  const isFree = player ? isFreePlayer(player.player_name) : false;
+  const isPicksTrial = !!initialTrigger; // came from Oportunidades do Dia top 2
+
+  // Logado mas não premium: jogador não grátis e não via Picks trial → paywall
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    if (!subscriptionLoading && user && player && !isPremium && !isFree && !isPicksTrial) {
       const playerFullName = player.player_name;
       toast({
         title: 'Acesso Premium Necessário',
@@ -180,7 +221,7 @@ export default function NBADashboard() {
   }, [gameStats, selectedStatType]);
 
   // Early returns (after all hooks)
-  if (!authLoading && !user && player && !isFree) {
+  if (!authLoading && !user && player && !isFree && !isPicksTrial) {
     return <Navigate to="/auth" state={{ from: location }} replace />;
   }
 
@@ -264,33 +305,14 @@ export default function NBADashboard() {
       } catch (e) { console.error('Error loading props:', e); }
       setPropsLoading(false);
 
-      // 3.5. Daily opportunities for this player (same data as Picks page)
-      try {
-        const allOpps = await nbaDataService.getDailyOpportunities();
-        const playerOpps = allOpps.filter(o => o.backup_player_name === playerData.player_name);
-        setDailyOpps(playerOpps);
-      } catch (e) { console.error('Error loading daily opportunities:', e); }
+      // 3.5. Daily opportunities loaded via separate effect below
 
       // 4. Teammates
       try {
         loadedTeammates = await nbaDataService.getTeamPlayers(playerData.team_id);
         setTeammates(loadedTeammates);
 
-        // Auto-apply trigger filter from URL (e.g., from Picks page "Analisar" button)
-        if (pendingTriggerFilter) {
-          const triggerTeammate = loadedTeammates.find(
-            t => t.player_name.toLowerCase() === pendingTriggerFilter.toLowerCase()
-          );
-          if (triggerTeammate) {
-            handleTeammateFilterChange([{
-              playerId: triggerTeammate.player_id,
-              playerName: triggerTeammate.player_name,
-              mode: 'without',
-            }]);
-            setLastNGames('all');
-          }
-          setPendingTriggerFilter(null);
-        }
+        // Trigger filter applied via separate useEffect when teammates are ready
       } catch (e) { console.error('Error loading teammates:', e); }
       setTeammatesLoading(false);
 
@@ -565,7 +587,6 @@ export default function NBADashboard() {
             ) : (
               <GameChart
                 gameStats={filteredGameStats}
-                statType={selectedStatType}
                 currentLine={currentLine}
                 seasonAvg={(() => { const s = gameStats.filter(g => g.stat_type === selectedStatType); return s.length > 0 ? s.reduce((sum, g) => sum + (g.stat_value ?? 0), 0) / s.length : 0; })()}
                 lastNGames={lastNGames}

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -154,11 +154,11 @@ export default function Onboarding() {
         <div className="space-y-4">
           <button
             type="button"
-            onClick={() => navigate('/home-games')}
+            onClick={() => navigate('/home-nba')}
             className="terminal-button w-full h-auto py-6 flex flex-col items-center gap-2 rounded border-2 border-terminal-green/40 hover:border-terminal-green hover:bg-terminal-dark-gray/80 transition-all text-terminal-text"
           >
-            <Gamepad2 className="w-8 h-8 text-terminal-green" />
-            <span className="font-semibold text-terminal-green">Conhecer análises</span>
+            <Gamepad2 className="w-8 h-8 text-terminal-blue" />
+            <span className="font-semibold text-terminal-blue">Conhecer análises</span>
             <span className="text-sm text-terminal-text opacity-80 font-normal">
               Ver jogos, props e dashboards da NBA
             </span>
@@ -168,8 +168,8 @@ export default function Onboarding() {
             onClick={() => whatsappSynced ? navigate('/bets') : setCurrentStep(1)}
             className="terminal-button w-full h-auto py-6 flex flex-col items-center gap-2 rounded border-2 border-terminal-green/40 hover:border-terminal-green hover:bg-terminal-dark-gray/80 transition-all text-terminal-text"
           >
-            <Send className="w-8 h-8 text-terminal-green" />
-            <span className="font-semibold text-terminal-green">
+            <Send className="w-8 h-8 text-terminal-blue" />
+            <span className="font-semibold text-terminal-blue">
               {whatsappSynced ? 'Acessar Betinho' : 'Configurar Betinho (Telegram)'}
             </span>
             <span className="text-sm text-terminal-text opacity-80 font-normal">
@@ -327,7 +327,7 @@ export default function Onboarding() {
         <AnalyticsNav />
         <div className="container mx-auto px-4 py-8 md:py-12">
           <div className="text-center mb-8">
-            <h1 className="text-2xl md:text-3xl font-bold tracking-wider text-terminal-green mb-2">
+            <h1 className="text-2xl md:text-3xl font-bold tracking-wider text-terminal-blue mb-2">
               BEM-VINDO AO SMARTBETTING
             </h1>
             <p className="text-sm text-terminal-text opacity-70">

--- a/src/pages/Picks.tsx
+++ b/src/pages/Picks.tsx
@@ -292,7 +292,7 @@ export default function Picks() {
         <td className="py-2 px-3">
           <div className="flex items-center gap-2">
             <PlayerPhoto name={opp.backup_player_name} teamAbbr={opp.trigger_team_abbr} />
-            <span className="font-bold text-terminal-green">{opp.backup_player_name}</span>
+            <span className="font-bold text-terminal-text">{opp.backup_player_name}</span>
           </div>
         </td>
         {/* STAT */}
@@ -311,7 +311,7 @@ export default function Picks() {
         {/* COM */}
         <td className={`text-right py-2 px-3 opacity-50 tabular-nums ${rowBlur}`}>{opp.avg_com?.toFixed(1) ?? '—'}</td>
         {/* SEM */}
-        <td className={`text-right py-2 px-3 font-bold text-terminal-green tabular-nums ${rowBlur}`}>{opp.avg_sem?.toFixed(1) ?? '—'}</td>
+        <td className={`text-right py-2 px-3 font-bold text-terminal-text tabular-nums ${rowBlur}`}>{opp.avg_sem?.toFixed(1) ?? '—'}</td>
         {/* GAP% */}
         <td className={`text-right py-2 px-3 ${rowBlur}`}>
           <span className={`font-bold tabular-nums ${(opp.gap_pct ?? 0) >= 30 ? 'text-orange-400' : (opp.gap_pct ?? 0) >= 15 ? 'text-terminal-green' : 'text-terminal-blue'}`}>
@@ -345,7 +345,7 @@ export default function Picks() {
                   navigate(canAccess ? dashboardHref : '/paywall-platform');
                 }}
                 title={canAccess ? `Ver ${opp.backup_player_name} — ${STAT_LABELS[opp.stat_type] || opp.stat_type} sem ${opp.trigger_name}` : 'Recurso exclusivo Premium'}
-                className="inline-flex items-center gap-1 px-2 py-1 text-[9px] rounded border border-terminal-green/30 text-terminal-green hover:bg-terminal-green/10 hover:border-terminal-green/60 transition-all">
+                className="inline-flex items-center gap-1 px-2 py-1 text-[9px] rounded border border-terminal-blue/30 text-terminal-blue hover:bg-terminal-blue/10 hover:border-terminal-blue/60 transition-all">
                 <ExternalLink className="w-3 h-3" /> {canAccess ? 'Analisar' : 'Premium'}
               </a>
             );
@@ -409,7 +409,7 @@ export default function Picks() {
   if (error) {
     return (
       <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
-        <AnalyticsNav />
+        <AnalyticsNav showBack />
         <div className="flex items-center justify-center py-20">
           <div className="text-center">
             <AlertTriangle className="w-8 h-8 text-terminal-red mx-auto mb-4" />
@@ -425,17 +425,17 @@ export default function Picks() {
 
   return (
     <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
-      <AnalyticsNav />
+      <AnalyticsNav showBack />
 
       <div className="container mx-auto px-4 py-6 max-w-7xl">
         {/* Header */}
         <div className="mb-6">
           <div className="flex items-center gap-3 mb-2">
-            <div className="w-10 h-10 bg-terminal-green/20 border border-terminal-green rounded-lg flex items-center justify-center">
-              <TrendingUp className="w-5 h-5 text-terminal-green" />
+            <div className="w-10 h-10 bg-terminal-blue/20 border border-terminal-blue rounded-lg flex items-center justify-center">
+              <TrendingUp className="w-5 h-5 text-terminal-blue" />
             </div>
             <div>
-              <h1 className="text-xl md:text-2xl font-bold tracking-wider text-terminal-green">
+              <h1 className="text-xl md:text-2xl font-bold tracking-wider text-terminal-blue">
                 OPORTUNIDADES DO DIA
               </h1>
               <p className="text-[10px] md:text-xs text-terminal-text opacity-50">
@@ -506,11 +506,11 @@ export default function Picks() {
             {/* View mode toggle — same line on desktop, new line on mobile */}
             <div className="hidden md:flex gap-1 ml-auto">
               <button onClick={() => setViewMode('score')}
-                className={`px-2 py-1 text-[10px] rounded border transition-all ${viewMode === 'score' ? 'bg-terminal-green/20 border-terminal-green text-terminal-green' : 'border-terminal-border-subtle text-terminal-text opacity-50 hover:opacity-80'}`}>
+                className={`px-2 py-1 text-[10px] rounded border transition-all ${viewMode === 'score' ? 'bg-terminal-blue/20 border-terminal-blue text-terminal-blue' : 'border-terminal-border-subtle text-terminal-text opacity-50 hover:opacity-80'}`}>
                 Por Score
               </button>
               <button onClick={() => setViewMode('game')}
-                className={`px-2 py-1 text-[10px] rounded border transition-all flex items-center gap-1 ${viewMode === 'game' ? 'bg-terminal-green/20 border-terminal-green text-terminal-green' : 'border-terminal-border-subtle text-terminal-text opacity-50 hover:opacity-80'}`}>
+                className={`px-2 py-1 text-[10px] rounded border transition-all flex items-center gap-1 ${viewMode === 'game' ? 'bg-terminal-blue/20 border-terminal-blue text-terminal-blue' : 'border-terminal-border-subtle text-terminal-text opacity-50 hover:opacity-80'}`}>
                 <LayoutList className="w-3 h-3" /> Por Jogo
               </button>
             </div>
@@ -518,11 +518,11 @@ export default function Picks() {
           {/* Mobile: view mode toggle on separate line */}
           <div className="flex gap-1 mt-2 md:hidden">
             <button onClick={() => setViewMode('score')}
-              className={`flex-1 py-1.5 text-[10px] rounded border transition-all text-center ${viewMode === 'score' ? 'bg-terminal-green/20 border-terminal-green text-terminal-green' : 'border-terminal-border-subtle text-terminal-text opacity-50'}`}>
+              className={`flex-1 py-1.5 text-[10px] rounded border transition-all text-center ${viewMode === 'score' ? 'bg-terminal-blue/20 border-terminal-blue text-terminal-blue' : 'border-terminal-border-subtle text-terminal-text opacity-50'}`}>
               Por Score
             </button>
             <button onClick={() => setViewMode('game')}
-              className={`flex-1 py-1.5 text-[10px] rounded border transition-all text-center flex items-center justify-center gap-1 ${viewMode === 'game' ? 'bg-terminal-green/20 border-terminal-green text-terminal-green' : 'border-terminal-border-subtle text-terminal-text opacity-50'}`}>
+              className={`flex-1 py-1.5 text-[10px] rounded border transition-all text-center flex items-center justify-center gap-1 ${viewMode === 'game' ? 'bg-terminal-blue/20 border-terminal-blue text-terminal-blue' : 'border-terminal-border-subtle text-terminal-text opacity-50'}`}>
               <LayoutList className="w-3 h-3" /> Por Jogo
             </button>
           </div>
@@ -624,10 +624,10 @@ export default function Picks() {
                         <div className="flex items-center gap-3">
                           <PlayerPhoto name={opp.backup_player_name} teamAbbr={opp.trigger_team_abbr} />
                           <div className="flex-1 min-w-0">
-                            <span className="font-bold text-terminal-green text-sm truncate block">{opp.backup_player_name}</span>
+                            <span className="font-bold text-terminal-text text-sm truncate block">{opp.backup_player_name}</span>
                             <div className="flex items-center gap-1.5 mt-0.5">
                               <span className={`text-[9px] px-1.5 py-0.5 rounded border ${statusBadge.cls}`}>SEM {triggerLastName} ({statusBadge.text})</span>
-                              <span className={`text-xs font-bold bg-terminal-green/10 text-terminal-green border border-terminal-green/30 px-1.5 py-0.5 rounded ${groupBlur}`}>{statLabel}</span>
+                              <span className={`text-xs font-bold bg-terminal-blue/10 text-terminal-blue border border-terminal-blue/30 px-1.5 py-0.5 rounded ${groupBlur}`}>{statLabel}</span>
                             </div>
                           </div>
                           <span className={groupBlur}>
@@ -674,7 +674,7 @@ export default function Picks() {
                     <div className="flex items-center gap-3">
                       <PlayerPhoto name={opp.backup_player_name} teamAbbr={opp.trigger_team_abbr} />
                       <div className="flex-1 min-w-0">
-                        <span className="font-bold text-terminal-green text-sm truncate block">{opp.backup_player_name}</span>
+                        <span className="font-bold text-terminal-text text-sm truncate block">{opp.backup_player_name}</span>
                         <div className="flex items-center gap-1.5 mt-0.5">
                           <span className="text-[10px] opacity-50">{opp.trigger_team_abbr} vs {opp.opponent_abbr}</span>
                           {opp.is_b2b && <span className="text-[8px] bg-terminal-yellow/20 text-terminal-yellow px-1 rounded">B2B</span>}
@@ -697,7 +697,7 @@ export default function Picks() {
                       <span className={`text-[9px] px-1.5 py-0.5 rounded border ${statusBadge.cls}`}>
                         SEM {triggerLastName} ({statusBadge.text})
                       </span>
-                      <span className={`text-xs font-bold bg-terminal-green/10 text-terminal-green border border-terminal-green/30 px-2 py-0.5 rounded ${mobileBlur}`}>
+                      <span className={`text-xs font-bold bg-terminal-blue/10 text-terminal-blue border border-terminal-blue/30 px-2 py-0.5 rounded ${mobileBlur}`}>
                         {statLabel}
                       </span>
                     </div>
@@ -708,7 +708,7 @@ export default function Picks() {
                       <span className="opacity-60">{opp.avg_com?.toFixed(1) ?? '—'}</span>
                       <span className="mx-1.5 opacity-30">→</span>
                       <span>Sem: </span>
-                      <span className="font-bold text-terminal-green">{opp.avg_sem?.toFixed(1) ?? '—'}</span>
+                      <span className="font-bold text-terminal-text">{opp.avg_sem?.toFixed(1) ?? '—'}</span>
                       <span className={`ml-1.5 font-bold ${(opp.gap_pct ?? 0) >= 30 ? 'text-orange-400' : 'text-terminal-green'}`}>
                         (+{opp.gap_pct?.toFixed(1) ?? '—'}%)
                       </span>
@@ -739,7 +739,7 @@ export default function Picks() {
 
                       <a href={mobileCanAccess ? analyzeHref : '/paywall-platform'}
                         onClick={(e) => { e.preventDefault(); e.stopPropagation(); navigate(mobileCanAccess ? analyzeHref : '/paywall-platform'); }}
-                        className="flex items-center justify-center gap-1.5 w-full py-2 text-xs font-bold text-terminal-green border border-terminal-green/30 rounded hover:bg-terminal-green/10 transition-all">
+                        className="flex items-center justify-center gap-1.5 w-full py-2 text-xs font-bold text-terminal-blue border border-terminal-blue/30 rounded hover:bg-terminal-blue/10 transition-all">
                         <ExternalLink className="w-3.5 h-3.5" /> {mobileCanAccess ? 'VER ANÁLISE COMPLETA' : 'ASSINAR PREMIUM'}
                       </a>
                     </div>

--- a/src/pages/Picks.tsx
+++ b/src/pages/Picks.tsx
@@ -90,8 +90,10 @@ export default function Picks() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Free users see blurred data
-  const blur = !isPremium ? 'blur-sm select-none pointer-events-none' : '';
+  // Free users: top 2 opportunities visible, rest blurred
+  const FREE_VISIBLE_COUNT = 2;
+  const isRowFree = (idx: number) => isPremium || idx < FREE_VISIBLE_COUNT;
+  const getBlur = (idx: number) => isRowFree(idx) ? '' : 'blur-sm select-none pointer-events-none';
 
   // View mode
   const [viewMode, setViewMode] = useState<ViewMode>('score');
@@ -218,6 +220,21 @@ export default function Picks() {
   const highConfidence = filtered.filter(o => (o.score ?? 0) >= 80).length;
   const gamesCount = new Set(filtered.map(o => o.game_id)).size;
 
+  // Map each opportunity to its global index (for consistent free/blur across views)
+  const globalIndexMap = useMemo(() => {
+    const map = new Map<string, number>();
+    filtered.forEach((opp, idx) => {
+      const key = `${opp.trigger_player_id}-${opp.backup_player_id}-${opp.stat_type}`;
+      map.set(key, idx);
+    });
+    return map;
+  }, [filtered]);
+
+  const getGlobalIndex = (opp: DailyOpportunity) => {
+    const key = `${opp.trigger_player_id}-${opp.backup_player_id}-${opp.stat_type}`;
+    return globalIndexMap.get(key) ?? 999;
+  };
+
   const InfoTip = ({ text }: { text: string }) => (
     <span className="inline-flex items-center justify-center w-4 h-4 rounded-full bg-terminal-gray border border-terminal-border-subtle text-[9px] font-bold text-terminal-text opacity-60 hover:opacity-100 hover:bg-terminal-green/20 hover:border-terminal-green hover:text-terminal-green cursor-help transition-all ml-1 shrink-0" title={text}>i</span>
   );
@@ -227,13 +244,15 @@ export default function Picks() {
     const statusBadge = getTriggerStatusBadge(opp.trigger_status);
     const triggerLastName = opp.trigger_name.split(' ').pop();
     const isHighConf = (opp.score ?? 0) >= 80;
+    const rowBlur = getBlur(idx);
+    const rowFree = isRowFree(idx);
 
     return (
       <tr key={`${opp.trigger_player_id}-${opp.backup_player_id}-${opp.stat_type}-${idx}`}
         className={`border-b border-terminal-border-subtle hover:bg-terminal-light-gray/50 transition-colors ${isHighConf ? 'border-l-2 border-l-terminal-green bg-white/[0.02]' : ''}`}>
         {/* SCORE */}
         <td className="text-center py-2 px-3">
-          <span className={blur}>
+          <span className={rowBlur}>
           {isHighConf ? (
             <span className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-terminal-green/15 border border-terminal-green/40 text-base font-black tabular-nums text-terminal-green">
               {opp.score}
@@ -256,7 +275,7 @@ export default function Picks() {
             </div>
             {opp.game_time && (
               <div className="text-[9px] opacity-40 mt-0.5">
-                {opp.game_date ? new Date(opp.game_date + 'T12:00:00').toLocaleDateString('pt-BR', { day: '2-digit', month: 'short' }) : ''} • {opp.game_time}
+                {opp.game_time}h
               </div>
             )}
           </td>
@@ -277,7 +296,7 @@ export default function Picks() {
           </div>
         </td>
         {/* STAT */}
-        <td className="py-2 px-3">
+        <td className={`py-2 px-3 ${rowBlur}`}>
           <span className="text-[10px] bg-terminal-gray border border-terminal-border-subtle px-1.5 py-0.5 rounded cursor-help"
             title={{
               player_points_rebounds_assists: 'Pontos + Rebotes + Assistências',
@@ -290,21 +309,21 @@ export default function Picks() {
           </span>
         </td>
         {/* COM */}
-        <td className={`text-right py-2 px-3 opacity-50 tabular-nums ${blur}`}>{opp.avg_com?.toFixed(1) ?? '—'}</td>
+        <td className={`text-right py-2 px-3 opacity-50 tabular-nums ${rowBlur}`}>{opp.avg_com?.toFixed(1) ?? '—'}</td>
         {/* SEM */}
-        <td className={`text-right py-2 px-3 font-bold text-terminal-green tabular-nums ${blur}`}>{opp.avg_sem?.toFixed(1) ?? '—'}</td>
+        <td className={`text-right py-2 px-3 font-bold text-terminal-green tabular-nums ${rowBlur}`}>{opp.avg_sem?.toFixed(1) ?? '—'}</td>
         {/* GAP% */}
-        <td className={`text-right py-2 px-3 ${blur}`}>
+        <td className={`text-right py-2 px-3 ${rowBlur}`}>
           <span className={`font-bold tabular-nums ${(opp.gap_pct ?? 0) >= 30 ? 'text-orange-400' : (opp.gap_pct ?? 0) >= 15 ? 'text-terminal-green' : 'text-terminal-blue'}`}>
             +{opp.gap_pct?.toFixed(1) ?? '—'}%
           </span>
         </td>
         {/* LINHA */}
-        <td className="text-right py-2 px-3 tabular-nums">
+        <td className={`text-right py-2 px-3 tabular-nums ${rowBlur}`}>
           {opp.line_value ? <span className="font-medium">{opp.line_value?.toFixed(1) ?? '—'}</span> : <span className="opacity-30">—</span>}
         </td>
         {/* vs LINHA */}
-        <td className={`text-right py-2 px-3 tabular-nums ${blur}`}>
+        <td className={`text-right py-2 px-3 tabular-nums ${rowBlur}`}>
           {opp.gap_vs_line_pct != null ? (
             <span className={`font-bold ${opp.gap_vs_line_pct > 10 ? 'text-terminal-green' : opp.gap_vs_line_pct > 0 ? 'text-terminal-blue' : 'text-terminal-red'}`}>
               {opp.gap_vs_line_pct > 0 ? '+' : ''}{opp.gap_vs_line_pct?.toFixed(1) ?? '—'}%
@@ -317,16 +336,17 @@ export default function Picks() {
             const slug = opp.backup_player_name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '-');
             const params = new URLSearchParams({ stat: opp.stat_type, trigger: opp.trigger_name });
             const dashboardHref = `/nba-dashboard/${slug}?${params.toString()}`;
-            const href = isPremium ? dashboardHref : '/paywall-platform';
+            const canAccess = rowFree; // top 2 can access dashboard, rest goes to paywall
+            const href = canAccess ? dashboardHref : '/paywall-platform';
             return (
               <a href={href}
                 onClick={(e) => {
                   e.preventDefault();
-                  navigate(isPremium ? dashboardHref : '/paywall-platform');
+                  navigate(canAccess ? dashboardHref : '/paywall-platform');
                 }}
-                title={isPremium ? `Ver ${opp.backup_player_name} — ${STAT_LABELS[opp.stat_type] || opp.stat_type} sem ${opp.trigger_name}` : 'Recurso exclusivo Premium'}
+                title={canAccess ? `Ver ${opp.backup_player_name} — ${STAT_LABELS[opp.stat_type] || opp.stat_type} sem ${opp.trigger_name}` : 'Recurso exclusivo Premium'}
                 className="inline-flex items-center gap-1 px-2 py-1 text-[9px] rounded border border-terminal-green/30 text-terminal-green hover:bg-terminal-green/10 hover:border-terminal-green/60 transition-all">
-                <ExternalLink className="w-3 h-3" /> {isPremium ? 'Analisar' : 'Premium'}
+                <ExternalLink className="w-3 h-3" /> {canAccess ? 'Analisar' : 'Premium'}
               </a>
             );
           })()}
@@ -558,7 +578,7 @@ export default function Picks() {
                     <table className="w-full text-xs">
                       {tableHeaders(false)}
                       <tbody>
-                        {group.opps.map((opp, idx) => renderRow(opp, idx, false))}
+                        {group.opps.map((opp) => renderRow(opp, getGlobalIndex(opp), false))}
                       </tbody>
                     </table>
                   </div>
@@ -585,33 +605,40 @@ export default function Picks() {
                   <ChevronDown className={`w-4 h-4 opacity-40 shrink-0 transition-transform ${collapsedGames.has(gameId) ? '-rotate-90' : ''}`} />
                 </button>
                 {!collapsedGames.has(gameId) && <div className="space-y-2">
-                  {group.opps.map((opp, idx) => {
+                  {group.opps.map((opp) => {
+                    const gIdx = getGlobalIndex(opp);
                     const statusBadge = getTriggerStatusBadge(opp.trigger_status);
                     const triggerLastName = opp.trigger_name.split(' ').pop();
                     const isHighConf = (opp.score ?? 0) >= 80;
                     const statLabel = STAT_LABELS[opp.stat_type] || opp.stat_type;
                     const slug = opp.backup_player_name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '-');
                     const analyzeHref = `/nba-dashboard/${slug}?stat=${opp.stat_type}&trigger=${encodeURIComponent(opp.trigger_name)}`;
+                    const groupBlur = getBlur(gIdx);
+                    const groupCanAccess = isRowFree(gIdx);
 
                     return (
-                      <a key={idx} href={analyzeHref} onClick={(e) => { if (!e.ctrlKey && !e.metaKey) { e.preventDefault(); navigate(analyzeHref); } }}
+                      <a key={`${opp.trigger_player_id}-${opp.backup_player_id}-${opp.stat_type}`}
+                        href={groupCanAccess ? analyzeHref : '/paywall-platform'}
+                        onClick={(e) => { if (!e.ctrlKey && !e.metaKey) { e.preventDefault(); navigate(groupCanAccess ? analyzeHref : '/paywall-platform'); } }}
                         className={`block terminal-container p-3 ${isHighConf ? 'border-terminal-green/30' : ''}`}>
                         <div className="flex items-center gap-3">
                           <PlayerPhoto name={opp.backup_player_name} teamAbbr={opp.trigger_team_abbr} />
                           <div className="flex-1 min-w-0">
                             <span className="font-bold text-terminal-green text-sm truncate block">{opp.backup_player_name}</span>
                             <div className="flex items-center gap-1.5 mt-0.5">
-                              <span className="text-xs font-bold bg-terminal-green/10 text-terminal-green border border-terminal-green/30 px-1.5 py-0.5 rounded">{statLabel}</span>
                               <span className={`text-[9px] px-1.5 py-0.5 rounded border ${statusBadge.cls}`}>SEM {triggerLastName} ({statusBadge.text})</span>
+                              <span className={`text-xs font-bold bg-terminal-green/10 text-terminal-green border border-terminal-green/30 px-1.5 py-0.5 rounded ${groupBlur}`}>{statLabel}</span>
                             </div>
                           </div>
+                          <span className={groupBlur}>
                           {isHighConf ? (
                             <span className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-terminal-green/15 border border-terminal-green/40 text-base font-black tabular-nums text-terminal-green shrink-0">{opp.score}</span>
                           ) : (
                             <span className={`text-lg font-bold tabular-nums shrink-0 ${getScoreColor(opp.score)}`}>{opp.score ?? '—'}</span>
                           )}
+                          </span>
                         </div>
-                        <div className="mt-2 text-[11px] text-terminal-text opacity-80">
+                        <div className={`mt-2 text-[11px] text-terminal-text opacity-80 ${groupBlur}`}>
                           Com {triggerLastName}: <span className="opacity-60">{opp.avg_com?.toFixed(1) ?? '—'}</span>
                           <span className="mx-1.5 opacity-30">→</span>
                           Sem: <span className="font-bold text-terminal-green">{opp.avg_sem?.toFixed(1) ?? '—'}</span>
@@ -637,6 +664,8 @@ export default function Picks() {
               const statLabel = STAT_LABELS[opp.stat_type] || opp.stat_type;
               const slug = opp.backup_player_name.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/\s+/g, '-');
               const analyzeHref = `/nba-dashboard/${slug}?stat=${opp.stat_type}&trigger=${encodeURIComponent(opp.trigger_name)}`;
+              const mobileBlur = getBlur(idx);
+              const mobileCanAccess = isRowFree(idx);
 
               return (
                 <div key={idx} className={`terminal-container overflow-hidden ${isHighConf ? 'border-terminal-green/30' : ''}`}>
@@ -651,7 +680,7 @@ export default function Picks() {
                           {opp.is_b2b && <span className="text-[8px] bg-terminal-yellow/20 text-terminal-yellow px-1 rounded">B2B</span>}
                         </div>
                       </div>
-                      <span className={blur}>
+                      <span className={mobileBlur}>
                       {isHighConf ? (
                         <span className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-terminal-green/15 border border-terminal-green/40 text-lg font-black tabular-nums text-terminal-green shrink-0">
                           {opp.score}
@@ -663,18 +692,18 @@ export default function Picks() {
                       <ChevronDown className={`w-4 h-4 opacity-30 shrink-0 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
                     </div>
 
-                    {/* Row 2: Stat + Trigger context */}
+                    {/* Row 2: Trigger (always visible) + Stat (blurred for non-free) */}
                     <div className="flex items-center gap-2 mt-2">
-                      <span className="text-xs font-bold bg-terminal-green/10 text-terminal-green border border-terminal-green/30 px-2 py-0.5 rounded">
-                        {statLabel}
-                      </span>
                       <span className={`text-[9px] px-1.5 py-0.5 rounded border ${statusBadge.cls}`}>
                         SEM {triggerLastName} ({statusBadge.text})
+                      </span>
+                      <span className={`text-xs font-bold bg-terminal-green/10 text-terminal-green border border-terminal-green/30 px-2 py-0.5 rounded ${mobileBlur}`}>
+                        {statLabel}
                       </span>
                     </div>
 
                     {/* Row 3: Storytelling — readable numbers */}
-                    <div className={`mt-2 text-[11px] text-terminal-text opacity-80 ${blur}`}>
+                    <div className={`mt-2 text-[11px] text-terminal-text opacity-80 ${mobileBlur}`}>
                       <span>Com {triggerLastName}: </span>
                       <span className="opacity-60">{opp.avg_com?.toFixed(1) ?? '—'}</span>
                       <span className="mx-1.5 opacity-30">→</span>
@@ -685,7 +714,7 @@ export default function Picks() {
                       </span>
                     </div>
                     {opp.line_value && (
-                      <div className={`mt-1 text-[11px] opacity-60 ${blur}`}>
+                      <div className={`mt-1 text-[11px] opacity-60 ${mobileBlur}`}>
                         Linha atual: <span className="font-medium text-terminal-text">{opp.line_value?.toFixed(1) ?? '—'}</span>
                         {opp.gap_vs_line_pct != null && (
                           <span className={`ml-1.5 font-bold ${opp.gap_vs_line_pct > 0 ? 'text-terminal-green' : 'text-terminal-red'}`}>
@@ -708,10 +737,10 @@ export default function Picks() {
                         </div>
                       )}
 
-                      <a href={analyzeHref}
-                        onClick={(e) => { if (!e.ctrlKey && !e.metaKey && e.button === 0) { e.preventDefault(); e.stopPropagation(); navigate(analyzeHref); } }}
+                      <a href={mobileCanAccess ? analyzeHref : '/paywall-platform'}
+                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); navigate(mobileCanAccess ? analyzeHref : '/paywall-platform'); }}
                         className="flex items-center justify-center gap-1.5 w-full py-2 text-xs font-bold text-terminal-green border border-terminal-green/30 rounded hover:bg-terminal-green/10 transition-all">
-                        <ExternalLink className="w-3.5 h-3.5" /> VER ANÁLISE COMPLETA
+                        <ExternalLink className="w-3.5 h-3.5" /> {mobileCanAccess ? 'VER ANÁLISE COMPLETA' : 'ASSINAR PREMIUM'}
                       </a>
                     </div>
                   )}

--- a/src/pages/Report.tsx
+++ b/src/pages/Report.tsx
@@ -161,7 +161,7 @@ export default function WeeklyReport() {
   if (accessLoading) {
     return (
       <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
-        <AnalyticsNav />
+        <AnalyticsNav showBack />
         <div className="flex flex-col items-center justify-center py-20 gap-3">
           <Loader2 className="w-8 h-8 animate-spin text-terminal-green" />
         </div>
@@ -172,7 +172,7 @@ export default function WeeklyReport() {
   if (!hasAccess) {
     return (
       <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
-        <AnalyticsNav />
+        <AnalyticsNav showBack />
         <div className="flex flex-col items-center justify-center py-20 gap-4 text-center px-4">
           <div className="w-16 h-16 bg-terminal-yellow/10 border border-terminal-yellow/30 rounded-full flex items-center justify-center">
             <Lock className="w-8 h-8 text-terminal-yellow" />
@@ -196,17 +196,17 @@ export default function WeeklyReport() {
 
   return (
     <div className="min-h-screen bg-terminal-black text-terminal-text font-mono">
-      <AnalyticsNav />
+      <AnalyticsNav showBack />
 
       <div className="max-w-5xl mx-auto px-3 sm:px-4 py-4 sm:py-6">
         {/* Header */}
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4 mb-4 sm:mb-6">
           <div className="flex items-center gap-2 sm:gap-3">
-            <div className="w-8 h-8 bg-terminal-green/20 border border-terminal-green/50 rounded flex items-center justify-center">
-              <FileText className="w-4 h-4 text-terminal-green" />
+            <div className="w-8 h-8 bg-terminal-blue/20 border border-terminal-blue/50 rounded flex items-center justify-center">
+              <FileText className="w-4 h-4 text-terminal-blue" />
             </div>
             <div>
-              <h1 className="text-lg sm:text-xl font-bold tracking-wider text-terminal-green">
+              <h1 className="text-lg sm:text-xl font-bold tracking-wider text-terminal-blue">
                 RELATÓRIO
               </h1>
               <p className="text-[10px] sm:text-xs text-terminal-text opacity-60">

--- a/src/utils/team-logos.ts
+++ b/src/utils/team-logos.ts
@@ -1,5 +1,22 @@
 import { supabase } from '@/integrations/supabase/client';
 
+const ABBR_TO_NAME: Record<string, string> = {
+  ATL: 'Atlanta Hawks', BOS: 'Boston Celtics', BKN: 'Brooklyn Nets',
+  CHA: 'Charlotte Hornets', CHI: 'Chicago Bulls', CLE: 'Cleveland Cavaliers',
+  DAL: 'Dallas Mavericks', DEN: 'Denver Nuggets', DET: 'Detroit Pistons',
+  GSW: 'Golden State Warriors', HOU: 'Houston Rockets', IND: 'Indiana Pacers',
+  LAC: 'LA Clippers', LAL: 'Los Angeles Lakers', MEM: 'Memphis Grizzlies',
+  MIA: 'Miami Heat', MIL: 'Milwaukee Bucks', MIN: 'Minnesota Timberwolves',
+  NOP: 'New Orleans Pelicans', NYK: 'New York Knicks', OKC: 'Oklahoma City Thunder',
+  ORL: 'Orlando Magic', PHI: 'Philadelphia 76ers', PHX: 'Phoenix Suns',
+  POR: 'Portland Trail Blazers', SAC: 'Sacramento Kings', SAS: 'San Antonio Spurs',
+  TOR: 'Toronto Raptors', UTA: 'Utah Jazz', WAS: 'Washington Wizards',
+};
+
+export function teamAbbrToName(abbr: string): string {
+  return ABBR_TO_NAME[abbr?.toUpperCase()] || abbr;
+}
+
 function normalizeAssetBaseName(name: string): string {
   return name
     .normalize('NFD')


### PR DESCRIPTION
## Resumo

Este PR consolida um conjunto de melhorias de UX aplicadas em toda a plataforma após o PR da tela Análise 360. As mudanças abrangem 3 eixos principais: navegação consistente, sistema de cores semântico e suporte a middle-click.

---

## 1. Navegação — Botão Voltar Universal

- **`AnalyticsNav`**: back button agora usa `navigate(-1)` (histórico do browser) em vez de rotas hardcoded, incluindo fallback `backTo ? navigate(backTo) : navigate(-1)`
- **`BetsHeader`**: prop `showBack` adicionada; botão "Voltar" com `navigate(-1)` alinhado visualmente com o AnalyticsNav
- **Páginas com `showBack` adicionado**: `Picks`, `Analise360List`, `Analise360Detail`, `Report`, `Games`, `GameDetail`, `NBADashboard`, `BettingDashboard`, `Bets`, `Bankroll`
- **`GameDetail`**: removido `backTo="/home-games"` hardcoded — agora volta para a página real anterior
- **`Onboarding`**: botão "Conhecer análises" corrigido para navegar para `/home-nba` em vez de `/home-games`

---

## 2. Sistema de Cores Semântico (Azul vs Verde)

Regra aplicada em toda a plataforma:
- **Azul** → elementos estruturais de UI: títulos, labels, estados ativos, CTAs de navegação, horários de jogos
- **Verde** → desempenho positivo: vitórias, percentuais de performance, scores altos, status "Available"
- **Vermelho** → lesões, valores negativos

### Componentes e páginas atualizados:

| Arquivo | O que mudou |
|---|---|
| `FreePropCard` | Nome do jogador, badge de stat, `avg_sem` e `gap_pct`: verde → azul/branco |
| `GameChart` | Todos os filtros ativos (períodos, home/away, B2B, teammate): verde → azul |
| `NextGamesCard` | Horário do próximo jogo: verde → azul |
| `TeammatesCard` | Bordas, avatar, iniciais, nome do jogador: verde → azul |
| `Picks` | Título "Oportunidades do Dia", ícone, botões de sort ativos, badges de stat, "Analisar →": verde → azul; nomes e `avg_sem`: verde → branco |
| `Games` | Horário do jogo, "Relatório do Dia", banner freemium: verde → azul |
| `GameDetail` | Spinner, horário, colunas ativas, tabs ativas, filtros box score, toggle "Detalhado": verde → azul; nome do time home: verde → branco |
| `NBADashboard` | Label "Oportunidades do Dia", bordas de card: verde → azul; `avg_sem`/`gap_pct`: verde → branco |
| `Analise360List` | Título "Análise 360": verde → azul |
| `Report` | Título + ícone da seção: verde → azul |
| `HomeNBA` | Título "Hoje na NBA", label "Destaques do Dia", horários de jogos: verde → azul |

---

## 3. Suporte a Middle-Click (abrir em nova aba)

Padrão implementado: `<a href="...">` com `onClick={(e) => { if (!e.ctrlKey && !e.metaKey && e.button === 0) { e.preventDefault(); navigate(...); } }}` para não quebrar o SPA routing mas permitir Ctrl+Click / middle-click.

Elementos atualizados em **HomeNBA**:
- "Ver Todas as Oportunidades"
- Cards de "Ver impacto" (lesões)
- Links "Análise 360" e "Relatório do Dia"
- Todos os cards de jogos
- "Ver todos" no SectionHeader (agora com prop `actionHref`)

---

## 4. BetsHeader — Alinhamento Visual com AnalyticsNav

- Logo `<img src="/logo.png">` substituindo o ícone + texto anterior
- Click na logo navega para `/home-nba`
- Menu "Análises" atualizado: Hoje, Oportunidades, Análise 360, Jogos, Relatório
- Módulo Betinho reordenado: **Apostas primeiro**, Dashboard segundo
- Mesmo reordenamento aplicado no `AnalyticsNav`

---

## 5. HomeNBA — Melhorias de Layout Mobile

- Header: `items-center` → `items-start` para data em 2 linhas no mobile
- Data sem `whitespace-nowrap` (permite quebra de linha intencional)
- Campo de busca redimensionado: `w-44 sm:w-48 lg:w-56`
- Pills de filtro: removido `flex-wrap` para manter na mesma linha
- Cards de stats: fonte reduzida para caber dentro do grid sem overflow

---

## 6. InjuryReportModal — Limpeza

- Removidos botões "Ver Análise 360" inline no modal de lesões (ícone Radar em jogadores Out/Doubtful)
- Simplificada a prop `onNavigate360` do `TeamRow` — não era mais necessária com a nova navegação

---

## 7. App.tsx — Rota `/home-nba`

- Adicionada rota `/home-nba` → `HomeNBA` como rota pública (antes só existia `/home-players`)

---

## Test plan

- [ ] Clicar em "Voltar" em todas as páginas — deve voltar para a página anterior real (não hardcoded)
- [ ] Middle-click / Ctrl+Click nos cards de jogos e oportunidades na HomeNBA abre nova aba
- [ ] Verificar que elementos verdes mantidos são exclusivamente de desempenho positivo
- [ ] Navegar para `/home-nba` diretamente pela URL
- [ ] Módulo Betinho no nav: Apostas aparece antes do Dashboard
- [ ] BetsHeader em `/bets`, `/betting-dashboard`, `/bankroll` mostra logo correta + botão Voltar

🤖 Generated with [Claude Code](https://claude.com/claude-code)