### PR TITLE
feat: Bolão Copa do Mundo 2026 — produto completo

### DIFF
--- a/docs/bolao-copa-2026-produto.md
+++ b/docs/bolao-copa-2026-produto.md
@@ -1,0 +1,253 @@
+# Bolao Copa do Mundo 2026 — Documentacao do Produto
+
+## Visao Geral
+
+O **Bolao Copa do Mundo 2026** e um produto de topo de funil (ToFu) integrado ao Smart Betting, projetado para viralidade e aquisicao de usuarios. Permite que qualquer pessoa crie um bolao entre amigos, familia ou colegas de trabalho para a Copa do Mundo 2026 (EUA, Mexico e Canada — 48 selecoes, 12 grupos, 104 jogos).
+
+O racional e simples: bolao e o produto mais viral do futebol. Cada bolao criado gera convites para 10-100+ pessoas que entram na plataforma Smart Betting. O bolao serve como porta de entrada para o ecossistema de analytics.
+
+---
+
+## Como Funciona
+
+### Fluxo do Usuario
+
+1. **Criar bolao** — Usuario logado acessa `/bolao`, clica em "+ Criar", escolhe Free ou Premium
+2. **Configurar** — Apos criar, abre automaticamente o modal de configuracoes (pontuacao, modalidades, tema)
+3. **Convidar** — Compartilha o codigo de convite (ex: `ABC123`) ou link direto via WhatsApp/Telegram
+4. **Palpitar** — Cada participante faz palpites nos 104 jogos (bloqueio automatico antes de cada partida)
+5. **Acompanhar** — Ranking atualizado em tempo real apos cada jogo, com pontos calculados automaticamente
+
+### Tipos de Palpites
+
+| Tipo | Descricao | Pontuacao Padrao |
+|------|-----------|-----------------|
+| **Palpite de Jogo** | Placar de cada partida (ex: BRA 2x1 ARG) | 1pt resultado / 3pts placar exato |
+| **Palpite de Campeao** | Qual selecao ganha a Copa | 10pts (configuravel) |
+| **Finalistas** | 2 selecoes que vao a final | 10pts cada (configuravel) |
+| **Semifinalistas** | 4 selecoes que chegam a semi | 5pts cada (configuravel) |
+| **Quartas de Final** | 8 selecoes que chegam as quartas | 3pts cada (configuravel) |
+| **Mata-mata (32)** | 32 selecoes que passam da fase de grupos | 1pt cada (configuravel) |
+
+---
+
+## Monetizacao
+
+### Free (volume e viralidade)
+
+- Ate **10 participantes**
+- Pontuacao fixa: 1pt resultado / 3pts placar exato
+- Palpite de campeao
+- Ranking geral
+- Compartilhamento via link/WhatsApp
+
+### Premium por Bolao — R$ 19,90 (pagamento unico)
+
+- **Participantes ilimitados**
+- Pontuacao customizavel (presets + personalizado)
+- Multiplicador por fase (mata-mata vale ate 5x mais)
+- Palpites especiais (finalistas, semis, quartas, mata-mata 32)
+- Pontos configuraveis por categoria
+- Toggle on/off por modalidade (campeao, cada tipo de especial)
+- Ranking por fase + estatisticas detalhadas
+- Customizacao visual (cor tema + logo do bolao)
+- Badge PREMIUM
+
+### Opcao PIX
+
+Como o Stripe nao suporta PIX nativamente, oferecemos pagamento via WhatsApp:
+- Link direto para contato: `wa.me/5511952136845`
+- Equipe envia PIX, confirma pagamento e executa upgrade manual via:
+  ```sql
+  SELECT upgrade_bolao_to_premium('CODIGO_CONVITE');
+  ```
+
+### Fluxo de Pagamento (Cartao)
+
+1. Usuario seleciona Premium no modal de criacao
+2. Frontend gera UUID pre-criado para o bolao
+3. Chama Edge Function `stripe-create-checkout` com metadata (bolaoId, nome, descricao)
+4. Stripe redireciona para checkout (mode: `payment`, one-time)
+5. Apos pagamento, webhook `checkout.session.completed` cria o bolao no banco
+6. Redirect de volta para `/bolao/{id}?success=true` → abre configuracoes automaticamente
+
+---
+
+## Arquitetura Tecnica
+
+### Stack
+
+- **Frontend:** React 18 + TypeScript + Vite + Tailwind + shadcn/ui
+- **Backend:** Supabase (PostgreSQL + Auth + RLS + Edge Functions + Storage)
+- **Pagamento:** Stripe (checkout session + webhook)
+- **Deploy:** Vercel (frontend) + Supabase Cloud (backend)
+
+### Estrutura de Arquivos
+
+```
+src/
+  pages/
+    BolaoHome.tsx         — Lista de boloes + criacao
+    BolaoDetail.tsx       — Tela principal (ranking + sidebar com palpites)
+    BolaoPalpites.tsx     — Tela de palpites (rota standalone)
+    BolaoJoin.tsx         — Entrar via codigo de convite
+  components/bolao/
+    CreateBolaoModal.tsx  — Modal de criacao (Free vs Premium)
+    BolaoAdminPanel.tsx   — Modal de configuracoes (pontuacao, modalidades, tema, membros)
+    BolaoRankingTable.tsx — Tabela de ranking
+    MatchPredictionCard.tsx — Card de palpite por jogo
+    ChampionPickModal.tsx — Modal de escolha de campeao
+    PredictionsModal.tsx  — Modal de palpites dos jogos
+    SpecialPredictionsSection.tsx — Palpites especiais (finalistas, semis, etc)
+    BolaoShareButton.tsx  — Botao compartilhar (WhatsApp/Telegram/copiar)
+    BolaoStatsPanel.tsx   — Painel de estatisticas
+    TeamFlag.tsx          — Bandeira da selecao
+    CopaGruposModal.tsx   — Modal com tabela de grupos
+    CopaBracketModal.tsx  — Modal com chave mata-mata
+  services/
+    bolao.service.ts      — Camada de dados (Supabase client)
+  hooks/
+    use-bolao.ts          — 20+ React Query hooks
+```
+
+### Banco de Dados (Supabase/PostgreSQL)
+
+```
+boloes                    — Boloes criados (config, premium, tema)
+bolao_members             — Participantes (role: owner/member)
+bolao_predictions         — Palpites por jogo (placar)
+bolao_special_predictions — Palpites especiais (campeao, finalistas, etc)
+bolao_subscriptions       — Registro de compras premium
+wc_matches                — 104 jogos da Copa (seed oficial)
+```
+
+**Colunas de configuracao do bolao (`boloes`):**
+
+| Coluna | Tipo | Descricao |
+|--------|------|-----------|
+| scoring_result | int | Pontos por acertar resultado (default 1) |
+| scoring_exact | int | Pontos por placar exato (default 3) |
+| scoring_preset | text | 'standard' / 'classic' / 'weighted_stages' / 'custom' |
+| champion_enabled | bool | Habilitar palpite de campeao |
+| champion_points | int | Pontos por acertar campeao (default 10) |
+| special_predictions_enabled | bool | Algum palpite especial habilitado |
+| special_predictions_config | jsonb | Toggle por tipo: `{finalist: true, semifinalist: false, ...}` |
+| special_predictions_points | jsonb | Pontos por tipo: `{finalist: 10, semifinalist: 5, ...}` |
+| custom_color | text | Cor tema (blue/green/gold/purple/red/cyan/orange) |
+| custom_banner_url | text | URL do logo (Supabase Storage) |
+| is_closed | bool | Inscricoes abertas/fechadas |
+| max_participants | int | 10 (free) ou 9999 (premium) |
+
+**RPC Functions principais:**
+- `calculate_bolao_scores(p_match_id)` — Calcula pontos apos resultado
+- `get_bolao_ranking(p_bolao_id)` — Ranking com RANK() window function
+- `get_user_boloes()` — Lista boloes do usuario com stats (CTE otimizado)
+- `join_bolao_by_code(p_invite_code)` — Entrar via codigo
+- `toggle_special_prediction()` — Adicionar/remover palpite especial
+- `update_bolao_scoring()` — Atualizar preset de pontuacao
+- `upgrade_bolao_to_premium(p_invite_code)` — Upgrade manual (PIX)
+
+### Edge Functions (Supabase)
+
+| Funcao | Descricao |
+|--------|-----------|
+| `stripe-create-checkout` | Cria sessao Stripe (mode: payment para bolao, subscription para outros) |
+| `stripe-webhook` | Recebe `checkout.session.completed` e cria o bolao premium no banco |
+
+### Layout da Pagina Principal (BolaoDetail)
+
+Desktop usa layout de 2 colunas:
+
+```
++------------------------------------------+----------------------------+
+| Header: Nome [PREMIUM] [Compartilhar] [Config] |
+| Info: participantes · codigo · pontuacao                               |
++------------------------------------------+----------------------------+
+| [Ranking] [Palpites] [Estatisticas]      | Palpites dos Jogos         |
+|                                          | 0 feitos · 72 disponiveis  |
+| Ranking table...                         |----------------------------|
+|                                          | Palpite de Campeao         |
+|                                          | Quem ganha a Copa 2026?    |
+|                                          |----------------------------|
+|                                          | Palpites Especiais         |
+|                                          | Finalistas, Semis...       |
++------------------------------------------+----------------------------+
+```
+
+Mobile empilha: conteudo principal → sidebar abaixo.
+
+---
+
+## Configuracoes do Bolao (Modal)
+
+O modal de configuracoes e aberto automaticamente apos criacao e acessivel via botao no header. Secoes:
+
+1. **Inscricoes** — Abrir/encerrar entradas
+2. **Modalidades** — Toggle on/off para campeao (com pontos) e cada tipo de palpite especial (com pontos individuais)
+3. **Pontuacao** — Presets rapidos (Padrao, Classico, Fases valem +) + inputs editaveis + toggle multiplicador por fase
+4. **Cor do bolao** — 8 opcoes de tema (premium)
+5. **Logo do bolao** — Upload JPG/PNG ate 2MB (premium)
+6. **Participantes** — Lista com opcao de remover
+
+---
+
+## Multiplicador por Fase (weighted_stages)
+
+Quando habilitado, os pontos dos palpites sao multiplicados conforme a fase:
+
+| Fase | Multiplicador |
+|------|--------------|
+| Fase de Grupos | 1.0x |
+| Round of 32/16 | 1.5x |
+| Quartas de Final | 2.0x |
+| Semifinal | 3.0x |
+| 3o Lugar | 2.0x |
+| Final | 5.0x |
+
+Exemplo: se o usuario acerta o placar exato da final (3pts base), ganha 3 × 5 = **15 pontos**.
+
+---
+
+## Status de Deploy
+
+### Staging (kpbjuplcwiyrymafhehz) — COMPLETO
+- Todas as migrations aplicadas
+- Edge Functions deployadas (v19 checkout, v16 webhook)
+- Stripe test mode configurado (Price ID: `price_1TMelW01CLJUO7HdF16XSddA`)
+- Webhook signing secret configurado
+- Fluxo de pagamento testado e validado
+
+### Producao (lavclmlvvfzkblrstojd) — PENDENTE
+
+Checklist:
+- [ ] Rodar migrations do bolao (tabelas + RLS + RPCs + seed 104 jogos)
+- [ ] Deploy Edge Functions com suporte a bolao
+- [ ] Verificar webhook endpoint Stripe live
+- [ ] Configurar `STRIPE_WEBHOOK_SIGNING_SECRET` live nos secrets
+- [ ] Adicionar `VITE_STRIPE_PRICE_ID_BOLAO=price_1TMdRI01CLJUO7HdmB5hMMBv` no Vercel
+- [ ] Confirmar `SITE_URL=https://smartbetting.app` nos secrets
+- [ ] Deploy frontend com rotas `/bolao/*`
+- [ ] Testar pagamento real
+
+---
+
+## Metricas de Sucesso
+
+| Metrica | Objetivo |
+|---------|----------|
+| Boloes criados | Volume de adocao |
+| Taxa de convite | Quantos convites por bolao (viralidade) |
+| Conversao Free → Premium | % de boloes que fazem upgrade |
+| Participantes por bolao | Engajamento medio |
+| Palpites por usuario | Retencao e engajamento |
+| Receita por bolao premium | R$ 19,90 × conversao |
+
+---
+
+## Proximos Passos (pos-lancamento)
+
+1. **Deploy em producao** — Seguir checklist acima
+2. **Notificacoes** — Push/email quando resultado sai e pontuacao muda
+3. **Ranking publico** — Link compartilhavel do ranking sem auth
+4. **API de resultados** — Automatizar atualizacao de placares (hoje e manual via Dashboard)
+5. **Premium por usuario** — R$ 9,90/mes para criar boloes premium ilimitados

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,10 @@ const SharePage = React.lazy(() => import("./pages/SharePage"));
 const Analise360List = React.lazy(() => import("./pages/Analise360List"));
 const Analise360Detail = React.lazy(() => import("./pages/Analise360Detail"));
 const HomeNBA = React.lazy(() => import("./pages/HomeNBA"));
+const BolaoHome = React.lazy(() => import("./pages/BolaoHome"));
+const BolaoDetail = React.lazy(() => import("./pages/BolaoDetail"));
+const BolaoPalpites = React.lazy(() => import("./pages/BolaoPalpites"));
+const BolaoJoin = React.lazy(() => import("./pages/BolaoJoin"));
 
 const queryClient = new QueryClient();
 
@@ -142,6 +146,27 @@ const App = () => (
             <Route path="/settings" element={
               <ProtectedRoute>
                 <Settings />
+              </ProtectedRoute>
+            } />
+            {/* Bolão Copa do Mundo */}
+            <Route path="/bolao" element={
+              <ProtectedRoute>
+                <BolaoHome />
+              </ProtectedRoute>
+            } />
+            <Route path="/bolao/entrar/:code" element={
+              <ProtectedRoute>
+                <BolaoJoin />
+              </ProtectedRoute>
+            } />
+            <Route path="/bolao/:id" element={
+              <ProtectedRoute>
+                <BolaoDetail />
+              </ProtectedRoute>
+            } />
+            <Route path="/bolao/:id/palpites" element={
+              <ProtectedRoute>
+                <BolaoPalpites />
               </ProtectedRoute>
             } />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -14,7 +14,8 @@ import {
   Target,
   FileText,
   TrendingUp,
-  Radar
+  Radar,
+  Trophy,
 } from 'lucide-react';
 import { useAuth } from '../hooks/use-auth';
 import { useSubscription } from '@/hooks/use-subscription';
@@ -172,6 +173,20 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                 })}
               </DropdownMenuContent>
             </DropdownMenu>
+
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate('/bolao')}
+              className={`flex items-center gap-2 px-4 h-9 hover:bg-terminal-dark-gray ${
+                location.pathname.startsWith('/bolao')
+                  ? 'text-terminal-blue'
+                  : 'text-terminal-text hover:text-terminal-blue'
+              }`}
+            >
+              <Trophy className="w-3.5 h-3.5" />
+              <span className="text-xs font-semibold uppercase tracking-wide">Bolão Copa 2026</span>
+            </Button>
           </div>
 
           {/* Right side - Auth & Premium */}
@@ -259,6 +274,25 @@ export default function AnalyticsNav({ className, showBack, backTo, title }: Ana
                     );
                   })}
                 </div>
+              </div>
+
+              {/* Divisor */}
+              <div className="border-t border-terminal-border-subtle" />
+
+              {/* Bolão Copa */}
+              <div>
+                <Button
+                  variant="ghost"
+                  onClick={() => handleNavigation('/bolao')}
+                  className={`w-full justify-start h-10 ${
+                    location.pathname.startsWith('/bolao')
+                      ? 'bg-terminal-blue/10 text-terminal-blue'
+                      : 'text-terminal-text hover:text-terminal-blue hover:bg-terminal-dark-gray'
+                  }`}
+                >
+                  <Trophy className="w-4 h-4 mr-3" />
+                  <span className="text-sm">Bolão Copa 2026</span>
+                </Button>
               </div>
 
               {/* Divisor */}

