### PR TITLE
fix: apostas anuladas contam corretamente nos KPIs

### DIFF
--- a/src/components/bets/BankrollEvolutionChart.tsx
+++ b/src/components/bets/BankrollEvolutionChart.tsx
@@ -51,7 +51,7 @@ export const BankrollEvolutionChart: React.FC<BankrollEvolutionChartProps> = ({
     const startAmount = initialBankroll || 0;
 
     const betEvents: { date: Date; profit: number; label: string }[] = bets
-      .filter((bet) => ['won', 'lost', 'cashout', 'half_won', 'half_lost'].includes(bet.status))
+      .filter((bet) => ['won', 'lost', 'cashout', 'half_won', 'half_lost', 'void'].includes(bet.status))
       .map((bet) => {
         let profit = 0;
         if (bet.status === 'won') profit = bet.potential_return - bet.stake_amount;
@@ -59,6 +59,7 @@ export const BankrollEvolutionChart: React.FC<BankrollEvolutionChartProps> = ({
         else if (bet.status === 'cashout' && bet.cashout_amount) profit = bet.cashout_amount - bet.stake_amount;
         else if (bet.status === 'half_won') profit = (bet.stake_amount + bet.potential_return) / 2 - bet.stake_amount;
         else if (bet.status === 'half_lost') profit = bet.stake_amount / 2 - bet.stake_amount;
+        // void: profit = 0 (dinheiro devolvido)
         return { date: new Date(bet.bet_date), profit, label: bet.bet_description };
       });
 

--- a/src/components/bets/CashFlowTable.tsx
+++ b/src/components/bets/CashFlowTable.tsx
@@ -28,7 +28,7 @@ interface CashFlowEntry {
   date: string;
   dateSort: number;
   description: string;
-  type: 'win' | 'loss' | 'cashout' | 'half_win' | 'half_loss' | 'initial' | 'deposit' | 'withdrawal';
+  type: 'win' | 'loss' | 'cashout' | 'half_win' | 'half_loss' | 'void' | 'initial' | 'deposit' | 'withdrawal';
   amount: number;
   balance: number;
   affectsBalance: boolean;
@@ -50,7 +50,7 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
     const startBalance = initialBankroll || 0;
 
     const betEntries: Omit<CashFlowEntry, 'balance' | 'affectsBalance'>[] = bets
-      .filter((bet) => ['won', 'lost', 'cashout', 'half_won', 'half_lost'].includes(bet.status))
+      .filter((bet) => ['won', 'lost', 'cashout', 'half_won', 'half_lost', 'void'].includes(bet.status))
       .map((bet) => {
         let amount = 0;
         let type: CashFlowEntry['type'] = 'loss';
@@ -69,6 +69,9 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
         } else if (bet.status === 'half_lost') {
           amount = bet.stake_amount / 2 - bet.stake_amount;
           type = 'half_loss';
+        } else if (bet.status === 'void') {
+          amount = 0;
+          type = 'void';
         }
         return {
           id: bet.id,
@@ -142,6 +145,8 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
         return '1/2 GREEN';
       case 'half_loss':
         return '1/2 RED';
+      case 'void':
+        return 'ANULADA';
       case 'initial':
         return 'INICIAL';
       case 'deposit':
@@ -163,6 +168,8 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
         return 'text-terminal-green opacity-80';
       case 'half_loss':
         return 'text-terminal-red opacity-80';
+      case 'void':
+        return 'text-terminal-text opacity-50';
       case 'initial':
         return 'text-terminal-text opacity-70';
       case 'deposit':

--- a/src/components/bets/ProfitByLeagueChart.tsx
+++ b/src/components/bets/ProfitByLeagueChart.tsx
@@ -39,7 +39,7 @@ export const ProfitByLeagueChart: React.FC<ProfitByLeagueChartProps> = ({
 }) => {
   const data = useMemo(() => {
     const settled = bets.filter((b) =>
-      ['won', 'lost', 'cashout', 'half_won', 'half_lost'].includes(b.status)
+      ['won', 'lost', 'cashout', 'half_won', 'half_lost', 'void'].includes(b.status)
     );
     const byLeague = new Map<string, number>();
     settled.forEach((bet) => {

--- a/src/components/bets/ProfitByMarketChart.tsx
+++ b/src/components/bets/ProfitByMarketChart.tsx
@@ -39,7 +39,7 @@ export const ProfitByMarketChart: React.FC<ProfitByMarketChartProps> = ({
 }) => {
   const data = useMemo(() => {
     const settled = bets.filter((b) =>
-      ['won', 'lost', 'cashout', 'half_won', 'half_lost'].includes(b.status)
+      ['won', 'lost', 'cashout', 'half_won', 'half_lost', 'void'].includes(b.status)
     );
     const byMarket = new Map<string, number>();
     settled.forEach((bet) => {

--- a/src/components/bets/ProfitBySportChart.tsx
+++ b/src/components/bets/ProfitBySportChart.tsx
@@ -41,7 +41,7 @@ export const ProfitBySportChart: React.FC<ProfitBySportChartProps> = ({
 }) => {
   const data = useMemo(() => {
     const settled = bets.filter((b) =>
-      ['won', 'lost', 'cashout', 'half_won', 'half_lost'].includes(b.status)
+      ['won', 'lost', 'cashout', 'half_won', 'half_lost', 'void'].includes(b.status)
     );
     const bySport = new Map<string, number>();
     settled.forEach((bet) => {

--- a/src/components/bets/ProfitByTagChart.tsx
+++ b/src/components/bets/ProfitByTagChart.tsx
@@ -53,7 +53,7 @@ export const ProfitByTagChart: React.FC<ProfitByTagChartProps> = ({
 
   const fullSeries = useMemo(() => {
     const settled = bets.filter((b) =>
-      ['won', 'lost', 'cashout', 'half_won', 'half_lost'].includes(b.status)
+      ['won', 'lost', 'cashout', 'half_won', 'half_lost', 'void'].includes(b.status)
     );
     const byTag = new Map<string, { profit: number; color?: string }>();
     settled.forEach((bet) => {

--- a/src/pages/Bets.tsx
+++ b/src/pages/Bets.tsx
@@ -813,29 +813,30 @@ export default function Bets() {
     if (!isMountedRef.current) return;
     
     const totalBets = betsData.length;
-    const totalStaked = betsData
-      .filter(bet => bet.status !== 'void')
-      .reduce((sum, bet) => sum + bet.stake_amount, 0);
-    
+    const totalStaked = betsData.reduce((sum, bet) => sum + bet.stake_amount, 0);
+
     const wonBets = betsData.filter(bet => bet.status === 'won');
     const lostBets = betsData.filter(bet => bet.status === 'lost');
     const cashoutBets = betsData.filter(bet => bet.status === 'cashout');
     const halfWonBets = betsData.filter(bet => bet.status === 'half_won');
     const halfLostBets = betsData.filter(bet => bet.status === 'half_lost');
+    const voidBets = betsData.filter(bet => bet.status === 'void');
 
     const settledStaked =
       wonBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
       lostBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
       cashoutBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
       halfWonBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
-      halfLostBets.reduce((sum, bet) => sum + bet.stake_amount, 0);
-    
+      halfLostBets.reduce((sum, bet) => sum + bet.stake_amount, 0) +
+      voidBets.reduce((sum, bet) => sum + bet.stake_amount, 0);
+
     const totalReturn = wonBets.reduce((sum, bet) => sum + bet.potential_return, 0);
     const totalCashout = cashoutBets.reduce((sum, bet) => sum + (bet.cashout_amount || 0), 0);
     const totalHalfWon = halfWonBets.reduce((sum, bet) => sum + (bet.stake_amount + bet.potential_return) / 2, 0);
     const totalHalfLost = halfLostBets.reduce((sum, bet) => sum + bet.stake_amount / 2, 0);
-    
-    const totalEarnings = totalReturn + totalCashout + totalHalfWon + totalHalfLost;
+    const totalVoidReturn = voidBets.reduce((sum, bet) => sum + bet.stake_amount, 0);
+
+    const totalEarnings = totalReturn + totalCashout + totalHalfWon + totalHalfLost + totalVoidReturn;
     const settledCount = wonBets.length + lostBets.length + cashoutBets.length + halfWonBets.length + halfLostBets.length;
     const winEquiv = wonBets.length + cashoutBets.length + halfWonBets.length * 0.5;
     const lossEquiv = lostBets.length + halfLostBets.length * 0.5;


### PR DESCRIPTION
## Summary

Apostas com status **ANULADA** (void) estavam sendo completamente excluídas dos cálculos de KPIs e gráficos. O comportamento correto em apostas esportivas é:

- **Aposta anulada = dinheiro devolvido**
- Deve contar no **Total Apostado** (o dinheiro foi apostado)
- **Retorno = valor apostado** (devolveu)
- **Lucro = R$ 0,00** (não ganhou nem perdeu)

### Bug anterior

```
totalStaked = betsData
  .filter(bet => bet.status !== 'void')  // ← excluía anuladas completamente
  .reduce(...)
```

A aposta anulada simplesmente "sumia" de todos os cálculos — Total Apostado, Retorno Bruto e todos os gráficos.

### Fix aplicado

| KPI | Antes | Depois |
|-----|-------|--------|
| Total Apostado | Excluía void | Inclui void |
| Retorno Bruto | Ignorava void | Soma stake_amount (devolvido) |
| Lucro Líquido | Sem impacto | Sem impacto (R$ 0) |
| ROI | Sem void no denominador | Inclui void (mais conservador) |

## Arquivos alterados

| Arquivo | Mudança |
|---------|---------|
| `src/pages/Bets.tsx` | `totalStaked` sem filtro void, `voidBets` no `settledStaked` e `totalEarnings` |
| `src/components/bets/BankrollEvolutionChart.tsx` | Void entra no gráfico com profit=0 |
| `src/components/bets/CashFlowTable.tsx` | Novo tipo `void`, label "ANULADA", cor cinza |
| `src/components/bets/ProfitBySportChart.tsx` | Void no filtro settled |
| `src/components/bets/ProfitByTagChart.tsx` | Void no filtro settled |
| `src/components/bets/ProfitByMarketChart.tsx` | Void no filtro settled |
| `src/components/bets/ProfitByLeagueChart.tsx` | Void no filtro settled |

## Test plan

- [ ] Criar aposta e marcar como ANULADA — verificar que Total Apostado inclui o valor
- [ ] Retorno Bruto deve subir pelo valor da aposta anulada (dinheiro devolvido)
- [ ] Lucro Líquido deve permanecer inalterado (void = R$ 0 de lucro)
- [ ] Gráfico de evolução da banca: curva não deve ser afetada por void
- [ ] Fluxo de Caixa: void aparece como "ANULADA" com R$ 0,00 em cinza
- [ ] Gráficos de profit por Sport/Tag/Market/League: sem impacto visual

🤖 Generated with [Claude Code](https://claude.com/claude-code)