### PR TITLE
feat: Análise 360 com RPC dedicada + loaded_at nos Picks

### DIFF
--- a/src/hooks/use-analise360.ts
+++ b/src/hooks/use-analise360.ts
@@ -1,10 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { nbaDataService, DailyOpportunity } from '@/services/nba-data.service';
 
-interface PlayerStarsMap {
-  map: Map<number, number>;
-}
-
+// Hook para a lista de triggers (usa daily opportunities para ter info de jogo)
 async function fetchAnalise360Data(): Promise<{
   opportunities: DailyOpportunity[];
   playerStarsMap: Map<number, number>;
@@ -22,8 +19,20 @@ export function useAnalise360Data() {
   return useQuery({
     queryKey: ['analise360', 'data'],
     queryFn: fetchAnalise360Data,
-    staleTime: 2 * 60 * 1000,    // 2 min — data is fresh
-    gcTime: 10 * 60 * 1000,      // 10 min — keep in cache
+    staleTime: 2 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+// Hook para o detalhe de um trigger (usa nova tabela de impacto completo)
+export function useTeammateImpact360(triggerPlayerId: number | null) {
+  return useQuery({
+    queryKey: ['teammate-impact-360', triggerPlayerId],
+    queryFn: () => nbaDataService.getTeammateImpact360(triggerPlayerId!),
+    enabled: triggerPlayerId != null,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 }

--- a/src/pages/Analise360Detail.tsx
+++ b/src/pages/Analise360Detail.tsx
@@ -3,7 +3,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Loader2, Radar, Star, ChevronDown, ChevronUp, ExternalLink } from 'lucide-react';
 import { getPlayerPhotoUrl, tryNextPlayerPhotoUrl, getTeamLogoUrl, teamAbbrToName } from '@/utils/team-logos';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { useAnalise360Data } from '@/hooks/use-analise360';
+import { useTeammateImpact360, useAnalise360Data } from '@/hooks/use-analise360';
+import { TeammateImpact360 } from '@/services/nba-data.service';
 import AnalyticsNav from '@/components/AnalyticsNav';
 
 // --- Types ---
@@ -141,9 +142,10 @@ function PlayerPhoto({ name, teamAbbr, size = 'md' }: { name: string; teamAbbr: 
     md: 'text-sm',
     sm: 'text-[10px]',
   }[size];
+  const bgClass = size === 'center' ? 'bg-white' : 'bg-terminal-gray';
 
   return (
-    <div className={`${sizeClass} rounded-full overflow-hidden bg-terminal-gray shrink-0 flex items-center justify-center relative`}>
+    <div className={`${sizeClass} rounded-full overflow-hidden ${bgClass} shrink-0 flex items-center justify-center relative`}>
       <img
         src={getPlayerPhotoUrl(name, teamAbbr)}
         alt={name}
@@ -505,85 +507,85 @@ export default function Analise360Detail() {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
 
-  const { data, isLoading, error } = useAnalise360Data();
-  const opportunities = data?.opportunities ?? [];
-  const playerStarsMap = data?.playerStarsMap ?? new Map<number, number>();
+  const triggerIdNum = Number(triggerPlayerId);
+  const { data: impactData, isLoading: impactLoading, error: impactError } = useTeammateImpact360(triggerIdNum || null);
+  const { data: oppData, isLoading: oppLoading } = useAnalise360Data();
+  const impacts = impactData ?? [];
+  const isLoading = impactLoading || oppLoading;
+  const error = impactError;
   const [selectedStat, setSelectedStat] = useState<string>('player_points');
   const [selectedBackup, setSelectedBackup] = useState<BackupSatellite | null>(null);
 
-  const triggerIdNum = Number(triggerPlayerId);
-
-  const triggerOpps = useMemo(() => {
-    return opportunities.filter(o => o.trigger_player_id === triggerIdNum);
-  }, [opportunities, triggerIdNum]);
+  // Enriquecer trigger info com dados de jogo do daily opportunities
+  const gameInfo = useMemo(() => {
+    const opps = oppData?.opportunities ?? [];
+    return opps.find(o => o.trigger_player_id === triggerIdNum) ?? null;
+  }, [oppData, triggerIdNum]);
 
   const triggerInfo = useMemo((): TriggerInfo | null => {
-    if (triggerOpps.length === 0) return null;
-    const first = triggerOpps[0];
+    if (impacts.length === 0) return null;
+    const first = impacts[0];
+    const playerStarsMap = oppData?.playerStarsMap ?? new Map<number, number>();
     return {
       triggerPlayerId: first.trigger_player_id,
       triggerName: first.trigger_name,
       triggerStatus: first.trigger_status,
       triggerTeamAbbr: first.trigger_team_abbr,
-      triggerDaysOut: first.trigger_days_out,
+      triggerDaysOut: gameInfo?.trigger_days_out ?? null,
       ratingStars: playerStarsMap.get(first.trigger_player_id) ?? 0,
-      gameLabel: `${first.home_team_abbr} vs ${first.visitor_team_abbr}`,
-      gameDate: first.game_date,
-      homeTeamAbbr: first.home_team_abbr,
-      visitorTeamAbbr: first.visitor_team_abbr,
-      opponentAbbr: first.opponent_abbr,
-      opponentDefRank: first.opponent_def_rank,
-      opponentOffRank: first.opponent_off_rank,
-      isHome: first.is_home,
-      isB2b: first.is_b2b,
-      gameTime: first.game_time,
+      gameLabel: gameInfo ? `${gameInfo.home_team_abbr} vs ${gameInfo.visitor_team_abbr}` : first.trigger_team_abbr,
+      gameDate: gameInfo?.game_date ?? '',
+      homeTeamAbbr: gameInfo?.home_team_abbr ?? first.trigger_team_abbr,
+      visitorTeamAbbr: gameInfo?.visitor_team_abbr ?? '',
+      opponentAbbr: gameInfo?.opponent_abbr ?? null,
+      opponentDefRank: gameInfo?.opponent_def_rank ?? null,
+      opponentOffRank: gameInfo?.opponent_off_rank ?? null,
+      isHome: gameInfo?.is_home ?? false,
+      isB2b: gameInfo?.is_b2b ?? false,
+      gameTime: gameInfo?.game_time ?? null,
     };
-  }, [triggerOpps, playerStarsMap]);
+  }, [impacts, gameInfo, oppData]);
 
   const satellites = useMemo((): BackupSatellite[] => {
-    const byBackup = new Map<number, DailyOpportunity[]>();
-    triggerOpps.forEach(o => {
-      if (o.backup_player_id == null) return;
-      if (!byBackup.has(o.backup_player_id)) byBackup.set(o.backup_player_id, []);
-      byBackup.get(o.backup_player_id)!.push(o);
+    const byTeammate = new Map<number, TeammateImpact360[]>();
+    impacts.forEach(o => {
+      if (!byTeammate.has(o.teammate_player_id)) byTeammate.set(o.teammate_player_id, []);
+      byTeammate.get(o.teammate_player_id)!.push(o);
     });
 
     const sats: BackupSatellite[] = [];
-    byBackup.forEach((opps, backupId) => {
-      let pick = opps.find(o => o.stat_type === selectedStat);
-      const isFallback = !pick;
-      if (!pick) {
-        pick = opps.reduce((best, o) => (o.gap_pct > (best?.gap_pct ?? -Infinity) ? o : best), opps[0]);
-      }
+    byTeammate.forEach((rows, teammateId) => {
+      const pick = rows.find(o => o.stat_type === selectedStat);
+      if (!pick) return; // Com a nova tabela, PTS/AST/REB sempre existem
       sats.push({
-        backupPlayerId: backupId,
-        backupPlayerName: pick.backup_player_name,
+        backupPlayerId: teammateId,
+        backupPlayerName: pick.teammate_name,
         avgCom: pick.avg_com,
         avgSem: pick.avg_sem,
         gap: pick.gap,
         gapPct: pick.gap_pct,
-        score: pick.score,
+        score: null,
         jogosCom: pick.jogos_com,
         jogosSem: pick.jogos_sem,
-        lineValue: pick.line_value,
-        gapVsLine: pick.gap_vs_line,
-        gapVsLinePct: pick.gap_vs_line_pct,
-        cvSem: pick.cv_sem,
+        lineValue: null,
+        gapVsLine: null,
+        gapVsLinePct: null,
+        cvSem: null,
         stddevSem: pick.stddev_sem,
-        ratingStars: pick.rating_stars,
+        ratingStars: 0,
         statType: pick.stat_type,
-        isFallback,
+        isFallback: false,
       });
     });
 
     sats.sort((a, b) => b.gapPct - a.gapPct);
     return sats;
-  }, [triggerOpps, selectedStat]);
+  }, [impacts, selectedStat]);
 
   const availableTabs = useMemo(() => {
-    const statTypes = new Set(triggerOpps.map(o => o.stat_type));
+    const statTypes = new Set(impacts.map(o => o.stat_type));
     return STAT_TABS.filter(t => statTypes.has(t.key));
-  }, [triggerOpps]);
+  }, [impacts]);
 
   useEffect(() => {
     setSelectedBackup(null);

--- a/src/pages/Picks.tsx
+++ b/src/pages/Picks.tsx
@@ -449,6 +449,11 @@ export default function Picks() {
               <span className="text-[10px] bg-terminal-gray border border-terminal-border-subtle px-2 py-1 rounded">
                 {gamesCount} jogos • {totalOpps} oportunidades
               </span>
+              {opportunities[0]?.loaded_at && (
+                <span className="text-[10px] text-terminal-text/30">
+                  Atualizado às {new Date(opportunities[0].loaded_at + 'Z').toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit', timeZone: 'America/Sao_Paulo' })} (Horário de Brasília)
+                </span>
+              )}
               {highConfidence > 0 && (
                 <button
                   onClick={() => setMinScore(prev => prev === 80 ? 0 : 80)}

--- a/src/services/nba-data.service.ts
+++ b/src/services/nba-data.service.ts
@@ -271,6 +271,27 @@ export interface DailyOpportunity {
   rating_stars: number;
   spread: number | null;
   blowout_deflator: number | null;
+  loaded_at: string | null;
+}
+
+export interface TeammateImpact360 {
+  trigger_player_id: number;
+  trigger_name: string;
+  trigger_team_id: number;
+  trigger_team_abbr: string;
+  trigger_status: string;
+  teammate_player_id: number;
+  teammate_name: string;
+  teammate_position: string;
+  stat_type: string;
+  avg_com: number;
+  avg_sem: number;
+  stddev_sem: number | null;
+  gap: number;
+  gap_pct: number;
+  jogos_com: number;
+  jogos_sem: number;
+  teammate_avg_minutes: number;
 }
 
 export const nbaDataService = {
@@ -471,6 +492,16 @@ export const nbaDataService = {
       });
       if (error) throw error;
       return (data || []) as B2BBoxScorePlayer[];
+    });
+  },
+
+  async getTeammateImpact360(triggerPlayerId: number): Promise<TeammateImpact360[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_teammate_impact_360', {
+        p_trigger_player_id: triggerPlayerId,
+      });
+      if (error) throw error;
+      return (data || []) as TeammateImpact360[];
     });
   },
 

--- a/supabase/migrations/037_create_fdw_dim_teammate_impact_360.sql
+++ b/supabase/migrations/037_create_fdw_dim_teammate_impact_360.sql
@@ -1,0 +1,33 @@
+-- Migration: create_fdw_dim_teammate_impact_360
+-- Creates foreign table for BigQuery dim_teammate_impact_360
+-- Contains all teammates of a trigger player with impact stats (PTS/AST/REB)
+-- Used by the Análise 360 mandala detail view
+--
+-- Applied to staging (kpbjuplcwiyrymafhehz) and production (lavclmlvvfzkblrstojd)
+
+DROP FOREIGN TABLE IF EXISTS bigquery.dim_teammate_impact_360;
+
+CREATE FOREIGN TABLE bigquery.dim_teammate_impact_360 (
+  trigger_player_id    bigint,
+  trigger_name         text,
+  trigger_team_id      bigint,
+  trigger_team_abbr    text,
+  trigger_status       text,
+  teammate_player_id   bigint,
+  teammate_name        text,
+  teammate_position    text,
+  stat_type            text,
+  avg_com              double precision,
+  avg_sem              double precision,
+  stddev_sem           double precision,
+  gap                  double precision,
+  gap_pct              double precision,
+  jogos_com            bigint,
+  jogos_sem            bigint,
+  teammate_avg_minutes double precision
+)
+SERVER bigquery_wrapper_server
+OPTIONS (
+  table 'dim_teammate_impact_360',
+  location 'us-east1'
+);

--- a/supabase/migrations/038_create_rpc_get_teammate_impact_360.sql
+++ b/supabase/migrations/038_create_rpc_get_teammate_impact_360.sql
@@ -1,0 +1,51 @@
+-- Migration: create_rpc_get_teammate_impact_360
+-- RPC that returns all teammates for a given trigger player with impact stats
+-- Used by the Análise 360 mandala detail view (useTeammateImpact360 hook)
+-- Depends on: 037_create_fdw_dim_teammate_impact_360.sql
+--
+-- Applied to staging (kpbjuplcwiyrymafhehz) and production (lavclmlvvfzkblrstojd)
+
+CREATE OR REPLACE FUNCTION public.get_teammate_impact_360(p_trigger_player_id bigint)
+RETURNS TABLE(
+  trigger_player_id    bigint,
+  trigger_name         text,
+  trigger_team_id      bigint,
+  trigger_team_abbr    text,
+  trigger_status       text,
+  teammate_player_id   bigint,
+  teammate_name        text,
+  teammate_position    text,
+  stat_type            text,
+  avg_com              double precision,
+  avg_sem              double precision,
+  stddev_sem           double precision,
+  gap                  double precision,
+  gap_pct              double precision,
+  jogos_com            bigint,
+  jogos_sem            bigint,
+  teammate_avg_minutes double precision
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    d.trigger_player_id, d.trigger_name,
+    d.trigger_team_id, d.trigger_team_abbr, d.trigger_status,
+    d.teammate_player_id, d.teammate_name, d.teammate_position,
+    d.stat_type,
+    d.avg_com, d.avg_sem, d.stddev_sem,
+    d.gap, d.gap_pct,
+    d.jogos_com, d.jogos_sem,
+    d.teammate_avg_minutes
+  FROM bigquery.dim_teammate_impact_360 d
+  WHERE d.trigger_player_id = p_trigger_player_id
+  ORDER BY d.stat_type, d.gap_pct DESC NULLS LAST;
+END;
+$$;
+
+-- Grant execute to authenticated and anon roles
+GRANT EXECUTE ON FUNCTION public.get_teammate_impact_360(bigint) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_teammate_impact_360(bigint) TO anon;

--- a/supabase/migrations/039_add_loaded_at_to_dim_daily_opportunities.sql
+++ b/supabase/migrations/039_add_loaded_at_to_dim_daily_opportunities.sql
@@ -1,0 +1,60 @@
+-- Migration: add_loaded_at_to_dim_daily_opportunities
+-- Adds loaded_at timestamp column to the BigQuery foreign table dim_daily_opportunities
+-- Used to display "Atualizado às HH:MM (Horário de Brasília)" in the Picks header
+--
+-- Note: ALTER FOREIGN TABLE ... ADD COLUMN is not supported in PostgreSQL.
+-- The foreign table must be dropped and recreated with the new column.
+-- This migration recreates the full table definition with loaded_at appended.
+--
+-- Applied to staging (kpbjuplcwiyrymafhehz) and production (lavclmlvvfzkblrstojd)
+
+DROP FOREIGN TABLE IF EXISTS bigquery.dim_daily_opportunities;
+
+CREATE FOREIGN TABLE bigquery.dim_daily_opportunities (
+  game_id                   bigint,
+  game_date                 date,
+  game_time                 text,
+  home_team_abbr            text,
+  visitor_team_abbr         text,
+  trigger_player_id         bigint,
+  trigger_name              text,
+  trigger_status            text,
+  trigger_team_abbr         text,
+  trigger_team_id           bigint,
+  trigger_days_out          bigint,
+  trigger_freshness         text,
+  trigger_participation_pct double precision,
+  is_b2b                    boolean,
+  fatigue_level             text,
+  backup_player_id          bigint,
+  backup_player_name        text,
+  stat_type                 text,
+  avg_com                   double precision,
+  avg_sem                   double precision,
+  stddev_sem                double precision,
+  cv_sem                    double precision,
+  gap                       double precision,
+  gap_pct                   double precision,
+  jogos_com                 bigint,
+  jogos_sem                 bigint,
+  line_value                double precision,
+  gap_vs_line               double precision,
+  gap_vs_line_pct           double precision,
+  signal                    text,
+  score                     bigint,
+  score_base                bigint,
+  score_label               text,
+  opponent_abbr             text,
+  opponent_def_rank         bigint,
+  opponent_off_rank         bigint,
+  is_home                   boolean,
+  rating_stars              bigint,
+  spread                    double precision,
+  blowout_deflator          double precision,
+  loaded_at                 timestamp without time zone
+)
+SERVER bigquery_wrapper_server
+OPTIONS (
+  table 'dim_daily_opportunities',
+  location 'us-east1'
+);

--- a/supabase/migrations/040_fix_get_daily_opportunities_timezone.sql
+++ b/supabase/migrations/040_fix_get_daily_opportunities_timezone.sql
@@ -1,0 +1,15 @@
+-- Migration: fix_get_daily_opportunities_timezone
+-- Bug: WHERE game_date = CURRENT_DATE used UTC from Supabase server.
+-- At 21h+ Brasilia (UTC-3), the server was already "next day", showing
+-- tomorrow's games instead of today's.
+-- Fix: Changed to MIN(game_date) from games without winner_team_id
+-- in a ±1 day window — timezone-safe.
+--
+-- This migration is superseded by 041 which adds loaded_at to the output,
+-- but is kept for historical documentation of the timezone fix.
+--
+-- Applied to staging (kpbjuplcwiyrymafhehz) and production (lavclmlvvfzkblrstojd)
+
+-- (No-op: the full replacement is in 041_replace_get_daily_opportunities_with_loaded_at.sql)
+-- This file documents the intermediate fix that was applied before loaded_at was added.
+-- The timezone-safe logic (MIN game_date from unfinished games) is preserved in 041.

--- a/supabase/migrations/041_replace_get_daily_opportunities_with_loaded_at.sql
+++ b/supabase/migrations/041_replace_get_daily_opportunities_with_loaded_at.sql
@@ -1,0 +1,121 @@
+-- Migration: replace_get_daily_opportunities_with_loaded_at
+-- Recreates get_daily_opportunities RPC with:
+--   1. loaded_at column in the output (from dim_daily_opportunities FDW)
+--   2. Timezone-safe date logic: MIN(game_date) from unfinished games in ±1 day window
+-- Depends on: 039_add_loaded_at_to_dim_daily_opportunities.sql
+--
+-- Applied to staging (kpbjuplcwiyrymafhehz) and production (lavclmlvvfzkblrstojd)
+
+CREATE OR REPLACE FUNCTION public.get_daily_opportunities(p_game_date date DEFAULT NULL::date)
+RETURNS TABLE(
+  game_id                   bigint,
+  game_date                 date,
+  game_time                 text,
+  home_team_abbr            text,
+  visitor_team_abbr         text,
+  trigger_player_id         bigint,
+  trigger_name              text,
+  trigger_status            text,
+  trigger_team_abbr         text,
+  trigger_team_id           bigint,
+  trigger_days_out          bigint,
+  trigger_freshness         text,
+  trigger_participation_pct double precision,
+  is_b2b                    boolean,
+  fatigue_level             text,
+  backup_player_id          bigint,
+  backup_player_name        text,
+  stat_type                 text,
+  avg_com                   double precision,
+  avg_sem                   double precision,
+  stddev_sem                double precision,
+  cv_sem                    double precision,
+  gap                       double precision,
+  gap_pct                   double precision,
+  jogos_com                 bigint,
+  jogos_sem                 bigint,
+  line_value                double precision,
+  gap_vs_line               double precision,
+  gap_vs_line_pct           double precision,
+  signal                    text,
+  score                     bigint,
+  score_base                bigint,
+  score_label               text,
+  opponent_abbr             text,
+  opponent_def_rank         bigint,
+  opponent_off_rank         bigint,
+  is_home                   boolean,
+  rating_stars              bigint,
+  spread                    double precision,
+  blowout_deflator          double precision,
+  loaded_at                 timestamp without time zone
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_target_date date;
+BEGIN
+  IF p_game_date IS NOT NULL THEN
+    v_target_date := p_game_date;
+  ELSE
+    -- Timezone-safe: find the earliest game_date from unfinished games
+    -- within a ±1 day window instead of relying on CURRENT_DATE (UTC)
+    SELECT MIN(g.game_date) INTO v_target_date
+    FROM bigquery.ft_games g
+    WHERE g.winner_team_id IS NULL
+      AND g.game_date >= CURRENT_DATE - INTERVAL '1 day'
+      AND g.game_date <= CURRENT_DATE + INTERVAL '1 day';
+
+    -- Fallback: use dim_daily_opportunities if no unfinished games found
+    IF v_target_date IS NULL THEN
+      SELECT MIN(d.game_date) INTO v_target_date
+      FROM bigquery.dim_daily_opportunities d
+      WHERE d.game_date >= CURRENT_DATE - INTERVAL '1 day';
+    END IF;
+
+    -- Last resort: use CURRENT_DATE
+    IF v_target_date IS NULL THEN
+      v_target_date := CURRENT_DATE;
+    END IF;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    d.game_id, d.game_date, d.game_time,
+    d.home_team_abbr, d.visitor_team_abbr,
+    d.trigger_player_id, d.trigger_name, d.trigger_status,
+    d.trigger_team_abbr, d.trigger_team_id,
+    d.trigger_days_out, d.trigger_freshness, d.trigger_participation_pct,
+    d.is_b2b, d.fatigue_level,
+    d.backup_player_id, d.backup_player_name,
+    d.stat_type,
+    d.avg_com, d.avg_sem,
+    d.stddev_sem, d.cv_sem,
+    d.gap, d.gap_pct,
+    d.jogos_com, d.jogos_sem,
+    d.line_value, d.gap_vs_line, d.gap_vs_line_pct,
+    d.signal,
+    d.score, d.score_base, d.score_label,
+    d.opponent_abbr, d.opponent_def_rank, d.opponent_off_rank,
+    d.is_home, d.rating_stars,
+    d.spread, d.blowout_deflator,
+    d.loaded_at
+  FROM bigquery.dim_daily_opportunities d
+  WHERE d.game_date = v_target_date
+    AND d.stat_type != 'player_minutes'
+    AND d.signal IS NOT NULL
+    AND d.score >= 60
+    AND (d.trigger_days_out IS NULL OR d.trigger_days_out <= 7)
+    AND (d.trigger_participation_pct IS NULL OR d.trigger_participation_pct >= 0.5)
+    AND d.trigger_status NOT IN ('Out For Season')
+    AND d.gap >= 1.0
+    AND d.rating_stars IS NOT NULL AND d.rating_stars >= 1
+  ORDER BY d.score DESC NULLS LAST;
+END;
+$$;
+
+-- Grant execute to authenticated and anon roles
+GRANT EXECUTE ON FUNCTION public.get_daily_opportunities(date) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_daily_opportunities(date) TO anon;


### PR DESCRIPTION
## Summary

Duas entregas principais neste PR:

### 1. Análise 360 — Nova RPC e FDW dedicados

A tela de detalhe do Análise 360 (mandala de impacto de lesões) foi refatorada para usar uma **RPC dedicada** (`get_teammate_impact_360`) em vez de reutilizar os dados do `dim_daily_opportunities`.

**Por que a mudança:**
- A `dim_daily_opportunities` filtra por score/gap, excluindo muitos teammates relevantes
- A nova tabela `dim_teammate_impact_360` no BigQuery contém **todos os teammates** do trigger, sem filtros, incluindo impactos negativos
- Dados mais completos = mandala mais rica

**O que foi feito no Supabase (staging + produção):**
- **FDW**: Criada foreign table `bigquery.dim_teammate_impact_360` apontando para BigQuery (com `location 'us-east1'`)
- **RPC**: Criada `get_teammate_impact_360(p_trigger_player_id bigint)` que retorna todos os teammates com stats PTS/AST/REB
- Dados de jogo (adversário, horário, B2B) continuam vindo do `useAnalise360Data()` existente via enrichment

**Frontend:**
- Novo hook `useTeammateImpact360` em `use-analise360.ts`
- Nova interface `TeammateImpact360` e método `getTeammateImpact360()` no service
- `Analise360Detail.tsx` refatorado para consumir a nova RPC
- Centro da mandala com `bg-white` para hierarquia visual (satélites mantêm `bg-terminal-gray`)

### 2. Picks — Timestamp de atualização + fix timezone

**loaded_at:**
- FDW: Adicionada coluna `loaded_at timestamp` na foreign table `dim_daily_opportunities` (staging + produção)
- RPC: `get_daily_opportunities` agora retorna `loaded_at`
- Frontend: exibe discretamente "Atualizado às HH:MM (Horário de Brasília)" no header da tela de Picks

**Fix timezone na RPC `get_daily_opportunities`:**
- **Bug**: `WHERE game_date = CURRENT_DATE` usava UTC do servidor Supabase. Às 21h+ de Brasília (UTC-3), o servidor já era "dia seguinte", mostrando jogos de amanhã em vez de hoje
- **Fix**: Trocado para `MIN(game_date)` dos jogos sem `winner_team_id` numa janela de ±1 dia — timezone-safe
- Aplicado em **staging e produção**

## Mudanças por arquivo

| Arquivo | Mudança |
|---------|---------|
| `src/hooks/use-analise360.ts` | Novo hook `useTeammateImpact360`, removida interface não usada |
| `src/pages/Analise360Detail.tsx` | Refatorado para nova RPC, enrichment de game info, bg-white no centro |
| `src/pages/Picks.tsx` | Exibe `loaded_at` no header com timezone Brasília |
| `src/services/nba-data.service.ts` | Nova interface `TeammateImpact360`, método `getTeammateImpact360()`, campo `loaded_at` na `DailyOpportunity` |

## Migrações Supabase aplicadas (staging + produção)

1. `create_fdw_dim_teammate_impact_360` — Foreign table para BigQuery
2. `create_rpc_get_teammate_impact_360` — RPC de impacto 360
3. `add_loaded_at_to_dim_daily_opportunities` — Coluna FDW
4. `fix_get_daily_opportunities_timezone` — Lógica timezone-safe
5. `replace_get_daily_opportunities_with_loaded_at` — RPC com `loaded_at` no retorno

## Test plan

- [ ] Abrir tela Análise 360 e clicar em um trigger → mandala deve carregar com todos os teammates
- [ ] Alternar entre PTS/AST/REB → satélites atualizam corretamente
- [ ] Verificar que info de jogo (adversário, horário) aparece no painel lateral
- [ ] Abrir tela Oportunidades do Dia → deve mostrar jogos de hoje (não amanhã) enquanto jogos não terminaram
- [ ] Verificar texto "Atualizado às XX:XX (Horário de Brasília)" no header dos Picks
- [ ] Testar no mobile — layout responsivo mantido

🤖 Generated with [Claude Code](https://claude.com/claude-code)