--- a/src/components/bolao/BolaoAdminPanel.tsx
+++ b/src/components/bolao/BolaoAdminPanel.tsx
@@ -1,0 +1,685 @@
+import React, { useState, useRef } from 'react';
+import {
+  Shield,
+  UserX,
+  Lock,
+  Unlock,
+  AlertTriangle,
+  Palette,
+  SlidersHorizontal,
+  ImagePlus,
+  X,
+  Users,
+  Trophy,
+  Star,
+  ToggleLeft,
+  ToggleRight,
+  ChevronDown,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  useRemoveMember,
+  useToggleBolaoClose,
+  useUpdateBolaoScoring,
+  useUpdateBolaoTheme,
+  useUploadBolaoLogo,
+  useUpdateBolaoSettings,
+} from '@/hooks/use-bolao';
+import { useToast } from '@/hooks/use-toast';
+import type { BolaoRankingEntry } from '@/services/bolao.service';
+
+interface BolaoAdminPanelProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  bolaoId: string;
+  isClosed: boolean;
+  isPremium: boolean;
+  scoringPreset: string | null;
+  scoringResult: number;
+  scoringExact: number;
+  customColor: string | null;
+  customBannerUrl: string | null;
+  championEnabled: boolean;
+  specialPredictionsEnabled: boolean;
+  specialPredictionsConfig: Record<string, boolean>;
+  specialPredictionsPoints: Record<string, number>;
+  championPoints: number;
+  ranking: BolaoRankingEntry[];
+  currentUserId: string | undefined;
+  ownerUserId: string;
+}
+
+// ── Color Theme ────────────────────────────────────────────────────
+const THEME_COLORS: { value: string; label: string; bg: string; border: string }[] = [
+  { value: 'blue',    label: 'Azul',     bg: 'bg-blue-900/30',    border: 'border-blue-500/60'    },
+  { value: 'green',   label: 'Verde',    bg: 'bg-emerald-900/30', border: 'border-emerald-500/60' },
+  { value: 'gold',    label: 'Dourado',  bg: 'bg-yellow-900/30',  border: 'border-yellow-500/60'  },
+  { value: 'purple',  label: 'Roxo',     bg: 'bg-purple-900/30',  border: 'border-purple-500/60'  },
+  { value: 'red',     label: 'Vinho',    bg: 'bg-red-900/30',     border: 'border-red-700/60'     },
+  { value: 'cyan',    label: 'Ciano',    bg: 'bg-cyan-900/30',    border: 'border-cyan-500/60'    },
+  { value: 'orange',  label: 'Laranja',  bg: 'bg-orange-900/30',  border: 'border-orange-500/60'  },
+  { value: 'default', label: 'Padrão',   bg: 'bg-transparent',    border: 'border-terminal-border'},
+];
+
+// ── Scoring Presets (quick-fill shortcuts) ─────────────────────────
+const SCORING_PRESETS = [
+  { value: 'standard',        label: 'Padrão',        result: 1, exact: 3, weighted: false },
+  { value: 'classic',         label: 'Clássico',       result: 1, exact: 5, weighted: false },
+  { value: 'weighted_stages', label: 'Fases valem +',  result: 1, exact: 3, weighted: true  },
+] as const;
+
+const SPECIAL_TYPES: Record<string, string> = {
+  finalist: 'Finalistas',
+  semifinalist: 'Semifinalistas',
+  quarterfinalist: 'Quartas de Final',
+  round_of_32: 'Mata-mata (32)',
+};
+
+
+export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
+  open,
+  onOpenChange,
+  bolaoId,
+  isClosed,
+  isPremium,
+  scoringPreset,
+  scoringResult,
+  scoringExact,
+  customColor,
+  customBannerUrl,
+  championEnabled,
+  specialPredictionsEnabled,
+  specialPredictionsConfig,
+  specialPredictionsPoints,
+  championPoints,
+  ranking,
+  currentUserId,
+  ownerUserId,
+}) => {
+  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
+  const [specialExpanded, setSpecialExpanded] = useState(false);
+
+  // Scoring state
+  const [customResult, setCustomResult] = useState(scoringResult);
+  const [customExact, setCustomExact] = useState(scoringExact);
+  const [useWeighted, setUseWeighted] = useState(scoringPreset === 'weighted_stages');
+
+  // Feature toggles state
+  const [champEnabled, setChampEnabled] = useState(championEnabled);
+  const [specialConfig, setSpecialConfig] = useState<Record<string, boolean>>(specialPredictionsConfig);
+  const [specialPoints, setSpecialPoints] = useState<Record<string, number>>(specialPredictionsPoints);
+  const [champPoints, setChampPoints] = useState(championPoints);
+
+  const { toast } = useToast();
+  const removeMember = useRemoveMember();
+  const toggleClose = useToggleBolaoClose();
+  const updateScoring = useUpdateBolaoScoring();
+  const updateTheme = useUpdateBolaoTheme();
+  const uploadLogo = useUploadBolaoLogo();
+  const updateSettings = useUpdateBolaoSettings();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  if (currentUserId !== ownerUserId) return null;
+
+  const handleRemove = (userId: string, userName: string) => {
+    if (confirmRemove !== userId) {
+      setConfirmRemove(userId);
+      return;
+    }
+    removeMember.mutate(
+      { bolaoId, userId },
+      {
+        onSuccess: () => {
+          toast({ title: `${userName} removido do bolão` });
+          setConfirmRemove(null);
+        },
+        onError: (err: any) => {
+          toast({ title: 'Erro', description: err.message, variant: 'destructive' });
+          setConfirmRemove(null);
+        },
+      }
+    );
+  };
+
+  const handleToggleClose = () => {
+    toggleClose.mutate(bolaoId, {
+      onSuccess: (result) => {
+        toast({ title: result.is_closed ? 'Inscrições encerradas' : 'Inscrições reabertas' });
+      },
+      onError: (err: any) => {
+        toast({ title: 'Erro', description: err.message, variant: 'destructive' });
+      },
+    });
+  };
+
+  const handleApplyPreset = (preset: typeof SCORING_PRESETS[number]) => {
+    setCustomResult(preset.result);
+    setCustomExact(preset.exact);
+    setUseWeighted(preset.weighted);
+  };
+
+  const handleSaveScoring = () => {
+    const preset = useWeighted ? 'weighted_stages' : 'custom';
+    updateScoring.mutate(
+      {
+        bolaoId,
+        preset,
+        scoringResult: customResult,
+        scoringExact: customExact,
+      },
+      {
+        onSuccess: (res) => {
+          toast({ title: `Pontuação atualizada: ${res.scoring_result}pt / ${res.scoring_exact}pts` });
+        },
+        onError: (err: any) => {
+          toast({ title: 'Erro', description: err.message, variant: 'destructive' });
+        },
+      }
+    );
+  };
+
+  const handleToggleChampion = () => {
+    const newVal = !champEnabled;
+    setChampEnabled(newVal);
+    updateSettings.mutate(
+      { bolaoId, settings: { champion_enabled: newVal } },
+      {
+        onSuccess: () => toast({ title: newVal ? 'Palpite de campeão habilitado' : 'Palpite de campeão desabilitado' }),
+        onError: (err: any) => {
+          setChampEnabled(!newVal);
+          toast({ title: 'Erro', description: err.message, variant: 'destructive' });
+        },
+      }
+    );
+  };
+
+  const handleToggleSpecialType = (type: string) => {
+    const newConfig = { ...specialConfig, [type]: !specialConfig[type] };
+    const prevConfig = { ...specialConfig };
+    setSpecialConfig(newConfig);
+    const anyEnabled = Object.values(newConfig).some(Boolean);
+    updateSettings.mutate(
+      { bolaoId, settings: { special_predictions_config: newConfig, special_predictions_enabled: anyEnabled } },
+      {
+        onSuccess: () => toast({ title: newConfig[type] ? `${SPECIAL_TYPES[type]} habilitado` : `${SPECIAL_TYPES[type]} desabilitado` }),
+        onError: (err: any) => {
+          setSpecialConfig(prevConfig);
+          toast({ title: 'Erro', description: err.message, variant: 'destructive' });
+        },
+      }
+    );
+  };
+
+  const handleSaveChampionPoints = () => {
+    updateSettings.mutate(
+      { bolaoId, settings: { champion_points: champPoints } },
+      {
+        onSuccess: () => toast({ title: `Pontos do campeão: ${champPoints}pts` }),
+        onError: (err: any) => toast({ title: 'Erro', description: err.message, variant: 'destructive' }),
+      }
+    );
+  };
+
+  const handleColorChange = (color: string) => {
+    const finalColor = color === 'default' ? null : color;
+    updateTheme.mutate(
+      { bolaoId, color: finalColor ?? undefined },
+      {
+        onSuccess: () => toast({ title: 'Cor atualizada!' }),
+        onError: (err: any) => toast({ title: 'Erro', description: err.message, variant: 'destructive' }),
+      }
+    );
+  };
+
+  const handleLogoFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 2 * 1024 * 1024) {
+      toast({ title: 'Arquivo muito grande', description: 'Máximo 2MB', variant: 'destructive' });
+      return;
+    }
+    uploadLogo.mutate(
+      { bolaoId, file },
+      {
+        onSuccess: (logoUrl) => {
+          updateTheme.mutate(
+            { bolaoId, logoUrl },
+            {
+              onSuccess: () => toast({ title: 'Logo atualizado!' }),
+              onError: (err: any) => toast({ title: 'Erro', description: err.message, variant: 'destructive' }),
+            }
+          );
+        },
+        onError: (err: any) => toast({ title: 'Erro no upload', description: err.message, variant: 'destructive' }),
+      }
+    );
+    e.target.value = '';
+  };
+
+  const handleRemoveLogo = () => {
+    updateTheme.mutate(
+      { bolaoId, logoUrl: '' },
+      {
+        onSuccess: () => toast({ title: 'Logo removido' }),
+        onError: (err: any) => toast({ title: 'Erro', description: err.message, variant: 'destructive' }),
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-terminal-bg border-terminal-border max-w-lg max-h-[85vh] overflow-y-auto minimal-scrollbar p-0">
+        <DialogHeader className="px-5 pt-5 pb-0">
+          <DialogTitle className="flex items-center gap-2 text-terminal-text">
+            <Shield className="w-5 h-5 text-terminal-blue" />
+            Configurações do Bolão
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="px-5 pb-5 pt-4 space-y-5">
+
+          {/* ── Inscrições ── */}
+          <div className="flex items-center justify-between gap-3">
+            <div>
+              <p className="text-sm font-medium">
+                {isClosed ? 'Inscrições encerradas' : 'Inscrições abertas'}
+              </p>
+              <p className="text-xs opacity-50 mt-0.5">
+                {isClosed
+                  ? 'Ninguém mais pode entrar no bolão'
+                  : 'Qualquer um com o código pode entrar'}
+              </p>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleToggleClose}
+              disabled={toggleClose.isPending}
+              className={`shrink-0 gap-1.5 text-xs ${
+                isClosed
+                  ? 'border-terminal-green/40 text-terminal-green hover:bg-terminal-green/10'
+                  : 'border-terminal-red/40 text-terminal-red/80 hover:bg-terminal-red/10'
+              }`}
+            >
+              {isClosed ? (
+                <><Unlock className="w-3 h-3" /> Reabrir</>
+              ) : (
+                <><Lock className="w-3 h-3" /> Encerrar</>
+              )}
+            </Button>
+          </div>
+
+          {/* ── Features do Bolão ── */}
+          <div className="border-t border-terminal-border-subtle pt-4">
+            <div className="flex items-center gap-2 mb-3">
+              <Star className="w-3.5 h-3.5 opacity-50" />
+              <p className="text-xs font-bold uppercase tracking-wider opacity-50">Modalidades</p>
+            </div>
+
+            <div className="space-y-3">
+              {/* Champion toggle + points inline */}
+              <div className="rounded border border-terminal-border-subtle p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Trophy className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
+                    <p className="text-xs font-medium">Palpite de Campeão</p>
+                  </div>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <input
+                      type="number"
+                      min={1} max={50}
+                      value={champPoints}
+                      onChange={(e) => setChampPoints(Number(e.target.value))}
+                      disabled={!champEnabled}
+                      className="w-10 text-center text-[11px] font-bold bg-terminal-dark-gray border border-terminal-border rounded py-0.5 focus:border-terminal-blue focus:outline-none disabled:opacity-20"
+                    />
+                    <span className="text-[9px] opacity-30 w-5">pts</span>
+                    <button onClick={handleToggleChampion} className="shrink-0">
+                      {champEnabled ? (
+                        <ToggleRight className="w-6 h-6 text-terminal-blue" />
+                      ) : (
+                        <ToggleLeft className="w-6 h-6 opacity-30" />
+                      )}
+                    </button>
+                  </div>
+                </div>
+                {champPoints !== championPoints && champEnabled && (
+                  <button
+                    onClick={handleSaveChampionPoints}
+                    disabled={updateSettings.isPending}
+                    className="w-full text-[10px] text-terminal-blue hover:underline disabled:opacity-30 mt-2"
+                  >
+                    Salvar pontuação
+                  </button>
+                )}
+              </div>
+
+              {/* Special predictions — collapsible individual toggles */}
+              <div className="rounded border border-terminal-border-subtle overflow-hidden">
+                <button
+                  type="button"
+                  onClick={() => setSpecialExpanded(!specialExpanded)}
+                  className="w-full flex items-center justify-between gap-3 p-3 hover:bg-terminal-dark-gray/20 transition-colors"
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <Star className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
+                    <div className="min-w-0">
+                      <p className="text-xs font-medium">Palpites Especiais</p>
+                      <p className="text-[10px] opacity-40">
+                        {Object.values(specialConfig).filter(Boolean).length} de {Object.keys(specialConfig).length} habilitados
+                      </p>
+                    </div>
+                  </div>
+                  <ChevronDown className={`w-3.5 h-3.5 opacity-30 transition-transform ${specialExpanded ? 'rotate-180' : ''}`} />
+                </button>
+                {specialExpanded && (
+                  <div className="border-t border-terminal-border-subtle px-3 pb-3 pt-2 space-y-2.5">
+                    {Object.entries(SPECIAL_TYPES).map(([type, label]) => (
+                      <div key={type} className="flex items-center justify-between gap-2 pl-5">
+                        <p className="text-[11px] flex-1 min-w-0">{label}</p>
+                        <div className="flex items-center gap-1.5 shrink-0">
+                          <input
+                            type="number"
+                            min={1} max={50}
+                            value={specialPoints[type] ?? 0}
+                            onChange={(e) => setSpecialPoints({ ...specialPoints, [type]: Number(e.target.value) })}
+                            disabled={!specialConfig[type]}
+                            className="w-10 text-center text-[11px] font-bold bg-terminal-dark-gray border border-terminal-border rounded py-0.5 focus:border-terminal-blue focus:outline-none disabled:opacity-20"
+                          />
+                          <span className="text-[9px] opacity-30 w-5">pts</span>
+                          <button onClick={() => handleToggleSpecialType(type)} className="shrink-0">
+                            {specialConfig[type] ? (
+                              <ToggleRight className="w-6 h-6 text-terminal-blue" />
+                            ) : (
+                              <ToggleLeft className="w-6 h-6 opacity-30" />
+                            )}
+                          </button>
+                        </div>
+                      </div>
+                    ))}
+                    {JSON.stringify(specialPoints) !== JSON.stringify(specialPredictionsPoints) && (
+                      <button
+                        onClick={() => {
+                          updateSettings.mutate(
+                            { bolaoId, settings: { special_predictions_points: specialPoints } },
+                            {
+                              onSuccess: () => toast({ title: 'Pontuação dos palpites especiais atualizada' }),
+                              onError: (err: any) => toast({ title: 'Erro', description: err.message, variant: 'destructive' }),
+                            }
+                          );
+                        }}
+                        disabled={updateSettings.isPending}
+                        className="w-full text-[10px] text-terminal-blue hover:underline disabled:opacity-30 pt-1"
+                      >
+                        Salvar pontuação
+                      </button>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* ── Pontuação ── */}
+          <div className="border-t border-terminal-border-subtle pt-4">
+            <div className="flex items-center gap-2 mb-3">
+              <SlidersHorizontal className="w-3.5 h-3.5 opacity-50" />
+              <p className="text-xs font-bold uppercase tracking-wider opacity-50">Pontuação</p>
+              {!isPremium && (
+                <span className="text-[9px] px-1.5 py-0.5 bg-yellow-500/20 text-yellow-400 rounded font-bold ml-auto">
+                  PREMIUM
+                </span>
+              )}
+            </div>
+
+            {isPremium ? (
+              <div className="space-y-4">
+                {/* Quick presets */}
+                <div>
+                  <p className="text-[10px] opacity-40 mb-2">Presets rápidos</p>
+                  <div className="flex gap-1.5">
+                    {SCORING_PRESETS.map((p) => (
+                      <button
+                        key={p.value}
+                        onClick={() => handleApplyPreset(p)}
+                        className={`px-3 py-1.5 rounded border text-[10px] font-medium transition-all ${
+                          customResult === p.result && customExact === p.exact && useWeighted === p.weighted
+                            ? 'border-terminal-blue bg-terminal-blue/10 text-terminal-blue'
+                            : 'border-terminal-border-subtle opacity-50 hover:opacity-80'
+                        }`}
+                      >
+                        {p.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Editable values */}
+                <div className="p-3 rounded border border-terminal-border-subtle bg-terminal-dark-gray/20 space-y-3">
+                  <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-2 flex-1">
+                      <label className="text-[10px] opacity-50 shrink-0">Acertar resultado</label>
+                      <input
+                        type="number"
+                        min={1} max={10}
+                        value={customResult}
+                        onChange={(e) => setCustomResult(Number(e.target.value))}
+                        className="w-14 text-center text-sm font-bold bg-terminal-dark-gray border border-terminal-border rounded py-1 focus:border-terminal-blue focus:outline-none"
+                      />
+                      <span className="text-[10px] opacity-30">pts</span>
+                    </div>
+                    <div className="flex items-center gap-2 flex-1">
+                      <label className="text-[10px] opacity-50 shrink-0">Placar exato</label>
+                      <input
+                        type="number"
+                        min={1} max={20}
+                        value={customExact}
+                        onChange={(e) => setCustomExact(Number(e.target.value))}
+                        className="w-14 text-center text-sm font-bold bg-terminal-dark-gray border border-terminal-border rounded py-1 focus:border-terminal-blue focus:outline-none"
+                      />
+                      <span className="text-[10px] opacity-30">pts</span>
+                    </div>
+                  </div>
+
+                  {/* Weighted stages toggle */}
+                  <div className="flex items-center justify-between gap-3 pt-2 border-t border-terminal-border-subtle">
+                    <div>
+                      <p className="text-xs font-medium">Multiplicador por fase</p>
+                      <p className="text-[10px] opacity-40">Mata-mata vale mais pontos</p>
+                    </div>
+                    <button onClick={() => setUseWeighted(!useWeighted)} className="shrink-0">
+                      {useWeighted ? (
+                        <ToggleRight className="w-7 h-7 text-terminal-blue" />
+                      ) : (
+                        <ToggleLeft className="w-7 h-7 opacity-30" />
+                      )}
+                    </button>
+                  </div>
+
+                  {useWeighted && (
+                    <div className="text-[10px] opacity-50 space-y-0.5 pl-1">
+                      <p>Grupos: 1× · R32/R16: 1.5× · Quartas: 2×</p>
+                      <p>Semis: 3× · 3º lugar: 2× · Final: 5×</p>
+                    </div>
+                  )}
+                </div>
+
+                <Button
+                  size="sm"
+                  onClick={handleSaveScoring}
+                  disabled={updateScoring.isPending}
+                  className="w-full bg-terminal-blue/20 text-terminal-blue border border-terminal-blue/30 hover:bg-terminal-blue/30 text-xs h-8"
+                >
+                  {updateScoring.isPending ? 'Salvando...' : 'Salvar pontuação'}
+                </Button>
+              </div>
+            ) : (
+              <div className="p-3 rounded border border-terminal-border-subtle bg-terminal-dark-gray/10 opacity-50">
+                <p className="text-xs">Pontuação padrão: {scoringResult}pt resultado / {scoringExact}pts placar exato</p>
+                <p className="text-[10px] opacity-50 mt-1">Personalização disponível no Premium</p>
+              </div>
+            )}
+          </div>
+
+          {/* ── Cor do bolão ── */}
+          <div className="border-t border-terminal-border-subtle pt-4">
+            <div className="flex items-center gap-2 mb-3">
+              <Palette className="w-3.5 h-3.5 opacity-50" />
+              <p className="text-xs font-bold uppercase tracking-wider opacity-50">Cor do bolão</p>
+              {!isPremium && (
+                <span className="text-[9px] px-1.5 py-0.5 bg-yellow-500/20 text-yellow-400 rounded font-bold ml-auto">
+                  PREMIUM
+                </span>
+              )}
+            </div>
+
+            {isPremium ? (
+              <div className="grid grid-cols-4 gap-1.5">
+                {THEME_COLORS.map((c) => {
+                  const isActive = customColor === c.value || (c.value === 'default' && !customColor);
+                  return (
+                    <button
+                      key={c.value}
+                      onClick={() => handleColorChange(c.value)}
+                      disabled={updateTheme.isPending}
+                      className={`flex flex-col items-center gap-1 p-2 rounded border transition-all ${
+                        isActive ? 'border-terminal-green' : 'border-terminal-border-subtle hover:border-terminal-border'
+                      }`}
+                    >
+                      <div className={`w-6 h-6 rounded border ${c.bg} ${c.border}`} />
+                      <span className={`text-[9px] ${isActive ? 'text-terminal-green font-bold' : 'opacity-40'}`}>
+                        {c.label}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="grid grid-cols-4 gap-1.5 opacity-30 pointer-events-none">
+                {THEME_COLORS.map((c) => (
+                  <div key={c.value} className="flex flex-col items-center gap-1 p-2 rounded border border-terminal-border-subtle">
+                    <div className={`w-6 h-6 rounded border ${c.bg} ${c.border}`} />
+                    <span className="text-[9px] opacity-40">{c.label}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* ── Logo do bolão ── */}
+          <div className="border-t border-terminal-border-subtle pt-4">
+            <div className="flex items-center gap-2 mb-3">
+              <ImagePlus className="w-3.5 h-3.5 opacity-50" />
+              <p className="text-xs font-bold uppercase tracking-wider opacity-50">Logo do bolão</p>
+              {!isPremium && (
+                <span className="text-[9px] px-1.5 py-0.5 bg-yellow-500/20 text-yellow-400 rounded font-bold ml-auto">
+                  PREMIUM
+                </span>
+              )}
+            </div>
+
+            {isPremium ? (
+              <div className="flex items-center gap-3">
+                {customBannerUrl ? (
+                  <>
+                    <img
+                      src={customBannerUrl}
+                      alt="Logo"
+                      className="w-12 h-12 rounded border border-terminal-border object-cover shrink-0"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[10px] opacity-50 truncate">{customBannerUrl.split('/').pop()}</p>
+                    </div>
+                    <button
+                      onClick={handleRemoveLogo}
+                      disabled={updateTheme.isPending}
+                      className="shrink-0 p-1.5 rounded border border-terminal-border-subtle hover:border-terminal-red/40 hover:text-terminal-red transition-colors opacity-50 hover:opacity-100"
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={uploadLogo.isPending || updateTheme.isPending}
+                    className="flex items-center gap-2 px-3 py-2 rounded border border-dashed border-terminal-border hover:border-terminal-blue/50 transition-colors text-xs opacity-60 hover:opacity-100 w-full justify-center"
+                  >
+                    <ImagePlus className="w-3.5 h-3.5" />
+                    {uploadLogo.isPending ? 'Enviando...' : 'Escolher imagem (JPG/PNG, max 2MB)'}
+                  </button>
+                )}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/jpeg,image/png,image/webp"
+                  className="hidden"
+                  onChange={handleLogoFileChange}
+                />
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 p-3 rounded border border-dashed border-terminal-border-subtle opacity-30 pointer-events-none">
+                <ImagePlus className="w-3.5 h-3.5" />
+                <span className="text-xs">Upload disponível no Premium</span>
+              </div>
+            )}
+          </div>
+
+          {/* ── Participantes ── */}
+          <div className="border-t border-terminal-border-subtle pt-4">
+            <div className="flex items-center gap-2 mb-3">
+              <Users className="w-3.5 h-3.5 opacity-50" />
+              <p className="text-xs font-bold uppercase tracking-wider opacity-50">Participantes</p>
+              <span className="text-[10px] opacity-30 ml-auto">{ranking.length}</span>
+            </div>
+            <div className="space-y-1.5 max-h-48 overflow-y-auto minimal-scrollbar">
+              {ranking.map((member) => {
+                const isOwner = member.user_id === ownerUserId;
+                const isConfirming = confirmRemove === member.user_id;
+                return (
+                  <div
+                    key={member.user_id}
+                    className="flex items-center gap-3 py-2 px-3 rounded border border-terminal-border-subtle bg-terminal-dark-gray/20"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        {member.user_name || member.user_email}
+                      </p>
+                      <p className="text-[10px] opacity-40">
+                        {member.total_points} pts · {member.total_predictions} palpites
+                      </p>
+                    </div>
+                    {isOwner ? (
+                      <span className="text-[10px] text-terminal-green font-bold shrink-0">Criador</span>
+                    ) : (
+                      <button
+                        onClick={() => handleRemove(member.user_id, member.user_name || member.user_email)}
+                        disabled={removeMember.isPending}
+                        className={`shrink-0 flex items-center gap-1 text-[10px] font-bold transition-colors px-2 py-1 rounded border ${
+                          isConfirming
+                            ? 'border-terminal-red/60 text-terminal-red bg-terminal-red/10'
+                            : 'border-terminal-border opacity-50 hover:opacity-80 hover:border-terminal-red/40 hover:text-terminal-red'
+                        }`}
+                      >
+                        {isConfirming ? (
+                          <><AlertTriangle className="w-2.5 h-2.5" /> Confirmar</>
+                        ) : (
+                          <><UserX className="w-2.5 h-2.5" /> Remover</>
+                        )}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/bolao/BolaoRankingTable.tsx
+++ b/src/components/bolao/BolaoRankingTable.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { Trophy, Target, Crosshair } from 'lucide-react';
+import type { BolaoRankingEntry } from '@/services/bolao.service';
+
+interface BolaoRankingTableProps {
+  ranking: BolaoRankingEntry[];
+  currentUserId?: string;
+}
+
+function getRankBadge(rank: number) {
+  if (rank === 1) return '🥇';
+  if (rank === 2) return '🥈';
+  if (rank === 3) return '🥉';
+  return `${rank}º`;
+}
+
+export const BolaoRankingTable: React.FC<BolaoRankingTableProps> = ({
+  ranking,
+  currentUserId,
+}) => {
+  if (ranking.length === 0) {
+    return (
+      <div className="text-center py-8 opacity-50">
+        <Trophy className="w-10 h-10 mx-auto mb-2 opacity-30" />
+        <p className="text-sm">Nenhum participante ainda</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Header */}
+      <div className="grid grid-cols-[40px_1fr_60px_50px_50px] md:grid-cols-[50px_1fr_80px_70px_70px] gap-2 px-3 py-2 text-[10px] uppercase opacity-50 font-bold">
+        <div>#</div>
+        <div>Jogador</div>
+        <div className="text-center">Pts</div>
+        <div className="text-center hidden md:block">
+          <Crosshair className="w-3 h-3 mx-auto" title="Placares exatos" />
+        </div>
+        <div className="text-center hidden md:block">
+          <Target className="w-3 h-3 mx-auto" title="Resultados corretos" />
+        </div>
+      </div>
+
+      {/* Rows */}
+      {ranking.map((entry) => {
+        const isCurrentUser = entry.user_id === currentUserId;
+        return (
+          <div
+            key={entry.user_id}
+            className={`grid grid-cols-[40px_1fr_60px_50px_50px] md:grid-cols-[50px_1fr_80px_70px_70px] gap-2 px-3 py-3 rounded transition-colors ${
+              isCurrentUser
+                ? 'bg-terminal-green/10 border border-terminal-green/30'
+                : 'bg-terminal-dark-gray/30 border border-terminal-border-subtle hover:bg-terminal-dark-gray/50'
+            }`}
+          >
+            <div className="flex items-center text-sm font-bold">
+              {getRankBadge(Number(entry.rank))}
+            </div>
+            <div className="flex items-center">
+              <span className={`text-sm font-medium truncate ${isCurrentUser ? 'text-terminal-green' : ''}`}>
+                {entry.user_name}
+                {isCurrentUser && <span className="text-[10px] opacity-50 ml-1">(você)</span>}
+              </span>
+            </div>
+            <div className="flex items-center justify-center">
+              <span className="text-sm font-bold text-terminal-green">{entry.total_points}</span>
+            </div>
+            <div className="hidden md:flex items-center justify-center">
+              <span className="text-xs opacity-70">{entry.exact_scores}</span>
+            </div>
+            <div className="hidden md:flex items-center justify-center">
+              <span className="text-xs opacity-70">{entry.correct_results}</span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/bolao/BolaoShareButton.tsx
+++ b/src/components/bolao/BolaoShareButton.tsx
@@ -1,0 +1,165 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Share2, Copy, Check, MessageCircle, Send } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface BolaoShareButtonProps {
+  bolaoName: string;
+  inviteCode: string;
+  variant?: 'default' | 'icon' | 'compact';
+}
+
+export const BolaoShareButton: React.FC<BolaoShareButtonProps> = ({
+  bolaoName,
+  inviteCode,
+  variant = 'default',
+}) => {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const inviteUrl = `${window.location.origin}/bolao/entrar/${inviteCode}`;
+  const shareText = `Participe do bolão "${bolaoName}" da Copa do Mundo 2026!\n${inviteUrl}`;
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+    } catch {
+      const ta = document.createElement('textarea');
+      ta.value = inviteUrl;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+    setCopied(true);
+    setTimeout(() => {
+      setCopied(false);
+      setOpen(false);
+    }, 1800);
+  };
+
+  const handleWhatsApp = () => {
+    window.open(
+      `https://wa.me/?text=${encodeURIComponent(shareText)}`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+    setOpen(false);
+  };
+
+  const handleTelegram = () => {
+    window.open(
+      `https://t.me/share/url?url=${encodeURIComponent(inviteUrl)}&text=${encodeURIComponent(`Participe do bolão "${bolaoName}" da Copa do Mundo 2026!`)}`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+    setOpen(false);
+  };
+
+  const trigger =
+    variant === 'icon' ? (
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        onClick={() => setOpen((v) => !v)}
+        className="h-8 w-8 text-terminal-text hover:text-terminal-blue"
+        title="Compartilhar"
+      >
+        <Share2 className="h-4 w-4" />
+      </Button>
+    ) : variant === 'compact' ? (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => setOpen((v) => !v)}
+        className="gap-1.5 text-xs opacity-60 hover:opacity-100 h-8"
+      >
+        <Share2 className="w-3.5 h-3.5" />
+        Compartilhar
+      </Button>
+    ) : (
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => setOpen((v) => !v)}
+        className="border-terminal-green/50 text-terminal-green hover:bg-terminal-green/10 gap-2"
+      >
+        <Share2 className="w-4 h-4" />
+        Convidar amigos
+      </Button>
+    );
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      {trigger}
+
+      {open && (
+        <div className="absolute right-0 top-full mt-2 z-50 w-64 rounded-lg border border-terminal-border bg-terminal-dark-gray shadow-xl overflow-hidden">
+          {/* Header */}
+          <div className="px-4 py-3 border-b border-terminal-border-subtle">
+            <p className="text-[11px] font-semibold uppercase tracking-wider opacity-50">
+              Convidar para o bolão
+            </p>
+            <p className="text-xs font-mono text-terminal-blue mt-0.5 truncate">{inviteUrl}</p>
+          </div>
+
+          {/* Actions */}
+          <div className="p-2 flex flex-col gap-1">
+            {/* Copy link */}
+            <button
+              onClick={handleCopy}
+              className="flex items-center gap-3 px-3 py-2.5 rounded hover:bg-terminal-gray/40 transition-colors w-full text-left"
+            >
+              <div className="w-8 h-8 rounded bg-terminal-gray/40 flex items-center justify-center shrink-0">
+                {copied ? (
+                  <Check className="w-4 h-4 text-terminal-green" />
+                ) : (
+                  <Copy className="w-4 h-4 text-terminal-text" />
+                )}
+              </div>
+              <span className="text-sm font-medium">
+                {copied ? 'Copiado!' : 'Copiar link'}
+              </span>
+            </button>
+
+            {/* WhatsApp */}
+            <button
+              onClick={handleWhatsApp}
+              className="flex items-center gap-3 px-3 py-2.5 rounded hover:bg-terminal-gray/40 transition-colors w-full text-left"
+            >
+              <div className="w-8 h-8 rounded bg-[#25D366]/10 flex items-center justify-center shrink-0">
+                <MessageCircle className="w-4 h-4 text-[#25D366]" />
+              </div>
+              <span className="text-sm font-medium">WhatsApp</span>
+            </button>
+
+            {/* Telegram */}
+            <button
+              onClick={handleTelegram}
+              className="flex items-center gap-3 px-3 py-2.5 rounded hover:bg-terminal-gray/40 transition-colors w-full text-left"
+            >
+              <div className="w-8 h-8 rounded bg-[#229ED9]/10 flex items-center justify-center shrink-0">
+                <Send className="w-4 h-4 text-[#229ED9]" />
+              </div>
+              <span className="text-sm font-medium">Telegram</span>
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/bolao/BolaoStatsPanel.tsx
+++ b/src/components/bolao/BolaoStatsPanel.tsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import {
+  BarChart3,
+  Target,
+  Trophy,
+  Users,
+  Zap,
+  CheckCircle,
+  Star,
+  Flame,
+  Crown,
+  Lock,
+} from 'lucide-react';
+import { useBolaoStats, useBolaoRoundRanking } from '@/hooks/use-bolao';
+import { BolaoRankingTable } from './BolaoRankingTable';
+
+const STAGES = [
+  { key: 'group',        label: 'Fase de Grupos' },
+  { key: 'round_of_32',  label: 'R32' },
+  { key: 'round_of_16',  label: 'Oitavas' },
+  { key: 'quarter',      label: 'Quartas' },
+  { key: 'semi',         label: 'Semifinal' },
+  { key: 'final',        label: 'Final' },
+] as const;
+
+interface Props {
+  bolaoId: string;
+  currentUserId: string | undefined;
+  isPremium: boolean;
+}
+
+function StatCard({ icon, label, value, sub }: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  sub?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 p-3 rounded border border-terminal-border-subtle bg-terminal-dark-gray/20">
+      <div className="opacity-50 shrink-0">{icon}</div>
+      <div className="min-w-0">
+        <p className="text-[10px] opacity-40 uppercase tracking-wider">{label}</p>
+        <p className="text-lg font-bold leading-tight tabular-nums">{value}</p>
+        {sub && <p className="text-[10px] opacity-40">{sub}</p>}
+      </div>
+    </div>
+  );
+}
+
+function DestaqueBadge({ icon, label, name, value }: {
+  icon: React.ReactNode;
+  label: string;
+  name: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-center gap-3 p-3 rounded border border-terminal-border-subtle bg-terminal-dark-gray/20">
+      <div className="shrink-0 text-terminal-blue opacity-70">{icon}</div>
+      <div className="flex-1 min-w-0">
+        <p className="text-[10px] opacity-40 uppercase tracking-wider">{label}</p>
+        <p className="text-sm font-bold truncate">{name}</p>
+      </div>
+      <span className="shrink-0 text-xs font-bold text-terminal-blue tabular-nums">{value}</span>
+    </div>
+  );
+}
+
+export const BolaoStatsPanel: React.FC<Props> = ({ bolaoId, currentUserId, isPremium }) => {
+  const [activeStage, setActiveStage] = React.useState<string | undefined>(undefined);
+  const { data: stats, isLoading: loadingStats } = useBolaoStats(bolaoId, isPremium);
+  const { data: roundRanking, isLoading: loadingRound } = useBolaoRoundRanking(
+    isPremium ? bolaoId : undefined,
+    activeStage
+  );
+
+  // ── Premium gate ──────────────────────────────────────────────────
+  if (!isPremium) {
+    return (
+      <div className="terminal-container p-8 text-center border-terminal-border-subtle/50">
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-12 h-12 rounded-full border border-yellow-500/30 bg-yellow-500/10 flex items-center justify-center">
+            <Lock className="w-5 h-5 text-yellow-400" />
+          </div>
+          <div>
+            <p className="text-sm font-bold text-yellow-400">Estatísticas — Bolão PRO</p>
+            <p className="text-xs opacity-50 mt-1">
+              Acerto geral, ranking por fase e destaques automáticos disponíveis no PRO
+            </p>
+          </div>
+          <div className="flex gap-2 flex-wrap justify-center mt-1">
+            {['% Acerto', 'Top scorer', 'Ranking por fase', 'Destaques'].map((f) => (
+              <span key={f} className="text-[10px] px-2 py-0.5 rounded border border-yellow-500/20 bg-yellow-500/5 text-yellow-400/70">
+                {f}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (loadingStats) {
+    return (
+      <div className="space-y-3">
+        {[1, 2].map((i) => (
+          <div key={i} className="h-20 rounded border border-terminal-border animate-pulse bg-terminal-dark-gray/30" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!stats) {
+    return (
+      <div className="text-center py-8 opacity-40">
+        <BarChart3 className="w-8 h-8 mx-auto mb-2" />
+        <p className="text-sm">Estatísticas disponíveis após os primeiros jogos</p>
+      </div>
+    );
+  }
+
+  const totalPossible = stats.finished_games > 0
+    ? `de ${stats.finished_games} jogos encerrados`
+    : 'nenhum jogo encerrado';
+
+  const accuracy = stats.total_predictions > 0
+    ? Math.round(((stats.exact_scores + stats.correct_results) / stats.total_predictions) * 100)
+    : 0;
+
+  // Compute destaques from general ranking (activeStage === undefined)
+  const generalRanking = activeStage === undefined ? (roundRanking ?? []) : [];
+  const topScorer    = generalRanking.reduce<typeof generalRanking[0] | null>((best, m) =>
+    !best || m.total_points > best.total_points ? m : best, null);
+  const topExact     = generalRanking.reduce<typeof generalRanking[0] | null>((best, m) =>
+    !best || m.exact_scores > best.exact_scores ? m : best, null);
+  const topEngaged   = generalRanking.reduce<typeof generalRanking[0] | null>((best, m) =>
+    !best || m.total_predictions > best.total_predictions ? m : best, null);
+
+  const hasDestaques = generalRanking.length > 1 && stats.finished_games > 0;
+
+  return (
+    <div className="space-y-5">
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 gap-2">
+        <StatCard
+          icon={<Users className="w-4 h-4" />}
+          label="Participantes"
+          value={stats.total_members}
+        />
+        <StatCard
+          icon={<Zap className="w-4 h-4" />}
+          label="Palpites"
+          value={stats.total_predictions}
+          sub={totalPossible}
+        />
+        <StatCard
+          icon={<Target className="w-4 h-4" />}
+          label="Placares exatos"
+          value={stats.exact_scores}
+        />
+        <StatCard
+          icon={<CheckCircle className="w-4 h-4" />}
+          label="Resultados certos"
+          value={stats.correct_results}
+        />
+        <StatCard
+          icon={<BarChart3 className="w-4 h-4" />}
+          label="% acerto geral"
+          value={`${accuracy}%`}
+        />
+        {stats.top_team_champion && (
+          <StatCard
+            icon={<Trophy className="w-4 h-4" />}
+            label="Favorito ao título"
+            value={stats.top_team_champion}
+            sub={`${stats.champion_pick_count} palpites`}
+          />
+        )}
+      </div>
+
+      {/* Destaques automáticos */}
+      {hasDestaques && (
+        <div>
+          <p className="text-[10px] uppercase font-bold tracking-wider opacity-40 mb-3">Destaques</p>
+          <div className="space-y-2">
+            {topScorer && topScorer.total_points > 0 && (
+              <DestaqueBadge
+                icon={<Crown className="w-4 h-4" />}
+                label="Líder"
+                name={topScorer.user_name || topScorer.user_email.split('@')[0]}
+                value={`${topScorer.total_points} pts`}
+              />
+            )}
+            {topExact && topExact.exact_scores > 0 && (
+              <DestaqueBadge
+                icon={<Star className="w-4 h-4" />}
+                label="Mais placares exatos"
+                name={topExact.user_name || topExact.user_email.split('@')[0]}
+                value={`${topExact.exact_scores} exatos`}
+              />
+            )}
+            {topEngaged && topEngaged.total_predictions > 0 && (
+              <DestaqueBadge
+                icon={<Flame className="w-4 h-4" />}
+                label="Mais engajado"
+                name={topEngaged.user_name || topEngaged.user_email.split('@')[0]}
+                value={`${topEngaged.total_predictions} palpites`}
+              />
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Round ranking */}
+      <div>
+        <p className="text-[10px] uppercase font-bold tracking-wider opacity-40 mb-3">
+          Ranking por Fase
+        </p>
+
+        {/* Stage tabs */}
+        <div className="flex gap-1 flex-wrap mb-4">
+          <button
+            onClick={() => setActiveStage(undefined)}
+            className={`px-3 py-1 text-xs rounded border transition-colors shrink-0 ${
+              activeStage === undefined
+                ? 'border-terminal-green text-terminal-green bg-terminal-green/10'
+                : 'border-terminal-border opacity-50 hover:opacity-80'
+            }`}
+          >
+            Geral
+          </button>
+          {STAGES.filter((s) => stats.finished_games > 0 || s.key === 'group').map((s) => (
+            <button
+              key={s.key}
+              onClick={() => setActiveStage(s.key)}
+              className={`px-3 py-1 text-xs rounded border transition-colors shrink-0 ${
+                activeStage === s.key
+                  ? 'border-terminal-green text-terminal-green bg-terminal-green/10'
+                  : 'border-terminal-border opacity-50 hover:opacity-80'
+              }`}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+
+        {loadingRound ? (
+          <div className="h-32 rounded border border-terminal-border animate-pulse bg-terminal-dark-gray/30" />
+        ) : (
+          <>
+            {activeStage && (
+              <p className="text-[10px] opacity-40 mb-3 text-center">
+                Pontos acumulados apenas nos jogos da fase selecionada
+              </p>
+            )}
+            <BolaoRankingTable ranking={roundRanking || []} currentUserId={currentUserId} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/bolao/ChampionPickModal.tsx
+++ b/src/components/bolao/ChampionPickModal.tsx
@@ -1,0 +1,196 @@
+import React, { useState, useMemo } from 'react';
+import { Trophy, Search, Check, X } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import type { WcMatch } from '@/services/bolao.service';
+
+interface Team {
+  code: string;
+  name: string;
+}
+
+interface ChampionPickModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  matches: WcMatch[];
+  currentPick: string | null;
+  onConfirm: (teamCode: string) => void;
+  isLoading?: boolean;
+}
+
+function extractTeams(matches: WcMatch[]): Team[] {
+  const teamMap = new Map<string, string>();
+  for (const m of matches) {
+    if (m.home_team_code && m.home_team_code !== 'TBD') {
+      teamMap.set(m.home_team_code, m.home_team);
+    }
+    if (m.away_team_code && m.away_team_code !== 'TBD') {
+      teamMap.set(m.away_team_code, m.away_team);
+    }
+  }
+  return Array.from(teamMap.entries())
+    .map(([code, name]) => ({ code, name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export const ChampionPickModal: React.FC<ChampionPickModalProps> = ({
+  open,
+  onOpenChange,
+  matches,
+  currentPick,
+  onConfirm,
+  isLoading,
+}) => {
+  const [selected, setSelected] = useState<string | null>(currentPick);
+  const [search, setSearch] = useState('');
+
+  const teams = useMemo(() => extractTeams(matches), [matches]);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    if (!q) return teams;
+    return teams.filter(
+      (t) =>
+        t.name.toLowerCase().includes(q) ||
+        t.code.toLowerCase().includes(q)
+    );
+  }, [teams, search]);
+
+  const handleOpen = (v: boolean) => {
+    if (!v) setSearch('');
+    onOpenChange(v);
+  };
+
+  const handleConfirm = () => {
+    if (selected) {
+      onConfirm(selected);
+    }
+  };
+
+  // Sync with external currentPick when modal opens
+  React.useEffect(() => {
+    if (open) setSelected(currentPick);
+  }, [open, currentPick]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpen}>
+      <DialogContent className="bg-terminal-bg border-terminal-border max-w-lg p-0 overflow-hidden flex flex-col max-h-[90vh]">
+        <DialogHeader className="px-5 pt-5 pb-3 shrink-0">
+          <DialogTitle className="flex items-center gap-2 text-terminal-text">
+            <Trophy className="w-5 h-5 text-yellow-400" />
+            Palpite de Campeão
+          </DialogTitle>
+          <p className="text-xs opacity-50 mt-0.5">
+            Quem vai vencer a Copa do Mundo 2026?
+          </p>
+        </DialogHeader>
+
+        {/* Search */}
+        <div className="px-5 pb-3 shrink-0">
+          <div className="relative">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 opacity-40" />
+            <Input
+              placeholder="Buscar seleção..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="pl-8 h-8 text-xs bg-terminal-dark-gray border-terminal-border text-terminal-text"
+            />
+            {search && (
+              <button
+                onClick={() => setSearch('')}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 opacity-40 hover:opacity-70"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Team grid */}
+        <div className="flex-1 overflow-y-auto scrollbar-thin px-5 pb-3">
+          {filtered.length === 0 ? (
+            <p className="text-center text-xs opacity-40 py-8">
+              Nenhuma seleção encontrada
+            </p>
+          ) : (
+            <div className="grid grid-cols-3 gap-1.5">
+              {filtered.map((team) => {
+                const isSelected = selected === team.code;
+                return (
+                  <button
+                    key={team.code}
+                    onClick={() => setSelected(team.code)}
+                    className={`relative flex flex-col items-center gap-1.5 p-2.5 rounded border text-left transition-all ${
+                      isSelected
+                        ? 'border-yellow-500/60 bg-yellow-500/5'
+                        : 'border-terminal-border hover:border-terminal-border-subtle bg-terminal-dark-gray/30'
+                    }`}
+                  >
+                    {isSelected && (
+                      <div className="absolute top-1.5 right-1.5 w-3.5 h-3.5 rounded-full bg-yellow-500 flex items-center justify-center">
+                        <Check className="w-2 h-2 text-terminal-bg" />
+                      </div>
+                    )}
+                    {/* Flag placeholder */}
+                    <div className="w-8 h-5 rounded-sm bg-terminal-border-subtle/40 border border-terminal-border-subtle/30 shrink-0" />
+                    <div className="text-center w-full">
+                      <p
+                        className={`text-[11px] font-bold ${isSelected ? 'text-yellow-400' : 'text-terminal-text'}`}
+                      >
+                        {team.code}
+                      </p>
+                      <p className="text-[9px] opacity-50 leading-tight line-clamp-1">
+                        {team.name}
+                      </p>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-4 border-t border-terminal-border shrink-0 flex items-center justify-between gap-3">
+          {selected ? (
+            <p className="text-xs opacity-60 flex-1">
+              Selecionado:{' '}
+              <span className="font-bold text-yellow-400">
+                {teams.find((t) => t.code === selected)?.name ?? selected}
+              </span>
+            </p>
+          ) : (
+            <p className="text-xs opacity-40 flex-1">Nenhuma seleção escolhida</p>
+          )}
+          <div className="flex gap-2 shrink-0">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => handleOpen(false)}
+              className="text-terminal-text text-xs"
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={!selected || isLoading}
+              onClick={handleConfirm}
+              className="bg-yellow-500 text-terminal-bg hover:bg-yellow-500/90 text-xs gap-1.5"
+            >
+              <Trophy className="w-3 h-3" />
+              {isLoading ? 'Salvando...' : 'Confirmar'}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/bolao/CopaBracketModal.tsx
+++ b/src/components/bolao/CopaBracketModal.tsx
@@ -1,0 +1,399 @@
+import React, { useMemo, useState, useRef, useCallback } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useWcMatches } from '@/hooks/use-bolao';
+import { TeamFlag } from './TeamFlag';
+import { Plus, Minus, RotateCcw } from 'lucide-react';
+import type { WcMatch } from '@/services/bolao.service';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// ── Layout constants ──────────────────────────────────────────────
+const CARD_W = 128;
+const CARD_H = 40;
+const BASE_GAP = 4;
+const SLOT = CARD_H + BASE_GAP;
+const STAGE_GAP = 40;
+const STAGE_STEP = CARD_W + STAGE_GAP;
+const LABEL_H = 28;
+const R32_COUNT = 16;
+const TOTAL_H = R32_COUNT * SLOT + LABEL_H;
+const BRACKET_W = 5 * CARD_W + 4 * STAGE_GAP;
+
+const STAGES: { key: string; label: string; count: number }[] = [
+  { key: 'round_of_32', label: 'Rodada 32', count: 16 },
+  { key: 'round_of_16', label: 'Oitavas', count: 8 },
+  { key: 'quarter', label: 'Quartas', count: 4 },
+  { key: 'semi', label: 'Semis', count: 2 },
+  { key: 'final', label: 'Final', count: 1 },
+];
+
+function stageX(i: number) {
+  return i * STAGE_STEP;
+}
+function cardCenterY(stageIdx: number, cardIdx: number) {
+  const slotH = SLOT * Math.pow(2, stageIdx);
+  return LABEL_H + slotH / 2 + cardIdx * slotH;
+}
+
+// ── Match card ────────────────────────────────────────────────────
+function BracketMatchCard({
+  match,
+  style,
+}: {
+  match: WcMatch;
+  style: React.CSSProperties;
+}) {
+  const isTbd = match.home_team_code === 'TBD';
+  const homeWin =
+    match.is_finished &&
+    match.home_score != null &&
+    match.away_score != null &&
+    match.home_score > match.away_score;
+  const awayWin =
+    match.is_finished &&
+    match.home_score != null &&
+    match.away_score != null &&
+    match.away_score > match.home_score;
+
+  const dateStr = new Date(match.match_date + 'T00:00:00').toLocaleDateString(
+    'pt-BR',
+    { day: '2-digit', month: 'short' }
+  );
+  const timeStr = match.match_time_brasilia.slice(0, 5);
+
+  return (
+    <div
+      className={`absolute rounded border text-[10px] leading-tight overflow-hidden ${
+        match.is_finished
+          ? 'border-terminal-border bg-terminal-dark-gray/40'
+          : isTbd
+          ? 'border-terminal-border-subtle/40 bg-terminal-dark-gray/15'
+          : 'border-terminal-border bg-terminal-dark-gray/20'
+      }`}
+      style={{ ...style, width: CARD_W, height: CARD_H }}
+    >
+      <div
+        className={`flex items-center gap-1 px-1.5 h-1/2 ${
+          homeWin ? 'text-terminal-green font-bold' : isTbd ? 'opacity-40' : ''
+        }`}
+      >
+        <TeamFlag code={match.home_team_code} />
+        <span className="font-mono flex-1 truncate">{match.home_team_code}</span>
+        {match.is_finished ? (
+          <span className="tabular-nums">{match.home_score}</span>
+        ) : (
+          <span className="text-[8px] opacity-30 tabular-nums shrink-0">{dateStr}</span>
+        )}
+      </div>
+      <div className="border-t border-terminal-border-subtle/20" />
+      <div
+        className={`flex items-center gap-1 px-1.5 h-1/2 ${
+          awayWin ? 'text-terminal-green font-bold' : isTbd ? 'opacity-40' : ''
+        }`}
+      >
+        <TeamFlag code={match.away_team_code} />
+        <span className="font-mono flex-1 truncate">{match.away_team_code}</span>
+        {match.is_finished ? (
+          <span className="tabular-nums">{match.away_score}</span>
+        ) : (
+          <span className="text-[8px] opacity-30 tabular-nums shrink-0">{timeStr}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Modal ─────────────────────────────────────────────────────────
+export const CopaBracketModal: React.FC<Props> = ({ open, onOpenChange }) => {
+  const { data: matches } = useWcMatches();
+
+  // Zoom & pan state
+  const [zoom, setZoom] = useState(0.85);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const dragRef = useRef<{
+    startX: number;
+    startY: number;
+    panX: number;
+    panY: number;
+  } | null>(null);
+
+  const zoomIn = useCallback(() => setZoom((z) => Math.min(2, +(z + 0.15).toFixed(2))), []);
+  const zoomOut = useCallback(() => setZoom((z) => Math.max(0.3, +(z - 0.15).toFixed(2))), []);
+  const resetView = useCallback(() => {
+    setZoom(0.85);
+    setPan({ x: 0, y: 0 });
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      setIsDragging(true);
+      (e.target as HTMLElement).setPointerCapture(e.pointerId);
+      dragRef.current = {
+        startX: e.clientX,
+        startY: e.clientY,
+        panX: pan.x,
+        panY: pan.y,
+      };
+    },
+    [pan]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDragging || !dragRef.current) return;
+      const dx = e.clientX - dragRef.current.startX;
+      const dy = e.clientY - dragRef.current.startY;
+      setPan({
+        x: dragRef.current.panX + dx / zoom,
+        y: dragRef.current.panY + dy / zoom,
+      });
+    },
+    [isDragging, zoom]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    setIsDragging(false);
+    dragRef.current = null;
+  }, []);
+
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      const delta = e.deltaY > 0 ? -0.1 : 0.1;
+      setZoom((z) => Math.max(0.3, Math.min(2, +(z + delta).toFixed(2))));
+    },
+    []
+  );
+
+  const stageMatches = useMemo(() => {
+    if (!matches) return {} as Record<string, WcMatch[]>;
+    const byStage: Record<string, WcMatch[]> = {};
+    matches
+      .filter((m) => !m.group_name)
+      .forEach((m) => {
+        if (!byStage[m.stage]) byStage[m.stage] = [];
+        byStage[m.stage].push(m);
+      });
+    Object.values(byStage).forEach((arr) =>
+      arr.sort((a, b) => a.match_number - b.match_number)
+    );
+    return byStage;
+  }, [matches]);
+
+  const thirdPlace = stageMatches['third_place']?.[0];
+  const hasKnockout = Object.values(stageMatches).some(
+    (arr) => arr.length > 0
+  );
+
+  const connectorLines = useMemo(() => {
+    const lines: { x1: number; y1: number; x2: number; y2: number }[] = [];
+    for (let si = 0; si < STAGES.length - 1; si++) {
+      const count = STAGES[si].count;
+      const xStart = stageX(si) + CARD_W + 3;
+      const xEnd = stageX(si + 1) - 3;
+      const xMid = (xStart + xEnd) / 2;
+      for (let p = 0; p < count / 2; p++) {
+        const yTop = cardCenterY(si, p * 2);
+        const yBot = cardCenterY(si, p * 2 + 1);
+        const yMid = (yTop + yBot) / 2;
+        lines.push({ x1: xStart, y1: yTop, x2: xMid, y2: yTop });
+        lines.push({ x1: xStart, y1: yBot, x2: xMid, y2: yBot });
+        lines.push({ x1: xMid, y1: yTop, x2: xMid, y2: yBot });
+        lines.push({ x1: xMid, y1: yMid, x2: xEnd, y2: yMid });
+      }
+    }
+    return lines;
+  }, []);
+
+  // Reset view when modal opens
+  React.useEffect(() => {
+    if (open) resetView();
+  }, [open, resetView]);
+
+  if (!hasKnockout) {
+    return (
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="bg-terminal-bg border-terminal-border text-terminal-text max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="text-base font-bold">
+              Mata-mata — Copa 2026
+            </DialogTitle>
+          </DialogHeader>
+          <div className="text-center py-10">
+            <div className="w-16 h-16 rounded-full border-2 border-terminal-border-subtle flex items-center justify-center mx-auto mb-4 opacity-30">
+              <span className="text-2xl font-bold">?</span>
+            </div>
+            <p className="text-sm font-medium opacity-60">
+              Mata-mata ainda não começou
+            </p>
+            <p className="text-xs opacity-40 mt-1">
+              Os confrontos serão definidos após a fase de grupos
+            </p>
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  const zoomPct = Math.round(zoom * 100);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-terminal-bg border-terminal-border text-terminal-text max-w-[95vw] w-auto max-h-[90vh] flex flex-col overflow-hidden p-0">
+        <DialogHeader className="shrink-0 px-6 pt-6 pb-3">
+          <DialogTitle className="text-base font-bold">
+            Mata-mata — Copa 2026
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Viewport with zoom + pan */}
+        <div
+          className="flex-1 overflow-hidden relative select-none"
+          style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          onWheel={handleWheel}
+        >
+          {/* Zoom controls — floating bottom-right */}
+          <div className="absolute bottom-4 right-4 z-10 flex items-center gap-1 bg-terminal-dark-gray/90 border border-terminal-border-subtle rounded-lg p-1 backdrop-blur-sm pointer-events-auto">
+            <button
+              onClick={(e) => { e.stopPropagation(); zoomOut(); }}
+              className="w-7 h-7 rounded flex items-center justify-center hover:bg-terminal-gray/40 transition-colors text-terminal-text"
+              title="Diminuir zoom"
+            >
+              <Minus className="w-3.5 h-3.5" />
+            </button>
+            <span className="text-[10px] tabular-nums opacity-60 w-9 text-center">
+              {zoomPct}%
+            </span>
+            <button
+              onClick={(e) => { e.stopPropagation(); zoomIn(); }}
+              className="w-7 h-7 rounded flex items-center justify-center hover:bg-terminal-gray/40 transition-colors text-terminal-text"
+              title="Aumentar zoom"
+            >
+              <Plus className="w-3.5 h-3.5" />
+            </button>
+            <div className="w-px h-4 bg-terminal-border-subtle mx-0.5" />
+            <button
+              onClick={(e) => { e.stopPropagation(); resetView(); }}
+              className="w-7 h-7 rounded flex items-center justify-center hover:bg-terminal-gray/40 transition-colors text-terminal-text"
+              title="Resetar visualização"
+            >
+              <RotateCcw className="w-3 h-3" />
+            </button>
+          </div>
+
+          {/* Transformable canvas */}
+          <div
+            className="origin-top-left will-change-transform"
+            style={{
+              transform: `scale(${zoom}) translate(${pan.x}px, ${pan.y}px)`,
+              width: BRACKET_W,
+              height: TOTAL_H + 80,
+            }}
+          >
+            {/* Bracket */}
+            <div
+              className="relative"
+              style={{ width: BRACKET_W, height: TOTAL_H }}
+            >
+              {/* Stage labels */}
+              {STAGES.map((stage, i) => (
+                <div
+                  key={stage.key + '-label'}
+                  className="absolute text-[9px] uppercase font-bold tracking-wider text-terminal-blue text-center"
+                  style={{ left: stageX(i), top: 0, width: CARD_W }}
+                >
+                  {stage.label}
+                </div>
+              ))}
+
+              {/* SVG connectors */}
+              <svg
+                className="absolute inset-0 pointer-events-none"
+                width={BRACKET_W}
+                height={TOTAL_H}
+              >
+                {connectorLines.map((l, i) => (
+                  <line
+                    key={i}
+                    x1={l.x1}
+                    y1={l.y1}
+                    x2={l.x2}
+                    y2={l.y2}
+                    stroke="rgba(255,255,255,0.12)"
+                    strokeWidth="1.5"
+                  />
+                ))}
+              </svg>
+
+              {/* Match cards */}
+              {STAGES.map((stage, si) => {
+                const roundMatches = stageMatches[stage.key] || [];
+                return roundMatches.map((m, mi) => (
+                  <BracketMatchCard
+                    key={m.id}
+                    match={m}
+                    style={{
+                      left: stageX(si),
+                      top: cardCenterY(si, mi) - CARD_H / 2,
+                    }}
+                  />
+                ));
+              })}
+            </div>
+
+            {/* 3rd place */}
+            {thirdPlace && (
+              <div className="mt-4 pt-4 border-t border-terminal-border-subtle/30">
+                <p className="text-[9px] uppercase font-bold tracking-wider text-terminal-blue mb-2">
+                  Disputa de 3º Lugar
+                </p>
+                <div
+                  className={`inline-block rounded border text-[10px] leading-tight overflow-hidden ${
+                    thirdPlace.home_team_code === 'TBD'
+                      ? 'border-terminal-border-subtle/40 bg-terminal-dark-gray/15'
+                      : 'border-terminal-border bg-terminal-dark-gray/20'
+                  }`}
+                  style={{ width: CARD_W, height: CARD_H }}
+                >
+                  <div
+                    className={`flex items-center gap-1 px-1.5 h-1/2 ${
+                      thirdPlace.home_team_code === 'TBD' ? 'opacity-40' : ''
+                    }`}
+                  >
+                    <TeamFlag code={thirdPlace.home_team_code} />
+                    <span className="font-mono flex-1 truncate">
+                      {thirdPlace.home_team_code}
+                    </span>
+                  </div>
+                  <div className="border-t border-terminal-border-subtle/20" />
+                  <div
+                    className={`flex items-center gap-1 px-1.5 h-1/2 ${
+                      thirdPlace.away_team_code === 'TBD' ? 'opacity-40' : ''
+                    }`}
+                  >
+                    <TeamFlag code={thirdPlace.away_team_code} />
+                    <span className="font-mono flex-1 truncate">
+                      {thirdPlace.away_team_code}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/bolao/CopaGruposModal.tsx
+++ b/src/components/bolao/CopaGruposModal.tsx
@@ -1,0 +1,136 @@
+import React, { useMemo } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useWcMatches } from '@/hooks/use-bolao';
+import { TeamFlag } from './TeamFlag';
+
+interface StandingEntry {
+  code: string;
+  p: number;
+  w: number;
+  d: number;
+  l: number;
+  gf: number;
+  ga: number;
+  pts: number;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const CopaGruposModal: React.FC<Props> = ({ open, onOpenChange }) => {
+  const { data: matches } = useWcMatches();
+
+  const groupStandings = useMemo(() => {
+    if (!matches) return {} as Record<string, StandingEntry[]>;
+    const raw: Record<string, Record<string, StandingEntry>> = {};
+
+    matches
+      .filter((m) => m.group_name && m.home_team_code !== 'TBD')
+      .forEach((m) => {
+        const g = m.group_name!;
+        if (!raw[g]) raw[g] = {};
+        if (!raw[g][m.home_team_code])
+          raw[g][m.home_team_code] = { code: m.home_team_code, p: 0, w: 0, d: 0, l: 0, gf: 0, ga: 0, pts: 0 };
+        if (!raw[g][m.away_team_code])
+          raw[g][m.away_team_code] = { code: m.away_team_code, p: 0, w: 0, d: 0, l: 0, gf: 0, ga: 0, pts: 0 };
+
+        if (m.is_finished && m.home_score != null && m.away_score != null) {
+          const home = raw[g][m.home_team_code];
+          const away = raw[g][m.away_team_code];
+          home.p++; away.p++;
+          home.gf += m.home_score; home.ga += m.away_score;
+          away.gf += m.away_score; away.ga += m.home_score;
+          if (m.home_score > m.away_score) {
+            home.w++; home.pts += 3; away.l++;
+          } else if (m.away_score > m.home_score) {
+            away.w++; away.pts += 3; home.l++;
+          } else {
+            home.d++; home.pts++; away.d++; away.pts++;
+          }
+        }
+      });
+
+    const sorted: Record<string, StandingEntry[]> = {};
+    Object.entries(raw).forEach(([g, teams]) => {
+      sorted[g] = Object.values(teams).sort((a, b) => {
+        if (b.pts !== a.pts) return b.pts - a.pts;
+        if (b.gf - b.ga !== a.gf - a.ga) return (b.gf - b.ga) - (a.gf - a.ga);
+        return b.gf - a.gf;
+      });
+    });
+    return sorted;
+  }, [matches]);
+
+  const sortedGroups = Object.entries(groupStandings).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-terminal-bg border-terminal-border text-terminal-text max-w-3xl max-h-[85vh] flex flex-col overflow-hidden">
+        {/* Fixed header */}
+        <DialogHeader className="shrink-0">
+          <DialogTitle className="text-base font-bold">Tabela dos Grupos — Copa 2026</DialogTitle>
+        </DialogHeader>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto scrollbar-thin pr-1">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {sortedGroups.map(([groupName, teams]) => (
+              <div key={groupName} className="terminal-container p-3">
+                <p className="text-[10px] uppercase font-bold tracking-wider opacity-50 mb-2">
+                  Grupo {groupName}
+                </p>
+
+                {/* Column header */}
+                <div className="grid grid-cols-[1fr_18px_18px_18px_18px_26px] gap-1 text-[9px] uppercase opacity-40 pb-1 border-b border-terminal-border-subtle mb-1 text-center">
+                  <span className="text-left">Sel.</span>
+                  <span>J</span>
+                  <span>V</span>
+                  <span>E</span>
+                  <span>D</span>
+                  <span className="font-bold">Pts</span>
+                </div>
+
+                {teams.map((team, idx) => (
+                  <div
+                    key={team.code}
+                    className={`grid grid-cols-[1fr_18px_18px_18px_18px_26px] gap-1 py-1 text-xs text-center items-center ${
+                      idx < 2 ? '' : 'opacity-50'
+                    }`}
+                  >
+                    <div className="flex items-center gap-1 text-left">
+                      <span
+                        className={`w-1 h-3 rounded-sm shrink-0 ${
+                          idx < 2 ? 'bg-terminal-green' : 'bg-transparent'
+                        }`}
+                      />
+                      <TeamFlag code={team.code} />
+                      <span className="font-mono font-bold text-[10px]">{team.code}</span>
+                    </div>
+                    <span>{team.p}</span>
+                    <span>{team.w}</span>
+                    <span>{team.d}</span>
+                    <span>{team.l}</span>
+                    <span className="font-bold text-terminal-green">{team.pts}</span>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+
+          <p className="text-[10px] opacity-30 text-center mt-3 pb-1">
+            Verde = classificado · Tabela atualizada após cada resultado
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/bolao/CreateBolaoModal.tsx
+++ b/src/components/bolao/CreateBolaoModal.tsx
@@ -1,0 +1,285 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import {
+  Trophy,
+  Crown,
+  Users,
+  Target,
+  BarChart3,
+  Check,
+  Zap,
+  Star,
+  Palette,
+  ChevronRight,
+  CreditCard,
+  MessageCircle,
+} from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+
+const schema = z.object({
+  name: z
+    .string()
+    .min(3, 'Mínimo 3 caracteres')
+    .max(50, 'Máximo 50 caracteres'),
+  description: z.string().max(200, 'Máximo 200 caracteres').optional(),
+});
+
+type FormData = z.infer<typeof schema>;
+
+type Plan = 'free' | 'pro';
+
+interface CreateBolaoModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (data: FormData & { plan: Plan }) => void;
+  isLoading?: boolean;
+}
+
+const FREE_FEATURES = [
+  { icon: Users,    text: 'Até 10 participantes' },
+  { icon: Target,   text: '1pt resultado · 3pts placar' },
+  { icon: Trophy,   text: 'Palpite de campeão' },
+  { icon: BarChart3,text: 'Ranking geral' },
+];
+
+const PREMIUM_FEATURES = [
+  { icon: Users,    text: 'Participantes ilimitados',       highlight: true  },
+  { icon: Target,   text: 'Pontuação customizável',         highlight: false },
+  { icon: Star,     text: 'Palpites especiais (semis, quartas...)', highlight: true },
+  { icon: BarChart3,text: 'Ranking por fase + destaques',   highlight: false },
+  { icon: Zap,      text: 'Fases finais valem mais (até 5×)', highlight: true },
+  { icon: Palette,  text: 'Logo e cor personalizados',      highlight: false },
+];
+
+export const CreateBolaoModal: React.FC<CreateBolaoModalProps> = ({
+  open,
+  onOpenChange,
+  onSubmit,
+  isLoading,
+}) => {
+  const [plan, setPlan] = useState<Plan>('free');
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  });
+
+  const handleFormSubmit = (data: FormData) => {
+    onSubmit({ ...data, plan });
+    reset();
+  };
+
+  const handleOpenChange = (v: boolean) => {
+    if (!v) {
+      setPlan('free');
+      reset();
+    }
+    onOpenChange(v);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="bg-terminal-bg border-terminal-border max-w-lg p-0 overflow-hidden">
+        <DialogHeader className="px-5 pt-5 pb-0">
+          <DialogTitle className="flex items-center gap-2 text-terminal-text">
+            <Trophy className="w-5 h-5 text-terminal-blue" />
+            Criar Bolão
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Plan selector */}
+        <div className="grid grid-cols-2 gap-3 px-5 pt-6 items-stretch">
+
+          {/* Free */}
+          <button
+            type="button"
+            onClick={() => setPlan('free')}
+            className={`relative rounded-lg border p-3 text-left transition-all flex flex-col justify-start ${
+              plan === 'free'
+                ? 'border-terminal-blue bg-terminal-blue/10 ring-1 ring-terminal-blue/30'
+                : 'border-terminal-border hover:border-terminal-border-subtle'
+            }`}
+          >
+            {plan === 'free' && (
+              <div className="absolute top-2 right-2 w-4 h-4 rounded-full bg-terminal-blue flex items-center justify-center">
+                <Check className="w-2.5 h-2.5 text-terminal-bg" />
+              </div>
+            )}
+            <p className="text-xs font-bold uppercase tracking-wider mb-3">Free</p>
+            <ul className="space-y-1.5">
+              {FREE_FEATURES.map((f) => (
+                <li key={f.text} className="flex items-center gap-1.5 text-[10px] opacity-50">
+                  <f.icon className="w-3 h-3 shrink-0" />
+                  {f.text}
+                </li>
+              ))}
+            </ul>
+          </button>
+
+          {/* Premium */}
+          <button
+            type="button"
+            onClick={() => setPlan('pro')}
+            className={`relative rounded-lg border p-3 text-left transition-all ${
+              plan === 'pro'
+                ? 'border-yellow-400/70 bg-yellow-500/8 ring-1 ring-yellow-500/20'
+                : 'border-yellow-500/30 bg-yellow-500/3 hover:border-yellow-400/50'
+            }`}
+          >
+            {/* Recommended badge */}
+            <div className="absolute -top-3.5 left-1/2 -translate-x-1/2">
+              <span className="text-[9px] px-2 py-0.5 bg-yellow-500 text-terminal-bg rounded-full font-bold uppercase tracking-wide whitespace-nowrap">
+                Recomendado
+              </span>
+            </div>
+
+            {plan === 'pro' ? (
+              <div className="absolute top-2 right-2 w-4 h-4 rounded-full bg-yellow-500 flex items-center justify-center">
+                <Check className="w-2.5 h-2.5 text-terminal-bg" />
+              </div>
+            ) : (
+              <ChevronRight className="absolute top-2 right-2 w-3.5 h-3.5 text-yellow-500/50" />
+            )}
+
+            <div className="flex items-baseline gap-2 mb-3">
+              <p className="text-xs font-bold uppercase tracking-wider text-yellow-400">Premium</p>
+              <span className="text-[10px] font-bold text-yellow-300">R$ 19,90</span>
+            </div>
+
+            {/* Features */}
+            <ul className="space-y-1.5">
+              {PREMIUM_FEATURES.map((f) => (
+                <li
+                  key={f.text}
+                  className={`flex items-center gap-1.5 text-[10px] ${
+                    f.highlight ? 'text-yellow-300 opacity-90' : 'text-terminal-text opacity-60'
+                  }`}
+                >
+                  <f.icon className={`w-3 h-3 shrink-0 ${f.highlight ? 'text-yellow-400' : ''}`} />
+                  {f.text}
+                </li>
+              ))}
+            </ul>
+
+            {/* Price footnote */}
+            <p className="text-[9px] opacity-30 mt-2">pagamento único · sem mensalidade</p>
+          </button>
+        </div>
+
+        {/* Premium payment options — below cards */}
+        {plan === 'pro' && (
+          <div className="mx-5 mt-3 rounded border border-yellow-500/20 bg-yellow-500/5 px-3 py-2.5 space-y-2">
+            <div className="flex items-center gap-2">
+              <CreditCard className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
+              <p className="text-[10px] text-yellow-400/80">
+                Pagamento de <span className="font-bold text-yellow-300">R$ 19,90</span> via cartão de crédito
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <MessageCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
+              <p className="text-[10px] text-terminal-text/60">
+                Quer pagar via PIX?{' '}
+                <a
+                  href="https://wa.me/5511952136845?text=Ol%C3%A1!%20Quero%20pagar%20o%20Bol%C3%A3o%20Premium%20via%20PIX"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-green-400 hover:text-green-300 underline underline-offset-2 font-medium"
+                >
+                  Fale conosco no WhatsApp
+                </a>
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Form */}
+        <form
+          onSubmit={handleSubmit(handleFormSubmit)}
+          className="px-5 pb-5 pt-4 space-y-4"
+        >
+          <div>
+            <Label
+              htmlFor="name"
+              className="text-terminal-text text-xs uppercase opacity-70"
+            >
+              Nome do Bolão
+            </Label>
+            <Input
+              id="name"
+              placeholder="Ex: Bolão da Firma"
+              className="mt-1 bg-terminal-dark-gray border-terminal-border text-terminal-text"
+              {...register('name')}
+            />
+            {errors.name && (
+              <p className="text-xs text-terminal-red mt-1">{errors.name.message}</p>
+            )}
+          </div>
+
+          <div>
+            <Label
+              htmlFor="description"
+              className="text-terminal-text text-xs uppercase opacity-70"
+            >
+              Descrição (opcional)
+            </Label>
+            <Textarea
+              id="description"
+              placeholder="Descreva seu bolão..."
+              rows={2}
+              className="mt-1 bg-terminal-dark-gray border-terminal-border text-terminal-text resize-none"
+              {...register('description')}
+            />
+            {errors.description && (
+              <p className="text-xs text-terminal-red mt-1">{errors.description.message}</p>
+            )}
+          </div>
+
+          <div className="flex gap-2 justify-end pt-1">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => handleOpenChange(false)}
+              className="text-terminal-text"
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={isLoading}
+              className={
+                plan === 'pro'
+                  ? 'bg-yellow-500 text-terminal-bg hover:bg-yellow-500/90 gap-1.5 font-bold'
+                  : 'bg-terminal-blue text-terminal-bg hover:bg-terminal-blue/90 gap-1.5'
+              }
+            >
+              {isLoading ? (
+                'Criando...'
+              ) : plan === 'pro' ? (
+                <>
+                  <Crown className="w-3.5 h-3.5" /> Criar Bolão Premium
+                </>
+              ) : (
+                'Criar Bolão'
+              )}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/bolao/MatchPredictionCard.tsx
+++ b/src/components/bolao/MatchPredictionCard.tsx
@@ -1,0 +1,190 @@
+import React, { useState, useEffect } from 'react';
+import { Lock, Check } from 'lucide-react';
+import type { WcMatch, BolaoPrediction } from '@/services/bolao.service';
+import { isMatchLocked } from '@/hooks/use-bolao';
+
+interface MatchPredictionCardProps {
+  match: WcMatch;
+  prediction?: BolaoPrediction;
+  onSave: (matchId: number, homeScore: number, awayScore: number) => void;
+  isSaving?: boolean;
+}
+
+export const MatchPredictionCard: React.FC<MatchPredictionCardProps> = ({
+  match,
+  prediction,
+  onSave,
+  isSaving,
+}) => {
+  const locked = isMatchLocked(match);
+  const [homeScore, setHomeScore] = useState<string>(
+    prediction?.predicted_home_score?.toString() ?? ''
+  );
+  const [awayScore, setAwayScore] = useState<string>(
+    prediction?.predicted_away_score?.toString() ?? ''
+  );
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (prediction) {
+      setHomeScore(prediction.predicted_home_score.toString());
+      setAwayScore(prediction.predicted_away_score.toString());
+    }
+  }, [prediction]);
+
+  const hasPrediction = prediction != null;
+  const canSave =
+    !locked &&
+    homeScore !== '' &&
+    awayScore !== '' &&
+    Number(homeScore) >= 0 &&
+    Number(awayScore) >= 0;
+
+  const isDirty =
+    !hasPrediction ||
+    homeScore !== prediction?.predicted_home_score.toString() ||
+    awayScore !== prediction?.predicted_away_score.toString();
+
+  const handleSave = () => {
+    if (!canSave || !isDirty) return;
+    onSave(match.id, Number(homeScore), Number(awayScore));
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
+  };
+
+  const matchDate = new Date(match.match_date + 'T00:00:00');
+  const dateStr = matchDate.toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+  });
+  const timeStr = match.match_time_brasilia.slice(0, 5);
+
+  // Points display for finished matches
+  const pointsDisplay =
+    match.is_finished && prediction?.points_earned != null ? (
+      <span
+        className={`text-xs font-bold px-2 py-0.5 rounded ${
+          prediction.points_earned > 0
+            ? 'bg-terminal-green/20 text-terminal-green'
+            : 'bg-terminal-dark-gray text-terminal-text/50'
+        }`}
+      >
+        {prediction.points_earned > 0 ? `+${prediction.points_earned} pts` : '0 pts'}
+      </span>
+    ) : null;
+
+  return (
+    <div
+      className={`border rounded p-3 transition-colors ${
+        match.is_finished
+          ? 'border-terminal-border-subtle bg-terminal-dark-gray/20 opacity-80'
+          : locked
+          ? 'border-terminal-border-subtle bg-terminal-dark-gray/10 opacity-60'
+          : hasPrediction
+          ? 'border-terminal-green/30 bg-terminal-green/5'
+          : 'border-terminal-border hover:border-terminal-border/80'
+      }`}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <span className="text-[10px] opacity-50 uppercase">
+            {match.group_name ? `Grupo ${match.group_name}` : match.stage}
+          </span>
+          {locked && <Lock className="w-3 h-3 opacity-40" />}
+        </div>
+        <div className="flex items-center gap-2">
+          {pointsDisplay}
+          <span className="text-[10px] opacity-50">
+            {dateStr} {timeStr}
+          </span>
+        </div>
+      </div>
+
+      {/* Match */}
+      <div className="flex items-center gap-2">
+        {/* Home team */}
+        <div className="flex-1 text-right">
+          <span className="text-sm font-medium">{match.home_team}</span>
+          <span className="text-[10px] opacity-40 ml-1">{match.home_team_code}</span>
+        </div>
+
+        {/* Score inputs or result */}
+        {match.is_finished ? (
+          <div className="flex items-center gap-1 px-2">
+            <span className="w-8 text-center text-sm font-bold">{match.home_score}</span>
+            <span className="text-xs opacity-40">x</span>
+            <span className="w-8 text-center text-sm font-bold">{match.away_score}</span>
+          </div>
+        ) : (
+          <div className="flex items-center gap-1 px-1">
+            <input
+              type="number"
+              min="0"
+              max="20"
+              value={homeScore}
+              onChange={(e) => setHomeScore(e.target.value)}
+              disabled={locked}
+              className="w-10 h-8 text-center text-sm font-bold bg-terminal-dark-gray border border-terminal-border rounded focus:border-terminal-green focus:outline-none disabled:opacity-40 text-terminal-text"
+              placeholder="-"
+            />
+            <span className="text-xs opacity-40">x</span>
+            <input
+              type="number"
+              min="0"
+              max="20"
+              value={awayScore}
+              onChange={(e) => setAwayScore(e.target.value)}
+              disabled={locked}
+              className="w-10 h-8 text-center text-sm font-bold bg-terminal-dark-gray border border-terminal-border rounded focus:border-terminal-green focus:outline-none disabled:opacity-40 text-terminal-text"
+              placeholder="-"
+            />
+          </div>
+        )}
+
+        {/* Away team */}
+        <div className="flex-1">
+          <span className="text-[10px] opacity-40 mr-1">{match.away_team_code}</span>
+          <span className="text-sm font-medium">{match.away_team}</span>
+        </div>
+      </div>
+
+      {/* Prediction display for finished matches */}
+      {match.is_finished && hasPrediction && (
+        <div className="mt-2 text-center">
+          <span className="text-[10px] opacity-50">
+            Seu palpite: {prediction.predicted_home_score} x {prediction.predicted_away_score}
+          </span>
+        </div>
+      )}
+
+      {/* Save button */}
+      {!locked && !match.is_finished && isDirty && canSave && (
+        <div className="mt-2 flex justify-center">
+          <button
+            onClick={handleSave}
+            disabled={isSaving}
+            className="flex items-center gap-1 px-3 py-1 text-xs font-medium bg-terminal-green/20 text-terminal-green border border-terminal-green/30 rounded hover:bg-terminal-green/30 transition-colors disabled:opacity-50"
+          >
+            {saved ? (
+              <>
+                <Check className="w-3 h-3" /> Salvo
+              </>
+            ) : isSaving ? (
+              'Salvando...'
+            ) : (
+              'Salvar palpite'
+            )}
+          </button>
+        </div>
+      )}
+
+      {/* Venue */}
+      <div className="mt-2 text-center">
+        <span className="text-[10px] opacity-30">
+          {match.venue} — {match.city}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/src/components/bolao/PredictionsModal.tsx
+++ b/src/components/bolao/PredictionsModal.tsx
@@ -1,0 +1,153 @@
+import React, { useState, useMemo } from 'react';
+import { Filter } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  useWcMatches,
+  useBolaoPredictions,
+  useUpsertPrediction,
+} from '@/hooks/use-bolao';
+import { MatchPredictionCard } from '@/components/bolao/MatchPredictionCard';
+import type { WcMatch } from '@/services/bolao.service';
+
+interface PredictionsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  bolaoId: string;
+  currentUserId: string | undefined;
+}
+
+export const PredictionsModal: React.FC<PredictionsModalProps> = ({
+  open,
+  onOpenChange,
+  bolaoId,
+  currentUserId,
+}) => {
+  const [groupFilter, setGroupFilter] = useState<string>('all');
+
+  const { data: matches, isLoading } = useWcMatches();
+  const { data: predictions } = useBolaoPredictions(bolaoId, currentUserId);
+  const upsertPrediction = useUpsertPrediction();
+
+  const predictionsByMatch = useMemo(
+    () => new Map((predictions || []).map((p) => [p.match_id, p])),
+    [predictions]
+  );
+
+  const groups = useMemo(() => {
+    if (!matches) return [];
+    const unique = new Set(matches.filter((m) => m.group_name).map((m) => m.group_name!));
+    return Array.from(unique).sort();
+  }, [matches]);
+
+  const filteredMatches = useMemo(() => {
+    if (!matches) return [];
+    if (groupFilter === 'all') return matches;
+    return matches.filter((m) => m.group_name === groupFilter);
+  }, [matches, groupFilter]);
+
+  const groupedMatches = useMemo(() => {
+    const grouped: Record<string, WcMatch[]> = {};
+    filteredMatches.forEach((m) => {
+      const key = m.group_name ? `Grupo ${m.group_name}` : m.stage;
+      if (!grouped[key]) grouped[key] = [];
+      grouped[key].push(m);
+    });
+    return grouped;
+  }, [filteredMatches]);
+
+  const handleSave = (matchId: number, homeScore: number, awayScore: number) => {
+    upsertPrediction.mutate({
+      bolao_id: bolaoId,
+      match_id: matchId,
+      predicted_home_score: homeScore,
+      predicted_away_score: awayScore,
+    });
+  };
+
+  const totalMatches = matches?.filter((m) => !m.is_finished && m.home_team_code !== 'TBD').length || 0;
+  const totalPredictions = predictions?.length || 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-terminal-bg border-terminal-border max-w-2xl max-h-[85vh] overflow-hidden p-0 flex flex-col">
+        <DialogHeader className="px-5 pt-5 pb-0 shrink-0">
+          <div className="flex items-center justify-between">
+            <DialogTitle className="flex items-center gap-2 text-terminal-text">
+              Fazer Palpites
+            </DialogTitle>
+            <div>
+              <span className="text-sm font-bold text-terminal-blue">{totalPredictions}</span>
+              <span className="text-xs opacity-40">/{totalMatches}</span>
+            </div>
+          </div>
+        </DialogHeader>
+
+        {/* Group filter */}
+        <div className="flex items-center gap-2 px-5 py-3 overflow-x-auto shrink-0 border-b border-terminal-border-subtle">
+          <Filter className="w-3 h-3 opacity-40 shrink-0" />
+          <button
+            onClick={() => setGroupFilter('all')}
+            className={`px-3 py-1 text-xs rounded border shrink-0 transition-colors ${
+              groupFilter === 'all'
+                ? 'border-terminal-blue text-terminal-blue bg-terminal-blue/10'
+                : 'border-terminal-border opacity-50 hover:opacity-80'
+            }`}
+          >
+            Todos
+          </button>
+          {groups.map((g) => (
+            <button
+              key={g}
+              onClick={() => setGroupFilter(g)}
+              className={`px-3 py-1 text-xs rounded border shrink-0 transition-colors ${
+                groupFilter === g
+                  ? 'border-terminal-blue text-terminal-blue bg-terminal-blue/10'
+                  : 'border-terminal-border opacity-50 hover:opacity-80'
+              }`}
+            >
+              {g}
+            </button>
+          ))}
+        </div>
+
+        {/* Matches — scrollable */}
+        <div className="flex-1 overflow-y-auto px-5 py-4 minimal-scrollbar">
+          {isLoading ? (
+            <div className="space-y-3">
+              {[1, 2, 3, 4].map((i) => (
+                <div
+                  key={i}
+                  className="h-32 rounded border border-terminal-border animate-pulse bg-terminal-dark-gray/30"
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-6">
+              {Object.entries(groupedMatches).map(([groupName, groupMatches]) => (
+                <div key={groupName}>
+                  <h3 className="text-xs uppercase font-bold opacity-50 mb-3">{groupName}</h3>
+                  <div className="space-y-3">
+                    {groupMatches.map((match) => (
+                      <MatchPredictionCard
+                        key={match.id}
+                        match={match}
+                        prediction={predictionsByMatch.get(match.id)}
+                        onSave={handleSave}
+                        isSaving={upsertPrediction.isPending}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/bolao/SpecialPredictionsSection.tsx
+++ b/src/components/bolao/SpecialPredictionsSection.tsx
@@ -1,0 +1,270 @@
+import React, { useMemo, useState } from 'react';
+import { Crown, Lock, ChevronDown, ChevronUp, Check, Search } from 'lucide-react';
+import {
+  useMySpecialPredictions,
+  useSpecialSummary,
+  useToggleSpecialPrediction,
+} from '@/hooks/use-bolao';
+import type { WcMatch } from '@/services/bolao.service';
+import { useToast } from '@/hooks/use-toast';
+
+interface Props {
+  bolaoId: string;
+  isPremium: boolean;
+  matches: WcMatch[];
+  hideChrome?: boolean;
+  enabledTypes?: Record<string, boolean>;
+}
+
+type SpecialType = 'finalist' | 'semifinalist' | 'quarterfinalist' | 'round_of_32';
+
+const TYPE_CONFIG: Record<SpecialType, { label: string; sublabel: string; max: number; pts: string }> = {
+  finalist:       { label: 'Finalistas',       sublabel: 'Escolha 2 times',   max: 2,  pts: '+10 pts cada' },
+  semifinalist:   { label: 'Semifinalistas',    sublabel: 'Escolha 4 times',   max: 4,  pts: '+5 pts cada'  },
+  quarterfinalist:{ label: 'Quartas de Final',  sublabel: 'Escolha 8 times',   max: 8,  pts: '+3 pts cada'  },
+  round_of_32:   { label: 'Mata-mata (32)',     sublabel: 'Escolha 32 seleções', max: 32, pts: '+1 pt cada'  },
+};
+
+function extractTeams(matches: WcMatch[]) {
+  const map = new Map<string, string>();
+  for (const m of matches) {
+    if (m.home_team_code && m.home_team_code !== 'TBD') map.set(m.home_team_code, m.home_team);
+    if (m.away_team_code && m.away_team_code !== 'TBD') map.set(m.away_team_code, m.away_team);
+  }
+  return Array.from(map.entries())
+    .map(([code, name]) => ({ code, name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+interface PickPanelProps {
+  type: SpecialType;
+  bolaoId: string;
+  myPicks: string[];
+  summaryCounts: Map<string, number>;
+  teams: { code: string; name: string }[];
+  totalMembers: number;
+}
+
+const PickPanel: React.FC<PickPanelProps> = ({ type, bolaoId, myPicks, summaryCounts, teams, totalMembers }) => {
+  const { label, sublabel, max, pts } = TYPE_CONFIG[type];
+  const [search, setSearch] = useState('');
+  const [open, setOpen] = useState(false);
+  const toggle = useToggleSpecialPrediction();
+  const { toast } = useToast();
+
+  const filtered = useMemo(() => {
+    if (!search) return teams;
+    const q = search.toLowerCase();
+    return teams.filter((t) => t.name.toLowerCase().includes(q) || t.code.toLowerCase().includes(q));
+  }, [teams, search]);
+
+  const handleToggle = (code: string) => {
+    const isPicked = myPicks.includes(code);
+    if (!isPicked && myPicks.length >= max) {
+      toast({ title: `Máximo de ${max} times para ${label}`, variant: 'destructive' });
+      return;
+    }
+    toggle.mutate(
+      { bolaoId, predictionType: type, teamCode: code },
+      {
+        onError: (err: any) => toast({ title: 'Erro', description: err.message, variant: 'destructive' }),
+      }
+    );
+  };
+
+  const filled = myPicks.length;
+
+  return (
+    <div className="border border-terminal-border-subtle rounded-lg overflow-hidden">
+      {/* Header */}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center justify-between gap-3 px-4 py-3 text-left hover:bg-terminal-dark-gray/30 transition-colors"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <div>
+            <p className="text-sm font-bold leading-tight">{label}</p>
+            <p className="text-[10px] opacity-40 mt-0.5">{sublabel} · <span className="text-terminal-blue">{pts}</span></p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {/* Progress chips */}
+          <div className="flex gap-1">
+            {Array.from({ length: max }).map((_, i) => (
+              <div
+                key={i}
+                className={`w-2.5 h-2.5 rounded-full border ${
+                  i < filled
+                    ? 'bg-terminal-blue border-terminal-blue'
+                    : 'border-terminal-border-subtle bg-transparent'
+                }`}
+              />
+            ))}
+          </div>
+          <span className="text-xs tabular-nums opacity-50">{filled}/{max}</span>
+          {open ? <ChevronUp className="w-3.5 h-3.5 opacity-40" /> : <ChevronDown className="w-3.5 h-3.5 opacity-40" />}
+        </div>
+      </button>
+
+      {/* Expanded team picker */}
+      {open && (
+        <div className="border-t border-terminal-border-subtle bg-terminal-dark-gray/10">
+          {/* Search */}
+          <div className="px-3 pt-3 pb-2">
+            <div className="relative">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 opacity-40" />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Buscar seleção..."
+                className="w-full bg-terminal-dark-gray border border-terminal-border rounded px-2 py-1.5 pl-7 text-xs placeholder:opacity-30 focus:outline-none focus:border-terminal-blue transition-colors"
+              />
+            </div>
+          </div>
+
+          {/* Team grid */}
+          <div className="px-3 pb-3 grid grid-cols-3 sm:grid-cols-4 gap-1.5 max-h-56 overflow-y-auto">
+            {filtered.map((team) => {
+              const picked = myPicks.includes(team.code);
+              const count = summaryCounts.get(team.code) ?? 0;
+              return (
+                <button
+                  key={team.code}
+                  onClick={() => handleToggle(team.code)}
+                  disabled={toggle.isPending}
+                  className={`relative flex flex-col items-center gap-0.5 p-2 rounded border text-center transition-all ${
+                    picked
+                      ? 'border-terminal-blue bg-terminal-blue/10 text-terminal-blue'
+                      : 'border-terminal-border-subtle hover:border-terminal-border bg-transparent opacity-70 hover:opacity-100'
+                  }`}
+                >
+                  {picked && (
+                    <div className="absolute top-1 right-1 w-3 h-3 bg-terminal-blue rounded-full flex items-center justify-center">
+                      <Check className="w-2 h-2 text-terminal-bg" />
+                    </div>
+                  )}
+                  <span className="font-mono font-bold text-[11px]">{team.code}</span>
+                  <span className="text-[9px] opacity-60 leading-tight text-center line-clamp-1">{team.name}</span>
+                  {count > 0 && totalMembers > 1 && (
+                    <span className="text-[8px] opacity-40 tabular-nums">{count} pick{count !== 1 ? 's' : ''}</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* My picks summary */}
+          {myPicks.length > 0 && (
+            <div className="px-3 pb-3 border-t border-terminal-border-subtle/50 pt-2">
+              <p className="text-[10px] opacity-40 mb-1 uppercase tracking-wider">Meus palpites</p>
+              <div className="flex flex-wrap gap-1">
+                {myPicks.map((code) => (
+                  <button
+                    key={code}
+                    onClick={() => handleToggle(code)}
+                    className="text-[10px] font-mono font-bold px-2 py-0.5 rounded border border-terminal-blue/50 bg-terminal-blue/10 text-terminal-blue hover:bg-terminal-red/10 hover:border-terminal-red/50 hover:text-terminal-red transition-colors"
+                    title="Clique para remover"
+                  >
+                    {code} ×
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export const SpecialPredictionsSection: React.FC<Props> = ({ bolaoId, isPremium, matches, hideChrome, enabledTypes }) => {
+  const { data: myPreds } = useMySpecialPredictions(bolaoId);
+  const { data: summary } = useSpecialSummary(bolaoId);
+
+  const teams = useMemo(() => extractTeams(matches), [matches]);
+
+  const myPicksByType = useMemo(() => {
+    const map: Record<string, string[]> = { finalist: [], semifinalist: [], quarterfinalist: [], round_of_32: [] };
+    for (const p of myPreds || []) {
+      if (p.prediction_type in map) map[p.prediction_type].push(p.predicted_team_code);
+    }
+    return map;
+  }, [myPreds]);
+
+  const summaryByType = useMemo(() => {
+    const map: Record<string, Map<string, number>> = {
+      finalist: new Map(),
+      semifinalist: new Map(),
+      quarterfinalist: new Map(),
+      round_of_32: new Map(),
+    };
+    for (const s of summary || []) {
+      if (s.prediction_type in map) map[s.prediction_type].set(s.predicted_team_code, s.pick_count);
+    }
+    return map;
+  }, [summary]);
+
+  const totalMembers = useMemo(() => {
+    const counts = new Set<string>();
+    for (const s of summary || []) {
+      if (s.prediction_type === 'finalist') counts.add(s.predicted_team_code);
+    }
+    return counts.size;
+  }, [summary]);
+
+  if (!isPremium) {
+    return (
+      <div className="terminal-container p-4 border-terminal-border-subtle/50">
+        <div className="flex items-center gap-2 mb-2">
+          <Crown className="w-4 h-4 text-yellow-400 shrink-0" />
+          <p className="text-xs font-bold uppercase tracking-wider text-yellow-400">
+            Palpites Especiais
+          </p>
+          <Lock className="w-3 h-3 opacity-40 ml-auto" />
+        </div>
+        <p className="text-xs opacity-50 mb-3">
+          Bolão PRO: palpite em finalistas (+10pts), semifinalistas (+5pts) e quartas (+3pts).
+        </p>
+        <div className="grid grid-cols-3 gap-2">
+          {(Object.entries(TYPE_CONFIG) as [SpecialType, typeof TYPE_CONFIG[SpecialType]][]).map(([type, cfg]) => (
+            <div key={type} className="text-center p-2 rounded border border-terminal-border-subtle/50 opacity-40">
+              <p className="text-[10px] font-bold">{cfg.label}</p>
+              <p className="text-[9px] opacity-60">{cfg.pts}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={hideChrome ? 'terminal-container p-4' : 'terminal-container p-4'}>
+      {!hideChrome && (
+        <div className="flex items-center gap-2 mb-4">
+          <Crown className="w-4 h-4 text-yellow-400 shrink-0" />
+          <p className="text-xs font-bold uppercase tracking-wider text-yellow-400">Palpites Especiais</p>
+          <span className="text-[9px] px-1.5 py-0.5 bg-yellow-500/20 text-yellow-400 rounded font-bold ml-auto">PRO</span>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {(Object.keys(TYPE_CONFIG) as SpecialType[]).filter((type) => !enabledTypes || enabledTypes[type] !== false).map((type) => (
+          <PickPanel
+            key={type}
+            type={type}
+            bolaoId={bolaoId}
+            myPicks={myPicksByType[type] || []}
+            summaryCounts={summaryByType[type] || new Map()}
+            teams={teams}
+            totalMembers={totalMembers}
+          />
+        ))}
+      </div>
+
+      <p className="text-[10px] opacity-30 mt-3 text-center">
+        Pontos extras somados ao ranking principal após cada fase
+      </p>
+    </div>
+  );
+};

--- a/src/components/bolao/TeamFlag.tsx
+++ b/src/components/bolao/TeamFlag.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+/** Placeholder for team flag/crest — will be replaced with actual image later */
+export function TeamFlag({ code }: { code: string }) {
+  return (
+    <div
+      className="w-5 h-3.5 rounded-sm bg-terminal-border-subtle/40 border border-terminal-border-subtle/60 shrink-0 overflow-hidden"
+      title={code}
+    />
+  );
+}

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -1,0 +1,332 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { bolaoService } from '@/services/bolao.service';
+import type { WcMatch } from '@/services/bolao.service';
+
+// =============================================
+// Matches
+// =============================================
+
+export function useWcMatches(params?: { stage?: string; groupName?: string }) {
+  return useQuery({
+    queryKey: ['wc-matches', params?.stage, params?.groupName],
+    queryFn: () => bolaoService.getMatches(params),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useWcMatch(matchId: number | undefined) {
+  return useQuery({
+    queryKey: ['wc-match', matchId],
+    queryFn: () => bolaoService.getMatchById(matchId!),
+    enabled: !!matchId,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+// =============================================
+// Bolões
+// =============================================
+
+export function useUserBoloes() {
+  return useQuery({
+    queryKey: ['user-boloes'],
+    queryFn: () => bolaoService.getUserBoloes(),
+    staleTime: 3 * 60 * 1000,  // 3 min — repeat visits são instantâneos
+    gcTime: 10 * 60 * 1000,    // 10 min — cache sobrevive navegação
+  });
+}
+
+export function useBolao(bolaoId: string | undefined) {
+  return useQuery({
+    queryKey: ['bolao', bolaoId],
+    queryFn: () => bolaoService.getBolaoById(bolaoId!),
+    enabled: !!bolaoId,
+  });
+}
+
+export function useCreateBolao() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: { name: string; description?: string }) =>
+      bolaoService.createBolao(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
+export function useJoinBolao() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (inviteCode: string) => bolaoService.joinByCode(inviteCode),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
+export function useLeaveBolao() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (bolaoId: string) => bolaoService.leaveBolao(bolaoId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
+// =============================================
+// Ranking
+// =============================================
+
+export function useBolaoRanking(bolaoId: string | undefined) {
+  return useQuery({
+    queryKey: ['bolao-ranking', bolaoId],
+    queryFn: () => bolaoService.getRanking(bolaoId!),
+    enabled: !!bolaoId,
+    refetchInterval: 60 * 1000, // refresh every minute during games
+  });
+}
+
+// =============================================
+// Predictions
+// =============================================
+
+export function useBolaoPredictions(bolaoId: string | undefined, userId?: string) {
+  return useQuery({
+    queryKey: ['bolao-predictions', bolaoId, userId],
+    queryFn: () => bolaoService.getPredictions(bolaoId!, userId),
+    enabled: !!bolaoId,
+  });
+}
+
+export function useUpsertPrediction() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: {
+      bolao_id: string;
+      match_id: number;
+      predicted_home_score: number;
+      predicted_away_score: number;
+    }) => bolaoService.upsertPrediction(params),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['bolao-predictions', variables.bolao_id] });
+    },
+  });
+}
+
+export function useUpsertPredictionsBatch() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: {
+      bolaoId: string;
+      predictions: { match_id: number; predicted_home_score: number; predicted_away_score: number }[];
+    }) => bolaoService.upsertPredictionsBatch(params.bolaoId, params.predictions),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['bolao-predictions', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['bolao-ranking', variables.bolaoId] });
+    },
+  });
+}
+
+// =============================================
+// Champion Prediction
+// =============================================
+
+export function useChampionPredictions(bolaoId: string | undefined) {
+  return useQuery({
+    queryKey: ['champion-predictions', bolaoId],
+    queryFn: () => bolaoService.getChampionPredictions(bolaoId!),
+    enabled: !!bolaoId,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useUpsertChampionPrediction() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: { bolaoId: string; teamCode: string }) =>
+      bolaoService.upsertChampionPrediction(params.bolaoId, params.teamCode),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['champion-predictions', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
+// =============================================
+// Admin
+// =============================================
+
+export function useRemoveMember() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: { bolaoId: string; userId: string }) =>
+      bolaoService.removeMember(params.bolaoId, params.userId),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['bolao-ranking', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
+export function useToggleBolaoClose() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (bolaoId: string) => bolaoService.toggleBolaoClose(bolaoId),
+    onSuccess: (_data, bolaoId) => {
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+      queryClient.invalidateQueries({ queryKey: ['bolao', bolaoId] });
+    },
+  });
+}
+
+// =============================================
+// Special Predictions (Wave 2)
+// =============================================
+
+export function useMySpecialPredictions(bolaoId: string | undefined) {
+  return useQuery({
+    queryKey: ['special-predictions-mine', bolaoId],
+    queryFn: () => bolaoService.getMySpecialPredictions(bolaoId!),
+    enabled: !!bolaoId,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useSpecialSummary(bolaoId: string | undefined) {
+  return useQuery({
+    queryKey: ['special-summary', bolaoId],
+    queryFn: () => bolaoService.getSpecialSummary(bolaoId!),
+    enabled: !!bolaoId,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useToggleSpecialPrediction() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: {
+      bolaoId: string;
+      predictionType: 'finalist' | 'semifinalist' | 'quarterfinalist' | 'round_of_32';
+      teamCode: string;
+    }) => bolaoService.toggleSpecialPrediction(params.bolaoId, params.predictionType, params.teamCode),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['special-predictions-mine', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['special-summary', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
+export function useUpdateBolaoScoring() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: {
+      bolaoId: string;
+      preset: 'standard' | 'classic' | 'weighted_stages' | 'custom';
+      scoringResult?: number;
+      scoringExact?: number;
+    }) => bolaoService.updateBolaoScoring(params.bolaoId, params.preset, params.scoringResult, params.scoringExact),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['bolao', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
+export function useUpdateBolaoSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: {
+      bolaoId: string;
+      settings: {
+        champion_enabled?: boolean;
+        special_predictions_enabled?: boolean;
+        special_predictions_config?: Record<string, boolean>;
+        special_predictions_points?: Record<string, number>;
+        champion_points?: number;
+      };
+    }) => bolaoService.updateBolaoSettings(params.bolaoId, params.settings),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['bolao', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
+// =============================================
+// Stats + Round Rankings (Wave 3)
+// =============================================
+
+export function useBolaoStats(bolaoId: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: ['bolao-stats', bolaoId],
+    queryFn: () => bolaoService.getBolaoStats(bolaoId!),
+    enabled: !!bolaoId && enabled,
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useBolaoRoundRanking(bolaoId: string | undefined, stage?: string) {
+  return useQuery({
+    queryKey: ['bolao-round-ranking', bolaoId, stage ?? 'all'],
+    queryFn: () => bolaoService.getRoundRanking(bolaoId!, stage),
+    enabled: !!bolaoId,
+    staleTime: 60 * 1000,
+  });
+}
+
+export function useUpdateBolaoTheme() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { bolaoId: string; color?: string; logoUrl?: string }) =>
+      bolaoService.updateBolaoTheme(params.bolaoId, params.color, params.logoUrl),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['bolao', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
+export function useUploadBolaoLogo() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { bolaoId: string; file: File }) =>
+      bolaoService.uploadBolaoLogo(params.bolaoId, params.file),
+    onSuccess: (_logoUrl, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['bolao', variables.bolaoId] });
+    },
+  });
+}
+
+// =============================================
+// Helpers
+// =============================================
+
+export function getStageLabel(stage: WcMatch['stage']): string {
+  switch (stage) {
+    case 'group': return 'Fase de Grupos';
+    case 'round_of_32': return 'Oitavas de Final';
+    case 'round_of_16': return '16 Avos de Final';
+    case 'quarter': return 'Quartas de Final';
+    case 'semi': return 'Semifinal';
+    case 'third_place': return 'Disputa de 3º Lugar';
+    case 'final': return 'Final';
+    default: return stage;
+  }
+}
+
+export function isMatchLocked(match: WcMatch): boolean {
+  const now = new Date();
+  const matchDateTime = new Date(`${match.match_date}T${match.match_time_brasilia}-03:00`);
+  return now >= matchDateTime || match.is_finished;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,25 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Minimal scrollbar for modals and panels */
+.minimal-scrollbar::-webkit-scrollbar {
+  width: 4px;
+}
+.minimal-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.minimal-scrollbar::-webkit-scrollbar-thumb {
+  background: hsl(0 0% 30%);
+  border-radius: 4px;
+}
+.minimal-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: hsl(0 0% 45%);
+}
+.minimal-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: hsl(0 0% 30%) transparent;
+}
+
 /* Mandala satellite entrance animation */
 @keyframes mandala-satellite-enter {
   0% { opacity: 0; transform: translate(-50%, -50%) scale(0.6); filter: blur(4px); }
@@ -210,6 +229,24 @@ All colors MUST be HSL.
   }
   .scrollbar-hide::-webkit-scrollbar {
     display: none;
+  }
+
+  .scrollbar-thin {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255, 255, 255, 0.1) transparent;
+  }
+  .scrollbar-thin::-webkit-scrollbar {
+    width: 4px;
+  }
+  .scrollbar-thin::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .scrollbar-thin::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 2px;
+  }
+  .scrollbar-thin::-webkit-scrollbar-thumb:hover {
+    background: rgba(255, 255, 255, 0.2);
   }
 }
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -703,6 +703,300 @@ export type Database = {
           },
         ]
       }
+      bolao_members: {
+        Row: {
+          bolao_id: string
+          id: string
+          joined_at: string
+          role: string
+          user_id: string
+        }
+        Insert: {
+          bolao_id: string
+          id?: string
+          joined_at?: string
+          role?: string
+          user_id: string
+        }
+        Update: {
+          bolao_id?: string
+          id?: string
+          joined_at?: string
+          role?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bolao_members_bolao_id_fkey"
+            columns: ["bolao_id"]
+            isOneToOne: false
+            referencedRelation: "boloes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bolao_predictions: {
+        Row: {
+          bolao_id: string
+          created_at: string
+          id: string
+          match_id: number
+          points_earned: number | null
+          predicted_away_score: number
+          predicted_home_score: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          bolao_id: string
+          created_at?: string
+          id?: string
+          match_id: number
+          points_earned?: number | null
+          predicted_away_score: number
+          predicted_home_score: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          bolao_id?: string
+          created_at?: string
+          id?: string
+          match_id?: number
+          points_earned?: number | null
+          predicted_away_score?: number
+          predicted_home_score?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bolao_predictions_bolao_id_fkey"
+            columns: ["bolao_id"]
+            isOneToOne: false
+            referencedRelation: "boloes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "bolao_predictions_match_id_fkey"
+            columns: ["match_id"]
+            isOneToOne: false
+            referencedRelation: "wc_matches"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bolao_special_predictions: {
+        Row: {
+          bolao_id: string
+          created_at: string
+          id: string
+          points_earned: number | null
+          predicted_team_code: string
+          prediction_type: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          bolao_id: string
+          created_at?: string
+          id?: string
+          points_earned?: number | null
+          predicted_team_code: string
+          prediction_type: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          bolao_id?: string
+          created_at?: string
+          id?: string
+          points_earned?: number | null
+          predicted_team_code?: string
+          prediction_type?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bolao_special_predictions_bolao_id_fkey"
+            columns: ["bolao_id"]
+            isOneToOne: false
+            referencedRelation: "boloes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      bolao_subscriptions: {
+        Row: {
+          bolao_id: string | null
+          created_at: string
+          expires_at: string | null
+          id: string
+          status: string
+          stripe_session_id: string | null
+          stripe_subscription_id: string | null
+          type: string
+          user_id: string
+        }
+        Insert: {
+          bolao_id?: string | null
+          created_at?: string
+          expires_at?: string | null
+          id?: string
+          status?: string
+          stripe_session_id?: string | null
+          stripe_subscription_id?: string | null
+          type: string
+          user_id: string
+        }
+        Update: {
+          bolao_id?: string | null
+          created_at?: string
+          expires_at?: string | null
+          id?: string
+          status?: string
+          stripe_session_id?: string | null
+          stripe_subscription_id?: string | null
+          type?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bolao_subscriptions_bolao_id_fkey"
+            columns: ["bolao_id"]
+            isOneToOne: false
+            referencedRelation: "boloes"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      boloes: {
+        Row: {
+          champion_enabled: boolean
+          champion_points: number
+          created_at: string
+          custom_banner_url: string | null
+          custom_color: string | null
+          description: string | null
+          id: string
+          invite_code: string
+          is_closed: boolean
+          is_premium: boolean
+          is_public: boolean
+          max_participants: number
+          name: string
+          owner_id: string
+          scoring_exact: number
+          scoring_preset: string | null
+          scoring_result: number
+          special_predictions_config: Record<string, boolean>
+          special_predictions_enabled: boolean
+        }
+        Insert: {
+          champion_enabled?: boolean
+          champion_points?: number
+          created_at?: string
+          custom_banner_url?: string | null
+          custom_color?: string | null
+          description?: string | null
+          id?: string
+          invite_code: string
+          is_closed?: boolean
+          is_premium?: boolean
+          is_public?: boolean
+          max_participants?: number
+          name: string
+          owner_id: string
+          scoring_exact?: number
+          scoring_preset?: string | null
+          scoring_result?: number
+          special_predictions_config?: Record<string, boolean>
+          special_predictions_enabled?: boolean
+        }
+        Update: {
+          champion_enabled?: boolean
+          champion_points?: number
+          created_at?: string
+          custom_banner_url?: string | null
+          custom_color?: string | null
+          description?: string | null
+          id?: string
+          invite_code?: string
+          is_closed?: boolean
+          is_premium?: boolean
+          is_public?: boolean
+          max_participants?: number
+          name?: string
+          owner_id?: string
+          scoring_exact?: number
+          scoring_preset?: string | null
+          scoring_result?: number
+          special_predictions_config?: Record<string, boolean>
+          special_predictions_enabled?: boolean
+        }
+        Relationships: []
+      }
+      wc_matches: {
+        Row: {
+          away_score: number | null
+          away_team: string
+          away_team_code: string
+          city: string | null
+          created_at: string
+          group_name: string | null
+          home_score: number | null
+          home_team: string
+          home_team_code: string
+          id: number
+          is_finished: boolean
+          match_date: string
+          match_number: number
+          match_time_brasilia: string
+          stage: string
+          updated_at: string
+          venue: string | null
+        }
+        Insert: {
+          away_score?: number | null
+          away_team: string
+          away_team_code: string
+          city?: string | null
+          created_at?: string
+          group_name?: string | null
+          home_score?: number | null
+          home_team: string
+          home_team_code: string
+          id?: number
+          is_finished?: boolean
+          match_date: string
+          match_number: number
+          match_time_brasilia: string
+          stage?: string
+          updated_at?: string
+          venue?: string | null
+        }
+        Update: {
+          away_score?: number | null
+          away_team?: string
+          away_team_code?: string
+          city?: string | null
+          created_at?: string
+          group_name?: string | null
+          home_score?: number | null
+          home_team?: string
+          home_team_code?: string
+          id?: number
+          is_finished?: boolean
+          match_date?: string
+          match_number?: number
+          match_time_brasilia?: string
+          stage?: string
+          updated_at?: string
+          venue?: string | null
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never
@@ -725,6 +1019,7 @@ export type Database = {
         Args: { p_semana_inicio?: string }
         Returns: undefined
       }
+      calculate_bolao_scores: { Args: { p_match_id: number }; Returns: Json }
       calculate_weekly_performance: {
         Args: { p_week_start_date?: string }
         Returns: undefined
@@ -908,6 +1203,98 @@ export type Database = {
           right_corner_3_fga: number
           right_corner_3_fgm: number
         }[]
+      }
+      get_bolao_ranking: {
+        Args: { p_bolao_id: string }
+        Returns: {
+          correct_results: number
+          exact_scores: number
+          rank: number
+          total_points: number
+          total_predictions: number
+          user_email: string
+          user_id: string
+          user_name: string
+        }[]
+      }
+      get_champion_predictions: {
+        Args: { p_bolao_id: string }
+        Returns: {
+          created_at: string
+          points_earned: number
+          predicted_team_code: string
+          user_id: string
+          user_name: string
+        }[]
+      }
+      get_user_bolao_ids: { Args: { p_user_id?: string }; Returns: string[] }
+      get_user_boloes: {
+        Args: { p_user_id?: string }
+        Returns: {
+          created_at: string
+          description: string
+          has_champion_prediction: boolean
+          id: string
+          invite_code: string
+          is_closed: boolean
+          is_premium: boolean
+          max_participants: number
+          member_count: number
+          name: string
+          owner_id: string
+          owner_name: string
+          pending_predictions: number
+          user_points: number
+          user_predictions: number
+          user_rank: number
+        }[]
+      }
+      join_bolao_by_code: { Args: { p_invite_code: string }; Returns: Json }
+      remove_bolao_member: {
+        Args: { p_bolao_id: string; p_user_id: string }
+        Returns: Json
+      }
+      toggle_bolao_closed: { Args: { p_bolao_id: string }; Returns: Json }
+      upsert_champion_prediction: {
+        Args: { p_bolao_id: string; p_team_code: string }
+        Returns: Json
+      }
+      toggle_special_prediction: {
+        Args: { p_bolao_id: string; p_prediction_type: string; p_team_code: string }
+        Returns: Json
+      }
+      get_my_special_predictions: {
+        Args: { p_bolao_id: string }
+        Returns: { prediction_type: string; predicted_team_code: string; points_earned: number | null }[]
+      }
+      get_bolao_special_summary: {
+        Args: { p_bolao_id: string }
+        Returns: { prediction_type: string; predicted_team_code: string; pick_count: number }[]
+      }
+      update_bolao_scoring: {
+        Args: { p_bolao_id: string; p_preset: string; p_scoring_result?: number; p_scoring_exact?: number }
+        Returns: Json
+      }
+      get_bolao_stats: {
+        Args: { p_bolao_id: string }
+        Returns: Json
+      }
+      get_bolao_round_ranking: {
+        Args: { p_bolao_id: string; p_stage?: string }
+        Returns: {
+          user_id: string
+          user_name: string
+          user_email: string
+          total_points: number
+          exact_scores: number
+          correct_results: number
+          total_predictions: number
+          rank: number
+        }[]
+      }
+      update_bolao_theme: {
+        Args: { p_bolao_id: string; p_color?: string; p_logo_url?: string }
+        Returns: Json
       }
       get_referral_count: { Args: { p_user_id: string }; Returns: number }
       get_referred_users: {

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -1,0 +1,736 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import AnalyticsNav from '@/components/AnalyticsNav';
+import {
+  Trophy,
+  ArrowLeft,
+  Users,
+  Hash,
+  ClipboardList,
+  Share2,
+  BarChart3,
+  Image,
+  Settings,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  useBolao,
+  useBolaoRanking,
+  useWcMatches,
+  useBolaoPredictions,
+  useChampionPredictions,
+  useUpsertChampionPrediction,
+} from '@/hooks/use-bolao';
+import { BolaoRankingTable } from '@/components/bolao/BolaoRankingTable';
+import { BolaoShareButton } from '@/components/bolao/BolaoShareButton';
+import { ChampionPickModal } from '@/components/bolao/ChampionPickModal';
+import { BolaoAdminPanel } from '@/components/bolao/BolaoAdminPanel';
+import { SpecialPredictionsSection } from '@/components/bolao/SpecialPredictionsSection';
+import { PredictionsModal } from '@/components/bolao/PredictionsModal';
+
+import { BolaoStatsPanel } from '@/components/bolao/BolaoStatsPanel';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+import type { WcMatch, BolaoRankingEntry } from '@/services/bolao.service';
+
+type Tab = 'ranking' | 'meus-palpites' | 'estatisticas';
+
+// ── Theme accent colors ────────────────────────────────────────────
+const THEME_ACCENT: Record<string, { badge: string; header: string }> = {
+  blue:    { badge: 'bg-blue-900/20 border-blue-500/30',    header: 'border-blue-500/20'    },
+  green:   { badge: 'bg-emerald-900/20 border-emerald-500/30', header: 'border-emerald-500/20' },
+  gold:    { badge: 'bg-yellow-900/20 border-yellow-500/30', header: 'border-yellow-500/20'  },
+  purple:  { badge: 'bg-purple-900/20 border-purple-500/30', header: 'border-purple-500/20'  },
+  red:     { badge: 'bg-red-900/20 border-red-700/30',       header: 'border-red-700/20'     },
+  cyan:    { badge: 'bg-cyan-900/20 border-cyan-500/30',     header: 'border-cyan-500/20'    },
+  orange:  { badge: 'bg-orange-900/20 border-orange-500/30', header: 'border-orange-500/20'  },
+};
+
+// ── Ranking share text ─────────────────────────────────────────────
+function buildRankingText(
+  bolaoName: string,
+  ranking: { user_name: string; user_email: string; total_points: number; rank: number }[]
+) {
+  const lines = [
+    `🏆 ${bolaoName} — Copa do Mundo 2026`,
+    '',
+    ...ranking.slice(0, 10).map((r) => {
+      const medal = r.rank === 1 ? '🥇' : r.rank === 2 ? '🥈' : r.rank === 3 ? '🥉' : `${r.rank}.`;
+      const name = r.user_name || r.user_email.split('@')[0];
+      return `${medal} ${name} — ${r.total_points} pts`;
+    }),
+    '',
+    'smartbetting.app/bolao',
+  ];
+  return lines.join('\n');
+}
+
+// ── Ranking share image ────────────────────────────────────────────
+async function generateRankingImageBlob(
+  bolaoName: string,
+  ranking: BolaoRankingEntry[]
+): Promise<Blob> {
+  const top10 = ranking.slice(0, 10);
+  const rowH = 46;
+  const headerH = 76;
+  const footerH = 36;
+  const width = 420;
+  const height = headerH + top10.length * rowH + footerH;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d')!;
+
+  ctx.fillStyle = '#0D1117';
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.fillStyle = '#161B22';
+  ctx.fillRect(0, 0, width, headerH);
+
+  ctx.fillStyle = '#F0A500';
+  ctx.fillRect(20, 20, 36, 36);
+  ctx.fillStyle = '#0D1117';
+  ctx.font = 'bold 22px monospace';
+  ctx.fillText('🏆', 22, 46);
+
+  ctx.fillStyle = '#E6EDF3';
+  ctx.font = 'bold 15px system-ui, sans-serif';
+  ctx.fillText(bolaoName.length > 26 ? bolaoName.slice(0, 26) + '…' : bolaoName, 68, 38);
+  ctx.fillStyle = '#8B949E';
+  ctx.font = '11px system-ui, sans-serif';
+  ctx.fillText('Copa do Mundo 2026', 68, 58);
+
+  const medals = ['🥇', '🥈', '🥉'];
+  top10.forEach((entry, i) => {
+    const y = headerH + i * rowH;
+    if (i % 2 === 0) {
+      ctx.fillStyle = '#161B22';
+      ctx.fillRect(0, y, width, rowH);
+    }
+
+    const rankStr = i < 3 ? medals[i] : `${i + 1}.`;
+    const name = (entry.user_name || entry.user_email.split('@')[0]).slice(0, 22);
+
+    ctx.fillStyle = i === 0 ? '#F0A500' : i === 1 ? '#C0C0C0' : i === 2 ? '#CD7F32' : '#E6EDF3';
+    ctx.font = `bold 13px system-ui, sans-serif`;
+    ctx.textAlign = 'left';
+    ctx.fillText(rankStr, 20, y + 28);
+
+    ctx.fillStyle = '#E6EDF3';
+    ctx.font = '13px system-ui, sans-serif';
+    ctx.fillText(name, 52, y + 28);
+
+    ctx.fillStyle = '#58A6FF';
+    ctx.font = 'bold 13px monospace';
+    ctx.textAlign = 'right';
+    ctx.fillText(`${entry.total_points} pts`, width - 20, y + 28);
+    ctx.textAlign = 'left';
+  });
+
+  ctx.fillStyle = '#0D1117';
+  ctx.fillRect(0, headerH + top10.length * rowH, width, footerH);
+  ctx.fillStyle = '#8B949E';
+  ctx.font = '10px system-ui, sans-serif';
+  ctx.fillText('smartbetting.app/bolao', 20, headerH + top10.length * rowH + 22);
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error('Canvas toBlob failed'));
+    }, 'image/png');
+  });
+}
+
+// ── Component ──────────────────────────────────────────────────────
+const BolaoDetail: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { toast } = useToast();
+  const [activeTab, setActiveTab] = useState<Tab>('ranking');
+  const [currentUserId, setCurrentUserId] = useState<string | undefined>();
+  const [showAdmin, setShowAdmin] = useState(false);
+
+  React.useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setCurrentUserId(data.user?.id);
+    });
+  }, []);
+
+  const [championModalOpen, setChampionModalOpen] = useState(false);
+  const [predictionsModalOpen, setPredictionsModalOpen] = useState(false);
+  const [specialPredictionsOpen, setSpecialPredictionsOpen] = useState(false);
+
+  const { data: bolao, isLoading: loadingBolao } = useBolao(id);
+  const { data: ranking } = useBolaoRanking(id);
+  const { data: matches } = useWcMatches();
+  const { data: myPredictions } = useBolaoPredictions(id, currentUserId);
+  const { data: championPredictions } = useChampionPredictions(id);
+  const upsertChampion = useUpsertChampionPrediction();
+
+  // ── Handle query params: Stripe success + auto-open settings ──────
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (params.get('success') === 'true') {
+      toast({
+        title: 'Bolão Premium ativado!',
+        description: 'Pagamento confirmado. Aproveite os recursos exclusivos.',
+      });
+      setShowAdmin(true);
+      navigate(`/bolao/${id}`, { replace: true });
+    }
+    if (params.get('settings') === 'true') {
+      setShowAdmin(true);
+      navigate(`/bolao/${id}`, { replace: true });
+    }
+  }, [location.search, id, navigate, toast]);
+
+  const myChampionPick = useMemo(
+    () => championPredictions?.find((p) => p.user_id === currentUserId) ?? null,
+    [championPredictions, currentUserId]
+  );
+
+  const handleChampionConfirm = (teamCode: string) => {
+    if (!id) return;
+    upsertChampion.mutate(
+      { bolaoId: id, teamCode },
+      { onSuccess: () => setChampionModalOpen(false) }
+    );
+  };
+
+  const predictionsByMatch = useMemo(
+    () => new Map((myPredictions || []).map((p) => [p.match_id, p])),
+    [myPredictions]
+  );
+
+
+
+  const matchesByStage = useMemo(
+    () =>
+      (matches || []).reduce<Record<string, WcMatch[]>>((acc, m) => {
+        const key = m.group_name ? `Grupo ${m.group_name}` : m.stage;
+        if (!acc[key]) acc[key] = [];
+        acc[key].push(m);
+        return acc;
+      }, {}),
+    [matches]
+  );
+
+  const showOnboarding = useMemo(
+    () =>
+      bolao != null &&
+      (ranking?.length ?? 0) <= 1 &&
+      (myPredictions?.length ?? 0) === 0,
+    [bolao, ranking, myPredictions]
+  );
+
+  // ── Ranking share: text ────────────────────────────────────────────
+  const handleShareRanking = async () => {
+    if (!bolao || !ranking) return;
+    const text = buildRankingText(bolao.name, ranking);
+    if (navigator.share) {
+      try {
+        await navigator.share({ text });
+        return;
+      } catch {
+        // fallback to clipboard
+      }
+    }
+    await navigator.clipboard.writeText(text);
+    toast({ title: 'Ranking copiado!', description: 'Cole no WhatsApp ou Telegram.' });
+  };
+
+  // ── Ranking share: image (premium) ────────────────────────────────
+  const handleShareRankingImage = async () => {
+    if (!bolao || !ranking) return;
+    try {
+      const blob = await generateRankingImageBlob(bolao.name, ranking);
+      const file = new File([blob], `ranking-${bolao.invite_code}.png`, { type: 'image/png' });
+      if (navigator.share && navigator.canShare?.({ files: [file] })) {
+        await navigator.share({ files: [file], title: `${bolao.name} — Ranking` });
+      } else {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = file.name;
+        a.click();
+        URL.revokeObjectURL(url);
+        toast({ title: 'Imagem baixada!' });
+      }
+    } catch {
+      toast({ title: 'Erro ao gerar imagem', variant: 'destructive' });
+    }
+  };
+
+  // Theme accent
+  const accent = bolao?.custom_color ? THEME_ACCENT[bolao.custom_color] : null;
+
+  const tabs: { key: Tab; label: string; icon: React.ReactNode }[] = [
+    { key: 'ranking',      label: 'Ranking',      icon: <Trophy className="w-4 h-4" /> },
+    { key: 'meus-palpites',label: 'Palpites',      icon: <ClipboardList className="w-4 h-4" /> },
+    { key: 'estatisticas', label: 'Estatísticas',  icon: <BarChart3 className="w-4 h-4" /> },
+  ];
+
+  if (loadingBolao) {
+    return (
+      <div className="min-h-screen bg-terminal-bg flex items-center justify-center">
+        <div className="animate-pulse text-terminal-text opacity-50">Carregando...</div>
+      </div>
+    );
+  }
+
+  if (!bolao) {
+    return (
+      <div className="min-h-screen bg-terminal-bg flex items-center justify-center text-terminal-text">
+        <div className="text-center">
+          <p className="text-lg mb-4">Bolão não encontrado</p>
+          <Button variant="ghost" onClick={() => navigate('/bolao')}>Voltar</Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Sidebar content (rendered in both mobile and desktop positions) ──
+  const sidebarContent = (
+    <>
+      {/* 1. Palpites dos Jogos */}
+      <div className="terminal-container p-4 border-terminal-blue/20 bg-terminal-blue/[0.03]">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            <ClipboardList className="w-4 h-4 text-terminal-blue shrink-0" />
+            <div className="min-w-0">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-terminal-blue">
+                Palpites dos Jogos
+              </p>
+              <p className="text-xs opacity-50">
+                {myPredictions?.length || 0} feitos · {matches?.filter((m) => !m.is_finished && m.home_team_code !== 'TBD').length || 0} disponíveis
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => setPredictionsModalOpen(true)}
+            className="text-[10px] font-bold text-terminal-blue hover:text-terminal-blue/80 shrink-0 border border-terminal-blue/30 rounded px-2 py-1 hover:bg-terminal-blue/10 transition-colors"
+          >
+            Fazer palpites →
+          </button>
+        </div>
+      </div>
+
+      {/* 2. Palpite de Campeão */}
+      {(bolao.champion_enabled ?? true) && <div className="terminal-container p-4 border-yellow-500/20 bg-yellow-500/[0.03]">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            <Trophy className="w-4 h-4 text-yellow-400 shrink-0" />
+            <div className="min-w-0">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-yellow-400">
+                Palpite de Campeão
+              </p>
+              {myChampionPick ? (
+                <p className="text-sm font-semibold truncate">
+                  {myChampionPick.predicted_team_code}
+                  {matches && (() => {
+                    const name =
+                      matches.find(m => m.home_team_code === myChampionPick.predicted_team_code)?.home_team ||
+                      matches.find(m => m.away_team_code === myChampionPick.predicted_team_code)?.away_team;
+                    return name ? ` — ${name}` : '';
+                  })()}
+                </p>
+              ) : (
+                <p className="text-xs opacity-50">Quem vai ganhar a Copa 2026?</p>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={() => setChampionModalOpen(true)}
+            className="text-[10px] font-bold text-yellow-400 hover:text-yellow-300 shrink-0 border border-yellow-500/30 rounded px-2 py-1 hover:bg-yellow-500/10 transition-colors"
+          >
+            {myChampionPick ? 'Alterar' : 'Escolher →'}
+          </button>
+        </div>
+
+        {championPredictions && championPredictions.length > 0 && (
+          <div className="mt-3 pt-3 border-t border-yellow-500/10">
+            <p className="text-[10px] opacity-40 mb-2 uppercase tracking-wider">
+              {championPredictions.length} palpite{championPredictions.length !== 1 ? 's' : ''} registrado{championPredictions.length !== 1 ? 's' : ''}
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {(() => {
+                const counts = new Map<string, number>();
+                for (const p of championPredictions) {
+                  counts.set(p.predicted_team_code, (counts.get(p.predicted_team_code) ?? 0) + 1);
+                }
+                return Array.from(counts.entries())
+                  .sort((a, b) => b[1] - a[1])
+                  .map(([code, count]) => (
+                    <span
+                      key={code}
+                      className={`text-[10px] px-2 py-0.5 rounded border font-mono ${
+                        code === myChampionPick?.predicted_team_code
+                          ? 'border-yellow-500/50 bg-yellow-500/10 text-yellow-400'
+                          : 'border-terminal-border-subtle bg-terminal-dark-gray/40 opacity-60'
+                      }`}
+                    >
+                      {code} {count > 1 && <span className="opacity-60">×{count}</span>}
+                    </span>
+                  ));
+              })()}
+            </div>
+          </div>
+        )}
+      </div>}
+
+      {/* 3. Palpites Especiais — same card style */}
+      {(bolao.special_predictions_enabled ?? true) && <div className="terminal-container p-4 border-emerald-500/20 bg-emerald-500/[0.03]">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            <Trophy className="w-4 h-4 text-emerald-400 shrink-0" />
+            <div className="min-w-0">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-emerald-400">
+                Palpites Especiais
+              </p>
+              <p className="text-xs opacity-50">
+                {(() => {
+                  const cfg = bolao.special_predictions_config;
+                  if (!cfg) return 'Finalistas, semis, quartas...';
+                  const labels: string[] = [];
+                  if (cfg.finalist) labels.push('Finalistas');
+                  if (cfg.semifinalist) labels.push('Semis');
+                  if (cfg.quarterfinalist) labels.push('Quartas');
+                  if (cfg.round_of_32) labels.push('Mata-mata');
+                  return labels.join(', ') || 'Nenhum habilitado';
+                })()}
+              </p>
+            </div>
+          </div>
+          {!bolao.is_premium && (
+            <span className="text-[9px] px-1.5 py-0.5 bg-yellow-500/20 text-yellow-400 rounded border border-yellow-500/30 font-bold shrink-0">
+              PREMIUM
+            </span>
+          )}
+          {bolao.is_premium && (
+            <button
+              onClick={() => setSpecialPredictionsOpen(true)}
+              className="text-[10px] font-bold text-emerald-400 hover:text-emerald-300 shrink-0 border border-emerald-500/30 rounded px-2 py-1 hover:bg-emerald-500/10 transition-colors"
+            >
+              Ver palpites →
+            </button>
+          )}
+        </div>
+      </div>}
+    </>
+  );
+
+  return (
+    <div className="min-h-screen bg-terminal-bg text-terminal-text">
+      <AnalyticsNav />
+
+      <div className="max-w-6xl mx-auto px-4 py-6">
+
+        {/* ── Header ── */}
+        <div className={`flex items-center gap-3 mb-4 pb-4 ${accent ? `border-b ${accent.header}` : ''}`}>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => navigate('/bolao')}
+            className="h-8 w-8 shrink-0"
+          >
+            <ArrowLeft className="w-4 h-4" />
+          </Button>
+
+          {bolao.custom_banner_url && (
+            <img
+              src={bolao.custom_banner_url}
+              alt="Logo"
+              className="w-9 h-9 rounded border border-terminal-border object-cover shrink-0"
+            />
+          )}
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h1 className="text-xl font-bold truncate">{bolao.name}</h1>
+              {bolao.is_premium && (
+                <span className={`text-[10px] px-1.5 py-0.5 rounded border font-bold shrink-0 ${
+                  accent ? accent.badge : 'bg-yellow-500/20 border-yellow-500/30 text-yellow-400'
+                } text-yellow-400`}>
+                  PREMIUM
+                </span>
+              )}
+            </div>
+            {bolao.description && (
+              <p className="text-xs opacity-50 truncate">{bolao.description}</p>
+            )}
+          </div>
+
+          <div className="flex items-center gap-1 shrink-0">
+            <BolaoShareButton
+              bolaoName={bolao.name}
+              inviteCode={bolao.invite_code}
+              variant="compact"
+            />
+            {currentUserId && currentUserId === bolao.owner_id && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setShowAdmin(true)}
+                className="gap-1.5 text-xs opacity-60 hover:opacity-100 h-8"
+              >
+                <Settings className="w-3.5 h-3.5" />
+                Configurações
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* ── Info bar ── */}
+        <div className="flex items-center gap-4 mb-5 text-xs opacity-50 flex-wrap">
+          <span className="flex items-center gap-1">
+            <Users className="w-3 h-3" />
+            {ranking?.length || 0} participantes
+          </span>
+          <span className="flex items-center gap-1">
+            <Hash className="w-3 h-3" />
+            {bolao.invite_code}
+          </span>
+          <span>
+            {bolao.scoring_result} pt resultado / {bolao.scoring_exact} pts placar
+            {bolao.scoring_preset === 'weighted_stages' && (
+              <span className="ml-1 text-terminal-blue">(×fase)</span>
+            )}
+          </span>
+        </div>
+
+        {/* ── Onboarding (full width, before grid) ── */}
+        {showOnboarding && (
+          <div className="terminal-container p-4 mb-5 border-terminal-blue/30 bg-terminal-blue/5">
+            <p className="text-xs font-bold uppercase tracking-wider text-terminal-blue mb-3">
+              Primeiros passos
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4">
+              <div className="flex items-start gap-3 flex-1">
+                <span className="text-[10px] font-bold text-terminal-blue bg-terminal-blue/20 rounded-full w-5 h-5 flex items-center justify-center shrink-0 mt-0.5">
+                  1
+                </span>
+                <div className="flex-1">
+                  <p className="text-sm font-medium">Compartilhe com seus amigos</p>
+                  <p className="text-xs opacity-50">
+                    Envie o código <span className="font-mono text-terminal-blue">{bolao.invite_code}</span> ou o link de convite
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-start gap-3 flex-1">
+                <span className="text-[10px] font-bold text-terminal-blue bg-terminal-blue/20 rounded-full w-5 h-5 flex items-center justify-center shrink-0 mt-0.5">
+                  2
+                </span>
+                <div className="flex-1">
+                  <p className="text-sm font-medium">Faça seus palpites</p>
+                  <p className="text-xs opacity-50">
+                    Palpite nos 104 jogos antes de cada partida começar
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* ── 2-column grid (desktop) / single column (mobile) ── */}
+        <div className="lg:grid lg:grid-cols-[1fr_340px] lg:gap-6">
+
+          {/* ── Main content ── */}
+          <div className="min-w-0">
+            {/* Tabs */}
+            <div className="flex gap-1 mb-6 border-b border-terminal-border">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.key}
+                  onClick={() => setActiveTab(tab.key)}
+                  className={`flex items-center gap-1.5 px-4 py-2.5 text-xs font-bold uppercase transition-colors border-b-2 -mb-px ${
+                    activeTab === tab.key
+                      ? 'border-terminal-blue text-terminal-blue'
+                      : 'border-transparent opacity-50 hover:opacity-80'
+                  }`}
+                >
+                  {tab.icon}
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            {/* Tab: Ranking */}
+            {activeTab === 'ranking' && (
+              <>
+                {ranking && ranking.length > 1 && (
+                  <div className="flex items-center justify-end gap-3 mb-3">
+                    <button
+                      onClick={handleShareRanking}
+                      className="flex items-center gap-1.5 text-xs opacity-50 hover:opacity-80 transition-opacity"
+                    >
+                      <Share2 className="w-3 h-3" />
+                      Texto
+                    </button>
+                    {bolao.is_premium && (
+                      <button
+                        onClick={handleShareRankingImage}
+                        className="flex items-center gap-1.5 text-xs opacity-50 hover:opacity-80 transition-opacity"
+                      >
+                        <Image className="w-3 h-3" />
+                        Imagem
+                      </button>
+                    )}
+                  </div>
+                )}
+                <BolaoRankingTable ranking={ranking || []} currentUserId={currentUserId} />
+              </>
+            )}
+
+            {/* Tab: Meus Palpites */}
+            {activeTab === 'meus-palpites' && (
+              <div>
+                <p className="text-xs opacity-50 mb-4">
+                  {myPredictions?.length || 0} palpites registrados
+                </p>
+
+                {(!myPredictions || myPredictions.length === 0) ? (
+                  <div className="text-center py-10 opacity-40">
+                    <ClipboardList className="w-10 h-10 mx-auto mb-3" />
+                    <p className="text-sm">Nenhum palpite ainda</p>
+                    <p className="text-xs mt-1">Use o botão abaixo para fazer seus palpites</p>
+                  </div>
+                ) : (
+                  Object.entries(matchesByStage).map(([stageName, stageMatches]) => {
+                    const matchesWithPrediction = stageMatches.filter((m) =>
+                      predictionsByMatch.has(m.id)
+                    );
+                    if (matchesWithPrediction.length === 0) return null;
+
+                    return (
+                      <div key={stageName} className="mb-6">
+                        <h3 className="text-xs uppercase font-bold opacity-50 mb-3">{stageName}</h3>
+                        <div className="space-y-2">
+                          {matchesWithPrediction.map((match) => {
+                            const pred = predictionsByMatch.get(match.id)!;
+                            return (
+                              <div
+                                key={match.id}
+                                className="flex items-center gap-2 p-3 rounded border border-terminal-border-subtle bg-terminal-dark-gray/20"
+                              >
+                                <div className="flex-1 flex items-center gap-1 text-sm">
+                                  <span className="flex-1 text-right font-medium">
+                                    {match.home_team_code}
+                                  </span>
+                                  <span className="px-2 font-bold text-terminal-green">
+                                    {pred.predicted_home_score} x {pred.predicted_away_score}
+                                  </span>
+                                  <span className="flex-1 font-medium">
+                                    {match.away_team_code}
+                                  </span>
+                                </div>
+                                {match.is_finished && pred.points_earned != null && (
+                                  <span
+                                    className={`text-xs font-bold px-2 py-0.5 rounded shrink-0 ${
+                                      pred.points_earned > 0
+                                        ? 'bg-terminal-green/20 text-terminal-green'
+                                        : 'bg-terminal-dark-gray text-terminal-text/50'
+                                    }`}
+                                  >
+                                    {pred.points_earned > 0 ? `+${pred.points_earned}` : '0'}
+                                  </span>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            )}
+
+            {/* Tab: Estatísticas */}
+            {activeTab === 'estatisticas' && (
+              <BolaoStatsPanel
+                bolaoId={bolao.id}
+                currentUserId={currentUserId}
+                isPremium={bolao.is_premium}
+              />
+            )}
+          </div>
+
+          {/* ── Sidebar ── */}
+          <aside className="space-y-4 mt-6 lg:mt-0 lg:sticky lg:top-6 lg:self-start">
+            {sidebarContent}
+          </aside>
+        </div>
+      </div>
+
+      {/* Fixed bottom CTA removed — fazer palpites is accessible via tab */}
+
+      {/* Champion pick modal */}
+      <ChampionPickModal
+        open={championModalOpen}
+        onOpenChange={setChampionModalOpen}
+        matches={matches || []}
+        currentPick={myChampionPick?.predicted_team_code ?? null}
+        onConfirm={handleChampionConfirm}
+        isLoading={upsertChampion.isPending}
+      />
+
+      {/* Special Predictions modal */}
+      <Dialog open={specialPredictionsOpen} onOpenChange={setSpecialPredictionsOpen}>
+        <DialogContent className="bg-terminal-bg border-terminal-border max-w-2xl max-h-[90vh] overflow-y-auto p-0">
+          <DialogHeader className="px-5 pt-5 pb-0">
+            <DialogTitle className="flex items-center gap-2 text-terminal-text">
+              <Trophy className="w-5 h-5 text-emerald-400" />
+              Palpites Especiais
+            </DialogTitle>
+          </DialogHeader>
+          <div className="px-5 pb-5 pt-4">
+            <SpecialPredictionsSection
+              bolaoId={bolao.id}
+              isPremium={bolao.is_premium}
+              matches={matches || []}
+              hideChrome
+              enabledTypes={bolao.special_predictions_config ?? undefined}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Predictions modal */}
+      <PredictionsModal
+        open={predictionsModalOpen}
+        onOpenChange={setPredictionsModalOpen}
+        bolaoId={bolao.id}
+        currentUserId={currentUserId}
+      />
+
+      {/* Settings modal */}
+      {currentUserId && (
+        <BolaoAdminPanel
+          open={showAdmin}
+          onOpenChange={setShowAdmin}
+          bolaoId={bolao.id}
+          isClosed={bolao.is_closed}
+          isPremium={bolao.is_premium}
+          scoringPreset={bolao.scoring_preset ?? null}
+          scoringResult={bolao.scoring_result}
+          scoringExact={bolao.scoring_exact}
+          customColor={bolao.custom_color ?? null}
+          customBannerUrl={bolao.custom_banner_url ?? null}
+          championEnabled={bolao.champion_enabled ?? true}
+          specialPredictionsEnabled={bolao.special_predictions_enabled ?? true}
+          specialPredictionsConfig={bolao.special_predictions_config ?? { finalist: true, semifinalist: true, quarterfinalist: true, round_of_32: true }}
+          specialPredictionsPoints={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_32: 1 }}
+          championPoints={bolao.champion_points ?? 10}
+          ranking={ranking || []}
+          currentUserId={currentUserId}
+          ownerUserId={bolao.owner_id}
+        />
+      )}
+    </div>
+  );
+};
+
+export default BolaoDetail;

--- a/src/pages/BolaoHome.tsx
+++ b/src/pages/BolaoHome.tsx
@@ -1,0 +1,471 @@
+import React, { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Trophy,
+  Plus,
+  Users,
+  ChevronRight,
+  Hash,
+  ArrowRight,
+  Zap,
+  LayoutGrid,
+  GitBranch,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useUserBoloes, useCreateBolao, useJoinBolao, useWcMatches } from '@/hooks/use-bolao';
+import { CreateBolaoModal } from '@/components/bolao/CreateBolaoModal';
+import { CopaGruposModal } from '@/components/bolao/CopaGruposModal';
+import { CopaBracketModal } from '@/components/bolao/CopaBracketModal';
+import { TeamFlag } from '@/components/bolao/TeamFlag';
+import { useToast } from '@/hooks/use-toast';
+import AnalyticsNav from '@/components/AnalyticsNav';
+import { supabase } from '@/integrations/supabase/client';
+
+const COPA_START = new Date('2026-06-11T12:00:00-03:00');
+
+function CopaCountdown() {
+  const now = new Date();
+  const diff = COPA_START.getTime() - now.getTime();
+  const days = Math.max(0, Math.ceil(diff / (1000 * 60 * 60 * 24)));
+  if (days === 0) return <span className="text-terminal-blue font-bold text-xl">Hoje!</span>;
+  return (
+    <div className="flex items-baseline gap-1">
+      <span className="text-terminal-blue font-bold text-xl">{days}</span>
+      <span className="text-xs opacity-50">dias</span>
+    </div>
+  );
+}
+
+function RankLabel({ rank, memberCount }: { rank: number; memberCount: number }) {
+  if (memberCount <= 1) return null;
+  const label = `${rank}º lugar`;
+  const color =
+    rank === 1
+      ? 'text-yellow-400'
+      : rank === 2
+      ? 'text-slate-300'
+      : rank === 3
+      ? 'text-orange-400'
+      : 'opacity-40';
+  return <span className={`text-[10px] font-bold ${color}`}>{label}</span>;
+}
+
+
+const BolaoHome: React.FC = () => {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const { data: boloes, isLoading } = useUserBoloes();
+  const { data: matches } = useWcMatches();
+  const createBolao = useCreateBolao();
+  const joinBolao = useJoinBolao();
+  const [showCreate, setShowCreate] = useState(false);
+  const [showGrupos, setShowGrupos] = useState(false);
+  const [showBracket, setShowBracket] = useState(false);
+  const [inviteCode, setInviteCode] = useState('');
+  const [currentUserId, setCurrentUserId] = React.useState<string | undefined>();
+
+  React.useEffect(() => {
+    import('@/integrations/supabase/client').then(({ supabase }) => {
+      supabase.auth.getUser().then(({ data }) => setCurrentUserId(data.user?.id));
+    });
+  }, []);
+
+  // Group stage matches organised by matchday (Rodada 1/2/3), sorted chronologically.
+  // Group letter is shown as a label on each row instead of a section header.
+  const matchesByRound = useMemo(() => {
+    if (!matches) return {} as Record<string, NonNullable<typeof matches>>;
+
+    const byGroup: Record<string, NonNullable<typeof matches>> = {};
+    matches
+      .filter((m) => m.group_name && m.home_team_code !== 'TBD')
+      .forEach((m) => {
+        const g = m.group_name!;
+        if (!byGroup[g]) byGroup[g] = [];
+        byGroup[g].push(m);
+      });
+    Object.values(byGroup).forEach((gm) =>
+      gm.sort(
+        (a, b) =>
+          a.match_date.localeCompare(b.match_date) ||
+          a.match_time_brasilia.localeCompare(b.match_time_brasilia)
+      )
+    );
+
+    const rounds: Record<string, NonNullable<typeof matches>> = {
+      'Rodada 1': [],
+      'Rodada 2': [],
+      'Rodada 3': [],
+    };
+    Object.values(byGroup).forEach((gm) => {
+      gm.forEach((m, idx) => {
+        const key = idx < 2 ? 'Rodada 1' : idx < 4 ? 'Rodada 2' : 'Rodada 3';
+        rounds[key].push(m);
+      });
+    });
+    // Sort each round chronologically
+    Object.values(rounds).forEach((rm) =>
+      rm.sort(
+        (a, b) =>
+          a.match_date.localeCompare(b.match_date) ||
+          a.match_time_brasilia.localeCompare(b.match_time_brasilia)
+      )
+    );
+    return rounds;
+  }, [matches]);
+
+  // Stripe: dynamic checkout (preferred) or static payment link (fallback)
+  const BOLAO_PRO_PRICE_ID = import.meta.env.VITE_STRIPE_PRICE_ID_BOLAO as string | undefined;
+  const BOLAO_PRO_PAYMENT_LINK = 'https://buy.stripe.com/4gMcMXgG43089uVg6zaR20b';
+
+  const handleCreate = async (data: { name: string; description?: string; plan: 'free' | 'pro' }) => {
+    if (data.plan === 'free') {
+      // Free: cria imediatamente e navega
+      createBolao.mutate({ name: data.name, description: data.description }, {
+        onSuccess: (bolao) => {
+          setShowCreate(false);
+          toast({ title: 'Bolão criado!', description: `Código: ${bolao.invite_code}` });
+          navigate(`/bolao/${bolao.id}?settings=true`);
+        },
+        onError: (err: any) => {
+          toast({ title: 'Erro ao criar', description: err.message, variant: 'destructive' });
+        },
+      });
+      return;
+    }
+
+    // Premium — bolão só é criado APÓS confirmação do pagamento no webhook
+    if (BOLAO_PRO_PRICE_ID) {
+      // Checkout dinâmico: webhook cria o bolão com o UUID pré-gerado
+      setShowCreate(false);
+      const preGeneratedId = crypto.randomUUID();
+      toast({ title: 'Redirecionando para pagamento...', description: 'Bolão Premium criado após confirmação.' });
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session) throw new Error('Usuário não autenticado');
+        const { data: fnData, error } = await supabase.functions.invoke('stripe-create-checkout', {
+          body: {
+            priceId: BOLAO_PRO_PRICE_ID,
+            productType: 'bolao_premium',
+            bolaoId: preGeneratedId,
+            bolaoName: data.name,
+            bolaoDescription: data.description || null,
+          },
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+          },
+        });
+        if (error) throw error;
+        window.location.href = fnData.url;
+      } catch (err: any) {
+        toast({ title: 'Erro ao iniciar checkout', description: err?.message, variant: 'destructive' });
+      }
+    } else {
+      // Fallback sem Price ID: cria o bolão e redireciona para payment link estático
+      // O webhook upgrada via client_reference_id
+      createBolao.mutate({ name: data.name, description: data.description }, {
+        onSuccess: (bolao) => {
+          setShowCreate(false);
+          toast({ title: 'Redirecionando para pagamento...', description: 'Aguarde.' });
+          window.location.href = `${BOLAO_PRO_PAYMENT_LINK}?client_reference_id=${bolao.id}`;
+        },
+        onError: (err: any) => {
+          toast({ title: 'Erro ao criar bolão', description: err.message, variant: 'destructive' });
+        },
+      });
+    }
+  };
+
+  const handleJoin = () => {
+    const code = inviteCode.trim().toUpperCase();
+    if (!code || code.length < 4) return;
+    joinBolao.mutate(code, {
+      onSuccess: (result: any) => {
+        if (result.success && result.bolao_id) {
+          toast({ title: result.message || 'Você entrou no bolão!' });
+          navigate(`/bolao/${result.bolao_id}`);
+        } else {
+          toast({ title: 'Erro', description: result.error, variant: 'destructive' });
+        }
+      },
+      onError: (err: any) => {
+        toast({ title: 'Erro ao entrar', description: err.message, variant: 'destructive' });
+      },
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-terminal-bg text-terminal-text">
+      <AnalyticsNav />
+      <div className="max-w-6xl mx-auto px-4 py-6 space-y-5">
+
+        {/* Copa 2026 Hero — full width */}
+        <div className="terminal-container p-5">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1">
+                <Trophy className="w-5 h-5 text-terminal-blue shrink-0" />
+                <h1 className="text-lg font-bold leading-tight">Bolão Copa do Mundo 2026</h1>
+              </div>
+              <p className="text-xs opacity-40 mb-4">EUA · México · Canadá — 48 seleções, 104 jogos</p>
+
+              <div className="flex items-center gap-5">
+                <div>
+                  <p className="text-[10px] uppercase tracking-wider opacity-40 mb-0.5">Copa começa em</p>
+                  <CopaCountdown />
+                </div>
+                <div className="w-px h-8 bg-terminal-border-subtle" />
+                <div>
+                  <p className="text-[10px] uppercase tracking-wider opacity-40 mb-0.5">Jogos</p>
+                  <div className="flex items-baseline gap-1">
+                    <span className="text-terminal-blue font-bold text-xl">104</span>
+                  </div>
+                </div>
+                <div className="w-px h-8 bg-terminal-border-subtle" />
+                <div>
+                  <p className="text-[10px] uppercase tracking-wider opacity-40 mb-0.5">Grupos</p>
+                  <div className="flex items-baseline gap-1">
+                    <span className="text-terminal-blue font-bold text-xl">12</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Main two-column grid */}
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-5 items-start">
+
+          {/* LEFT COLUMN */}
+          <div className="space-y-4">
+
+            {/* Criar / Entrar — unified card */}
+            <div className="terminal-container p-4">
+              <p className="text-[10px] uppercase tracking-wider opacity-40 mb-3">Meus Bolões</p>
+
+              {/* Criar + Entrar — same row */}
+              <div className="flex gap-2 min-w-0">
+                <Button
+                  onClick={() => setShowCreate(true)}
+                  size="sm"
+                  className="bg-transparent border border-terminal-blue text-terminal-blue hover:bg-terminal-blue/10 gap-1 shrink-0 h-[38px] px-3"
+                >
+                  <Plus className="w-3.5 h-3.5" />
+                  <span className="hidden sm:inline">Criar</span>
+                </Button>
+                <input
+                  type="text"
+                  value={inviteCode}
+                  onChange={(e) => setInviteCode(e.target.value.toUpperCase())}
+                  onKeyDown={(e) => e.key === 'Enter' && handleJoin()}
+                  placeholder="Código de convite"
+                  maxLength={8}
+                  className="min-w-0 flex-1 bg-terminal-dark-gray border border-terminal-border rounded px-3 py-2 text-sm font-mono placeholder:opacity-30 focus:outline-none focus:border-terminal-blue transition-colors"
+                />
+                <Button
+                  onClick={handleJoin}
+                  disabled={inviteCode.trim().length < 4 || joinBolao.isPending}
+                  variant="outline"
+                  size="sm"
+                  className="border-terminal-blue/50 text-terminal-blue hover:bg-terminal-blue/10 gap-1 px-3 h-[38px] shrink-0"
+                >
+                  {joinBolao.isPending ? (
+                    'Entrando...'
+                  ) : (
+                    <>
+                      <span className="hidden sm:inline">Entrar</span> <ArrowRight className="w-3.5 h-3.5" />
+                    </>
+                  )}
+                </Button>
+              </div>
+            </div>
+
+            {/* Bolões list */}
+            {isLoading ? (
+              <div className="space-y-3">
+                {[1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="h-24 rounded border border-terminal-border animate-pulse bg-terminal-dark-gray/30"
+                  />
+                ))}
+              </div>
+            ) : !boloes || boloes.length === 0 ? (
+              <div className="terminal-container p-8 text-center">
+                <Trophy className="w-12 h-12 mx-auto mb-3 opacity-20" />
+                <h2 className="text-base font-bold mb-1">Nenhum bolão ainda</h2>
+                <p className="text-sm opacity-50">
+                  Crie o seu ou peça o código de convite para um amigo
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {boloes.map((bolao) => (
+                  <button
+                    key={bolao.id}
+                    onClick={() => navigate(`/bolao/${bolao.id}`)}
+                    className="w-full text-left terminal-container p-4 hover:border-terminal-blue/30 transition-colors group"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 mb-1.5 flex-wrap">
+                          <h3 className="font-bold text-sm truncate">{bolao.name}</h3>
+                          {bolao.is_premium && (
+                            <span className="text-[10px] px-1.5 py-0.5 bg-yellow-500/20 text-yellow-400 rounded font-bold shrink-0">
+                              PREMIUM
+                            </span>
+                          )}
+                          {bolao.pending_predictions > 0 && (
+                            <span className="text-[10px] px-1.5 py-0.5 bg-terminal-blue/15 text-terminal-blue rounded font-bold shrink-0 flex items-center gap-0.5">
+                              <Zap className="w-2.5 h-2.5" />
+                              {bolao.pending_predictions} pendentes
+                            </span>
+                          )}
+                          {!bolao.has_champion_prediction && (
+                            <span className="text-[10px] px-1.5 py-0.5 bg-yellow-500/10 text-yellow-400 rounded font-bold shrink-0 flex items-center gap-0.5">
+                              <Trophy className="w-2.5 h-2.5" />
+                              Campeão
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-3 text-xs opacity-50">
+                          <span className="flex items-center gap-1">
+                            <Users className="w-3 h-3" />
+                            {bolao.is_premium
+                              ? bolao.member_count
+                              : `${bolao.member_count}/${bolao.max_participants}`}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <Hash className="w-3 h-3" />
+                            {bolao.invite_code}
+                          </span>
+                          {bolao.owner_id === currentUserId && (
+                            <span className="text-terminal-green">Criador</span>
+                          )}
+                          {bolao.is_closed && (
+                            <span className="text-terminal-red opacity-80">Fechado</span>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-3 shrink-0">
+                        <div className="text-right">
+                          <RankLabel rank={bolao.user_rank} memberCount={bolao.member_count} />
+                          <div className="text-xl font-bold text-terminal-blue leading-tight">
+                            {bolao.user_points}
+                          </div>
+                          <div className="text-[10px] opacity-40">pontos</div>
+                        </div>
+                        <ChevronRight className="w-4 h-4 opacity-30 group-hover:opacity-70 transition-opacity" />
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* RIGHT COLUMN — Copa Info */}
+          <div className="terminal-container p-4 lg:sticky lg:top-20">
+            <div className="flex items-center justify-between mb-4">
+              <p className="text-[10px] uppercase tracking-wider opacity-40 font-bold">Tabela de Jogos</p>
+              <div className="flex gap-1.5">
+                <button
+                  onClick={() => setShowGrupos(true)}
+                  className="flex items-center gap-1.5 px-2.5 py-1.5 rounded border border-terminal-border text-xs hover:border-terminal-blue/50 hover:text-terminal-blue transition-colors"
+                >
+                  <LayoutGrid className="w-3 h-3" />
+                  Grupos
+                </button>
+                <button
+                  onClick={() => setShowBracket(true)}
+                  className="flex items-center gap-1.5 px-2.5 py-1.5 rounded border border-terminal-border text-xs hover:border-terminal-blue/50 hover:text-terminal-blue transition-colors"
+                >
+                  <GitBranch className="w-3 h-3" />
+                  Mata-mata
+                </button>
+              </div>
+            </div>
+
+            {/* Match schedule grouped by matchday → group */}
+            {/* Column header */}
+            <div className="flex items-center gap-1.5 pr-3 pb-2 border-b border-terminal-border-subtle mb-2">
+              <span className="text-[9px] uppercase opacity-30 w-[76px] shrink-0">Data</span>
+              <span className="text-[9px] uppercase opacity-30 w-[68px] shrink-0 text-right">Casa</span>
+              <span className="text-[9px] uppercase opacity-30 w-9 shrink-0 text-center"></span>
+              <span className="text-[9px] uppercase opacity-30 w-[68px] shrink-0">Fora</span>
+              <span className="ml-auto text-[9px] uppercase opacity-30 shrink-0">Gr</span>
+            </div>
+
+            <div className="overflow-y-auto max-h-[500px] pr-3 scrollbar-thin">
+              {Object.keys(matchesByRound).length === 0 ? (
+                <div className="text-center py-6 opacity-30 text-sm">Carregando...</div>
+              ) : (
+                Object.entries(matchesByRound).map(([roundName, roundMatches], roundIdx) => (
+                  <div key={roundName}>
+                    {/* Rodada divider */}
+                    {roundIdx > 0 && (
+                      <div className="flex items-center gap-2 my-3">
+                        <div className="flex-1 h-px bg-terminal-border-subtle" />
+                      </div>
+                    )}
+                    <p className="text-[10px] uppercase font-bold tracking-wider text-terminal-blue mb-1.5">
+                      {roundName}
+                    </p>
+                    <div className="space-y-0.5">
+                      {roundMatches.map((m) => {
+                        const dateStr = new Date(m.match_date + 'T00:00:00').toLocaleDateString(
+                          'pt-BR', { day: '2-digit', month: '2-digit' }
+                        );
+                        const timeStr = m.match_time_brasilia.slice(0, 5);
+                        return (
+                          <div
+                            key={m.id}
+                            className={`flex items-center gap-1.5 py-0.5 ${m.is_finished ? 'opacity-50' : ''}`}
+                          >
+                            <span className="opacity-40 tabular-nums text-[10px] shrink-0 w-[76px]">
+                              {dateStr} {timeStr}
+                            </span>
+                            <div className="flex items-center justify-end gap-1 w-[68px] shrink-0">
+                              <span className="font-mono font-bold text-[11px]">{m.home_team_code}</span>
+                              <TeamFlag code={m.home_team_code} />
+                            </div>
+                            {m.is_finished ? (
+                              <span className="font-bold text-[11px] w-9 text-center shrink-0">
+                                {m.home_score}x{m.away_score}
+                              </span>
+                            ) : (
+                              <span className="opacity-30 w-9 text-center shrink-0 text-[11px]">×</span>
+                            )}
+                            <div className="flex items-center gap-1 w-[68px] shrink-0">
+                              <TeamFlag code={m.away_team_code} />
+                              <span className="font-mono font-bold text-[11px]">{m.away_team_code}</span>
+                            </div>
+                            <span className="ml-auto text-[9px] font-bold opacity-30 shrink-0">
+                              {m.group_name}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Modals */}
+      <CreateBolaoModal
+        open={showCreate}
+        onOpenChange={setShowCreate}
+        onSubmit={handleCreate}
+        isLoading={createBolao.isPending}
+      />
+      <CopaGruposModal open={showGrupos} onOpenChange={setShowGrupos} />
+      <CopaBracketModal open={showBracket} onOpenChange={setShowBracket} />
+    </div>
+  );
+};
+
+export default BolaoHome;

--- a/src/pages/BolaoJoin.tsx
+++ b/src/pages/BolaoJoin.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Trophy, Loader2, CheckCircle, XCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useJoinBolao } from '@/hooks/use-bolao';
+
+const BolaoJoin: React.FC = () => {
+  const { code } = useParams<{ code: string }>();
+  const navigate = useNavigate();
+  const joinBolao = useJoinBolao();
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
+  const [message, setMessage] = useState('');
+  const [bolaoId, setBolaoId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!code) {
+      setStatus('error');
+      setMessage('Código de convite inválido');
+      return;
+    }
+
+    joinBolao.mutate(code, {
+      onSuccess: (result) => {
+        if (result.success) {
+          setStatus('success');
+          setMessage(result.already_member ? 'Você já está neste bolão!' : 'Você entrou no bolão!');
+          setBolaoId(result.bolao_id || null);
+        } else {
+          setStatus('error');
+          setMessage(result.error || 'Erro ao entrar no bolão');
+        }
+      },
+      onError: (err: any) => {
+        setStatus('error');
+        setMessage(err.message || 'Erro ao entrar no bolão');
+      },
+    });
+  }, [code]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="min-h-screen bg-terminal-bg text-terminal-text flex items-center justify-center">
+      <div className="max-w-sm w-full mx-4">
+        <div className="terminal-container p-8 text-center">
+          {status === 'loading' && (
+            <>
+              <Loader2 className="w-12 h-12 mx-auto mb-4 animate-spin text-terminal-green" />
+              <h2 className="text-lg font-bold mb-2">Entrando no bolão...</h2>
+              <p className="text-sm opacity-50">Código: {code}</p>
+            </>
+          )}
+
+          {status === 'success' && (
+            <>
+              <CheckCircle className="w-12 h-12 mx-auto mb-4 text-terminal-green" />
+              <h2 className="text-lg font-bold mb-2">{message}</h2>
+              <Button
+                onClick={() => navigate(bolaoId ? `/bolao/${bolaoId}` : '/bolao')}
+                className="mt-4 bg-terminal-green text-terminal-bg hover:bg-terminal-green/90 gap-2"
+              >
+                <Trophy className="w-4 h-4" />
+                {bolaoId ? 'Ver bolão' : 'Meus bolões'}
+              </Button>
+            </>
+          )}
+
+          {status === 'error' && (
+            <>
+              <XCircle className="w-12 h-12 mx-auto mb-4 text-terminal-red" />
+              <h2 className="text-lg font-bold mb-2">Ops!</h2>
+              <p className="text-sm opacity-70 mb-4">{message}</p>
+              <div className="flex gap-2 justify-center">
+                <Button variant="ghost" onClick={() => navigate('/bolao')}>
+                  Meus bolões
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BolaoJoin;

--- a/src/pages/BolaoPalpites.tsx
+++ b/src/pages/BolaoPalpites.tsx
@@ -1,0 +1,170 @@
+import React, { useState, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import AnalyticsNav from '@/components/AnalyticsNav';
+import { ArrowLeft, Filter } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  useBolao,
+  useWcMatches,
+  useBolaoPredictions,
+  useUpsertPrediction,
+} from '@/hooks/use-bolao';
+import { MatchPredictionCard } from '@/components/bolao/MatchPredictionCard';
+import { supabase } from '@/integrations/supabase/client';
+import type { WcMatch } from '@/services/bolao.service';
+
+type GroupFilter = 'all' | string; // 'all' or group letter
+
+const BolaoPalpites: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [currentUserId, setCurrentUserId] = useState<string | undefined>();
+  const [groupFilter, setGroupFilter] = useState<GroupFilter>('all');
+
+  React.useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setCurrentUserId(data.user?.id);
+    });
+  }, []);
+
+  const { data: bolao } = useBolao(id);
+  const { data: matches, isLoading: loadingMatches } = useWcMatches();
+  const { data: predictions } = useBolaoPredictions(id, currentUserId);
+  const upsertPrediction = useUpsertPrediction();
+
+  const predictionsByMatch = useMemo(
+    () => new Map((predictions || []).map((p) => [p.match_id, p])),
+    [predictions]
+  );
+
+  const filteredMatches = useMemo(() => {
+    if (!matches) return [];
+    let filtered = matches;
+
+    if (groupFilter !== 'all') {
+      filtered = filtered.filter((m) => m.group_name === groupFilter);
+    }
+
+    return filtered;
+  }, [matches, groupFilter]);
+
+  // Available groups for filter
+  const groups = useMemo(() => {
+    if (!matches) return [];
+    const unique = new Set(matches.filter((m) => m.group_name).map((m) => m.group_name!));
+    return Array.from(unique).sort();
+  }, [matches]);
+
+  // Group filtered matches by stage/group
+  const groupedMatches = useMemo(() => {
+    const grouped: Record<string, WcMatch[]> = {};
+    filteredMatches.forEach((m) => {
+      const key = m.group_name ? `Grupo ${m.group_name}` : m.stage;
+      if (!grouped[key]) grouped[key] = [];
+      grouped[key].push(m);
+    });
+    return grouped;
+  }, [filteredMatches]);
+
+  const handleSave = (matchId: number, homeScore: number, awayScore: number) => {
+    if (!id) return;
+    upsertPrediction.mutate({
+      bolao_id: id,
+      match_id: matchId,
+      predicted_home_score: homeScore,
+      predicted_away_score: awayScore,
+    });
+  };
+
+  // Stats
+  const totalMatches = matches?.filter((m) => !m.is_finished && m.home_team_code !== 'TBD').length || 0;
+  const totalPredictions = predictions?.length || 0;
+
+  return (
+    <div className="min-h-screen bg-terminal-bg text-terminal-text">
+      <AnalyticsNav />
+      <div className="max-w-2xl mx-auto px-4 py-6">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-4">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => navigate(`/bolao/${id}`)}
+            className="h-8 w-8"
+          >
+            <ArrowLeft className="w-4 h-4" />
+          </Button>
+          <div className="flex-1">
+            <h1 className="text-lg font-bold">Palpites</h1>
+            <p className="text-xs opacity-50">{bolao?.name}</p>
+          </div>
+          <div className="text-right">
+            <span className="text-sm font-bold text-terminal-green">{totalPredictions}</span>
+            <span className="text-xs opacity-40">/{totalMatches}</span>
+          </div>
+        </div>
+
+        {/* Group filter */}
+        <div className="flex items-center gap-2 mb-6 overflow-x-auto pb-2">
+          <Filter className="w-3 h-3 opacity-40 shrink-0" />
+          <button
+            onClick={() => setGroupFilter('all')}
+            className={`px-3 py-1 text-xs rounded border shrink-0 transition-colors ${
+              groupFilter === 'all'
+                ? 'border-terminal-green text-terminal-green bg-terminal-green/10'
+                : 'border-terminal-border opacity-50 hover:opacity-80'
+            }`}
+          >
+            Todos
+          </button>
+          {groups.map((g) => (
+            <button
+              key={g}
+              onClick={() => setGroupFilter(g)}
+              className={`px-3 py-1 text-xs rounded border shrink-0 transition-colors ${
+                groupFilter === g
+                  ? 'border-terminal-green text-terminal-green bg-terminal-green/10'
+                  : 'border-terminal-border opacity-50 hover:opacity-80'
+              }`}
+            >
+              {g}
+            </button>
+          ))}
+        </div>
+
+        {/* Matches */}
+        {loadingMatches ? (
+          <div className="space-y-3">
+            {[1, 2, 3, 4].map((i) => (
+              <div
+                key={i}
+                className="h-32 rounded border border-terminal-border animate-pulse bg-terminal-dark-gray/30"
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {Object.entries(groupedMatches).map(([groupName, groupMatches]) => (
+              <div key={groupName}>
+                <h3 className="text-xs uppercase font-bold opacity-50 mb-3">{groupName}</h3>
+                <div className="space-y-3">
+                  {groupMatches.map((match) => (
+                    <MatchPredictionCard
+                      key={match.id}
+                      match={match}
+                      prediction={predictionsByMatch.get(match.id)}
+                      onSave={handleSave}
+                      isSaving={upsertPrediction.isPending}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BolaoPalpites;

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -1,0 +1,521 @@
+import { supabase } from '@/integrations/supabase/client';
+
+// =============================================
+// Types
+// =============================================
+
+export interface WcMatch {
+  id: number;
+  match_number: number;
+  stage: 'group' | 'round_of_32' | 'round_of_16' | 'quarter' | 'semi' | 'third_place' | 'final';
+  group_name: string | null;
+  home_team: string;
+  away_team: string;
+  home_team_code: string;
+  away_team_code: string;
+  match_date: string;
+  match_time_brasilia: string;
+  venue: string | null;
+  city: string | null;
+  home_score: number | null;
+  away_score: number | null;
+  is_finished: boolean;
+}
+
+export interface Bolao {
+  id: string;
+  owner_id: string;
+  name: string;
+  description: string | null;
+  invite_code: string;
+  is_public: boolean;
+  max_participants: number;
+  is_premium: boolean;
+  is_closed: boolean;
+  scoring_exact: number;
+  scoring_result: number;
+  scoring_preset: string | null;
+  custom_color: string | null;
+  custom_banner_url: string | null;
+  champion_enabled: boolean;
+  special_predictions_enabled: boolean;
+  special_predictions_config: {
+    finalist: boolean;
+    semifinalist: boolean;
+    quarterfinalist: boolean;
+    round_of_32: boolean;
+  };
+  special_predictions_points: {
+    finalist: number;
+    semifinalist: number;
+    quarterfinalist: number;
+    round_of_32: number;
+  };
+  champion_points: number;
+  created_at: string;
+}
+
+export interface BolaoMember {
+  id: string;
+  bolao_id: string;
+  user_id: string;
+  role: 'owner' | 'member';
+  joined_at: string;
+}
+
+export interface BolaoPrediction {
+  id: string;
+  bolao_id: string;
+  user_id: string;
+  match_id: number;
+  predicted_home_score: number;
+  predicted_away_score: number;
+  points_earned: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BolaoRankingEntry {
+  user_id: string;
+  user_name: string;
+  user_email: string;
+  total_points: number;
+  exact_scores: number;
+  correct_results: number;
+  total_predictions: number;
+  rank: number;
+}
+
+export interface UserBolao {
+  id: string;
+  name: string;
+  description: string | null;
+  invite_code: string;
+  is_premium: boolean;
+  is_closed: boolean;
+  max_participants: number;
+  owner_id: string;
+  owner_name: string;
+  member_count: number;
+  user_points: number;
+  user_rank: number;
+  user_predictions: number;
+  pending_predictions: number;
+  has_champion_prediction: boolean;
+  created_at: string;
+}
+
+export interface ChampionPrediction {
+  user_id: string;
+  user_name: string;
+  predicted_team_code: string;
+  points_earned: number | null;
+  created_at: string;
+}
+
+export interface SpecialPrediction {
+  prediction_type: 'finalist' | 'semifinalist' | 'quarterfinalist' | 'round_of_32';
+  predicted_team_code: string;
+  points_earned: number | null;
+}
+
+export interface SpecialSummaryEntry {
+  prediction_type: string;
+  predicted_team_code: string;
+  pick_count: number;
+}
+
+export interface BolaoStats {
+  total_members: number;
+  total_predictions: number;
+  distinct_games: number;
+  exact_scores: number;
+  correct_results: number;
+  total_points_awarded: number;
+  finished_games: number;
+  top_team_champion: string | null;
+  champion_pick_count: number;
+}
+
+export const SPECIAL_PREDICTION_MAX: Record<string, number> = {
+  finalist: 2,
+  semifinalist: 4,
+  quarterfinalist: 8,
+  round_of_32: 32,
+};
+
+function generateInviteCode(): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no ambiguous chars
+  let code = '';
+  for (let i = 0; i < 6; i++) {
+    code += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return code;
+}
+
+// =============================================
+// Service
+// =============================================
+
+export const bolaoService = {
+  // --- Matches ---
+
+  async getMatches(params?: { stage?: string; groupName?: string }): Promise<WcMatch[]> {
+    let query = supabase
+      .from('wc_matches')
+      .select('id, match_number, stage, group_name, home_team, away_team, home_team_code, away_team_code, match_date, match_time_brasilia, venue, city, home_score, away_score, is_finished')
+      .order('match_date', { ascending: true })
+      .order('match_time_brasilia', { ascending: true });
+
+    if (params?.stage) {
+      query = query.eq('stage', params.stage);
+    }
+    if (params?.groupName) {
+      query = query.eq('group_name', params.groupName);
+    }
+
+    const { data, error } = await query;
+    if (error) throw error;
+    return (data || []) as WcMatch[];
+  },
+
+  async getMatchById(matchId: number): Promise<WcMatch | null> {
+    const { data, error } = await supabase
+      .from('wc_matches')
+      .select('id, match_number, stage, group_name, home_team, away_team, home_team_code, away_team_code, match_date, match_time_brasilia, venue, city, home_score, away_score, is_finished')
+      .eq('id', matchId)
+      .single();
+
+    if (error) throw error;
+    return data as WcMatch | null;
+  },
+
+  // --- Bolões ---
+
+  async getUserBoloes(): Promise<UserBolao[]> {
+    const { data, error } = await supabase.rpc('get_user_boloes');
+    if (error) throw error;
+    return (data || []) as UserBolao[];
+  },
+
+  async getBolaoById(bolaoId: string): Promise<Bolao | null> {
+    const { data, error } = await supabase
+      .from('boloes')
+      .select('*')
+      .eq('id', bolaoId)
+      .single();
+
+    if (error) throw error;
+    return data as Bolao | null;
+  },
+
+  async createBolao(params: {
+    name: string;
+    description?: string;
+  }): Promise<Bolao> {
+    const userId = (await supabase.auth.getUser()).data.user?.id;
+    if (!userId) throw new Error('Usuário não autenticado');
+
+    const invite_code = generateInviteCode();
+
+    const { data, error } = await supabase
+      .from('boloes')
+      .insert({
+        owner_id: userId,
+        name: params.name,
+        description: params.description || null,
+        invite_code,
+      })
+      .select()
+      .single();
+
+    if (error) throw error;
+
+    // Add owner as member
+    await supabase
+      .from('bolao_members')
+      .insert({
+        bolao_id: (data as any).id,
+        user_id: userId,
+        role: 'owner',
+      });
+
+    return data as Bolao;
+  },
+
+  async joinByCode(inviteCode: string): Promise<{ success: boolean; bolao_id?: string; already_member?: boolean; error?: string }> {
+    const { data, error } = await supabase.rpc('join_bolao_by_code', {
+      p_invite_code: inviteCode.toUpperCase(),
+    });
+
+    if (error) throw error;
+    return data as { success: boolean; bolao_id?: string; already_member?: boolean; error?: string };
+  },
+
+  async leaveBolao(bolaoId: string): Promise<void> {
+    const userId = (await supabase.auth.getUser()).data.user?.id;
+    if (!userId) throw new Error('Usuário não autenticado');
+
+    const { error } = await supabase
+      .from('bolao_members')
+      .delete()
+      .eq('bolao_id', bolaoId)
+      .eq('user_id', userId);
+
+    if (error) throw error;
+  },
+
+  // --- Members ---
+
+  async getMembers(bolaoId: string): Promise<BolaoMember[]> {
+    const { data, error } = await supabase
+      .from('bolao_members')
+      .select('*')
+      .eq('bolao_id', bolaoId)
+      .order('joined_at', { ascending: true });
+
+    if (error) throw error;
+    return (data || []) as BolaoMember[];
+  },
+
+  // --- Ranking ---
+
+  async getRanking(bolaoId: string): Promise<BolaoRankingEntry[]> {
+    const { data, error } = await supabase.rpc('get_bolao_ranking', {
+      p_bolao_id: bolaoId,
+    });
+
+    if (error) throw error;
+    return (data || []) as BolaoRankingEntry[];
+  },
+
+  // --- Champion Prediction ---
+
+  async upsertChampionPrediction(bolaoId: string, teamCode: string): Promise<void> {
+    const { data, error } = await supabase.rpc('upsert_champion_prediction', {
+      p_bolao_id: bolaoId,
+      p_team_code: teamCode,
+    });
+
+    if (error) throw error;
+    const result = data as { success: boolean; error?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao salvar palpite de campeão');
+  },
+
+  async getChampionPredictions(bolaoId: string): Promise<ChampionPrediction[]> {
+    const { data, error } = await supabase.rpc('get_champion_predictions', {
+      p_bolao_id: bolaoId,
+    });
+
+    if (error) throw error;
+    return (data || []) as ChampionPrediction[];
+  },
+
+  // --- Admin ---
+
+  async removeMember(bolaoId: string, userId: string): Promise<void> {
+    const { data, error } = await supabase.rpc('remove_bolao_member', {
+      p_bolao_id: bolaoId,
+      p_user_id: userId,
+    });
+
+    if (error) throw error;
+    const result = data as { success: boolean; error?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao remover participante');
+  },
+
+  async toggleBolaoClose(bolaoId: string): Promise<{ is_closed: boolean }> {
+    const { data, error } = await supabase.rpc('toggle_bolao_closed', {
+      p_bolao_id: bolaoId,
+    });
+
+    if (error) throw error;
+    const result = data as { success: boolean; is_closed: boolean; error?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao alterar inscrições');
+    return { is_closed: result.is_closed };
+  },
+
+  // --- Predictions ---
+
+  async getPredictions(bolaoId: string, userId?: string): Promise<BolaoPrediction[]> {
+    let query = supabase
+      .from('bolao_predictions')
+      .select('*')
+      .eq('bolao_id', bolaoId);
+
+    if (userId) {
+      query = query.eq('user_id', userId);
+    }
+
+    const { data, error } = await query.order('match_id', { ascending: true });
+    if (error) throw error;
+    return (data || []) as BolaoPrediction[];
+  },
+
+  async upsertPrediction(params: {
+    bolao_id: string;
+    match_id: number;
+    predicted_home_score: number;
+    predicted_away_score: number;
+  }): Promise<BolaoPrediction> {
+    const userId = (await supabase.auth.getUser()).data.user?.id;
+    if (!userId) throw new Error('Usuário não autenticado');
+
+    const { data, error } = await supabase
+      .from('bolao_predictions')
+      .upsert(
+        {
+          bolao_id: params.bolao_id,
+          user_id: userId,
+          match_id: params.match_id,
+          predicted_home_score: params.predicted_home_score,
+          predicted_away_score: params.predicted_away_score,
+        },
+        { onConflict: 'bolao_id,user_id,match_id' }
+      )
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data as BolaoPrediction;
+  },
+
+  async upsertPredictionsBatch(
+    bolaoId: string,
+    predictions: { match_id: number; predicted_home_score: number; predicted_away_score: number }[]
+  ): Promise<void> {
+    const userId = (await supabase.auth.getUser()).data.user?.id;
+    if (!userId) throw new Error('Usuário não autenticado');
+
+    const rows = predictions.map((p) => ({
+      bolao_id: bolaoId,
+      user_id: userId,
+      match_id: p.match_id,
+      predicted_home_score: p.predicted_home_score,
+      predicted_away_score: p.predicted_away_score,
+    }));
+
+    const { error } = await supabase
+      .from('bolao_predictions')
+      .upsert(rows, { onConflict: 'bolao_id,user_id,match_id' });
+
+    if (error) throw error;
+  },
+
+  // --- Special Predictions (Wave 2) ---
+
+  async getMySpecialPredictions(bolaoId: string): Promise<SpecialPrediction[]> {
+    const { data, error } = await supabase.rpc('get_my_special_predictions', {
+      p_bolao_id: bolaoId,
+    });
+    if (error) throw error;
+    return (data || []) as SpecialPrediction[];
+  },
+
+  async getSpecialSummary(bolaoId: string): Promise<SpecialSummaryEntry[]> {
+    const { data, error } = await supabase.rpc('get_bolao_special_summary', {
+      p_bolao_id: bolaoId,
+    });
+    if (error) throw error;
+    return (data || []) as SpecialSummaryEntry[];
+  },
+
+  async toggleSpecialPrediction(
+    bolaoId: string,
+    predictionType: 'finalist' | 'semifinalist' | 'quarterfinalist' | 'round_of_32',
+    teamCode: string
+  ): Promise<{ action: 'added' | 'removed'; count?: number }> {
+    const { data, error } = await supabase.rpc('toggle_special_prediction', {
+      p_bolao_id: bolaoId,
+      p_prediction_type: predictionType,
+      p_team_code: teamCode,
+    });
+    if (error) throw error;
+    const result = data as { success: boolean; action?: string; count?: number; error?: string; max?: number };
+    if (!result.success) throw new Error(result.error || 'Erro ao salvar palpite');
+    return { action: result.action as 'added' | 'removed', count: result.count };
+  },
+
+  async updateBolaoScoring(
+    bolaoId: string,
+    preset: 'standard' | 'classic' | 'weighted_stages' | 'custom',
+    scoringResult?: number,
+    scoringExact?: number
+  ): Promise<{ scoring_result: number; scoring_exact: number }> {
+    const { data, error } = await supabase.rpc('update_bolao_scoring', {
+      p_bolao_id: bolaoId,
+      p_preset: preset,
+      p_scoring_result: scoringResult,
+      p_scoring_exact: scoringExact,
+    });
+    if (error) throw error;
+    const result = data as { success: boolean; scoring_result: number; scoring_exact: number; error?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao atualizar pontuação');
+    return { scoring_result: result.scoring_result, scoring_exact: result.scoring_exact };
+  },
+
+  // --- Stats + Round Rankings (Wave 3) ---
+
+  async getBolaoStats(bolaoId: string): Promise<BolaoStats | null> {
+    const { data, error } = await supabase.rpc('get_bolao_stats', {
+      p_bolao_id: bolaoId,
+    });
+    if (error) throw error;
+    return data as unknown as BolaoStats | null;
+  },
+
+  async getRoundRanking(bolaoId: string, stage?: string): Promise<BolaoRankingEntry[]> {
+    const { data, error } = await supabase.rpc('get_bolao_round_ranking', {
+      p_bolao_id: bolaoId,
+      p_stage: stage,
+    });
+    if (error) throw error;
+    return (data || []) as BolaoRankingEntry[];
+  },
+
+  async uploadBolaoLogo(bolaoId: string, file: File): Promise<string> {
+    const ext = file.name.split('.').pop() ?? 'png';
+    const path = `${bolaoId}/logo.${ext}`;
+
+    const { error: uploadError } = await supabase.storage
+      .from('bolao-logos')
+      .upload(path, file, { upsert: true });
+
+    if (uploadError) throw uploadError;
+
+    const { data } = supabase.storage.from('bolao-logos').getPublicUrl(path);
+    return data.publicUrl;
+  },
+
+  async updateBolaoTheme(
+    bolaoId: string,
+    color?: string,
+    logoUrl?: string
+  ): Promise<void> {
+    const { data, error } = await supabase.rpc('update_bolao_theme', {
+      p_bolao_id: bolaoId,
+      p_color: color,
+      p_logo_url: logoUrl,
+    });
+    if (error) throw error;
+    const result = data as { success: boolean; error?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao atualizar tema');
+  },
+
+  async updateBolaoSettings(
+    bolaoId: string,
+    settings: {
+      champion_enabled?: boolean;
+      special_predictions_enabled?: boolean;
+      special_predictions_config?: Record<string, boolean>;
+      special_predictions_points?: Record<string, number>;
+      champion_points?: number;
+    }
+  ): Promise<void> {
+    const { error } = await supabase
+      .from('boloes')
+      .update(settings as any)
+      .eq('id', bolaoId);
+    if (error) throw error;
+  },
+};

--- a/supabase/functions/stripe-create-checkout/index.ts
+++ b/supabase/functions/stripe-create-checkout/index.ts
@@ -71,8 +71,8 @@ serve(async (req) => {
     // Obter dados do body
     const body = await req.json();
     console.log('Request body:', body);
-    const { priceId, productType } = body;
-    
+    const { priceId, productType, bolaoId, bolaoName, bolaoDescription } = body;
+
     if (!priceId) {
       console.error('Missing priceId in body');
       return new Response(
@@ -89,8 +89,10 @@ serve(async (req) => {
       Deno.env.get('STRIPE_PRICE_ID_ANALYTICS'),
     ].filter(Boolean) as string[];
 
-    let finalProductType: 'analytics' | 'betinho';
-    if (normalizedProductType === 'analytics' || normalizedProductType === 'platform') {
+    let finalProductType: 'analytics' | 'betinho' | 'bolao_premium';
+    if (normalizedProductType === 'bolao_premium') {
+      finalProductType = 'bolao_premium';
+    } else if (normalizedProductType === 'analytics' || normalizedProductType === 'platform') {
       finalProductType = 'analytics';
     } else if (analyticsPriceIds.includes(priceId)) {
       finalProductType = 'analytics';
@@ -104,6 +106,7 @@ serve(async (req) => {
     console.log('Product Type received:', normalizedProductType);
     console.log('Referer:', referer || 'n/a');
     console.log('Product Type resolved:', finalProductType);
+    if (bolaoId) console.log('Bolao ID:', bolaoId);
 
     // Use SITE_URL for frontend redirects, fallback to SUPABASE_URL for local dev
     const SITE_URL = Deno.env.get('SITE_URL') || Deno.env.get('APP_BASE_URL') || 'http://localhost:8080';
@@ -185,35 +188,56 @@ serve(async (req) => {
 
     console.log('Creating Stripe checkout session with customer:', customerId);
 
-    // Redirect to the correct paywall route per product
-    const paywallPath = finalProductType === 'analytics' ? '/paywall-platform' : '/paywall';
-    const successUrl = `${SITE_URL}${paywallPath}?success=true&session_id={CHECKOUT_SESSION_ID}`;
-    const cancelUrl = `${SITE_URL}${paywallPath}?canceled=true`;
-    console.log('Selected paywallPath:', paywallPath);
+    // Redirect URLs depend on product type
+    let successUrl: string;
+    let cancelUrl: string;
+
+    if (finalProductType === 'bolao_premium' && bolaoId) {
+      successUrl = `${SITE_URL}/bolao/${bolaoId}?success=true&session_id={CHECKOUT_SESSION_ID}`;
+      cancelUrl = `${SITE_URL}/bolao/${bolaoId}?canceled=true`;
+    } else {
+      const paywallPath = finalProductType === 'analytics' ? '/paywall-platform' : '/paywall';
+      successUrl = `${SITE_URL}${paywallPath}?success=true&session_id={CHECKOUT_SESSION_ID}`;
+      cancelUrl = `${SITE_URL}${paywallPath}?canceled=true`;
+    }
+
     console.log('Success URL:', successUrl);
     console.log('Cancel URL:', cancelUrl);
 
-    // Criar sessão de checkout
-    const session = await stripe.checkout.sessions.create({
-      customer: customerId, // Usar customer_id ao invés de customer_email
+    // bolao_premium = one-time payment; others = subscription
+    const isBolao = finalProductType === 'bolao_premium';
+
+    const sessionMetadata: Record<string, string> = {
+      userId: user.id,
+      userEmail: user.email || '',
+      productType: finalProductType,
+    };
+    if (bolaoId) sessionMetadata.bolaoId = bolaoId;
+    if (bolaoName) sessionMetadata.bolaoName = String(bolaoName).slice(0, 200);
+    if (bolaoDescription) sessionMetadata.bolaoDescription = String(bolaoDescription).slice(0, 400);
+
+    const sessionParams: Stripe.Checkout.SessionCreateParams = {
+      customer: customerId,
       payment_method_types: ['card'],
       line_items: [{ price: priceId, quantity: 1 }],
-      mode: 'subscription', // ou 'payment' para pagamento único
+      mode: isBolao ? 'payment' : 'subscription',
       allow_promotion_codes: true,
       success_url: successUrl,
       cancel_url: cancelUrl,
-      metadata: {
-        userId: user.id,
-        userEmail: user.email || '',
-        productType: finalProductType, // Add productType to session metadata
-      },
-      subscription_data: {
+      metadata: sessionMetadata,
+    };
+
+    if (!isBolao) {
+      sessionParams.subscription_data = {
         metadata: {
           userId: user.id,
-          productType: finalProductType, // Add productType to subscription metadata
+          productType: finalProductType,
         },
-      },
-    });
+      };
+    }
+
+    // Criar sessão de checkout
+    const session = await stripe.checkout.sessions.create(sessionParams);
 
     console.log('Stripe checkout session created:', session.id);
     console.log('Checkout URL:', session.url);

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -97,35 +97,103 @@ serve(async (req) => {
         const session = event.data.object as Stripe.Checkout.Session;
         const userId = session.metadata?.userId;
         const productType = session.metadata?.productType;
-        const subscriptionField = getSubscriptionField(productType);
-        
+        // bolaoId may come from metadata (checkout session) or client_reference_id (payment link)
+        const bolaoId = session.metadata?.bolaoId || session.client_reference_id || null;
+
         console.log('[Webhook] Checkout session completed');
         console.log('[Webhook] Session ID:', session.id);
-        console.log('[Webhook] Session metadata:', JSON.stringify(session.metadata));
-        console.log('[Webhook] UserId from metadata:', userId);
-        console.log('[Webhook] ProductType from metadata:', productType);
-        console.log('[Webhook] Updating field:', subscriptionField);
-        
-        if (userId) {
+        console.log('[Webhook] ProductType:', productType);
+        console.log('[Webhook] UserId:', userId);
+        console.log('[Webhook] BolaoId:', bolaoId);
+        console.log('[Webhook] Mode:', session.mode);
+
+        // Bolão premium: one-time payment identified by bolaoId (UUID format)
+        const isUuid = (s: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
+        const isBolaoPayment = (productType === 'bolao_premium' && bolaoId) ||
+          (session.mode === 'payment' && bolaoId && isUuid(bolaoId));
+
+        if (isBolaoPayment && bolaoId) {
+          // Check if bolão already exists (old flow: created before payment)
+          const { data: existingBolao } = await supabase
+            .from('boloes')
+            .select('id')
+            .eq('id', bolaoId)
+            .maybeSingle();
+
+          if (existingBolao) {
+            // Old flow: bolão was created before payment — just upgrade it
+            const { error } = await supabase
+              .from('boloes')
+              .update({ is_premium: true, max_participants: 9999 })
+              .eq('id', bolaoId);
+            if (error) {
+              console.error('[Webhook] Error upgrading bolão to premium:', error);
+            } else {
+              console.log('[Webhook] ✅ Bolão upgraded to premium:', bolaoId);
+            }
+          } else {
+            // New flow: create the bolão now (user paid without prior creation)
+            const bolaoName = session.metadata?.bolaoName || 'Bolão Copa 2026';
+            const bolaoDescription = session.metadata?.bolaoDescription || null;
+            const inviteCode = Math.random().toString(36).substring(2, 8).toUpperCase();
+
+            const { error: createError } = await supabase.from('boloes').insert({
+              id: bolaoId,
+              owner_id: userId || null,
+              name: bolaoName,
+              description: bolaoDescription,
+              invite_code: inviteCode,
+              is_premium: true,
+              max_participants: 9999,
+            });
+
+            if (createError) {
+              console.error('[Webhook] Error creating premium bolão:', createError);
+            } else {
+              console.log('[Webhook] ✅ Premium bolão created:', bolaoId);
+              // Add owner as member
+              if (userId) {
+                await supabase.from('bolao_members').insert({
+                  bolao_id: bolaoId,
+                  user_id: userId,
+                  role: 'owner',
+                });
+              }
+            }
+          }
+
+          // Record the purchase
+          if (userId) {
+            const { error: subError } = await supabase.from('bolao_subscriptions').insert({
+              user_id: userId,
+              bolao_id: bolaoId,
+              type: 'bolao_premium',
+              stripe_session_id: session.id,
+              status: 'active',
+            });
+            if (subError) console.error('[Webhook] Error recording purchase:', subError);
+            else console.log('[Webhook] Purchase recorded for user:', userId);
+          }
+        } else if (userId) {
+          // Subscription product (betinho / analytics)
+          const subscriptionField = getSubscriptionField(productType);
           console.log(`[Webhook] Updating ${subscriptionField} to premium for user:`, userId);
           const updateData: Record<string, string> = {};
           updateData[subscriptionField] = 'premium';
-          
+
           const { data, error } = await supabase
             .from('users')
             .update(updateData)
             .eq('id', userId);
-          
+
           if (error) {
             console.error('[Webhook] Error updating subscription status:', error);
-            console.error('[Webhook] Error details:', JSON.stringify(error));
           } else {
             console.log(`[Webhook] ✅ ${subscriptionField} updated to premium for user:`, userId);
             console.log('[Webhook] Updated data:', JSON.stringify(data));
           }
         } else {
-          console.warn('[Webhook] ⚠️ No userId found in session metadata');
-          console.warn('[Webhook] Full session object:', JSON.stringify(session, null, 2));
+          console.warn('[Webhook] ⚠️ No userId or bolaoId found in session metadata');
         }
         break;
       }

--- a/supabase/migrations/037_bolao_wave2_special_preds_and_scoring.sql
+++ b/supabase/migrations/037_bolao_wave2_special_preds_and_scoring.sql
@@ -1,0 +1,187 @@
+-- ============================================================
+-- WAVE 2: Special Predictions (multi-pick) + Scoring Presets
+-- Applied to staging: 2026-04-15
+-- ============================================================
+
+-- 1. Fix UNIQUE constraint to allow multi-pick per type
+ALTER TABLE bolao_special_predictions
+  DROP CONSTRAINT bolao_special_predictions_bolao_id_user_id_prediction_type_key;
+
+ALTER TABLE bolao_special_predictions
+  ADD CONSTRAINT bolao_special_predictions_unique
+  UNIQUE (bolao_id, user_id, prediction_type, predicted_team_code);
+
+-- 2. Update upsert_champion_prediction for new constraint (DELETE+INSERT)
+CREATE OR REPLACE FUNCTION upsert_champion_prediction(
+  p_bolao_id uuid,
+  p_team_code text
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id uuid;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+  ) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member');
+  END IF;
+  DELETE FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = 'champion';
+  INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_team_code)
+    VALUES (p_bolao_id, v_user_id, 'champion', p_team_code);
+  RETURN json_build_object('success', true);
+END;
+$$;
+
+-- 3. toggle_special_prediction — finalist/semifinalist/quarterfinalist (premium)
+CREATE OR REPLACE FUNCTION toggle_special_prediction(
+  p_bolao_id uuid,
+  p_prediction_type text,
+  p_team_code text
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_is_premium boolean;
+  v_max_picks int;
+  v_current_count int;
+  v_exists boolean;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF p_prediction_type NOT IN ('finalist', 'semifinalist', 'quarterfinalist') THEN
+    RETURN json_build_object('success', false, 'error', 'Invalid prediction type');
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+  ) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member');
+  END IF;
+  SELECT is_premium INTO v_is_premium FROM boloes WHERE id = p_bolao_id;
+  IF NOT COALESCE(v_is_premium, false) THEN
+    RETURN json_build_object('success', false, 'error', 'Premium required');
+  END IF;
+  v_max_picks := CASE p_prediction_type
+    WHEN 'finalist'        THEN 2
+    WHEN 'semifinalist'    THEN 4
+    WHEN 'quarterfinalist' THEN 8
+    ELSE 4
+  END;
+  SELECT EXISTS(
+    SELECT 1 FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+      AND prediction_type = p_prediction_type AND predicted_team_code = p_team_code
+  ) INTO v_exists;
+  IF v_exists THEN
+    DELETE FROM bolao_special_predictions
+      WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+        AND prediction_type = p_prediction_type AND predicted_team_code = p_team_code;
+    RETURN json_build_object('success', true, 'action', 'removed');
+  ELSE
+    SELECT COUNT(*) INTO v_current_count
+    FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = p_prediction_type;
+    IF v_current_count >= v_max_picks THEN
+      RETURN json_build_object('success', false, 'error', 'Max picks reached', 'max', v_max_picks);
+    END IF;
+    INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_team_code)
+      VALUES (p_bolao_id, v_user_id, p_prediction_type, p_team_code);
+    RETURN json_build_object('success', true, 'action', 'added', 'count', v_current_count + 1);
+  END IF;
+END;
+$$;
+
+-- 4. get_my_special_predictions
+CREATE OR REPLACE FUNCTION get_my_special_predictions(p_bolao_id uuid)
+RETURNS TABLE (
+  prediction_type text,
+  predicted_team_code text,
+  points_earned int
+)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT prediction_type, predicted_team_code, points_earned
+  FROM bolao_special_predictions
+  WHERE bolao_id = p_bolao_id AND user_id = auth.uid()
+  ORDER BY prediction_type, predicted_team_code;
+$$;
+
+-- 5. get_bolao_special_summary
+CREATE OR REPLACE FUNCTION get_bolao_special_summary(p_bolao_id uuid)
+RETURNS TABLE (
+  prediction_type text,
+  predicted_team_code text,
+  pick_count bigint
+)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT prediction_type, predicted_team_code, COUNT(*) AS pick_count
+  FROM bolao_special_predictions
+  WHERE bolao_id = p_bolao_id
+    AND EXISTS (
+      SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = auth.uid()
+    )
+  GROUP BY prediction_type, predicted_team_code
+  ORDER BY prediction_type, pick_count DESC, predicted_team_code;
+$$;
+
+-- 6. update_bolao_scoring
+CREATE OR REPLACE FUNCTION update_bolao_scoring(
+  p_bolao_id uuid,
+  p_preset text,
+  p_scoring_result int DEFAULT NULL,
+  p_scoring_exact int DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_r int; v_e int;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM boloes WHERE id = p_bolao_id AND owner_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not the owner');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM boloes WHERE id = p_bolao_id AND is_premium = true) THEN
+    RETURN json_build_object('success', false, 'error', 'Premium required');
+  END IF;
+  IF p_preset = 'standard' THEN v_r := 1; v_e := 3;
+  ELSIF p_preset = 'classic'  THEN v_r := 1; v_e := 5;
+  ELSIF p_preset = 'custom' THEN
+    IF p_scoring_result IS NULL OR p_scoring_exact IS NULL THEN
+      RETURN json_build_object('success', false, 'error', 'Custom preset requires scoring values');
+    END IF;
+    IF p_scoring_result < 1 OR p_scoring_result > 5 THEN
+      RETURN json_build_object('success', false, 'error', 'scoring_result must be 1-5');
+    END IF;
+    IF p_scoring_exact < 3 OR p_scoring_exact > 10 THEN
+      RETURN json_build_object('success', false, 'error', 'scoring_exact must be 3-10');
+    END IF;
+    v_r := p_scoring_result; v_e := p_scoring_exact;
+  ELSE
+    RETURN json_build_object('success', false, 'error', 'Invalid preset');
+  END IF;
+  UPDATE boloes SET scoring_preset = p_preset, scoring_result = v_r, scoring_exact = v_e
+    WHERE id = p_bolao_id;
+  RETURN json_build_object('success', true, 'scoring_result', v_r, 'scoring_exact', v_e);
+END;
+$$;

--- a/supabase/migrations/038_bolao_wave3_stats_rounds_theme.sql
+++ b/supabase/migrations/038_bolao_wave3_stats_rounds_theme.sql
@@ -1,0 +1,130 @@
+-- ============================================================
+-- WAVE 3: Stats, Round Rankings, Color Theme, Logo
+-- Applied to staging: 2026-04-15
+-- ============================================================
+
+-- 1. get_bolao_stats
+CREATE OR REPLACE FUNCTION get_bolao_stats(p_bolao_id uuid)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_bolao boloes%ROWTYPE;
+  v_result json;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = auth.uid()) THEN
+    RETURN NULL;
+  END IF;
+  SELECT * INTO v_bolao FROM boloes WHERE id = p_bolao_id;
+  SELECT json_build_object(
+    'total_members',        (SELECT COUNT(*) FROM bolao_members WHERE bolao_id = p_bolao_id),
+    'total_predictions',    (SELECT COUNT(*) FROM bolao_predictions WHERE bolao_id = p_bolao_id),
+    'distinct_games',       (SELECT COUNT(DISTINCT match_id) FROM bolao_predictions WHERE bolao_id = p_bolao_id),
+    'exact_scores',         (SELECT COUNT(*) FROM bolao_predictions WHERE bolao_id = p_bolao_id AND points_earned = v_bolao.scoring_exact),
+    'correct_results',      (SELECT COUNT(*) FROM bolao_predictions WHERE bolao_id = p_bolao_id AND points_earned = v_bolao.scoring_result),
+    'total_points_awarded', (SELECT COALESCE(SUM(points_earned), 0) FROM bolao_predictions WHERE bolao_id = p_bolao_id),
+    'finished_games',       (SELECT COUNT(*) FROM wc_matches WHERE is_finished = true),
+    'top_team_champion',    (
+      SELECT predicted_team_code FROM bolao_special_predictions
+      WHERE bolao_id = p_bolao_id AND prediction_type = 'champion'
+      GROUP BY predicted_team_code ORDER BY COUNT(*) DESC LIMIT 1
+    ),
+    'champion_pick_count',  (
+      SELECT COUNT(DISTINCT user_id) FROM bolao_special_predictions
+      WHERE bolao_id = p_bolao_id AND prediction_type = 'champion'
+    )
+  ) INTO v_result;
+  RETURN v_result;
+END;
+$$;
+
+-- 2. get_bolao_round_ranking
+CREATE OR REPLACE FUNCTION get_bolao_round_ranking(
+  p_bolao_id uuid,
+  p_stage text DEFAULT NULL
+)
+RETURNS TABLE (
+  user_id uuid,
+  user_name text,
+  user_email text,
+  total_points bigint,
+  exact_scores bigint,
+  correct_results bigint,
+  total_predictions bigint,
+  rank bigint
+)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  WITH member_scores AS (
+    SELECT
+      bp.user_id,
+      COALESCE(SUM(bp.points_earned), 0)::bigint AS total_points,
+      COUNT(*) FILTER (WHERE bp.points_earned = b.scoring_exact)::bigint AS exact_scores,
+      COUNT(*) FILTER (WHERE bp.points_earned = b.scoring_result AND bp.points_earned != b.scoring_exact)::bigint AS correct_results,
+      COUNT(*)::bigint AS total_predictions
+    FROM bolao_predictions bp
+    JOIN boloes b ON b.id = bp.bolao_id
+    JOIN wc_matches m ON m.id = bp.match_id
+    WHERE bp.bolao_id = p_bolao_id
+      AND m.is_finished = true
+      AND (p_stage IS NULL OR m.stage = p_stage)
+    GROUP BY bp.user_id, b.scoring_exact, b.scoring_result
+  ),
+  all_members AS (
+    SELECT user_id FROM bolao_members WHERE bolao_id = p_bolao_id
+  ),
+  combined AS (
+    SELECT
+      am.user_id,
+      COALESCE(ms.total_points, 0)::bigint     AS total_points,
+      COALESCE(ms.exact_scores, 0)::bigint      AS exact_scores,
+      COALESCE(ms.correct_results, 0)::bigint   AS correct_results,
+      COALESCE(ms.total_predictions, 0)::bigint AS total_predictions
+    FROM all_members am
+    LEFT JOIN member_scores ms ON ms.user_id = am.user_id
+  )
+  SELECT
+    c.user_id,
+    COALESCE(u.raw_user_meta_data->>'full_name', u.raw_user_meta_data->>'name',
+             split_part(u.email, '@', 1)) AS user_name,
+    u.email AS user_email,
+    c.total_points,
+    c.exact_scores,
+    c.correct_results,
+    c.total_predictions,
+    RANK() OVER (ORDER BY c.total_points DESC, c.exact_scores DESC)::bigint AS rank
+  FROM combined c
+  JOIN auth.users u ON u.id = c.user_id
+  WHERE EXISTS (SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = auth.uid())
+  ORDER BY rank, c.user_id;
+$$;
+
+-- 3. update_bolao_theme
+CREATE OR REPLACE FUNCTION update_bolao_theme(
+  p_bolao_id uuid,
+  p_color text DEFAULT NULL,
+  p_logo_url text DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM boloes WHERE id = p_bolao_id AND owner_id = auth.uid()) THEN
+    RETURN json_build_object('success', false, 'error', 'Not the owner');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM boloes WHERE id = p_bolao_id AND is_premium = true) THEN
+    RETURN json_build_object('success', false, 'error', 'Premium required');
+  END IF;
+  UPDATE boloes
+    SET custom_color      = COALESCE(p_color, custom_color),
+        custom_banner_url = COALESCE(p_logo_url, custom_banner_url)
+    WHERE id = p_bolao_id;
+  RETURN json_build_object('success', true);
+END;
+$$;

--- a/supabase/migrations/039_bolao_wave4_weighted_stages_roundof32_storage.sql
+++ b/supabase/migrations/039_bolao_wave4_weighted_stages_roundof32_storage.sql
@@ -1,0 +1,219 @@
+-- ============================================================
+-- WAVE 4: Weighted Stages Preset, Round-of-32 Special Pred,
+--         Storage bucket para logos
+-- Applied to staging: 2026-04-15
+-- ============================================================
+
+-- 1. update calculate_bolao_scores to apply stage multipliers
+CREATE OR REPLACE FUNCTION calculate_bolao_scores(p_match_id integer)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_home_score int;
+  v_away_score int;
+  v_is_finished boolean;
+  v_match_result text;
+  v_match_stage text;
+  v_updated_count int := 0;
+  rec RECORD;
+BEGIN
+  SELECT home_score, away_score, is_finished, stage
+    INTO v_home_score, v_away_score, v_is_finished, v_match_stage
+  FROM wc_matches WHERE id = p_match_id;
+
+  IF NOT v_is_finished OR v_home_score IS NULL OR v_away_score IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Jogo não finalizado ou sem placar');
+  END IF;
+
+  IF v_home_score > v_away_score THEN v_match_result := 'home';
+  ELSIF v_away_score > v_home_score THEN v_match_result := 'away';
+  ELSE v_match_result := 'draw';
+  END IF;
+
+  FOR rec IN
+    SELECT bp.id, bp.predicted_home_score, bp.predicted_away_score,
+           b.scoring_exact, b.scoring_result, b.scoring_preset
+    FROM bolao_predictions bp
+    JOIN boloes b ON b.id = bp.bolao_id
+    WHERE bp.match_id = p_match_id
+  LOOP
+    DECLARE
+      v_pred_result text;
+      v_points int := 0;
+      v_multiplier numeric := 1.0;
+    BEGIN
+      IF rec.scoring_preset = 'weighted_stages' THEN
+        v_multiplier := CASE v_match_stage
+          WHEN 'group'       THEN 1.0
+          WHEN 'round_of_32' THEN 1.5
+          WHEN 'round_of_16' THEN 1.5
+          WHEN 'quarter'     THEN 2.0
+          WHEN 'semi'        THEN 3.0
+          WHEN 'third_place' THEN 2.0
+          WHEN 'final'       THEN 5.0
+          ELSE 1.0
+        END;
+      END IF;
+
+      IF rec.predicted_home_score > rec.predicted_away_score THEN v_pred_result := 'home';
+      ELSIF rec.predicted_away_score > rec.predicted_home_score THEN v_pred_result := 'away';
+      ELSE v_pred_result := 'draw';
+      END IF;
+
+      IF rec.predicted_home_score = v_home_score AND rec.predicted_away_score = v_away_score THEN
+        v_points := ROUND(rec.scoring_exact * v_multiplier);
+      ELSIF v_pred_result = v_match_result THEN
+        v_points := ROUND(rec.scoring_result * v_multiplier);
+      END IF;
+
+      UPDATE bolao_predictions
+        SET points_earned = v_points, updated_at = now()
+      WHERE id = rec.id;
+
+      v_updated_count := v_updated_count + 1;
+    END;
+  END LOOP;
+
+  RETURN json_build_object('success', true, 'updated', v_updated_count);
+END;
+$$;
+
+-- 2. update update_bolao_scoring to accept weighted_stages
+CREATE OR REPLACE FUNCTION update_bolao_scoring(
+  p_bolao_id uuid,
+  p_preset text,
+  p_scoring_result int DEFAULT NULL,
+  p_scoring_exact int DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_r int; v_e int;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM boloes WHERE id = p_bolao_id AND owner_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not the owner');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM boloes WHERE id = p_bolao_id AND is_premium = true) THEN
+    RETURN json_build_object('success', false, 'error', 'Premium required');
+  END IF;
+
+  IF p_preset = 'standard' THEN
+    v_r := 1; v_e := 3;
+  ELSIF p_preset = 'classic' THEN
+    v_r := 1; v_e := 5;
+  ELSIF p_preset = 'weighted_stages' THEN
+    v_r := 1; v_e := 3; -- base; multiplied per stage on calculation
+  ELSIF p_preset = 'custom' THEN
+    IF p_scoring_result IS NULL OR p_scoring_exact IS NULL THEN
+      RETURN json_build_object('success', false, 'error', 'Custom preset requires scoring values');
+    END IF;
+    IF p_scoring_result < 1 OR p_scoring_result > 5 THEN
+      RETURN json_build_object('success', false, 'error', 'scoring_result must be 1-5');
+    END IF;
+    IF p_scoring_exact < 3 OR p_scoring_exact > 10 THEN
+      RETURN json_build_object('success', false, 'error', 'scoring_exact must be 3-10');
+    END IF;
+    v_r := p_scoring_result; v_e := p_scoring_exact;
+  ELSE
+    RETURN json_build_object('success', false, 'error', 'Invalid preset');
+  END IF;
+
+  UPDATE boloes SET scoring_preset = p_preset, scoring_result = v_r, scoring_exact = v_e
+    WHERE id = p_bolao_id;
+  RETURN json_build_object('success', true, 'scoring_result', v_r, 'scoring_exact', v_e);
+END;
+$$;
+
+-- 3. update toggle_special_prediction to accept round_of_32
+CREATE OR REPLACE FUNCTION toggle_special_prediction(
+  p_bolao_id uuid,
+  p_prediction_type text,
+  p_team_code text
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_is_premium boolean;
+  v_max_picks int;
+  v_current_count int;
+  v_exists boolean;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF p_prediction_type NOT IN ('finalist', 'semifinalist', 'quarterfinalist', 'round_of_32') THEN
+    RETURN json_build_object('success', false, 'error', 'Invalid prediction type');
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+  ) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member');
+  END IF;
+  SELECT is_premium INTO v_is_premium FROM boloes WHERE id = p_bolao_id;
+  IF NOT COALESCE(v_is_premium, false) THEN
+    RETURN json_build_object('success', false, 'error', 'Premium required');
+  END IF;
+  v_max_picks := CASE p_prediction_type
+    WHEN 'finalist'        THEN 2
+    WHEN 'semifinalist'    THEN 4
+    WHEN 'quarterfinalist' THEN 8
+    WHEN 'round_of_32'     THEN 32
+    ELSE 4
+  END;
+  SELECT EXISTS(
+    SELECT 1 FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+      AND prediction_type = p_prediction_type AND predicted_team_code = p_team_code
+  ) INTO v_exists;
+  IF v_exists THEN
+    DELETE FROM bolao_special_predictions
+      WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+        AND prediction_type = p_prediction_type AND predicted_team_code = p_team_code;
+    RETURN json_build_object('success', true, 'action', 'removed');
+  ELSE
+    SELECT COUNT(*) INTO v_current_count
+    FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = p_prediction_type;
+    IF v_current_count >= v_max_picks THEN
+      RETURN json_build_object('success', false, 'error', 'Max picks reached', 'max', v_max_picks);
+    END IF;
+    INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_team_code)
+      VALUES (p_bolao_id, v_user_id, p_prediction_type, p_team_code);
+    RETURN json_build_object('success', true, 'action', 'added', 'count', v_current_count + 1);
+  END IF;
+END;
+$$;
+
+-- 4. Storage bucket para logos de bolão
+INSERT INTO storage.buckets (id, name, public)
+  VALUES ('bolao-logos', 'bolao-logos', true)
+  ON CONFLICT (id) DO NOTHING;
+
+CREATE POLICY "Public read bolao-logos"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'bolao-logos');
+
+CREATE POLICY "Authenticated upload bolao-logos"
+  ON storage.objects FOR INSERT
+  WITH CHECK (bucket_id = 'bolao-logos' AND auth.uid() IS NOT NULL);
+
+CREATE POLICY "Authenticated update bolao-logos"
+  ON storage.objects FOR UPDATE
+  USING (bucket_id = 'bolao-logos' AND auth.uid() IS NOT NULL);
+
+CREATE POLICY "Authenticated delete bolao-logos"
+  ON storage.objects FOR DELETE
+  USING (bucket_id = 'bolao-logos' AND auth.uid() IS NOT NULL);


### PR DESCRIPTION
## Summary

Produto de **topo de funil (ToFu)** para viralidade e aquisição de usuários durante a Copa do Mundo 2026 (EUA/México/Canadá — 48 seleções, 12 grupos, 104 jogos).

Cada bolão criado gera convites para 10-100+ pessoas que entram na plataforma Smart Betting. O bolão serve como porta de entrada para o ecossistema de analytics.

### O que está incluso

**28 arquivos** | **+6.545 linhas** | 12 componentes | 4 páginas | 20+ hooks | 3 migrations SQL

---

## Funcionalidades

### 🏆 Palpites
- **Palpites de jogos** — 104 partidas da Copa com bloqueio automático antes do início
- **Palpite de campeão** — Qual seleção ganha a Copa (configurável on/off + pontos)
- **Palpites especiais** — Finalistas (+10pts), semifinalistas (+5pts), quartas (+3pts), mata-mata 32 (+1pt)
- Cada tipo pode ser habilitado/desabilitado individualmente com pontuação customizável

### 📊 Pontuação
- 3 presets rápidos: Padrão (1/3), Clássico (1/5), Fases valem +
- Valores totalmente editáveis (pts resultado + pts placar exato)
- Multiplicador por fase: grupos 1×, R32 1.5×, quartas 2×, semis 3×, final 5×

### 💰 Monetização (Freemium)
| | Free | Premium (R$ 19,90) |
|---|---|---|
| Participantes | 10 | Ilimitado |
| Pontuação | Fixa | Customizável |
| Palpites especiais | ❌ | ✅ (configurável) |
| Multiplicador fase | ❌ | ✅ |
| Tema + Logo | ❌ | ✅ |
| Estatísticas | ❌ | ✅ |

- Stripe checkout integrado (create-after-payment flow com UUID pré-gerado)
- Opção PIX via WhatsApp + upgrade manual via `upgrade_bolao_to_premium('CODIGO')`

### 🎨 UI/UX
- Layout **2 colunas** no desktop (conteúdo principal + sidebar com palpites)
- **Modais** para palpites de jogos, campeão e especiais (não navega para outra página)
- **Modal de configurações** completo: modalidades, pontuação, tema, logo, participantes
- Auto-open configurações após criar bolão (Free e Premium)
- Compartilhamento via WhatsApp/Telegram/link com 3 variantes (icon, compact, default)
- Scrollbar minimalista nos modais

### ⚙️ Configurações do Bolão
- Toggle on/off para Palpite de Campeão + pontos editáveis
- Toggle individual por tipo de palpite especial (colapsável) + pontos editáveis
- Presets de pontuação + inputs manuais + toggle multiplicador por fase
- Cores do tema (8 opções) + upload de logo (JPG/PNG, 2MB)
- Abrir/encerrar inscrições + gerenciar participantes

---

## Arquitetura

```
src/
  pages/
    BolaoHome.tsx         — Lista de bolões + criação (Free/Premium)
    BolaoDetail.tsx       — Ranking + sidebar (2-col layout desktop)
    BolaoPalpites.tsx     — Tela standalone de palpites
    BolaoJoin.tsx         — Entrar via código de convite
  components/bolao/       — 12 componentes
  services/bolao.service.ts — Supabase client layer
  hooks/use-bolao.ts      — 20+ React Query hooks

supabase/
  migrations/037-039      — Tabelas, RLS, RPCs, seed
  functions/
    stripe-create-checkout — Suporte a mode:payment para bolão
    stripe-webhook         — Cria bolão premium pós-pagamento
```

### Banco de Dados
- `boloes` — Config completa (pontuação, toggles, tema, premium)
- `bolao_members` — Participantes (owner/member)
- `bolao_predictions` — Palpites por jogo
- `bolao_special_predictions` — Campeão, finalistas, semis, etc.
- `bolao_subscriptions` — Registro de compras
- `wc_matches` — 104 jogos (seed oficial da FIFA)

---

## Screenshots

Testado em staging (`hml.smartbetting.app`). Fluxo completo validado:
- Criação de bolão Free e Premium ✅
- Pagamento Stripe test mode ✅
- Webhook criando bolão pós-pagamento ✅
- Configurações abrindo automaticamente ✅
- Palpites via modal ✅

---

## Pendente para produção

- [ ] Rodar migrations no Supabase prod (`lavclmlvvfzkblrstojd`)
- [ ] Deploy Edge Functions em prod com suporte bolão
- [ ] Configurar `STRIPE_WEBHOOK_SIGNING_SECRET` live
- [ ] Adicionar `VITE_STRIPE_PRICE_ID_BOLAO=price_1TMdRI01CLJUO7HdmB5hMMBv` no Vercel
- [ ] Confirmar `SITE_URL=https://smartbetting.app` nos secrets
- [ ] Testar pagamento real

Ver documentação completa: `docs/bolao-copa-2026-produto.md`

## Test plan

- [ ] Criar bolão Free → abre configurações automaticamente
- [ ] Criar bolão Premium → redirect Stripe → pagamento → webhook cria bolão → redirect com config
- [ ] Fazer palpites via modal (filtrar por grupo)
- [ ] Escolher campeão via modal
- [ ] Fazer palpites especiais (apenas tipos habilitados)
- [ ] Desabilitar modalidades nas config → verificar que somem da sidebar
- [ ] Alterar pontuação (presets + manual + multiplicador)
- [ ] Compartilhar via WhatsApp
- [ ] Entrar via código de convite
- [ ] Testar layout mobile e desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)