### PR TITLE
feat(bolao): Onda 1 UX — touch targets, deadline visivel, share destaque, welcome premium

### DIFF
--- a/docs/bolao-audit-and-implementation-plan.md
+++ b/docs/bolao-audit-and-implementation-plan.md
@@ -1,0 +1,319 @@
+# Bolão Copa 2026 — Auditoria UX/CRO e Plano de Implementação
+
+**Data:** 2026-04-23
+**Autor:** Claude (auditoria via skill `ui-ux-pro-max` + exploração ponta-a-ponta do código)
+**Escopo:** fluxo completo — chegada → criar bolão → pagar → compartilhar → palpitar → ranking
+
+---
+
+## 1. Sumário executivo — top 5 problemas críticos
+
+1. **Touch targets violam WCAG em todo o sistema.** `h-8` (32px) é o padrão herdado do dashboard NBA; o mínimo acessível é 44px. ~30 dos ~40 botões auditados estão abaixo do limite. Inclui botões que o próprio Claude criou recentemente (`NumberStepper ±` com 24–28px).
+
+2. **Sem tela de boas-vindas pós-pagamento.** Usuário paga R$19,90 e cai direto no `BolaoAdminPanel` auto-aberto, com toast de 5s e nada mais. Queima o momento emocional mais importante da conversão — não tem celebração visual, lista do que desbloqueou, nem CTA próximo passo.
+
+3. **Share tratado como acessório.** `BolaoShareButton` em `variant="compact"` no header — ícone 32×32 `opacity-60`. Crítico pois sem amigos, o bolão não existe. Deveria ser CTA primário enquanto `ranking.length <= 1`.
+
+4. **Duas portas para a mesma sala.** `BolaoPalpites` page e `PredictionsModal` fazem a mesma coisa com lógica duplicada. Sidebar abre modal, deep-link abre página — sem critério claro de qual usar.
+
+5. **Deadline invisível até abrir o card.** Ninguém avisa "palpites fecham em 2h" na home, na lista de bolões ou no header do bolão. Só aparece dentro do `MatchPredictionCard` individual.
+
+---
+
+## 2. Análise por etapa
+
+### Etapa 1 — Chegada (`BolaoHome.tsx`) — nota 5/10
+
+**Bom:**
+- Countdown da Copa cria urgência natural.
+- Hero com dados concretos (104 jogos, 12 grupos), sem blabla.
+
+**Ruim:**
+- Botão "Criar" esconde texto em mobile (`hidden sm:inline`) — vira ícone Plus 14×14 dentro de botão 38px. Discoverability zero pro novo usuário.
+- Input "Código de convite" sem aria-label, sem helper text sobre formato. Validação "≥4 chars" sem feedback.
+- Empty state "Nenhum bolão ainda" **sem CTA próximo** — o botão Criar está no header, longe do empty.
+- Free vs Premium só visíveis **depois** de clicar Criar. Poderia ter strip comparativo no empty.
+
+### Etapa 2 — CreateBolaoModal — nota 7/10
+
+**Bom (após mudanças recentes):** form enxuto, plans lado-a-lado com Recommended badge.
+
+**Ruim:**
+- Descrição aparece visualmente obrigatória — Label sem indicação "opcional" em PT-BR (só no schema Zod).
+- Checks dos radios de plan pequenos (2.5×2.5) — affordance fraca; user seleciona pelo card inteiro mas o sinal visual é sutil.
+- Premium payment flow: toast "Redirecionando..." aparece **antes** do redirect, sem blocking overlay — user pode clicar de novo e duplicar checkout.
+
+### Etapa 3 — Pagamento → Retorno — nota 3/10 (PIOR PONTO)
+
+**Fluxo atual:**
+1. User paga na Stripe → redirect `/bolao/{id}?success=true`
+2. Toast "Bolão Premium ativado!" (5s, some)
+3. `BolaoAdminPanel` auto-abre
+
+**Falta:**
+- Celebração visual (confetti, hero "Bem-vindo ao Premium", checkmarks animados)
+- Lista do que desbloqueou ("✓ Participantes ilimitados ✓ Pontuação custom ✓ Logo...")
+- CTA próximo passo ("Convide seus amigos →")
+- Loading state enquanto webhook não confirma (se webhook atrasar, `is_premium=false` sem explicação)
+- Email de confirmação mencionado na UI
+
+### Etapa 4 — Compartilhar / Join — nota 4/10
+
+**Crítico:**
+- `BolaoShareButton` no header em compact = icon 32×32 `opacity-60`. Invisível.
+- `BolaoJoin.tsx` existe e é boa (loading/success/error bem tratados) mas só alcançável via URL direta.
+- Dropdown do share não tem trap-focus nem ESC para dismiss.
+- Copy feedback é só ícone mudando (Copy → Check) — pouco discoverable.
+- Onboarding card existe em `BolaoDetail` (linhas 505–535) mas **desaparece após 1 palpite**. Quem não fez palpite ainda e já recarregou perde a pista.
+
+### Etapa 5 — Fazer palpites — nota 5/10
+
+**OK:**
+- Lock state distinto visualmente (opacity, Lock icon).
+- Points display pós-finalização com cor condicional.
+- Deadline label amarelo quando modo ≠ `per_match`.
+
+**Problemas:**
+- Inputs de score `h-8 w-10` (32×40 px). **Mobile terrível** — dedo grande não acerta.
+- Zero empty state quando user abre e não tem o que palpitar.
+- Filter bar com scroll horizontal A–H **sem indicador de overflow**. Mobile não descobre metade dos grupos.
+- Sem push "Você tem X palpites faltando" — só `X/Y` passivo no header.
+- Save silencioso — sem toast. "Salvo" aparece 2s no botão.
+- Sem auto-save de rascunho (localStorage).
+
+### Etapa 6 — Admin Panel — nota 6/10
+
+**Bom (após mudanças recentes):**
+- Presets de pontuação como cards com preview.
+- Radios de deadline com Check ✓.
+- Warning amarelo quando tem palpites e muda deadline.
+- Upgrade CTA banner principal.
+
+**Problemas (incluindo auto-críticas):**
+- `NumberStepper` com botões 24–28px — **abaixo do mínimo de 44 px**.
+- Banner de upgrade com 5 benefícios em lista plana — CRO recomenda 3–5 com hierarquia (não peso igual).
+- CTA "Desbloquear →" aparece 3× inline (Pontuação, Cor, Logo) + 1 banner = 4 CTAs. Upsell saturation.
+- Nested scroll: modal → seção → Participantes → Special predictions collapse. 4 níveis.
+- Preview cards de pontuação em mobile (`grid-cols-3`) < 90px cada — apertado.
+
+### Etapa 7 — BolaoDetail — nota 6/10
+
+**Bom:**
+- Onboarding card quando `ranking ≤ 1 && myPredictions === 0`.
+- Sidebar right com 3 cards (palpites/campeão/especiais).
+
+**Ruim:**
+- Sidebar sticky só desktop (`lg:sticky`). Mobile vê cards **abaixo das tabs** — discoverability ruim.
+- Tabs (Ranking/Meus Palpites/Estatísticas) sem `aria-selected`. Active via className apenas.
+- "Meus Palpites" tab empty = Trophy + texto, **sem CTA**.
+- Card "Palpite de Campeão" subtitle "Quem vai ganhar a Copa 2026?" **sem deadline**.
+- Info bar com ícone Hash + invite_code é display only — perde oportunidade de copy-on-click que dispararia share.
+
+### Etapa 8 — Champion/Special Modals — nota 5/10
+
+**Problemas:**
+- ChampionPickModal com grid `grid-cols-3` com placeholder vazio 8×5 no lugar da bandeira.
+- Team buttons sem aria-label além do code+nome — delete de picks é "clicar chip com ×" sem button semântico.
+- Search inputs em `text-[11px]` com placeholder `opacity-30`. Legibilidade marginal.
+- PickPanel expandido dentro do modal = 3 scrolls simultâneos.
+- Max-reached toast sem `aria-live` — screen reader perde.
+
+---
+
+## 3. Problemas sistêmicos (atravessam tudo)
+
+**A. Touch targets quebrados por padrão**
+`h-8` = 32px é o padrão herdado do dashboard NBA. Fix: bumpar pra `h-11` (44px) em tudo que é interação primária.
+
+**B. Type scale caótico**
+Tamanhos usados: `[8px]`, `[9px]`, `[10px]`, `[11px]`, `xs`, `sm`, `base`, `lg`, `xl`... zero tokens semânticos (display/headline/body/label).
+
+**C. Cores hex vs tokens misturadas**
+`text-terminal-yellow/90` convive com `text-yellow-300` e `text-yellow-400`. São iguais ou diferentes? Impossível saber sem compilar.
+
+**D. Aria-labels ausentes em botões-ícone**
+Settings, ShareButton compact, close buttons, steppers ±, toggles Left/Right — nenhum tem aria-label.
+
+**E. Mobile descoberta ruim**
+Features escondidas em scroll horizontal (grupos), scroll vertical abaixo do fold (sidebar mobile), dropdowns (share), modais-dentro-de-modais (special predictions).
+
+**F. Sem confirmações destrutivas corretas**
+Remover membro: 2-click confirm sem undo toast. Sair do bolão? Não tem UI. Zerar palpite? Não existe.
+
+**G. Sem loading skeleton em lugares pesados**
+Ranking, Stats, Champion predictions, Special picks — todos vazios antes da query resolver.
+
+---
+
+## 4. Sumário quantitativo de fricção
+
+| Elemento | Tamanho | Mín. WCAG | Status |
+|---|---|---|---|
+| Botão "Criar" (home) | 38px | 44px | **Abaixo** |
+| Botão "Entrar" (home) | 38px | 44px | **Abaixo** |
+| Botão voltar BolaoPalpites | 32px | 44px | **Abaixo** |
+| Botão Settings (BolaoDetail) | 32px | 44px | **Abaixo** |
+| NumberStepper ± | 24–28px | 44px | **Abaixo** |
+| ShareButton compact | 32px | 44px | **Abaixo** |
+| ChampionPickModal confirm | h-auto | 44px | **Provável abaixo** |
+| MatchPredictionCard inputs | 32×40px | 44×44px | **Abaixo** |
+| Input "Código de convite" | aria-label | obrigatório | **Ausente** |
+
+---
+
+## 5. Plano de implementação completo
+
+> Todas as ondas agora cobrem os 40+ itens da auditoria. Ordem por impacto × esforço.
+
+### **Onda 1 — P0: Sangrando (1 semana)**
+
+Problemas que travam acessibilidade básica ou queimam conversão em momento crítico.
+
+**Design system & acessibilidade (base):**
+- [ ] 1.1 — Bump touch targets do sistema: `h-8` → `h-11` (44px) em todos os botões primários
+- [ ] 1.2 — `NumberStepper`: botões `±` pra 44×44 com hit-area expandida
+- [ ] 1.3 — `aria-label` em todos os botões-ícone (Settings, ShareButton compact, close, toggle Left/Right, stepper ±, dropdown triggers)
+- [ ] 1.4 — `aria-selected` nos tabs de BolaoDetail
+- [ ] 1.5 — Labels nos inputs de score do MatchPredictionCard + "Código de convite"
+
+**Conversão crítica:**
+- [ ] 1.6 — **Tela "Bem-vindo ao Premium" pós-pagamento** (substitui `admin auto-open`):
+  - Hero com checkmark animado + "Você desbloqueou o Premium!"
+  - Lista das 5 features desbloqueadas com ícones
+  - Dois CTAs: "Convidar amigos →" (primário) e "Configurar bolão →" (secundário)
+  - Loading state explícito enquanto `is_premium = false` e webhook pendente
+- [ ] 1.7 — **Share em destaque quando `ranking ≤ 1`**: card sticky no topo do BolaoDetail "Ninguém entrou ainda. Compartilhe o link 👉" com botão grande copy-to-clipboard
+- [ ] 1.8 — **Deadline visível fora do card**: badge no header do bolão + na lista de bolões da home ("Palpites fecham em 2h")
+
+**Pagamento & join:**
+- [ ] 1.9 — Bloquear botão "Criar Premium" durante redirect (loading overlay)
+- [ ] 1.10 — Loading state explícito em BolaoDetail quando `is_premium=false` mas `success=true` na URL (webhook pendente)
+
+---
+
+### **Onda 2 — P1: Fricção óbvia (2 semanas)**
+
+Problemas que o usuário resolve ignorando mas custam engajamento.
+
+**Consolidação & fluxo:**
+- [ ] 2.1 — **Consolidar BolaoPalpites + PredictionsModal** numa única tela. Escolher: modal (se é feature secundária) OU página (se é primária). Decisão: usar página + redirect do card "Fazer palpites →".
+- [ ] 2.2 — **Empty states com CTA**:
+  - BolaoHome "Nenhum bolão" → "Criar meu primeiro bolão →"
+  - Meus Palpites vazio → "Fazer meu primeiro palpite →"
+  - Ranking vazio → share CTA
+- [ ] 2.3 — **Auto-save draft palpites** em localStorage. Chave `bolao_{id}_draft_{match_id}`. Restaurar ao abrir.
+
+**Mobile & descoberta:**
+- [ ] 2.4 — **Bottom sheet mobile** pra sidebar do BolaoDetail (cards Campeão/Especiais viram bottom-sheet arrastável, não scroll abaixo)
+- [ ] 2.5 — **Filter bar com indicador de overflow**: fade-gradient nas bordas + scroll arrows (mesma solução do NBADashboard)
+- [ ] 2.6 — **Onboarding persistente**: não some após 1 palpite. Adicionar checklist de steps ("Compartilhar ✓", "Fazer 3 palpites", "Escolher campeão") que dismissa só quando tudo feito OU via botão X.
+
+**Upsell refinement:**
+- [ ] 2.7 — **Reduzir CTAs de upgrade**: manter só 1 banner top + 1 CTA sutil inline (não 3× "Desbloquear →"). A/B test sugerido.
+- [ ] 2.8 — **Banner Premium: 3 benefícios forte + 2 finos** (hierarquia visual), não 5 uniformes.
+- [ ] 2.9 — **"Grupos 1× → Final 5×"** vira texto mais concreto: "Palpite certo na Final vale 5× mais que em jogo de grupo"
+
+**Deadline UX:**
+- [ ] 2.10 — **Warning específico de deadline mode change**: "23 pessoas já fizeram 147 palpites. Mudar o prazo agora afeta todos eles. Confirmar?" (não genérico "pode confundir")
+
+**Push engajamento:**
+- [ ] 2.11 — **"Você tem X palpites faltando"** sticky no BolaoPalpites (ou toast se > 10).
+- [ ] 2.12 — **Save feedback aumentado** no palpite: toast breve de "Palpite salvo" por 2s (complementa o check inline).
+- [ ] 2.13 — **Deadline proximity alert**: se `deadline - now < 1h`, badge vermelho pulsante.
+
+---
+
+### **Onda 3 — P2: Qualidade (3+ semanas)**
+
+Polimento que separa produto "ok" de produto "gostoso de usar".
+
+**Design system explícito:**
+- [ ] 3.1 — **Token system** `tailwind.config`:
+  - Spacing scale (4, 8, 12, 16, 24, 32, 48, 64)
+  - Type scale (`text-label-sm`, `text-label-md`, `text-body`, `text-title`, `text-display`) — matar `text-[9px]` & co.
+  - Color semantic tokens (`bg-surface-primary`, `text-fg-muted`, `border-border-subtle`)
+  - Migrar componentes para usar tokens (começar pelo bolão, expandir)
+
+**Estados de carga:**
+- [ ] 3.2 — **Loading skeletons** em:
+  - Ranking table
+  - BolaoStats tab
+  - Champion predictions (sidebar card)
+  - Special picks panel
+
+**Confirmações & undo:**
+- [ ] 3.3 — **Undo toast** para remover membro (e qualquer ação destrutiva)
+- [ ] 3.4 — **Sair do bolão** — UI no admin panel quando não-owner
+- [ ] 3.5 — **Zerar palpite** — menu de 3 pontos no MatchPredictionCard
+
+**Milestones & gamificação:**
+- [ ] 3.6 — **Celebração primeira vez**:
+  - Primeiro palpite → confetti + toast
+  - Primeiro acerto → badge + som sutil
+  - Subiu pro pódio → banner
+- [ ] 3.7 — **Progresso visual** no card "Palpites dos Jogos": barra X/Y com cor azul→verde conforme completude
+
+**Acessibilidade avançada:**
+- [ ] 3.8 — **Reduced motion support** — envolver todas animações em `prefers-reduced-motion`
+- [ ] 3.9 — **Dynamic Type / Text zoom** — testar até 200% sem quebrar layouts
+- [ ] 3.10 — **aria-live regions** pros toasts + max-reached nos pick panels
+- [ ] 3.11 — **Focus trap correto** nos dropdowns do ShareButton + ESC dismiss
+- [ ] 3.12 — **Focus rings visíveis** (2-4px) em todos interactive — hoje está faltando em vários lugares
+
+**Correções menores:**
+- [ ] 3.13 — **Hash invite_code clicável** no info bar (copy-on-click + toast)
+- [ ] 3.14 — **Flag real** no ChampionPickModal (não só placeholder 8×5)
+- [ ] 3.15 — **Search inputs** nos modals com `text-sm` mínimo (não `text-[11px]`)
+- [ ] 3.16 — **Delete chips** com button semântico + aria-label "Remover {team}"
+- [ ] 3.17 — **Copy feedback do ShareButton** reforçada (toast + animation, não só ícone mudando)
+
+---
+
+### **Onda 4 — P3: Refinamento final (ongoing)**
+
+- [ ] 4.1 — **A/B testing** do banner Premium (3 vs 5 features, cores diferentes, preço destacado)
+- [ ] 4.2 — **Email de confirmação** pós-pagamento com link direto pro bolão + convites
+- [ ] 4.3 — **Deep-link WhatsApp** otimizado (mensagem pré-formatada específica por bolão)
+- [ ] 4.4 — **Notificações** (push/email) pre-deadline: "Você ainda não palpitou os jogos de hoje"
+- [ ] 4.5 — **Compartilhamento de ranking** em imagem (já existe botão, fazer imagem bonita)
+- [ ] 4.6 — **Landing page dedicada** do Bolão fora do dashboard NBA (SEO + conversão orgânica)
+- [ ] 4.7 — **Multi-usuário**: owner pode transferir bolão, múltiplos admins, convite com role
+
+---
+
+## 6. Métricas de sucesso (pra validar cada onda)
+
+**Onda 1:**
+- Accessibility score (Lighthouse) ≥ 90
+- Taxa de conclusão do onboarding pós-pagamento ≥ 60% (primeiro compartilhamento)
+- % de bolões com ≥ 2 membros em 24h após criação ≥ 40%
+
+**Onda 2:**
+- Taxa de abandono em `BolaoPalpites` antes do primeiro save ↓ 30%
+- Usuários que fazem 2º palpite na mesma sessão ↑ 25%
+- Upgrade rate (free → premium) ↑ (tracking após redução de CTA saturation)
+
+**Onda 3:**
+- NPS / CSAT survey pós-primeira semana de uso
+- Retention 7-day ≥ 50% (user volta pelo menos 1 vez)
+- Time-to-first-prediction < 90s
+
+---
+
+## 7. Dependências e considerações
+
+- **Webhook Stripe** precisa gravar `bolaoDeadlineMode` enviado no body (pendência conhecida) — bloqueia pleno funcionamento da feature de deadline em bolões premium criados via checkout dinâmico.
+- **Migration 041 (scoring_weights) + 042 (update_bolao_deadline_mode)** aplicadas em staging; **falta aplicar em prod** (`lavclmlvvfzkblrstojd`).
+- **Design system refactor (Onda 3.1)** tem overlap com dashboard NBA — decidir se faz escopo bolão-only ou global.
+- **Consolidação Palpites modal ↔ page (Onda 2.1)** precisa review com PM antes de implementar — impacto em analytics/funil existente.
+
+---
+
+## 8. Histórico
+
+- 2026-04-23 — auditoria inicial + plano criado por Claude (session)
+- 2026-??-?? — revisão humana + priorização real
+
+---
+
+*Fim do documento. Qualquer item riscado no checklist deve incluir commit SHA e data. Se novo problema aparecer durante implementação, adicionar na seção correspondente e atualizar.*

--- a/src/components/bolao/BolaoAdminPanel.tsx
+++ b/src/components/bolao/BolaoAdminPanel.tsx
@@ -157,11 +157,14 @@ const NumberStepper: React.FC<NumberStepperProps> = ({
   };
   const canDec = !disabled && value > min;
   const canInc = !disabled && value < max;
-  const btnW = size === 'sm' ? 'w-6' : 'w-7';
-  const btnText = size === 'sm' ? 'text-xs' : 'text-sm';
-  const inputPad = size === 'sm' ? 'py-0.5 text-[11px]' : 'py-1 text-xs';
+  // h-11 (44px) = WCAG touch target minimum. Smaller variants kept for non-primary
+  // contexts but minimum hit area always 44×44 via padding.
+  const containerH = size === 'sm' ? 'h-9' : 'h-11';
+  const btnW = size === 'sm' ? 'w-9' : 'w-11';
+  const btnText = size === 'sm' ? 'text-base' : 'text-lg';
+  const inputText = size === 'sm' ? 'text-xs' : 'text-sm';
   return (
-    <div className={`flex items-stretch rounded border overflow-hidden ${
+    <div className={`flex items-stretch ${containerH} rounded border overflow-hidden ${
       highlight ? 'border-terminal-blue/50' : 'border-terminal-border'
     } ${disabled ? 'opacity-30' : ''} ${className ?? ''}`}>
       <button
@@ -169,7 +172,7 @@ const NumberStepper: React.FC<NumberStepperProps> = ({
         onClick={() => bump(-step)}
         disabled={!canDec}
         aria-label={ariaLabel ? `Diminuir ${ariaLabel}` : 'Diminuir'}
-        className={`${btnW} flex items-center justify-center bg-terminal-dark-gray/60 hover:bg-terminal-blue/20 text-terminal-blue font-bold ${btnText} transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-terminal-dark-gray/60`}
+        className={`${btnW} flex items-center justify-center bg-terminal-dark-gray/60 hover:bg-terminal-blue/20 active:bg-terminal-blue/30 text-terminal-blue font-bold ${btnText} leading-none transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-terminal-dark-gray/60`}
       >
         −
       </button>
@@ -182,19 +185,19 @@ const NumberStepper: React.FC<NumberStepperProps> = ({
         onChange={(e) => handleInput(e.target.value)}
         disabled={disabled}
         aria-label={ariaLabel}
-        className={`flex-1 min-w-0 text-center font-bold bg-terminal-dark-gray ${inputPad} focus:bg-terminal-blue/10 focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none disabled:cursor-not-allowed ${
+        className={`flex-1 min-w-0 text-center font-bold bg-terminal-dark-gray ${inputText} focus:bg-terminal-blue/10 focus:outline-none focus:ring-1 focus:ring-terminal-blue/50 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none disabled:cursor-not-allowed ${
           highlight ? 'text-terminal-blue' : ''
         }`}
       />
       {suffix && (
-        <span className="flex items-center px-1 text-[10px] opacity-40 bg-terminal-dark-gray">{suffix}</span>
+        <span className="flex items-center px-1.5 text-xs opacity-40 bg-terminal-dark-gray">{suffix}</span>
       )}
       <button
         type="button"
         onClick={() => bump(step)}
         disabled={!canInc}
         aria-label={ariaLabel ? `Aumentar ${ariaLabel}` : 'Aumentar'}
-        className={`${btnW} flex items-center justify-center bg-terminal-dark-gray/60 hover:bg-terminal-blue/20 text-terminal-blue font-bold ${btnText} transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-terminal-dark-gray/60`}
+        className={`${btnW} flex items-center justify-center bg-terminal-dark-gray/60 hover:bg-terminal-blue/20 active:bg-terminal-blue/30 text-terminal-blue font-bold ${btnText} leading-none transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-terminal-dark-gray/60`}
       >
         +
       </button>
@@ -591,11 +594,16 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
                       className="w-24"
                     />
                     <span className="text-[9px] opacity-30 w-5">pts</span>
-                    <button onClick={handleToggleChampion} className="shrink-0">
+                    <button
+                      onClick={handleToggleChampion}
+                      aria-label={champEnabled ? 'Desabilitar palpite de campeão' : 'Habilitar palpite de campeão'}
+                      aria-pressed={champEnabled}
+                      className="shrink-0 w-11 h-11 flex items-center justify-center rounded hover:bg-terminal-blue/10 transition-colors"
+                    >
                       {champEnabled ? (
-                        <ToggleRight className="w-6 h-6 text-terminal-blue" />
+                        <ToggleRight className="w-7 h-7 text-terminal-blue" />
                       ) : (
-                        <ToggleLeft className="w-6 h-6 opacity-30" />
+                        <ToggleLeft className="w-7 h-7 opacity-30" />
                       )}
                     </button>
                   </div>
@@ -646,11 +654,16 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
                             className="w-24"
                           />
                           <span className="text-[9px] opacity-30 w-5">pts</span>
-                          <button onClick={() => handleToggleSpecialType(type)} className="shrink-0">
+                          <button
+                            onClick={() => handleToggleSpecialType(type)}
+                            aria-label={specialConfig[type] ? `Desabilitar ${label}` : `Habilitar ${label}`}
+                            aria-pressed={!!specialConfig[type]}
+                            className="shrink-0 w-11 h-11 flex items-center justify-center rounded hover:bg-terminal-blue/10 transition-colors"
+                          >
                             {specialConfig[type] ? (
-                              <ToggleRight className="w-6 h-6 text-terminal-blue" />
+                              <ToggleRight className="w-7 h-7 text-terminal-blue" />
                             ) : (
-                              <ToggleLeft className="w-6 h-6 opacity-30" />
+                              <ToggleLeft className="w-7 h-7 opacity-30" />
                             )}
                           </button>
                         </div>
@@ -821,7 +834,12 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
                       <p className="text-xs font-medium">Multiplicador por fase</p>
                       <p className="text-[10px] opacity-40">Mata-mata vale mais pontos</p>
                     </div>
-                    <button onClick={() => setUseWeighted(!useWeighted)} className="shrink-0">
+                    <button
+                      onClick={() => setUseWeighted(!useWeighted)}
+                      aria-label={useWeighted ? 'Desabilitar multiplicador por fase' : 'Habilitar multiplicador por fase'}
+                      aria-pressed={useWeighted}
+                      className="shrink-0 w-11 h-11 flex items-center justify-center rounded hover:bg-terminal-blue/10 transition-colors"
+                    >
                       {useWeighted ? (
                         <ToggleRight className="w-7 h-7 text-terminal-blue" />
                       ) : (

--- a/src/components/bolao/BolaoAdminPanel.tsx
+++ b/src/components/bolao/BolaoAdminPanel.tsx
@@ -15,7 +15,12 @@ import {
   ToggleLeft,
   ToggleRight,
   ChevronDown,
+  Check,
+  Crown,
+  Sparkles,
+  Zap,
 } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -30,6 +35,8 @@ import {
   useUpdateBolaoTheme,
   useUploadBolaoLogo,
   useUpdateBolaoSettings,
+  useUpdateBolaoDeadlineMode,
+  useBolaoStats,
 } from '@/hooks/use-bolao';
 import { useToast } from '@/hooks/use-toast';
 import type { BolaoRankingEntry } from '@/services/bolao.service';
@@ -43,6 +50,7 @@ interface BolaoAdminPanelProps {
   scoringPreset: string | null;
   scoringResult: number;
   scoringExact: number;
+  scoringWeights: Record<string, number> | null;
   customColor: string | null;
   customBannerUrl: string | null;
   championEnabled: boolean;
@@ -53,7 +61,14 @@ interface BolaoAdminPanelProps {
   ranking: BolaoRankingEntry[];
   currentUserId: string | undefined;
   ownerUserId: string;
+  predictionDeadlineMode: 'per_match' | 'per_round' | 'tournament_start';
 }
+
+const DEADLINE_MODE_LABELS: Record<string, { label: string; description: string }> = {
+  per_match:        { label: 'Por jogo',     description: 'Até o apito inicial de cada partida' },
+  per_round:        { label: 'Por fase',     description: 'Até o início da primeira partida da fase' },
+  tournament_start: { label: 'Copa inteira', description: 'Até a abertura da Copa' },
+};
 
 // ── Color Theme ────────────────────────────────────────────────────
 const THEME_COLORS: { value: string; label: string; bg: string; border: string }[] = [
@@ -69,10 +84,123 @@ const THEME_COLORS: { value: string; label: string; bg: string; border: string }
 
 // ── Scoring Presets (quick-fill shortcuts) ─────────────────────────
 const SCORING_PRESETS = [
-  { value: 'standard',        label: 'Padrão',        result: 1, exact: 3, weighted: false },
-  { value: 'classic',         label: 'Clássico',       result: 1, exact: 5, weighted: false },
-  { value: 'weighted_stages', label: 'Fases valem +',  result: 1, exact: 3, weighted: true  },
+  {
+    value: 'standard',
+    label: 'Casual',
+    description: 'Simples, sem multiplicador',
+    result: 1,
+    exact: 3,
+    weighted: false,
+  },
+  {
+    value: 'classic',
+    label: 'Clássico',
+    description: 'Placar exato vale mais',
+    result: 1,
+    exact: 5,
+    weighted: false,
+  },
+  {
+    value: 'weighted_stages',
+    label: 'Campeonato',
+    description: 'Mata-mata decide tudo',
+    result: 1,
+    exact: 3,
+    weighted: true,
+  },
 ] as const;
+
+// ── Stage labels + default multipliers ─────────────────────────────
+const STAGE_LABELS: { key: string; label: string; defaultWeight: number }[] = [
+  { key: 'group',       label: 'Grupos',    defaultWeight: 1.0 },
+  { key: 'round_of_32', label: 'R32',       defaultWeight: 1.5 },
+  { key: 'round_of_16', label: 'R16',       defaultWeight: 1.5 },
+  { key: 'quarter',     label: 'Quartas',   defaultWeight: 2.0 },
+  { key: 'semi',        label: 'Semis',     defaultWeight: 3.0 },
+  { key: 'third_place', label: '3º lugar',  defaultWeight: 2.0 },
+  { key: 'final',       label: 'Final',     defaultWeight: 5.0 },
+];
+
+const DEFAULT_WEIGHTS: Record<string, number> = STAGE_LABELS.reduce(
+  (acc, s) => ({ ...acc, [s.key]: s.defaultWeight }),
+  {}
+);
+
+// ── NumberStepper ─────────────────────────────────────────────────
+// Reusable numeric input with −/+ buttons. Snaps to `step`, clamps to [min,max].
+interface NumberStepperProps {
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  step?: number;
+  highlight?: boolean;
+  suffix?: string;
+  ariaLabel?: string;
+  className?: string;
+  disabled?: boolean;
+  size?: 'sm' | 'md';
+}
+
+const NumberStepper: React.FC<NumberStepperProps> = ({
+  value, onChange, min, max, step = 1, highlight, suffix, ariaLabel, className, disabled, size = 'md',
+}) => {
+  const bump = (delta: number) => {
+    const next = value + delta;
+    const snapped = step < 1 ? Math.round(next / step) * step : Math.round(next);
+    onChange(Math.min(max, Math.max(min, snapped)));
+  };
+  const handleInput = (raw: string) => {
+    const parsed = parseFloat(raw.replace(',', '.'));
+    if (!Number.isFinite(parsed)) return;
+    onChange(Math.min(max, Math.max(min, parsed)));
+  };
+  const canDec = !disabled && value > min;
+  const canInc = !disabled && value < max;
+  const btnW = size === 'sm' ? 'w-6' : 'w-7';
+  const btnText = size === 'sm' ? 'text-xs' : 'text-sm';
+  const inputPad = size === 'sm' ? 'py-0.5 text-[11px]' : 'py-1 text-xs';
+  return (
+    <div className={`flex items-stretch rounded border overflow-hidden ${
+      highlight ? 'border-terminal-blue/50' : 'border-terminal-border'
+    } ${disabled ? 'opacity-30' : ''} ${className ?? ''}`}>
+      <button
+        type="button"
+        onClick={() => bump(-step)}
+        disabled={!canDec}
+        aria-label={ariaLabel ? `Diminuir ${ariaLabel}` : 'Diminuir'}
+        className={`${btnW} flex items-center justify-center bg-terminal-dark-gray/60 hover:bg-terminal-blue/20 text-terminal-blue font-bold ${btnText} transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-terminal-dark-gray/60`}
+      >
+        −
+      </button>
+      <input
+        type="number"
+        step={step}
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => handleInput(e.target.value)}
+        disabled={disabled}
+        aria-label={ariaLabel}
+        className={`flex-1 min-w-0 text-center font-bold bg-terminal-dark-gray ${inputPad} focus:bg-terminal-blue/10 focus:outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none disabled:cursor-not-allowed ${
+          highlight ? 'text-terminal-blue' : ''
+        }`}
+      />
+      {suffix && (
+        <span className="flex items-center px-1 text-[10px] opacity-40 bg-terminal-dark-gray">{suffix}</span>
+      )}
+      <button
+        type="button"
+        onClick={() => bump(step)}
+        disabled={!canInc}
+        aria-label={ariaLabel ? `Aumentar ${ariaLabel}` : 'Aumentar'}
+        className={`${btnW} flex items-center justify-center bg-terminal-dark-gray/60 hover:bg-terminal-blue/20 text-terminal-blue font-bold ${btnText} transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-terminal-dark-gray/60`}
+      >
+        +
+      </button>
+    </div>
+  );
+};
 
 const SPECIAL_TYPES: Record<string, string> = {
   finalist: 'Finalistas',
@@ -91,6 +219,7 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   scoringPreset,
   scoringResult,
   scoringExact,
+  scoringWeights,
   customColor,
   customBannerUrl,
   championEnabled,
@@ -101,14 +230,19 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   ranking,
   currentUserId,
   ownerUserId,
+  predictionDeadlineMode,
 }) => {
   const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
   const [specialExpanded, setSpecialExpanded] = useState(false);
+  const [upgradeLoading, setUpgradeLoading] = useState(false);
 
   // Scoring state
   const [customResult, setCustomResult] = useState(scoringResult);
   const [customExact, setCustomExact] = useState(scoringExact);
   const [useWeighted, setUseWeighted] = useState(scoringPreset === 'weighted_stages');
+  const [customWeights, setCustomWeights] = useState<Record<string, number>>(
+    { ...DEFAULT_WEIGHTS, ...(scoringWeights ?? {}) }
+  );
 
   // Feature toggles state
   const [champEnabled, setChampEnabled] = useState(championEnabled);
@@ -123,6 +257,8 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   const updateTheme = useUpdateBolaoTheme();
   const uploadLogo = useUploadBolaoLogo();
   const updateSettings = useUpdateBolaoSettings();
+  const updateDeadlineMode = useUpdateBolaoDeadlineMode();
+  const { data: bolaoStats } = useBolaoStats(bolaoId, open && currentUserId === ownerUserId);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   if (currentUserId !== ownerUserId) return null;
@@ -162,6 +298,59 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
     setCustomResult(preset.result);
     setCustomExact(preset.exact);
     setUseWeighted(preset.weighted);
+    // Reset weights to defaults when applying a preset
+    if (preset.weighted) {
+      setCustomWeights({ ...DEFAULT_WEIGHTS });
+    }
+  };
+
+  const isPresetActive = (preset: typeof SCORING_PRESETS[number]) =>
+    customResult === preset.result
+    && customExact === preset.exact
+    && useWeighted === preset.weighted
+    && (!preset.weighted || STAGE_LABELS.every(s => customWeights[s.key] === s.defaultWeight));
+
+  const handleUpgradeToPremium = async () => {
+    const BOLAO_PRO_PRICE_ID = import.meta.env.VITE_STRIPE_PRICE_ID_BOLAO as string | undefined;
+    const BOLAO_PRO_PAYMENT_LINK = 'https://buy.stripe.com/4gMcMXgG43089uVg6zaR20b';
+    setUpgradeLoading(true);
+    try {
+      if (BOLAO_PRO_PRICE_ID) {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session) throw new Error('Usuário não autenticado');
+        const { data: fnData, error } = await supabase.functions.invoke('stripe-create-checkout', {
+          body: {
+            priceId: BOLAO_PRO_PRICE_ID,
+            productType: 'bolao_premium',
+            bolaoId, // upgrade existing bolão
+          },
+          headers: { Authorization: `Bearer ${session.access_token}` },
+        });
+        if (error) throw error;
+        window.location.href = fnData.url;
+      } else {
+        // Fallback payment link with client_reference_id for webhook match
+        window.location.href = `${BOLAO_PRO_PAYMENT_LINK}?client_reference_id=${bolaoId}`;
+      }
+    } catch (err: any) {
+      setUpgradeLoading(false);
+      toast({ title: 'Erro ao iniciar checkout', description: err?.message, variant: 'destructive' });
+    }
+  };
+
+  const handleDeadlineModeChange = (mode: 'per_match' | 'per_round' | 'tournament_start') => {
+    if (mode === predictionDeadlineMode) return;
+    updateDeadlineMode.mutate(
+      { bolaoId, mode },
+      {
+        onSuccess: () => {
+          toast({ title: `Prazo atualizado: ${DEADLINE_MODE_LABELS[mode]?.label}` });
+        },
+        onError: (err: any) => {
+          toast({ title: 'Erro', description: err.message, variant: 'destructive' });
+        },
+      }
+    );
   };
 
   const handleSaveScoring = () => {
@@ -172,6 +361,7 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
         preset,
         scoringResult: customResult,
         scoringExact: customExact,
+        scoringWeights: useWeighted ? customWeights : null,
       },
       {
         onSuccess: (res) => {
@@ -315,6 +505,65 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
             </Button>
           </div>
 
+          {/* ── Premium Upgrade CTA — only when not premium ── */}
+          {!isPremium && (
+            <div className="rounded-lg border border-yellow-500/40 bg-gradient-to-br from-yellow-500/10 to-yellow-500/5 p-4">
+              <div className="flex items-start gap-3">
+                <div className="w-9 h-9 rounded-full bg-yellow-500/20 border border-yellow-500/40 flex items-center justify-center shrink-0">
+                  <Crown className="w-4.5 h-4.5 text-yellow-400" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-bold text-yellow-300 flex items-center gap-1.5">
+                    Desbloqueie o Bolão Premium
+                    <Sparkles className="w-3.5 h-3.5" />
+                  </p>
+                  <p className="text-[11px] opacity-70 mt-0.5">
+                    Pagamento único de <span className="font-bold text-yellow-300">R$ 19,90</span> · sem mensalidade
+                  </p>
+                </div>
+              </div>
+
+              <ul className="mt-3 space-y-1.5 text-[11px]">
+                <li className="flex items-center gap-2">
+                  <Users className="w-3 h-3 text-yellow-400 shrink-0" />
+                  <span>Participantes <span className="font-medium text-yellow-200">ilimitados</span> (free: até 10)</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <SlidersHorizontal className="w-3 h-3 text-yellow-400 shrink-0" />
+                  <span>Pontuação customizável + multiplicador por fase</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <Star className="w-3 h-3 text-yellow-400 shrink-0" />
+                  <span>Palpites especiais (campeão, finalistas, semis...)</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <Zap className="w-3 h-3 text-yellow-400 shrink-0" />
+                  <span>Fases finais valem até <span className="font-medium text-yellow-200">5×</span> mais</span>
+                </li>
+                <li className="flex items-center gap-2">
+                  <Palette className="w-3 h-3 text-yellow-400 shrink-0" />
+                  <span>Logo e cor personalizados do bolão</span>
+                </li>
+              </ul>
+
+              <Button
+                size="sm"
+                onClick={handleUpgradeToPremium}
+                disabled={upgradeLoading}
+                className="w-full mt-3 bg-yellow-500 text-terminal-bg hover:bg-yellow-400 font-bold gap-1.5 text-xs h-9"
+              >
+                {upgradeLoading ? (
+                  'Redirecionando...'
+                ) : (
+                  <>
+                    <Crown className="w-3.5 h-3.5" />
+                    Fazer upgrade · R$ 19,90
+                  </>
+                )}
+              </Button>
+            </div>
+          )}
+
           {/* ── Features do Bolão ── */}
           <div className="border-t border-terminal-border-subtle pt-4">
             <div className="flex items-center gap-2 mb-3">
@@ -331,13 +580,15 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
                     <p className="text-xs font-medium">Palpite de Campeão</p>
                   </div>
                   <div className="flex items-center gap-1.5 shrink-0">
-                    <input
-                      type="number"
-                      min={1} max={50}
+                    <NumberStepper
                       value={champPoints}
-                      onChange={(e) => setChampPoints(Number(e.target.value))}
+                      onChange={setChampPoints}
+                      min={1}
+                      max={50}
+                      size="sm"
                       disabled={!champEnabled}
-                      className="w-10 text-center text-[11px] font-bold bg-terminal-dark-gray border border-terminal-border rounded py-0.5 focus:border-terminal-blue focus:outline-none disabled:opacity-20"
+                      ariaLabel="pontos do campeão"
+                      className="w-24"
                     />
                     <span className="text-[9px] opacity-30 w-5">pts</span>
                     <button onClick={handleToggleChampion} className="shrink-0">
@@ -384,13 +635,15 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
                       <div key={type} className="flex items-center justify-between gap-2 pl-5">
                         <p className="text-[11px] flex-1 min-w-0">{label}</p>
                         <div className="flex items-center gap-1.5 shrink-0">
-                          <input
-                            type="number"
-                            min={1} max={50}
-                            value={specialPoints[type] ?? 0}
-                            onChange={(e) => setSpecialPoints({ ...specialPoints, [type]: Number(e.target.value) })}
+                          <NumberStepper
+                            value={specialPoints[type] ?? 1}
+                            onChange={(v) => setSpecialPoints({ ...specialPoints, [type]: v })}
+                            min={1}
+                            max={50}
+                            size="sm"
                             disabled={!specialConfig[type]}
-                            className="w-10 text-center text-[11px] font-bold bg-terminal-dark-gray border border-terminal-border rounded py-0.5 focus:border-terminal-blue focus:outline-none disabled:opacity-20"
+                            ariaLabel={`pontos de ${label}`}
+                            className="w-24"
                           />
                           <span className="text-[9px] opacity-30 w-5">pts</span>
                           <button onClick={() => handleToggleSpecialType(type)} className="shrink-0">
@@ -426,6 +679,55 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
             </div>
           </div>
 
+          {/* ── Prazo de palpites ── */}
+          <div className="border-t border-terminal-border-subtle pt-4">
+            <div className="flex items-center gap-2 mb-3">
+              <SlidersHorizontal className="w-3.5 h-3.5 opacity-50" />
+              <p className="text-xs font-bold uppercase tracking-wider opacity-50">Prazo de palpites</p>
+            </div>
+            <div className="space-y-1.5">
+              {(['per_match', 'per_round', 'tournament_start'] as const).map((mode) => {
+                const active = predictionDeadlineMode === mode;
+                const meta = DEADLINE_MODE_LABELS[mode];
+                return (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => handleDeadlineModeChange(mode)}
+                    disabled={updateDeadlineMode.isPending}
+                    className={`w-full text-left rounded border p-2.5 transition-all disabled:opacity-60 ${
+                      active
+                        ? 'border-terminal-blue bg-terminal-blue/10'
+                        : 'border-terminal-border-subtle hover:border-terminal-blue/40 bg-terminal-dark-gray/20'
+                    }`}
+                  >
+                    <div className="flex items-start gap-2">
+                      <div className={`mt-0.5 w-4 h-4 rounded-full border-2 shrink-0 flex items-center justify-center transition-colors ${
+                        active ? 'border-terminal-blue bg-terminal-blue' : 'border-terminal-border-subtle'
+                      }`}>
+                        {active && <Check className="w-2.5 h-2.5 text-terminal-bg" strokeWidth={3} />}
+                      </div>
+                      <div className="min-w-0">
+                        <p className={`text-xs font-medium ${active ? 'text-terminal-blue' : ''}`}>
+                          {meta?.label}
+                        </p>
+                        <p className="text-[10px] opacity-50 mt-0.5">{meta?.description}</p>
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+            {bolaoStats && bolaoStats.total_predictions > 0 && (
+              <div className="mt-2 p-2 rounded border border-terminal-yellow/30 bg-terminal-yellow/5">
+                <p className="text-[10px] text-terminal-yellow/90">
+                  <AlertTriangle className="w-3 h-3 inline mr-1 -mt-0.5" />
+                  Atenção: já existem {bolaoStats.total_predictions} palpite{bolaoStats.total_predictions !== 1 ? 's' : ''} registrado{bolaoStats.total_predictions !== 1 ? 's' : ''}. Mudar o prazo agora pode confundir os participantes.
+                </p>
+              </div>
+            )}
+          </div>
+
           {/* ── Pontuação ── */}
           <div className="border-t border-terminal-border-subtle pt-4">
             <div className="flex items-center gap-2 mb-3">
@@ -440,50 +742,76 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
 
             {isPremium ? (
               <div className="space-y-4">
-                {/* Quick presets */}
+                {/* Quick presets — cards with description and values */}
                 <div>
-                  <p className="text-[10px] opacity-40 mb-2">Presets rápidos</p>
-                  <div className="flex gap-1.5">
-                    {SCORING_PRESETS.map((p) => (
-                      <button
-                        key={p.value}
-                        onClick={() => handleApplyPreset(p)}
-                        className={`px-3 py-1.5 rounded border text-[10px] font-medium transition-all ${
-                          customResult === p.result && customExact === p.exact && useWeighted === p.weighted
-                            ? 'border-terminal-blue bg-terminal-blue/10 text-terminal-blue'
-                            : 'border-terminal-border-subtle opacity-50 hover:opacity-80'
-                        }`}
-                      >
-                        {p.label}
-                      </button>
-                    ))}
+                  <p className="text-[10px] opacity-40 mb-2">Escolha um estilo</p>
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+                    {SCORING_PRESETS.map((p) => {
+                      const active = isPresetActive(p);
+                      return (
+                        <button
+                          key={p.value}
+                          onClick={() => handleApplyPreset(p)}
+                          className={`text-left p-3 rounded border transition-all ${
+                            active
+                              ? 'border-terminal-blue bg-terminal-blue/10'
+                              : 'border-terminal-border-subtle bg-terminal-dark-gray/20 hover:border-terminal-blue/40 hover:bg-terminal-dark-gray/40'
+                          }`}
+                        >
+                          <p className={`text-xs font-bold mb-1 ${active ? 'text-terminal-blue' : ''}`}>
+                            {p.label}
+                          </p>
+                          <p className="text-[10px] opacity-60 mb-2">{p.description}</p>
+                          <div className="flex items-center gap-1.5 flex-wrap">
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-terminal-dark-gray/60 font-mono">
+                              {p.result} pt
+                            </span>
+                            <span className="text-[10px] opacity-30">·</span>
+                            <span className="text-[10px] px-1.5 py-0.5 rounded bg-terminal-dark-gray/60 font-mono">
+                              {p.exact} pts
+                            </span>
+                          </div>
+                          {p.weighted && (
+                            <p className="text-[10px] text-terminal-blue/80 mt-2">
+                              Grupos 1× <span className="opacity-40">→</span> Final 5×
+                            </p>
+                          )}
+                        </button>
+                      );
+                    })}
                   </div>
                 </div>
 
                 {/* Editable values */}
                 <div className="p-3 rounded border border-terminal-border-subtle bg-terminal-dark-gray/20 space-y-3">
-                  <div className="flex items-center gap-4">
-                    <div className="flex items-center gap-2 flex-1">
-                      <label className="text-[10px] opacity-50 shrink-0">Acertar resultado</label>
-                      <input
-                        type="number"
-                        min={1} max={10}
-                        value={customResult}
-                        onChange={(e) => setCustomResult(Number(e.target.value))}
-                        className="w-14 text-center text-sm font-bold bg-terminal-dark-gray border border-terminal-border rounded py-1 focus:border-terminal-blue focus:outline-none"
-                      />
-                      <span className="text-[10px] opacity-30">pts</span>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="flex flex-col gap-1">
+                      <label className="text-[10px] opacity-50">Acertar resultado</label>
+                      <div className="flex items-center gap-2">
+                        <NumberStepper
+                          value={customResult}
+                          onChange={setCustomResult}
+                          min={1}
+                          max={10}
+                          ariaLabel="pontos por acertar resultado"
+                          className="flex-1"
+                        />
+                        <span className="text-[10px] opacity-30 shrink-0">pts</span>
+                      </div>
                     </div>
-                    <div className="flex items-center gap-2 flex-1">
-                      <label className="text-[10px] opacity-50 shrink-0">Placar exato</label>
-                      <input
-                        type="number"
-                        min={1} max={20}
-                        value={customExact}
-                        onChange={(e) => setCustomExact(Number(e.target.value))}
-                        className="w-14 text-center text-sm font-bold bg-terminal-dark-gray border border-terminal-border rounded py-1 focus:border-terminal-blue focus:outline-none"
-                      />
-                      <span className="text-[10px] opacity-30">pts</span>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-[10px] opacity-50">Placar exato</label>
+                      <div className="flex items-center gap-2">
+                        <NumberStepper
+                          value={customExact}
+                          onChange={setCustomExact}
+                          min={1}
+                          max={20}
+                          ariaLabel="pontos por placar exato"
+                          className="flex-1"
+                        />
+                        <span className="text-[10px] opacity-30 shrink-0">pts</span>
+                      </div>
                     </div>
                   </div>
 
@@ -503,9 +831,40 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
                   </div>
 
                   {useWeighted && (
-                    <div className="text-[10px] opacity-50 space-y-0.5 pl-1">
-                      <p>Grupos: 1× · R32/R16: 1.5× · Quartas: 2×</p>
-                      <p>Semis: 3× · 3º lugar: 2× · Final: 5×</p>
+                    <div className="space-y-2 pt-1">
+                      <p className="text-[10px] opacity-50">
+                        Ajuste o peso de cada fase com os botões <span className="font-mono">−</span> / <span className="font-mono">+</span>
+                      </p>
+                      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                        {STAGE_LABELS.map(stage => {
+                          const value = customWeights[stage.key] ?? stage.defaultWeight;
+                          const isCustom = value !== stage.defaultWeight;
+                          return (
+                            <div key={stage.key} className="flex flex-col gap-1">
+                              <label className="text-[9px] opacity-50 uppercase tracking-wider">
+                                {stage.label}
+                              </label>
+                              <NumberStepper
+                                value={value}
+                                onChange={(v) => setCustomWeights(w => ({ ...w, [stage.key]: v }))}
+                                min={0.5}
+                                max={10}
+                                step={0.5}
+                                highlight={isCustom}
+                                suffix="×"
+                                ariaLabel={`peso de ${stage.label}`}
+                              />
+                            </div>
+                          );
+                        })}
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setCustomWeights({ ...DEFAULT_WEIGHTS })}
+                        className="text-[10px] text-terminal-blue/70 hover:text-terminal-blue underline"
+                      >
+                        Resetar para valores padrão
+                      </button>
                     </div>
                   )}
                 </div>
@@ -520,9 +879,32 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
                 </Button>
               </div>
             ) : (
-              <div className="p-3 rounded border border-terminal-border-subtle bg-terminal-dark-gray/10 opacity-50">
-                <p className="text-xs">Pontuação padrão: {scoringResult}pt resultado / {scoringExact}pts placar exato</p>
-                <p className="text-[10px] opacity-50 mt-1">Personalização disponível no Premium</p>
+              <div className="space-y-2">
+                <div className="grid grid-cols-3 gap-1.5 opacity-50 pointer-events-none">
+                  {SCORING_PRESETS.map(p => (
+                    <div key={p.value} className="p-2 rounded border border-terminal-border-subtle bg-terminal-dark-gray/20">
+                      <p className="text-[10px] font-bold mb-0.5">{p.label}</p>
+                      <p className="text-[9px] opacity-60 leading-tight mb-1">{p.description}</p>
+                      <div className="flex items-center gap-1 flex-wrap">
+                        <span className="text-[9px] px-1 py-0.5 rounded bg-terminal-dark-gray/60 font-mono">{p.result}pt</span>
+                        <span className="text-[9px] px-1 py-0.5 rounded bg-terminal-dark-gray/60 font-mono">{p.exact}pts</span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex items-center justify-between gap-2 p-2.5 rounded border border-yellow-500/30 bg-yellow-500/5">
+                  <p className="text-[11px] text-yellow-200/90">
+                    <Lock className="w-3 h-3 inline mr-1 -mt-0.5" />
+                    Hoje: {scoringResult}pt resultado · {scoringExact}pts placar
+                  </p>
+                  <button
+                    onClick={handleUpgradeToPremium}
+                    disabled={upgradeLoading}
+                    className="text-[11px] font-bold text-yellow-300 hover:text-yellow-200 whitespace-nowrap disabled:opacity-50"
+                  >
+                    Desbloquear →
+                  </button>
+                </div>
               </div>
             )}
           </div>
@@ -561,13 +943,28 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
                 })}
               </div>
             ) : (
-              <div className="grid grid-cols-4 gap-1.5 opacity-30 pointer-events-none">
-                {THEME_COLORS.map((c) => (
-                  <div key={c.value} className="flex flex-col items-center gap-1 p-2 rounded border border-terminal-border-subtle">
-                    <div className={`w-6 h-6 rounded border ${c.bg} ${c.border}`} />
-                    <span className="text-[9px] opacity-40">{c.label}</span>
-                  </div>
-                ))}
+              <div className="space-y-2">
+                <div className="grid grid-cols-4 gap-1.5 opacity-40 pointer-events-none">
+                  {THEME_COLORS.map((c) => (
+                    <div key={c.value} className="flex flex-col items-center gap-1 p-2 rounded border border-terminal-border-subtle">
+                      <div className={`w-6 h-6 rounded border ${c.bg} ${c.border}`} />
+                      <span className="text-[9px] opacity-40">{c.label}</span>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex items-center justify-between gap-2 p-2.5 rounded border border-yellow-500/30 bg-yellow-500/5">
+                  <p className="text-[11px] text-yellow-200/90">
+                    <Lock className="w-3 h-3 inline mr-1 -mt-0.5" />
+                    8 cores para identificar seu bolão
+                  </p>
+                  <button
+                    onClick={handleUpgradeToPremium}
+                    disabled={upgradeLoading}
+                    className="text-[11px] font-bold text-yellow-300 hover:text-yellow-200 whitespace-nowrap disabled:opacity-50"
+                  >
+                    Desbloquear →
+                  </button>
+                </div>
               </div>
             )}
           </div>
@@ -623,9 +1020,21 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
                 />
               </div>
             ) : (
-              <div className="flex items-center gap-2 p-3 rounded border border-dashed border-terminal-border-subtle opacity-30 pointer-events-none">
-                <ImagePlus className="w-3.5 h-3.5" />
-                <span className="text-xs">Upload disponível no Premium</span>
+              <div className="flex items-center justify-between gap-2 p-3 rounded border border-yellow-500/30 bg-yellow-500/5">
+                <div className="flex items-center gap-2">
+                  <ImagePlus className="w-3.5 h-3.5 text-yellow-400/70" />
+                  <p className="text-[11px] text-yellow-200/90">
+                    <Lock className="w-3 h-3 inline mr-1 -mt-0.5" />
+                    Logo personalizado do bolão
+                  </p>
+                </div>
+                <button
+                  onClick={handleUpgradeToPremium}
+                  disabled={upgradeLoading}
+                  className="text-[11px] font-bold text-yellow-300 hover:text-yellow-200 whitespace-nowrap disabled:opacity-50"
+                >
+                  Desbloquear →
+                </button>
               </div>
             )}
           </div>

--- a/src/components/bolao/BolaoRankingTable.tsx
+++ b/src/components/bolao/BolaoRankingTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Trophy, Target, Crosshair } from 'lucide-react';
+import { Trophy, Target, Crosshair, Medal, Award } from 'lucide-react';
 import type { BolaoRankingEntry } from '@/services/bolao.service';
 
 interface BolaoRankingTableProps {
@@ -7,11 +7,21 @@ interface BolaoRankingTableProps {
   currentUserId?: string;
 }
 
-function getRankBadge(rank: number) {
-  if (rank === 1) return '🥇';
-  if (rank === 2) return '🥈';
-  if (rank === 3) return '🥉';
-  return `${rank}º`;
+/**
+ * Renders rank badge: top-3 get a medal/trophy icon, others show ordinal.
+ * Colors are tier-specific (gold/silver/bronze) to keep podium hierarchy.
+ */
+function RankBadge({ rank }: { rank: number }) {
+  if (rank === 1) {
+    return <Trophy className="w-5 h-5 text-yellow-400" aria-label="1º lugar" />;
+  }
+  if (rank === 2) {
+    return <Medal className="w-5 h-5 text-slate-300" aria-label="2º lugar" />;
+  }
+  if (rank === 3) {
+    return <Award className="w-5 h-5 text-orange-400" aria-label="3º lugar" />;
+  }
+  return <span className="text-sm font-bold opacity-60">{rank}º</span>;
 }
 
 export const BolaoRankingTable: React.FC<BolaoRankingTableProps> = ({
@@ -54,8 +64,8 @@ export const BolaoRankingTable: React.FC<BolaoRankingTableProps> = ({
                 : 'bg-terminal-dark-gray/30 border border-terminal-border-subtle hover:bg-terminal-dark-gray/50'
             }`}
           >
-            <div className="flex items-center text-sm font-bold">
-              {getRankBadge(Number(entry.rank))}
+            <div className="flex items-center">
+              <RankBadge rank={Number(entry.rank)} />
             </div>
             <div className="flex items-center">
               <span className={`text-sm font-medium truncate ${isCurrentUser ? 'text-terminal-green' : ''}`}>

--- a/src/components/bolao/BolaoShareButton.tsx
+++ b/src/components/bolao/BolaoShareButton.tsx
@@ -20,16 +20,23 @@ export const BolaoShareButton: React.FC<BolaoShareButtonProps> = ({
   const inviteUrl = `${window.location.origin}/bolao/entrar/${inviteCode}`;
   const shareText = `Participe do bolão "${bolaoName}" da Copa do Mundo 2026!\n${inviteUrl}`;
 
-  // Close on outside click
+  // Close on outside click + ESC
   useEffect(() => {
     if (!open) return;
-    const handler = (e: MouseEvent) => {
+    const clickHandler = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         setOpen(false);
       }
     };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', clickHandler);
+    document.addEventListener('keydown', keyHandler);
+    return () => {
+      document.removeEventListener('mousedown', clickHandler);
+      document.removeEventListener('keydown', keyHandler);
+    };
   }, [open]);
 
   const handleCopy = async () => {
@@ -75,28 +82,34 @@ export const BolaoShareButton: React.FC<BolaoShareButtonProps> = ({
         variant="ghost"
         size="icon"
         onClick={() => setOpen((v) => !v)}
-        className="h-8 w-8 text-terminal-text hover:text-terminal-blue"
-        title="Compartilhar"
+        aria-label="Compartilhar bolão"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="h-11 w-11 text-terminal-text hover:text-terminal-blue"
       >
-        <Share2 className="h-4 w-4" />
+        <Share2 className="h-5 w-5" />
       </Button>
     ) : variant === 'compact' ? (
       <Button
         type="button"
         variant="ghost"
-        size="sm"
         onClick={() => setOpen((v) => !v)}
-        className="gap-1.5 text-xs opacity-60 hover:opacity-100 h-8"
+        aria-label="Compartilhar bolão"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="gap-1.5 text-xs opacity-70 hover:opacity-100 h-11 px-3"
       >
-        <Share2 className="w-3.5 h-3.5" />
-        Compartilhar
+        <Share2 className="w-4 h-4" />
+        <span className="hidden sm:inline">Compartilhar</span>
       </Button>
     ) : (
       <Button
         type="button"
         variant="outline"
         onClick={() => setOpen((v) => !v)}
-        className="border-terminal-green/50 text-terminal-green hover:bg-terminal-green/10 gap-2"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className="border-terminal-green/50 text-terminal-green hover:bg-terminal-green/10 gap-2 h-11"
       >
         <Share2 className="w-4 h-4" />
         Convidar amigos
@@ -108,7 +121,7 @@ export const BolaoShareButton: React.FC<BolaoShareButtonProps> = ({
       {trigger}
 
       {open && (
-        <div className="absolute right-0 top-full mt-2 z-50 w-64 rounded-lg border border-terminal-border bg-terminal-dark-gray shadow-xl overflow-hidden">
+        <div role="menu" aria-label="Opções de compartilhamento" className="absolute right-0 top-full mt-2 z-50 w-64 rounded-lg border border-terminal-border bg-terminal-dark-gray shadow-xl overflow-hidden">
           {/* Header */}
           <div className="px-4 py-3 border-b border-terminal-border-subtle">
             <p className="text-[11px] font-semibold uppercase tracking-wider opacity-50">
@@ -121,8 +134,10 @@ export const BolaoShareButton: React.FC<BolaoShareButtonProps> = ({
           <div className="p-2 flex flex-col gap-1">
             {/* Copy link */}
             <button
+              role="menuitem"
               onClick={handleCopy}
-              className="flex items-center gap-3 px-3 py-2.5 rounded hover:bg-terminal-gray/40 transition-colors w-full text-left"
+              aria-label="Copiar link do convite"
+              className="flex items-center gap-3 px-3 py-2.5 min-h-11 rounded hover:bg-terminal-gray/40 focus:bg-terminal-gray/40 focus:outline-none transition-colors w-full text-left"
             >
               <div className="w-8 h-8 rounded bg-terminal-gray/40 flex items-center justify-center shrink-0">
                 {copied ? (
@@ -138,8 +153,10 @@ export const BolaoShareButton: React.FC<BolaoShareButtonProps> = ({
 
             {/* WhatsApp */}
             <button
+              role="menuitem"
               onClick={handleWhatsApp}
-              className="flex items-center gap-3 px-3 py-2.5 rounded hover:bg-terminal-gray/40 transition-colors w-full text-left"
+              aria-label="Compartilhar via WhatsApp"
+              className="flex items-center gap-3 px-3 py-2.5 min-h-11 rounded hover:bg-terminal-gray/40 focus:bg-terminal-gray/40 focus:outline-none transition-colors w-full text-left"
             >
               <div className="w-8 h-8 rounded bg-[#25D366]/10 flex items-center justify-center shrink-0">
                 <MessageCircle className="w-4 h-4 text-[#25D366]" />
@@ -149,8 +166,10 @@ export const BolaoShareButton: React.FC<BolaoShareButtonProps> = ({
 
             {/* Telegram */}
             <button
+              role="menuitem"
               onClick={handleTelegram}
-              className="flex items-center gap-3 px-3 py-2.5 rounded hover:bg-terminal-gray/40 transition-colors w-full text-left"
+              aria-label="Compartilhar via Telegram"
+              className="flex items-center gap-3 px-3 py-2.5 min-h-11 rounded hover:bg-terminal-gray/40 focus:bg-terminal-gray/40 focus:outline-none transition-colors w-full text-left"
             >
               <div className="w-8 h-8 rounded bg-[#229ED9]/10 flex items-center justify-center shrink-0">
                 <Send className="w-4 h-4 text-[#229ED9]" />

--- a/src/components/bolao/ChampionPickModal.tsx
+++ b/src/components/bolao/ChampionPickModal.tsx
@@ -94,19 +94,22 @@ export const ChampionPickModal: React.FC<ChampionPickModalProps> = ({
         {/* Search */}
         <div className="px-5 pb-3 shrink-0">
           <div className="relative">
-            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 opacity-40" />
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 opacity-40 pointer-events-none" />
             <Input
+              type="search"
               placeholder="Buscar seleção..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="pl-8 h-8 text-xs bg-terminal-dark-gray border-terminal-border text-terminal-text"
+              aria-label="Buscar seleção"
+              className="pl-9 h-11 text-sm bg-terminal-dark-gray border-terminal-border text-terminal-text"
             />
             {search && (
               <button
                 onClick={() => setSearch('')}
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 opacity-40 hover:opacity-70"
+                aria-label="Limpar busca"
+                className="absolute right-1 top-1/2 -translate-y-1/2 w-9 h-9 flex items-center justify-center rounded opacity-50 hover:opacity-100 hover:bg-terminal-gray/40 transition-colors"
               >
-                <X className="w-3 h-3" />
+                <X className="w-4 h-4" />
               </button>
             )}
           </div>
@@ -126,7 +129,9 @@ export const ChampionPickModal: React.FC<ChampionPickModalProps> = ({
                   <button
                     key={team.code}
                     onClick={() => setSelected(team.code)}
-                    className={`relative flex flex-col items-center gap-1.5 p-2.5 rounded border text-left transition-all ${
+                    aria-label={`Escolher ${team.name} como campeão${isSelected ? ' (selecionado)' : ''}`}
+                    aria-pressed={isSelected}
+                    className={`relative flex flex-col items-center gap-1.5 p-3 min-h-[72px] rounded border text-left transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500/50 ${
                       isSelected
                         ? 'border-yellow-500/60 bg-yellow-500/5'
                         : 'border-terminal-border hover:border-terminal-border-subtle bg-terminal-dark-gray/30'
@@ -172,20 +177,18 @@ export const ChampionPickModal: React.FC<ChampionPickModalProps> = ({
             <Button
               type="button"
               variant="ghost"
-              size="sm"
               onClick={() => handleOpen(false)}
-              className="text-terminal-text text-xs"
+              className="text-terminal-text text-sm h-11 px-4"
             >
               Cancelar
             </Button>
             <Button
               type="button"
-              size="sm"
               disabled={!selected || isLoading}
               onClick={handleConfirm}
-              className="bg-yellow-500 text-terminal-bg hover:bg-yellow-500/90 text-xs gap-1.5"
+              className="bg-yellow-500 text-terminal-bg hover:bg-yellow-500/90 text-sm gap-1.5 h-11 px-4 font-bold"
             >
-              <Trophy className="w-3 h-3" />
+              <Trophy className="w-4 h-4" />
               {isLoading ? 'Salvando...' : 'Confirmar'}
             </Button>
           </div>

--- a/src/components/bolao/DeadlineBadge.tsx
+++ b/src/components/bolao/DeadlineBadge.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { Clock, AlertCircle } from 'lucide-react';
+import {
+  getNextDeadline,
+  formatDeadlineRelative,
+  isDeadlineUrgent,
+} from '@/hooks/use-bolao';
+import type { WcMatch } from '@/services/bolao.service';
+
+interface DeadlineBadgeProps {
+  matches: WcMatch[] | undefined;
+  mode: 'per_match' | 'per_round' | 'tournament_start';
+  isClosed: boolean;
+  /** "compact" = single line, no icon prefix (use in tight cards) */
+  variant?: 'default' | 'compact';
+}
+
+/**
+ * Live-updating deadline indicator. Re-renders every 30s to keep the
+ * relative time fresh ("47min" → "46min" → ...). Shows urgent pulse
+ * when < 1h remains.
+ */
+export const DeadlineBadge: React.FC<DeadlineBadgeProps> = ({ matches, mode, isClosed, variant = 'default' }) => {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    // Refresh every 30s so the relative label stays accurate without
+    // rerendering on every animation frame.
+    const id = setInterval(() => setNow(new Date()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const next = getNextDeadline(mode, matches, isClosed);
+  if (!next) return null;
+
+  const urgent = isDeadlineUrgent(next.deadline, now);
+  const label = formatDeadlineRelative(next.deadline, now);
+
+  if (variant === 'compact') {
+    return (
+      <span
+        className={`inline-flex items-center gap-1 text-[11px] font-medium tabular-nums ${
+          urgent ? 'text-terminal-red animate-pulse' : 'text-terminal-yellow/80'
+        }`}
+        title={`Próximo prazo: ${next.deadline.toLocaleString('pt-BR')}`}
+      >
+        <Clock className="w-3 h-3" />
+        Fecha {label}
+      </span>
+    );
+  }
+
+  return (
+    <div
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium tabular-nums ${
+        urgent
+          ? 'border-terminal-red/40 bg-terminal-red/10 text-terminal-red animate-pulse'
+          : 'border-terminal-yellow/30 bg-terminal-yellow/5 text-terminal-yellow/90'
+      }`}
+      title={`Próximo prazo: ${next.deadline.toLocaleString('pt-BR')}`}
+      aria-live="polite"
+    >
+      {urgent ? <AlertCircle className="w-3.5 h-3.5" /> : <Clock className="w-3.5 h-3.5" />}
+      <span>Fecha {label}</span>
+    </div>
+  );
+};

--- a/src/components/bolao/MatchPredictionCard.tsx
+++ b/src/components/bolao/MatchPredictionCard.tsx
@@ -141,26 +141,30 @@ export const MatchPredictionCard: React.FC<MatchPredictionCardProps> = ({
             <span className="w-8 text-center text-sm font-bold">{match.away_score}</span>
           </div>
         ) : (
-          <div className="flex items-center gap-1 px-1">
+          <div className="flex items-center gap-1.5 px-1">
             <input
               type="number"
+              inputMode="numeric"
               min="0"
               max="20"
               value={homeScore}
               onChange={(e) => setHomeScore(e.target.value)}
               disabled={locked}
-              className="w-10 h-8 text-center text-sm font-bold bg-terminal-dark-gray border border-terminal-border rounded focus:border-terminal-green focus:outline-none disabled:opacity-40 text-terminal-text"
+              aria-label={`Placar ${match.home_team_code} (mandante)`}
+              className="w-12 h-11 text-center text-base font-bold bg-terminal-dark-gray border border-terminal-border rounded focus:border-terminal-green focus:outline-none focus:ring-1 focus:ring-terminal-green/40 disabled:opacity-40 text-terminal-text [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
               placeholder="-"
             />
             <span className="text-xs opacity-40">x</span>
             <input
               type="number"
+              inputMode="numeric"
               min="0"
               max="20"
               value={awayScore}
               onChange={(e) => setAwayScore(e.target.value)}
               disabled={locked}
-              className="w-10 h-8 text-center text-sm font-bold bg-terminal-dark-gray border border-terminal-border rounded focus:border-terminal-green focus:outline-none disabled:opacity-40 text-terminal-text"
+              aria-label={`Placar ${match.away_team_code} (visitante)`}
+              className="w-12 h-11 text-center text-base font-bold bg-terminal-dark-gray border border-terminal-border rounded focus:border-terminal-green focus:outline-none focus:ring-1 focus:ring-terminal-green/40 disabled:opacity-40 text-terminal-text [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
               placeholder="-"
             />
           </div>

--- a/src/components/bolao/MatchPredictionCard.tsx
+++ b/src/components/bolao/MatchPredictionCard.tsx
@@ -1,13 +1,17 @@
 import React, { useState, useEffect } from 'react';
 import { Lock, Check } from 'lucide-react';
 import type { WcMatch, BolaoPrediction } from '@/services/bolao.service';
-import { isMatchLocked } from '@/hooks/use-bolao';
+import { isMatchLocked, isMatchPredictionLocked, computeMatchDeadline } from '@/hooks/use-bolao';
 
 interface MatchPredictionCardProps {
   match: WcMatch;
   prediction?: BolaoPrediction;
   onSave: (matchId: number, homeScore: number, awayScore: number) => void;
   isSaving?: boolean;
+  // Optional — when passed, deadline is computed from bolão mode instead of kickoff
+  deadlineMode?: 'per_match' | 'per_round' | 'tournament_start';
+  allMatches?: WcMatch[];
+  isClosed?: boolean;
 }
 
 export const MatchPredictionCard: React.FC<MatchPredictionCardProps> = ({
@@ -15,8 +19,16 @@ export const MatchPredictionCard: React.FC<MatchPredictionCardProps> = ({
   prediction,
   onSave,
   isSaving,
+  deadlineMode,
+  allMatches,
+  isClosed,
 }) => {
-  const locked = isMatchLocked(match);
+  const locked = deadlineMode
+    ? isMatchPredictionLocked(match, deadlineMode, allMatches, !!isClosed)
+    : isMatchLocked(match);
+  const deadline = deadlineMode
+    ? computeMatchDeadline(match, deadlineMode, allMatches)
+    : null;
   const [homeScore, setHomeScore] = useState<string>(
     prediction?.predicted_home_score?.toString() ?? ''
   );
@@ -100,6 +112,18 @@ export const MatchPredictionCard: React.FC<MatchPredictionCardProps> = ({
           </span>
         </div>
       </div>
+      {/* Custom deadline indicator — only show when deadline differs from kickoff */}
+      {!match.is_finished && deadline && deadlineMode && deadlineMode !== 'per_match' && (() => {
+        const kickoff = new Date(`${match.match_date}T${match.match_time_brasilia}-03:00`);
+        if (deadline.getTime() === kickoff.getTime()) return null;
+        const d = deadline;
+        const label = `${String(d.getDate()).padStart(2,'0')}/${String(d.getMonth()+1).padStart(2,'0')} ${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}`;
+        return (
+          <p className="text-[10px] text-terminal-yellow/80 mb-2">
+            Palpites até {label}
+          </p>
+        );
+      })()}
 
       {/* Match */}
       <div className="flex items-center gap-2">

--- a/src/components/bolao/PredictionsModal.tsx
+++ b/src/components/bolao/PredictionsModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import {
+  useBolao,
   useWcMatches,
   useBolaoPredictions,
   useUpsertPrediction,
@@ -29,6 +30,7 @@ export const PredictionsModal: React.FC<PredictionsModalProps> = ({
 }) => {
   const [groupFilter, setGroupFilter] = useState<string>('all');
 
+  const { data: bolao } = useBolao(bolaoId);
   const { data: matches, isLoading } = useWcMatches();
   const { data: predictions } = useBolaoPredictions(bolaoId, currentUserId);
   const upsertPrediction = useUpsertPrediction();
@@ -139,6 +141,9 @@ export const PredictionsModal: React.FC<PredictionsModalProps> = ({
                         prediction={predictionsByMatch.get(match.id)}
                         onSave={handleSave}
                         isSaving={upsertPrediction.isPending}
+                        deadlineMode={bolao?.prediction_deadline_mode ?? 'per_match'}
+                        allMatches={matches}
+                        isClosed={bolao?.is_closed}
                       />
                     ))}
                   </div>

--- a/src/components/bolao/PremiumWelcomeModal.tsx
+++ b/src/components/bolao/PremiumWelcomeModal.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Crown, Sparkles, Users, SlidersHorizontal, Star, Zap, Palette, Check,
+  PartyPopper,
+} from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface PremiumWelcomeModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onShare: () => void;
+  onConfigure: () => void;
+}
+
+const FEATURES = [
+  { icon: Users,             text: 'Participantes ilimitados' },
+  { icon: SlidersHorizontal, text: 'Pontuação customizável' },
+  { icon: Star,              text: 'Palpites especiais (campeão, finalistas...)' },
+  { icon: Zap,               text: 'Multiplicador por fase: até 5× nos mata-matas' },
+  { icon: Palette,           text: 'Logo e cor personalizados' },
+];
+
+export const PremiumWelcomeModal: React.FC<PremiumWelcomeModalProps> = ({
+  open, onOpenChange, onShare, onConfigure,
+}) => {
+  const [revealed, setRevealed] = useState(0);
+
+  // Stagger feature reveal — 100ms por item, fica festivo sem ser exagerado.
+  useEffect(() => {
+    if (!open) {
+      setRevealed(0);
+      return;
+    }
+    const id = setInterval(() => {
+      setRevealed(r => {
+        if (r >= FEATURES.length) {
+          clearInterval(id);
+          return r;
+        }
+        return r + 1;
+      });
+    }, 100);
+    return () => clearInterval(id);
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-terminal-bg border-yellow-500/40 max-w-md p-0 overflow-hidden">
+        <DialogHeader className="px-6 pt-6 pb-2">
+          <DialogTitle className="sr-only">Bolão Premium ativado</DialogTitle>
+        </DialogHeader>
+
+        <div className="px-6 pb-6">
+          {/* Hero */}
+          <div className="text-center mb-6">
+            <div className="w-16 h-16 mx-auto mb-3 rounded-full bg-gradient-to-br from-yellow-400 to-yellow-600 flex items-center justify-center shadow-lg shadow-yellow-500/30">
+              <Crown className="w-8 h-8 text-terminal-bg" />
+            </div>
+            <h2 className="text-xl font-bold text-yellow-300 flex items-center justify-center gap-2">
+              <PartyPopper className="w-5 h-5" />
+              Bolão Premium ativado!
+              <Sparkles className="w-5 h-5" />
+            </h2>
+            <p className="text-sm opacity-60 mt-1">
+              Pagamento confirmado · Você desbloqueou tudo isso:
+            </p>
+          </div>
+
+          {/* Features list with stagger animation */}
+          <ul className="space-y-2.5 mb-6">
+            {FEATURES.map((f, i) => {
+              const isShown = i < revealed;
+              return (
+                <li
+                  key={f.text}
+                  className={`flex items-center gap-3 transition-all duration-300 ${
+                    isShown ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-2'
+                  }`}
+                >
+                  <div className="w-8 h-8 rounded-full bg-yellow-500/15 border border-yellow-500/30 flex items-center justify-center shrink-0">
+                    <Check className="w-4 h-4 text-yellow-400" />
+                  </div>
+                  <div className="flex items-center gap-2 flex-1 min-w-0">
+                    <f.icon className="w-3.5 h-3.5 text-yellow-400/80 shrink-0" />
+                    <span className="text-sm">{f.text}</span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+
+          {/* CTAs */}
+          <div className="space-y-2">
+            <Button
+              onClick={onShare}
+              className="w-full bg-yellow-500 text-terminal-bg hover:bg-yellow-400 active:bg-yellow-600 font-bold gap-1.5 h-12 text-sm"
+            >
+              <Users className="w-4 h-4" />
+              Convidar amigos agora
+            </Button>
+            <Button
+              variant="outline"
+              onClick={onConfigure}
+              className="w-full border-yellow-500/40 text-yellow-300 hover:bg-yellow-500/10 gap-1.5 h-11 text-sm"
+            >
+              <SlidersHorizontal className="w-4 h-4" />
+              Configurar pontuação e palpites especiais
+            </Button>
+          </div>
+
+          <p className="text-[11px] opacity-40 text-center mt-4">
+            Você pode mudar essas configurações a qualquer momento
+          </p>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/bolao/ShareCallout.tsx
+++ b/src/components/bolao/ShareCallout.tsx
@@ -1,0 +1,131 @@
+import React, { useEffect, useState } from 'react';
+import { PartyPopper, Copy, Check, MessageCircle, Send, X } from 'lucide-react';
+
+interface ShareCalloutProps {
+  bolaoId: string;
+  bolaoName: string;
+  inviteCode: string;
+}
+
+/**
+ * Big "invite friends" call-to-action shown on bolão detail page when
+ * the bolão has ≤ 1 member. Dismissible (per-bolão, persisted in
+ * localStorage), reappears if user navigates away and back.
+ */
+export const ShareCallout: React.FC<ShareCalloutProps> = ({ bolaoId, bolaoName, inviteCode }) => {
+  const dismissKey = `bolao_share_callout_dismissed_${bolaoId}`;
+  const [dismissed, setDismissed] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Read dismiss state on mount only — clears when user re-navigates here.
+  useEffect(() => {
+    setDismissed(sessionStorage.getItem(dismissKey) === '1');
+  }, [dismissKey]);
+
+  if (dismissed) return null;
+
+  const inviteUrl = `${window.location.origin}/bolao/entrar/${inviteCode}`;
+  const shareText = `Participe do bolão "${bolaoName}" da Copa do Mundo 2026!\n${inviteUrl}`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+    } catch {
+      const ta = document.createElement('textarea');
+      ta.value = inviteUrl;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleWhatsApp = () => {
+    window.open(
+      `https://wa.me/?text=${encodeURIComponent(shareText)}`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+  };
+
+  const handleTelegram = () => {
+    window.open(
+      `https://t.me/share/url?url=${encodeURIComponent(inviteUrl)}&text=${encodeURIComponent(`Participe do bolão "${bolaoName}" da Copa do Mundo 2026!`)}`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+  };
+
+  const handleDismiss = () => {
+    sessionStorage.setItem(dismissKey, '1');
+    setDismissed(true);
+  };
+
+  return (
+    <div className="relative rounded-lg border border-terminal-border bg-terminal-dark-gray/30 p-4 sm:p-5 mb-5">
+      <button
+        onClick={handleDismiss}
+        aria-label="Dispensar aviso de compartilhamento"
+        className="absolute top-2 right-2 w-8 h-8 flex items-center justify-center rounded text-terminal-text/40 hover:text-terminal-text/80 hover:bg-terminal-gray/30 transition-colors"
+      >
+        <X className="w-4 h-4" />
+      </button>
+
+      <div className="flex items-start gap-3 mb-3 pr-8">
+        <div className="w-10 h-10 rounded-full bg-terminal-blue/15 border border-terminal-blue/30 flex items-center justify-center shrink-0">
+          <PartyPopper className="w-5 h-5 text-terminal-blue" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm sm:text-base font-bold text-terminal-text">
+            Bolão criado! Agora chame os amigos
+          </p>
+          <p className="text-xs sm:text-sm text-terminal-text/60 mt-0.5">
+            Sem competição não tem graça. Mande o link em 1 clique:
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={handleCopy}
+          aria-label="Copiar link de convite do bolão"
+          className="flex items-center gap-2 h-11 px-4 rounded-lg border border-terminal-blue/40 bg-terminal-blue/10 text-terminal-blue hover:bg-terminal-blue/20 active:bg-terminal-blue/30 font-medium text-sm transition-colors flex-1 sm:flex-none justify-center"
+        >
+          {copied ? (
+            <>
+              <Check className="w-4 h-4" />
+              <span>Copiado!</span>
+            </>
+          ) : (
+            <>
+              <Copy className="w-4 h-4" />
+              <span>Copiar link</span>
+            </>
+          )}
+        </button>
+        <button
+          onClick={handleWhatsApp}
+          aria-label="Compartilhar bolão no WhatsApp"
+          className="flex items-center gap-2 h-11 px-4 rounded-lg border border-[#25D366]/40 bg-[#25D366]/10 text-[#25D366] hover:bg-[#25D366]/20 active:bg-[#25D366]/30 font-medium text-sm transition-colors flex-1 sm:flex-none justify-center"
+        >
+          <MessageCircle className="w-4 h-4" />
+          <span>WhatsApp</span>
+        </button>
+        <button
+          onClick={handleTelegram}
+          aria-label="Compartilhar bolão no Telegram"
+          className="flex items-center gap-2 h-11 px-4 rounded-lg border border-[#229ED9]/40 bg-[#229ED9]/10 text-[#229ED9] hover:bg-[#229ED9]/20 active:bg-[#229ED9]/30 font-medium text-sm transition-colors flex-1 sm:flex-none justify-center"
+        >
+          <Send className="w-4 h-4" />
+          <span>Telegram</span>
+        </button>
+      </div>
+
+      <p className="text-[11px] opacity-50 mt-3">
+        Código: <span className="font-mono font-bold text-terminal-text">{inviteCode}</span>
+      </p>
+    </div>
+  );
+};

--- a/src/components/bolao/SpecialPredictionsSection.tsx
+++ b/src/components/bolao/SpecialPredictionsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Crown, Lock, ChevronDown, ChevronUp, Check, Search } from 'lucide-react';
+import { Crown, Lock, ChevronDown, ChevronUp, Check, Search, X } from 'lucide-react';
 import {
   useMySpecialPredictions,
   useSpecialSummary,
@@ -112,13 +112,14 @@ const PickPanel: React.FC<PickPanelProps> = ({ type, bolaoId, myPicks, summaryCo
           {/* Search */}
           <div className="px-3 pt-3 pb-2">
             <div className="relative">
-              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3 h-3 opacity-40" />
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 opacity-40 pointer-events-none" />
               <input
-                type="text"
+                type="search"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Buscar seleção..."
-                className="w-full bg-terminal-dark-gray border border-terminal-border rounded px-2 py-1.5 pl-7 text-xs placeholder:opacity-30 focus:outline-none focus:border-terminal-blue transition-colors"
+                aria-label={`Buscar seleção em ${label}`}
+                className="w-full bg-terminal-dark-gray border border-terminal-border rounded px-3 pl-9 h-10 text-sm placeholder:opacity-30 focus:outline-none focus:border-terminal-blue focus:ring-1 focus:ring-terminal-blue/30 transition-colors"
               />
             </div>
           </div>
@@ -133,7 +134,9 @@ const PickPanel: React.FC<PickPanelProps> = ({ type, bolaoId, myPicks, summaryCo
                   key={team.code}
                   onClick={() => handleToggle(team.code)}
                   disabled={toggle.isPending}
-                  className={`relative flex flex-col items-center gap-0.5 p-2 rounded border text-center transition-all ${
+                  aria-label={`${picked ? 'Remover' : 'Escolher'} ${team.name} para ${label}`}
+                  aria-pressed={picked}
+                  className={`relative flex flex-col items-center gap-0.5 p-2 min-h-[60px] rounded border text-center transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-terminal-blue/50 ${
                     picked
                       ? 'border-terminal-blue bg-terminal-blue/10 text-terminal-blue'
                       : 'border-terminal-border-subtle hover:border-terminal-border bg-transparent opacity-70 hover:opacity-100'
@@ -144,10 +147,10 @@ const PickPanel: React.FC<PickPanelProps> = ({ type, bolaoId, myPicks, summaryCo
                       <Check className="w-2 h-2 text-terminal-bg" />
                     </div>
                   )}
-                  <span className="font-mono font-bold text-[11px]">{team.code}</span>
-                  <span className="text-[9px] opacity-60 leading-tight text-center line-clamp-1">{team.name}</span>
+                  <span className="font-mono font-bold text-xs">{team.code}</span>
+                  <span className="text-[10px] opacity-60 leading-tight text-center line-clamp-1">{team.name}</span>
                   {count > 0 && totalMembers > 1 && (
-                    <span className="text-[8px] opacity-40 tabular-nums">{count} pick{count !== 1 ? 's' : ''}</span>
+                    <span className="text-[9px] opacity-40 tabular-nums">{count} pick{count !== 1 ? 's' : ''}</span>
                   )}
                 </button>
               );
@@ -158,17 +161,21 @@ const PickPanel: React.FC<PickPanelProps> = ({ type, bolaoId, myPicks, summaryCo
           {myPicks.length > 0 && (
             <div className="px-3 pb-3 border-t border-terminal-border-subtle/50 pt-2">
               <p className="text-[10px] opacity-40 mb-1 uppercase tracking-wider">Meus palpites</p>
-              <div className="flex flex-wrap gap-1">
-                {myPicks.map((code) => (
-                  <button
-                    key={code}
-                    onClick={() => handleToggle(code)}
-                    className="text-[10px] font-mono font-bold px-2 py-0.5 rounded border border-terminal-blue/50 bg-terminal-blue/10 text-terminal-blue hover:bg-terminal-red/10 hover:border-terminal-red/50 hover:text-terminal-red transition-colors"
-                    title="Clique para remover"
-                  >
-                    {code} ×
-                  </button>
-                ))}
+              <div className="flex flex-wrap gap-1.5">
+                {myPicks.map((code) => {
+                  const team = teams.find(t => t.code === code);
+                  return (
+                    <button
+                      key={code}
+                      onClick={() => handleToggle(code)}
+                      aria-label={`Remover ${team?.name ?? code} dos meus palpites`}
+                      className="text-xs font-mono font-bold px-2.5 h-8 rounded border border-terminal-blue/50 bg-terminal-blue/10 text-terminal-blue hover:bg-terminal-red/10 hover:border-terminal-red/50 hover:text-terminal-red focus:outline-none focus-visible:ring-2 focus-visible:ring-terminal-red/50 transition-colors flex items-center gap-1"
+                    >
+                      <span>{code}</span>
+                      <X className="w-3 h-3" />
+                    </button>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -48,8 +48,11 @@ export function useCreateBolao() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (params: { name: string; description?: string }) =>
-      bolaoService.createBolao(params),
+    mutationFn: (params: {
+      name: string;
+      description?: string;
+      predictionDeadlineMode?: 'per_match' | 'per_round' | 'tournament_start';
+    }) => bolaoService.createBolao(params),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
     },
@@ -235,7 +238,28 @@ export function useUpdateBolaoScoring() {
       preset: 'standard' | 'classic' | 'weighted_stages' | 'custom';
       scoringResult?: number;
       scoringExact?: number;
-    }) => bolaoService.updateBolaoScoring(params.bolaoId, params.preset, params.scoringResult, params.scoringExact),
+      scoringWeights?: Record<string, number> | null;
+    }) => bolaoService.updateBolaoScoring(
+      params.bolaoId,
+      params.preset,
+      params.scoringResult,
+      params.scoringExact,
+      params.scoringWeights
+    ),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['bolao', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
+export function useUpdateBolaoDeadlineMode() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: {
+      bolaoId: string;
+      mode: 'per_match' | 'per_round' | 'tournament_start';
+    }) => bolaoService.updateBolaoDeadlineMode(params.bolaoId, params.mode),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['bolao', variables.bolaoId] });
       queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
@@ -329,4 +353,46 @@ export function isMatchLocked(match: WcMatch): boolean {
   const now = new Date();
   const matchDateTime = new Date(`${match.match_date}T${match.match_time_brasilia}-03:00`);
   return now >= matchDateTime || match.is_finished;
+}
+
+function matchKickoff(m: WcMatch): Date {
+  return new Date(`${m.match_date}T${m.match_time_brasilia}-03:00`);
+}
+
+/**
+ * Computes the prediction deadline for a match given the bolão's mode.
+ * Mirrors the server-side get_prediction_deadline function.
+ */
+export function computeMatchDeadline(
+  match: WcMatch,
+  mode: 'per_match' | 'per_round' | 'tournament_start',
+  allMatches: WcMatch[] | undefined
+): Date {
+  if (mode === 'per_match' || !allMatches || allMatches.length === 0) {
+    return matchKickoff(match);
+  }
+  if (mode === 'per_round') {
+    const stageMatches = allMatches.filter(m => m.stage === match.stage);
+    if (stageMatches.length === 0) return matchKickoff(match);
+    return stageMatches.reduce((min, m) => {
+      const t = matchKickoff(m);
+      return t < min ? t : min;
+    }, matchKickoff(stageMatches[0]));
+  }
+  // tournament_start
+  return allMatches.reduce((min, m) => {
+    const t = matchKickoff(m);
+    return t < min ? t : min;
+  }, matchKickoff(allMatches[0]));
+}
+
+export function isMatchPredictionLocked(
+  match: WcMatch,
+  mode: 'per_match' | 'per_round' | 'tournament_start',
+  allMatches: WcMatch[] | undefined,
+  isClosed: boolean
+): boolean {
+  if (match.is_finished || isClosed) return true;
+  const deadline = computeMatchDeadline(match, mode, allMatches);
+  return new Date() >= deadline;
 }

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -396,3 +396,66 @@ export function isMatchPredictionLocked(
   const deadline = computeMatchDeadline(match, mode, allMatches);
   return new Date() >= deadline;
 }
+
+/**
+ * Returns the next prediction deadline that hasn't passed yet, given the
+ * bolão mode + the user's already-made predictions. Used to show the user
+ * "Próximo palpite fecha em XYZ" outside of an individual match card.
+ *
+ * Returns null if everything is already locked or finished.
+ */
+export function getNextDeadline(
+  mode: 'per_match' | 'per_round' | 'tournament_start',
+  allMatches: WcMatch[] | undefined,
+  isClosed: boolean
+): { match: WcMatch; deadline: Date } | null {
+  if (isClosed || !allMatches || allMatches.length === 0) return null;
+  const now = new Date();
+  // Find every match that's still open and pick the earliest deadline.
+  const candidates = allMatches
+    .filter(m => !m.is_finished)
+    .map(m => ({ match: m, deadline: computeMatchDeadline(m, mode, allMatches) }))
+    .filter(c => c.deadline.getTime() > now.getTime())
+    .sort((a, b) => a.deadline.getTime() - b.deadline.getTime());
+  return candidates[0] ?? null;
+}
+
+/**
+ * Human-friendly relative time formatter. Returns "47min", "2h 15min",
+ * "Hoje 22:00", "23/04 22:00", etc. Suitable for deadline countdown badges.
+ */
+export function formatDeadlineRelative(deadline: Date, now: Date = new Date()): string {
+  const diffMs = deadline.getTime() - now.getTime();
+  if (diffMs <= 0) return 'Encerrado';
+
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 60) return `${diffMin}min`;
+
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 12) {
+    const remainingMin = diffMin % 60;
+    return remainingMin > 0 ? `${diffHours}h ${remainingMin}min` : `${diffHours}h`;
+  }
+
+  // Same calendar day → "Hoje 22:00"
+  const sameDay = deadline.toDateString() === now.toDateString();
+  const hh = String(deadline.getHours()).padStart(2, '0');
+  const mm = String(deadline.getMinutes()).padStart(2, '0');
+  if (sameDay) return `Hoje ${hh}:${mm}`;
+
+  // Tomorrow
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  if (deadline.toDateString() === tomorrow.toDateString()) return `Amanhã ${hh}:${mm}`;
+
+  // Otherwise → "23/04 22:00"
+  const dd = String(deadline.getDate()).padStart(2, '0');
+  const mo = String(deadline.getMonth() + 1).padStart(2, '0');
+  return `${dd}/${mo} ${hh}:${mm}`;
+}
+
+/** Returns true if the deadline is < 1 hour away → urgent (red pulse) */
+export function isDeadlineUrgent(deadline: Date, now: Date = new Date()): boolean {
+  const diffMs = deadline.getTime() - now.getTime();
+  return diffMs > 0 && diffMs < 60 * 60_000;
+}

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import {
   Trophy,
@@ -11,6 +12,7 @@ import {
   BarChart3,
   Image,
   Settings,
+  Target,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -30,6 +32,9 @@ import { SpecialPredictionsSection } from '@/components/bolao/SpecialPredictions
 import { PredictionsModal } from '@/components/bolao/PredictionsModal';
 
 import { BolaoStatsPanel } from '@/components/bolao/BolaoStatsPanel';
+import { DeadlineBadge } from '@/components/bolao/DeadlineBadge';
+import { ShareCallout } from '@/components/bolao/ShareCallout';
+import { PremiumWelcomeModal } from '@/components/bolao/PremiumWelcomeModal';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import type { WcMatch, BolaoRankingEntry } from '@/services/bolao.service';
@@ -149,9 +154,14 @@ const BolaoDetail: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState<Tab>('ranking');
   const [currentUserId, setCurrentUserId] = useState<string | undefined>();
   const [showAdmin, setShowAdmin] = useState(false);
+  const [showPremiumWelcome, setShowPremiumWelcome] = useState(false);
+  // Webhook polling state: true = ?success=true detectado mas is_premium ainda false
+  const [awaitingWebhook, setAwaitingWebhook] = useState(false);
+  const [webhookTimedOut, setWebhookTimedOut] = useState(false);
 
   React.useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
@@ -171,21 +181,53 @@ const BolaoDetail: React.FC = () => {
   const upsertChampion = useUpsertChampionPrediction();
 
   // ── Handle query params: Stripe success + auto-open settings ──────
+  // Two cases for ?success=true:
+  //   1. Bolão already premium → open welcome modal once
+  //   2. Webhook still pending → enter awaitingWebhook state, poll until premium
   useEffect(() => {
     const params = new URLSearchParams(location.search);
     if (params.get('success') === 'true') {
-      toast({
-        title: 'Bolão Premium ativado!',
-        description: 'Pagamento confirmado. Aproveite os recursos exclusivos.',
-      });
-      setShowAdmin(true);
-      navigate(`/bolao/${id}`, { replace: true });
+      if (bolao && bolao.is_premium) {
+        setShowPremiumWelcome(true);
+        navigate(`/bolao/${id}`, { replace: true });
+      } else if (bolao && !bolao.is_premium) {
+        setAwaitingWebhook(true);
+        // Don't strip ?success=true yet — keep polling until webhook fires
+      }
     }
     if (params.get('settings') === 'true') {
       setShowAdmin(true);
       navigate(`/bolao/${id}`, { replace: true });
     }
-  }, [location.search, id, navigate, toast]);
+  }, [location.search, id, navigate, bolao?.is_premium]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Webhook polling: while awaitingWebhook, refetch bolão every 4s up to 30s.
+  useEffect(() => {
+    if (!awaitingWebhook || !id) return;
+    let attempts = 0;
+    const MAX_ATTEMPTS = 8; // 8 × 4s = 32s window
+
+    const tick = setInterval(() => {
+      attempts++;
+      // Force a refetch via React Query — the bolao prop will reflect new state
+      queryClient.invalidateQueries({ queryKey: ['bolao', id] });
+      if (attempts >= MAX_ATTEMPTS) {
+        clearInterval(tick);
+        setWebhookTimedOut(true);
+      }
+    }, 4000);
+    return () => clearInterval(tick);
+  }, [awaitingWebhook, id, queryClient]);
+
+  // When premium flips to true while awaiting → open welcome modal, clean URL.
+  useEffect(() => {
+    if (awaitingWebhook && bolao?.is_premium) {
+      setAwaitingWebhook(false);
+      setWebhookTimedOut(false);
+      setShowPremiumWelcome(true);
+      navigate(`/bolao/${id}`, { replace: true });
+    }
+  }, [awaitingWebhook, bolao?.is_premium, id, navigate]);
 
   const myChampionPick = useMemo(
     () => championPredictions?.find((p) => p.user_id === currentUserId) ?? null,
@@ -472,19 +514,19 @@ const BolaoDetail: React.FC = () => {
             {currentUserId && currentUserId === bolao.owner_id && (
               <Button
                 variant="ghost"
-                size="sm"
                 onClick={() => setShowAdmin(true)}
-                className="gap-1.5 text-xs opacity-60 hover:opacity-100 h-8"
+                aria-label="Abrir configurações do bolão"
+                className="gap-1.5 text-xs opacity-70 hover:opacity-100 h-11 px-3"
               >
-                <Settings className="w-3.5 h-3.5" />
-                Configurações
+                <Settings className="w-4 h-4" />
+                <span className="hidden sm:inline">Configurações</span>
               </Button>
             )}
           </div>
         </div>
 
         {/* ── Info bar ── */}
-        <div className="flex items-center gap-4 mb-5 text-xs opacity-50 flex-wrap">
+        <div className="flex items-center gap-4 mb-3 text-xs opacity-50 flex-wrap">
           <span className="flex items-center gap-1">
             <Users className="w-3 h-3" />
             {ranking?.length || 0} participantes
@@ -501,34 +543,38 @@ const BolaoDetail: React.FC = () => {
           </span>
         </div>
 
-        {/* ── Onboarding (full width, before grid) ── */}
-        {showOnboarding && (
+        {/* ── Deadline badge (próximo prazo de palpite) ── */}
+        {!bolao.is_closed && (
+          <div className="mb-5">
+            <DeadlineBadge
+              matches={matches}
+              mode={bolao.prediction_deadline_mode ?? 'per_match'}
+              isClosed={bolao.is_closed}
+            />
+          </div>
+        )}
+
+        {/* ── Share callout: aparece quando bolão tem ≤ 1 membro ── */}
+        {ranking && ranking.length <= 1 && !bolao.is_closed && (
+          <ShareCallout
+            bolaoId={bolao.id}
+            bolaoName={bolao.name}
+            inviteCode={bolao.invite_code}
+          />
+        )}
+
+        {/* ── Onboarding "Faça palpites" (só pra quem ainda não palpitou) ── */}
+        {showOnboarding && (myPredictions?.length ?? 0) === 0 && (
           <div className="terminal-container p-4 mb-5 border-terminal-blue/30 bg-terminal-blue/5">
-            <p className="text-xs font-bold uppercase tracking-wider text-terminal-blue mb-3">
-              Primeiros passos
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4">
-              <div className="flex items-start gap-3 flex-1">
-                <span className="text-[10px] font-bold text-terminal-blue bg-terminal-blue/20 rounded-full w-5 h-5 flex items-center justify-center shrink-0 mt-0.5">
-                  1
-                </span>
-                <div className="flex-1">
-                  <p className="text-sm font-medium">Compartilhe com seus amigos</p>
-                  <p className="text-xs opacity-50">
-                    Envie o código <span className="font-mono text-terminal-blue">{bolao.invite_code}</span> ou o link de convite
-                  </p>
-                </div>
+            <div className="flex items-start gap-3">
+              <div className="bg-terminal-blue/15 border border-terminal-blue/30 rounded-full w-9 h-9 flex items-center justify-center shrink-0">
+                <Target className="w-4 h-4 text-terminal-blue" />
               </div>
-              <div className="flex items-start gap-3 flex-1">
-                <span className="text-[10px] font-bold text-terminal-blue bg-terminal-blue/20 rounded-full w-5 h-5 flex items-center justify-center shrink-0 mt-0.5">
-                  2
-                </span>
-                <div className="flex-1">
-                  <p className="text-sm font-medium">Faça seus palpites</p>
-                  <p className="text-xs opacity-50">
-                    Palpite nos 104 jogos antes de cada partida começar
-                  </p>
-                </div>
+              <div className="flex-1">
+                <p className="text-sm font-medium">Faça seus palpites</p>
+                <p className="text-xs opacity-60 mt-0.5">
+                  Palpite nos 104 jogos antes de cada partida começar
+                </p>
               </div>
             </div>
           </div>
@@ -540,26 +586,34 @@ const BolaoDetail: React.FC = () => {
           {/* ── Main content ── */}
           <div className="min-w-0">
             {/* Tabs */}
-            <div className="flex gap-1 mb-6 border-b border-terminal-border">
-              {tabs.map((tab) => (
-                <button
-                  key={tab.key}
-                  onClick={() => setActiveTab(tab.key)}
-                  className={`flex items-center gap-1.5 px-4 py-2.5 text-xs font-bold uppercase transition-colors border-b-2 -mb-px ${
-                    activeTab === tab.key
-                      ? 'border-terminal-blue text-terminal-blue'
-                      : 'border-transparent opacity-50 hover:opacity-80'
-                  }`}
-                >
-                  {tab.icon}
-                  {tab.label}
-                </button>
-              ))}
+            <div role="tablist" aria-label="Seções do bolão" className="flex gap-1 mb-6 border-b border-terminal-border">
+              {tabs.map((tab) => {
+                const isActive = activeTab === tab.key;
+                return (
+                  <button
+                    key={tab.key}
+                    role="tab"
+                    aria-selected={isActive}
+                    aria-controls={`bolao-tab-panel-${tab.key}`}
+                    id={`bolao-tab-${tab.key}`}
+                    tabIndex={isActive ? 0 : -1}
+                    onClick={() => setActiveTab(tab.key)}
+                    className={`flex items-center gap-1.5 px-4 h-11 text-xs font-bold uppercase transition-colors border-b-2 -mb-px focus:outline-none focus-visible:ring-2 focus-visible:ring-terminal-blue/50 ${
+                      isActive
+                        ? 'border-terminal-blue text-terminal-blue'
+                        : 'border-transparent opacity-60 hover:opacity-100'
+                    }`}
+                  >
+                    {tab.icon}
+                    {tab.label}
+                  </button>
+                );
+              })}
             </div>
 
             {/* Tab: Ranking */}
             {activeTab === 'ranking' && (
-              <>
+              <div role="tabpanel" id="bolao-tab-panel-ranking" aria-labelledby="bolao-tab-ranking">
                 {ranking && ranking.length > 1 && (
                   <div className="flex items-center justify-end gap-3 mb-3">
                     <button
@@ -581,12 +635,12 @@ const BolaoDetail: React.FC = () => {
                   </div>
                 )}
                 <BolaoRankingTable ranking={ranking || []} currentUserId={currentUserId} />
-              </>
+              </div>
             )}
 
             {/* Tab: Meus Palpites */}
             {activeTab === 'meus-palpites' && (
-              <div>
+              <div role="tabpanel" id="bolao-tab-panel-meus-palpites" aria-labelledby="bolao-tab-meus-palpites">
                 <p className="text-xs opacity-50 mb-4">
                   {myPredictions?.length || 0} palpites registrados
                 </p>
@@ -650,11 +704,13 @@ const BolaoDetail: React.FC = () => {
 
             {/* Tab: Estatísticas */}
             {activeTab === 'estatisticas' && (
-              <BolaoStatsPanel
-                bolaoId={bolao.id}
-                currentUserId={currentUserId}
-                isPremium={bolao.is_premium}
-              />
+              <div role="tabpanel" id="bolao-tab-panel-estatisticas" aria-labelledby="bolao-tab-estatisticas">
+                <BolaoStatsPanel
+                  bolaoId={bolao.id}
+                  currentUserId={currentUserId}
+                  isPremium={bolao.is_premium}
+                />
+              </div>
             )}
           </div>
 
@@ -730,6 +786,65 @@ const BolaoDetail: React.FC = () => {
           currentUserId={currentUserId}
           ownerUserId={bolao.owner_id}
         />
+      )}
+
+      {/* Premium welcome modal — shown once after successful payment */}
+      <PremiumWelcomeModal
+        open={showPremiumWelcome}
+        onOpenChange={setShowPremiumWelcome}
+        onShare={() => {
+          setShowPremiumWelcome(false);
+          // Scroll to ShareCallout (sticky atop). If no callout (already 2+ members),
+          // scroll to top so user can use the header share button.
+          window.scrollTo({ top: 0, behavior: 'smooth' });
+        }}
+        onConfigure={() => {
+          setShowPremiumWelcome(false);
+          setShowAdmin(true);
+        }}
+      />
+
+      {/* Webhook awaiting overlay — paid but is_premium not yet flipped */}
+      {awaitingWebhook && !bolao.is_premium && (
+        <div
+          className="fixed inset-0 z-[200] bg-black/85 backdrop-blur-sm flex items-center justify-center p-6"
+          role="alert"
+          aria-live="assertive"
+        >
+          <div className="bg-terminal-bg border border-yellow-500/40 rounded-lg p-6 max-w-sm text-center">
+            {webhookTimedOut ? (
+              <>
+                <p className="text-base font-bold text-yellow-300 mb-2">
+                  Pagamento sendo processado
+                </p>
+                <p className="text-sm opacity-70 mb-4">
+                  A confirmação está demorando mais do que o normal.
+                  Você receberá um email assim que for ativado, normalmente em poucos minutos.
+                </p>
+                <Button
+                  onClick={() => {
+                    setAwaitingWebhook(false);
+                    setWebhookTimedOut(false);
+                    navigate(`/bolao/${id}`, { replace: true });
+                  }}
+                  className="w-full bg-terminal-blue text-terminal-bg hover:bg-terminal-blue/90 h-11"
+                >
+                  Continuar usando o bolão
+                </Button>
+              </>
+            ) : (
+              <>
+                <div className="w-12 h-12 mx-auto mb-4 border-3 border-yellow-500/30 border-t-yellow-400 rounded-full animate-spin" />
+                <p className="text-base font-bold text-yellow-300 mb-1">
+                  Confirmando pagamento...
+                </p>
+                <p className="text-xs opacity-60">
+                  Aguarde até 30 segundos para a Stripe confirmar.
+                </p>
+              </>
+            )}
+          </div>
+        </div>
       )}
     </div>
   );

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -717,6 +717,8 @@ const BolaoDetail: React.FC = () => {
           scoringPreset={bolao.scoring_preset ?? null}
           scoringResult={bolao.scoring_result}
           scoringExact={bolao.scoring_exact}
+          scoringWeights={bolao.scoring_weights ?? null}
+          predictionDeadlineMode={bolao.prediction_deadline_mode ?? 'per_match'}
           customColor={bolao.custom_color ?? null}
           customBannerUrl={bolao.custom_banner_url ?? null}
           championEnabled={bolao.champion_enabled ?? true}

--- a/src/pages/BolaoHome.tsx
+++ b/src/pages/BolaoHome.tsx
@@ -17,6 +17,7 @@ import { CreateBolaoModal } from '@/components/bolao/CreateBolaoModal';
 import { CopaGruposModal } from '@/components/bolao/CopaGruposModal';
 import { CopaBracketModal } from '@/components/bolao/CopaBracketModal';
 import { TeamFlag } from '@/components/bolao/TeamFlag';
+import { DeadlineBadge } from '@/components/bolao/DeadlineBadge';
 import { useToast } from '@/hooks/use-toast';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { supabase } from '@/integrations/supabase/client';
@@ -62,6 +63,7 @@ const BolaoHome: React.FC = () => {
   const [showGrupos, setShowGrupos] = useState(false);
   const [showBracket, setShowBracket] = useState(false);
   const [inviteCode, setInviteCode] = useState('');
+  const [checkoutRedirecting, setCheckoutRedirecting] = useState(false);
   const [currentUserId, setCurrentUserId] = React.useState<string | undefined>();
 
   React.useEffect(() => {
@@ -137,8 +139,8 @@ const BolaoHome: React.FC = () => {
     if (BOLAO_PRO_PRICE_ID) {
       // Checkout dinâmico: webhook cria o bolão com o UUID pré-gerado
       setShowCreate(false);
+      setCheckoutRedirecting(true);
       const preGeneratedId = crypto.randomUUID();
-      toast({ title: 'Redirecionando para pagamento...', description: 'Bolão Premium criado após confirmação.' });
       try {
         const { data: { session } } = await supabase.auth.getSession();
         if (!session) throw new Error('Usuário não autenticado');
@@ -157,6 +159,7 @@ const BolaoHome: React.FC = () => {
         if (error) throw error;
         window.location.href = fnData.url;
       } catch (err: any) {
+        setCheckoutRedirecting(false);
         toast({ title: 'Erro ao iniciar checkout', description: err?.message, variant: 'destructive' });
       }
     } else {
@@ -165,7 +168,7 @@ const BolaoHome: React.FC = () => {
       createBolao.mutate({ name: data.name, description: data.description }, {
         onSuccess: (bolao) => {
           setShowCreate(false);
-          toast({ title: 'Redirecionando para pagamento...', description: 'Aguarde.' });
+          setCheckoutRedirecting(true);
           window.location.href = `${BOLAO_PRO_PAYMENT_LINK}?client_reference_id=${bolao.id}`;
         },
         onError: (err: any) => {
@@ -246,27 +249,28 @@ const BolaoHome: React.FC = () => {
               <div className="flex gap-2 min-w-0">
                 <Button
                   onClick={() => setShowCreate(true)}
-                  size="sm"
-                  className="bg-transparent border border-terminal-blue text-terminal-blue hover:bg-terminal-blue/10 gap-1 shrink-0 h-[38px] px-3"
+                  aria-label="Criar novo bolão"
+                  className="bg-transparent border border-terminal-blue text-terminal-blue hover:bg-terminal-blue/10 gap-1.5 shrink-0 h-11 px-4"
                 >
-                  <Plus className="w-3.5 h-3.5" />
-                  <span className="hidden sm:inline">Criar</span>
+                  <Plus className="w-4 h-4" />
+                  <span>Criar</span>
                 </Button>
                 <input
                   type="text"
                   value={inviteCode}
                   onChange={(e) => setInviteCode(e.target.value.toUpperCase())}
                   onKeyDown={(e) => e.key === 'Enter' && handleJoin()}
-                  placeholder="Código de convite"
+                  placeholder="Código (ex: ABC12345)"
                   maxLength={8}
-                  className="min-w-0 flex-1 bg-terminal-dark-gray border border-terminal-border rounded px-3 py-2 text-sm font-mono placeholder:opacity-30 focus:outline-none focus:border-terminal-blue transition-colors"
+                  aria-label="Código de convite do bolão"
+                  className="min-w-0 flex-1 bg-terminal-dark-gray border border-terminal-border rounded px-3 h-11 text-sm font-mono placeholder:opacity-30 focus:outline-none focus:border-terminal-blue focus:ring-1 focus:ring-terminal-blue/30 transition-colors"
                 />
                 <Button
                   onClick={handleJoin}
                   disabled={inviteCode.trim().length < 4 || joinBolao.isPending}
                   variant="outline"
-                  size="sm"
-                  className="border-terminal-blue/50 text-terminal-blue hover:bg-terminal-blue/10 gap-1 px-3 h-[38px] shrink-0"
+                  aria-label="Entrar em bolão usando código"
+                  className="border-terminal-blue/50 text-terminal-blue hover:bg-terminal-blue/10 gap-1.5 px-4 h-11 shrink-0"
                 >
                   {joinBolao.isPending ? (
                     'Entrando...'
@@ -325,6 +329,14 @@ const BolaoHome: React.FC = () => {
                               <Trophy className="w-2.5 h-2.5" />
                               Campeão
                             </span>
+                          )}
+                          {!bolao.is_closed && bolao.pending_predictions > 0 && (
+                            <DeadlineBadge
+                              matches={matches}
+                              mode={bolao.prediction_deadline_mode ?? 'per_match'}
+                              isClosed={bolao.is_closed}
+                              variant="compact"
+                            />
                           )}
                         </div>
                         <div className="flex items-center gap-3 text-xs opacity-50">
@@ -464,6 +476,25 @@ const BolaoHome: React.FC = () => {
       />
       <CopaGruposModal open={showGrupos} onOpenChange={setShowGrupos} />
       <CopaBracketModal open={showBracket} onOpenChange={setShowBracket} />
+
+      {/* Lock overlay durante redirect pra Stripe — previne duplo click */}
+      {checkoutRedirecting && (
+        <div
+          className="fixed inset-0 z-[200] bg-black/80 backdrop-blur-sm flex items-center justify-center p-6"
+          role="alert"
+          aria-live="assertive"
+        >
+          <div className="bg-terminal-bg border border-yellow-500/30 rounded-lg p-6 max-w-sm text-center">
+            <div className="w-12 h-12 mx-auto mb-4 border-3 border-yellow-500/30 border-t-yellow-400 rounded-full animate-spin" />
+            <p className="text-base font-bold text-yellow-300 mb-1">
+              Redirecionando para pagamento
+            </p>
+            <p className="text-xs opacity-60">
+              Aguarde a página da Stripe carregar. Não feche essa janela.
+            </p>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/BolaoPalpites.tsx
+++ b/src/pages/BolaoPalpites.tsx
@@ -155,6 +155,9 @@ const BolaoPalpites: React.FC = () => {
                       prediction={predictionsByMatch.get(match.id)}
                       onSave={handleSave}
                       isSaving={upsertPrediction.isPending}
+                      deadlineMode={bolao?.prediction_deadline_mode ?? 'per_match'}
+                      allMatches={matches}
+                      isClosed={bolao?.is_closed}
                     />
                   ))}
                 </div>

--- a/src/pages/BolaoPalpites.tsx
+++ b/src/pages/BolaoPalpites.tsx
@@ -90,9 +90,10 @@ const BolaoPalpites: React.FC = () => {
             variant="ghost"
             size="icon"
             onClick={() => navigate(`/bolao/${id}`)}
-            className="h-8 w-8"
+            aria-label="Voltar para o bolão"
+            className="h-11 w-11 shrink-0"
           >
-            <ArrowLeft className="w-4 h-4" />
+            <ArrowLeft className="w-5 h-5" />
           </Button>
           <div className="flex-1">
             <h1 className="text-lg font-bold">Palpites</h1>

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -105,6 +105,7 @@ export interface UserBolao {
   pending_predictions: number;
   has_champion_prediction: boolean;
   created_at: string;
+  prediction_deadline_mode: 'per_match' | 'per_round' | 'tournament_start';
 }
 
 export interface ChampionPrediction {

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -35,6 +35,8 @@ export interface Bolao {
   scoring_exact: number;
   scoring_result: number;
   scoring_preset: string | null;
+  scoring_weights: Record<string, number> | null;
+  prediction_deadline_mode: 'per_match' | 'per_round' | 'tournament_start';
   custom_color: string | null;
   custom_banner_url: string | null;
   champion_enabled: boolean;
@@ -212,6 +214,7 @@ export const bolaoService = {
   async createBolao(params: {
     name: string;
     description?: string;
+    predictionDeadlineMode?: 'per_match' | 'per_round' | 'tournament_start';
   }): Promise<Bolao> {
     const userId = (await supabase.auth.getUser()).data.user?.id;
     if (!userId) throw new Error('Usuário não autenticado');
@@ -225,6 +228,7 @@ export const bolaoService = {
         name: params.name,
         description: params.description || null,
         invite_code,
+        prediction_deadline_mode: params.predictionDeadlineMode ?? 'per_match',
       })
       .select()
       .single();
@@ -357,49 +361,58 @@ export const bolaoService = {
     match_id: number;
     predicted_home_score: number;
     predicted_away_score: number;
-  }): Promise<BolaoPrediction> {
-    const userId = (await supabase.auth.getUser()).data.user?.id;
-    if (!userId) throw new Error('Usuário não autenticado');
-
-    const { data, error } = await supabase
-      .from('bolao_predictions')
-      .upsert(
-        {
-          bolao_id: params.bolao_id,
-          user_id: userId,
-          match_id: params.match_id,
-          predicted_home_score: params.predicted_home_score,
-          predicted_away_score: params.predicted_away_score,
-        },
-        { onConflict: 'bolao_id,user_id,match_id' }
-      )
-      .select()
-      .single();
-
+  }): Promise<void> {
+    const { data, error } = await supabase.rpc('submit_bolao_prediction', {
+      p_bolao_id: params.bolao_id,
+      p_match_id: params.match_id,
+      p_predicted_home_score: params.predicted_home_score,
+      p_predicted_away_score: params.predicted_away_score,
+    });
     if (error) throw error;
-    return data as BolaoPrediction;
+    const result = data as { success: boolean; error?: string; deadline?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao salvar palpite');
   },
 
   async upsertPredictionsBatch(
     bolaoId: string,
     predictions: { match_id: number; predicted_home_score: number; predicted_away_score: number }[]
-  ): Promise<void> {
-    const userId = (await supabase.auth.getUser()).data.user?.id;
-    if (!userId) throw new Error('Usuário não autenticado');
-
-    const rows = predictions.map((p) => ({
-      bolao_id: bolaoId,
-      user_id: userId,
+  ): Promise<{ saved: number; skipped: number }> {
+    const payload = predictions.map((p) => ({
       match_id: p.match_id,
-      predicted_home_score: p.predicted_home_score,
-      predicted_away_score: p.predicted_away_score,
+      home: p.predicted_home_score,
+      away: p.predicted_away_score,
     }));
-
-    const { error } = await supabase
-      .from('bolao_predictions')
-      .upsert(rows, { onConflict: 'bolao_id,user_id,match_id' });
-
+    const { data, error } = await supabase.rpc('batch_submit_bolao_predictions', {
+      p_bolao_id: bolaoId,
+      p_predictions: payload,
+    });
     if (error) throw error;
+    const result = data as { success: boolean; saved: number; skipped: number; error?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao salvar palpites');
+    return { saved: result.saved, skipped: result.skipped };
+  },
+
+  async updateBolaoDeadlineMode(
+    bolaoId: string,
+    mode: 'per_match' | 'per_round' | 'tournament_start'
+  ): Promise<{ prediction_deadline_mode: string }> {
+    const { data, error } = await supabase.rpc('update_bolao_deadline_mode', {
+      p_bolao_id: bolaoId,
+      p_mode: mode,
+    });
+    if (error) throw error;
+    const result = data as { success: boolean; prediction_deadline_mode: string; error?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao atualizar prazo');
+    return { prediction_deadline_mode: result.prediction_deadline_mode };
+  },
+
+  async getPredictionDeadline(bolaoId: string, matchId: number): Promise<string | null> {
+    const { data, error } = await supabase.rpc('get_prediction_deadline', {
+      p_bolao_id: bolaoId,
+      p_match_id: matchId,
+    });
+    if (error) throw error;
+    return data as string | null;
   },
 
   // --- Special Predictions (Wave 2) ---
@@ -440,18 +453,30 @@ export const bolaoService = {
     bolaoId: string,
     preset: 'standard' | 'classic' | 'weighted_stages' | 'custom',
     scoringResult?: number,
-    scoringExact?: number
-  ): Promise<{ scoring_result: number; scoring_exact: number }> {
+    scoringExact?: number,
+    scoringWeights?: Record<string, number> | null
+  ): Promise<{ scoring_result: number; scoring_exact: number; scoring_weights: Record<string, number> | null }> {
     const { data, error } = await supabase.rpc('update_bolao_scoring', {
       p_bolao_id: bolaoId,
       p_preset: preset,
       p_scoring_result: scoringResult,
       p_scoring_exact: scoringExact,
+      p_scoring_weights: scoringWeights ?? null,
     });
     if (error) throw error;
-    const result = data as { success: boolean; scoring_result: number; scoring_exact: number; error?: string };
+    const result = data as {
+      success: boolean;
+      scoring_result: number;
+      scoring_exact: number;
+      scoring_weights: Record<string, number> | null;
+      error?: string;
+    };
     if (!result.success) throw new Error(result.error || 'Erro ao atualizar pontuação');
-    return { scoring_result: result.scoring_result, scoring_exact: result.scoring_exact };
+    return {
+      scoring_result: result.scoring_result,
+      scoring_exact: result.scoring_exact,
+      scoring_weights: result.scoring_weights,
+    };
   },
 
   // --- Stats + Round Rankings (Wave 3) ---

--- a/supabase/migrations/040_bolao_custom_scoring_weights.sql
+++ b/supabase/migrations/040_bolao_custom_scoring_weights.sql
@@ -1,0 +1,197 @@
+-- ============================================================
+-- BOLÃO: Custom scoring weights per stage
+-- Adds scoring_weights JSONB to boloes so owners can customize
+-- the multiplier for each stage (not just the fixed preset).
+-- ============================================================
+
+-- 1. Add scoring_weights column (nullable = use defaults)
+ALTER TABLE public.boloes
+  ADD COLUMN IF NOT EXISTS scoring_weights jsonb;
+
+COMMENT ON COLUMN public.boloes.scoring_weights IS
+  'Optional per-stage multipliers when scoring_preset = weighted_stages. '
+  'Shape: { "group": 1.0, "round_of_32": 1.5, "round_of_16": 1.5, '
+  '"quarter": 2.0, "semi": 3.0, "third_place": 2.0, "final": 5.0 }. '
+  'NULL = use defaults.';
+
+-- 2. Update calculate_bolao_scores to read custom weights
+CREATE OR REPLACE FUNCTION public.calculate_bolao_scores(p_match_id integer)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_home_score int;
+  v_away_score int;
+  v_is_finished boolean;
+  v_match_result text;
+  v_match_stage text;
+  v_updated_count int := 0;
+  rec RECORD;
+BEGIN
+  SELECT home_score, away_score, is_finished, stage
+    INTO v_home_score, v_away_score, v_is_finished, v_match_stage
+  FROM public.wc_matches WHERE id = p_match_id;
+
+  IF NOT v_is_finished OR v_home_score IS NULL OR v_away_score IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Jogo não finalizado ou sem placar');
+  END IF;
+
+  IF v_home_score > v_away_score THEN v_match_result := 'home';
+  ELSIF v_away_score > v_home_score THEN v_match_result := 'away';
+  ELSE v_match_result := 'draw';
+  END IF;
+
+  FOR rec IN
+    SELECT bp.id, bp.predicted_home_score, bp.predicted_away_score,
+           b.scoring_exact, b.scoring_result, b.scoring_preset, b.scoring_weights
+    FROM public.bolao_predictions bp
+    JOIN public.boloes b ON b.id = bp.bolao_id
+    WHERE bp.match_id = p_match_id
+  LOOP
+    DECLARE
+      v_pred_result text;
+      v_points int := 0;
+      v_multiplier numeric := 1.0;
+      v_default numeric;
+    BEGIN
+      IF rec.scoring_preset = 'weighted_stages' THEN
+        v_default := CASE v_match_stage
+          WHEN 'group'       THEN 1.0
+          WHEN 'round_of_32' THEN 1.5
+          WHEN 'round_of_16' THEN 1.5
+          WHEN 'quarter'     THEN 2.0
+          WHEN 'semi'        THEN 3.0
+          WHEN 'third_place' THEN 2.0
+          WHEN 'final'       THEN 5.0
+          ELSE 1.0
+        END;
+        -- Read custom weight from scoring_weights jsonb; fallback to default
+        v_multiplier := COALESCE(
+          (rec.scoring_weights ->> v_match_stage)::numeric,
+          v_default
+        );
+      END IF;
+
+      IF rec.predicted_home_score > rec.predicted_away_score THEN v_pred_result := 'home';
+      ELSIF rec.predicted_away_score > rec.predicted_home_score THEN v_pred_result := 'away';
+      ELSE v_pred_result := 'draw';
+      END IF;
+
+      IF rec.predicted_home_score = v_home_score AND rec.predicted_away_score = v_away_score THEN
+        v_points := ROUND(rec.scoring_exact * v_multiplier);
+      ELSIF v_pred_result = v_match_result THEN
+        v_points := ROUND(rec.scoring_result * v_multiplier);
+      END IF;
+
+      UPDATE public.bolao_predictions
+        SET points_earned = v_points, updated_at = now()
+      WHERE id = rec.id;
+
+      v_updated_count := v_updated_count + 1;
+    END;
+  END LOOP;
+
+  RETURN json_build_object('success', true, 'updated', v_updated_count);
+END;
+$$;
+
+-- 3. Update update_bolao_scoring to accept optional scoring_weights
+DROP FUNCTION IF EXISTS public.update_bolao_scoring(uuid, text, int, int);
+
+CREATE OR REPLACE FUNCTION public.update_bolao_scoring(
+  p_bolao_id uuid,
+  p_preset text,
+  p_scoring_result int DEFAULT NULL,
+  p_scoring_exact int DEFAULT NULL,
+  p_scoring_weights jsonb DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_r int; v_e int;
+  v_weights jsonb;
+  v_allowed_stages text[] := ARRAY['group','round_of_32','round_of_16','quarter','semi','third_place','final'];
+  v_key text;
+  v_val numeric;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.boloes WHERE id = p_bolao_id AND owner_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not the owner');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.boloes WHERE id = p_bolao_id AND is_premium = true) THEN
+    RETURN json_build_object('success', false, 'error', 'Premium required');
+  END IF;
+
+  IF p_preset = 'standard' THEN
+    v_r := 1; v_e := 3;
+  ELSIF p_preset = 'classic' THEN
+    v_r := 1; v_e := 5;
+  ELSIF p_preset = 'weighted_stages' THEN
+    v_r := COALESCE(p_scoring_result, 1);
+    v_e := COALESCE(p_scoring_exact, 3);
+  ELSIF p_preset = 'custom' THEN
+    IF p_scoring_result IS NULL OR p_scoring_exact IS NULL THEN
+      RETURN json_build_object('success', false, 'error', 'Custom preset requires scoring values');
+    END IF;
+    v_r := p_scoring_result; v_e := p_scoring_exact;
+  ELSE
+    RETURN json_build_object('success', false, 'error', 'Invalid preset');
+  END IF;
+
+  IF v_r < 1 OR v_r > 10 THEN
+    RETURN json_build_object('success', false, 'error', 'scoring_result must be 1-10');
+  END IF;
+  IF v_e < 1 OR v_e > 20 THEN
+    RETURN json_build_object('success', false, 'error', 'scoring_exact must be 1-20');
+  END IF;
+
+  -- Validate scoring_weights if provided
+  IF p_scoring_weights IS NOT NULL THEN
+    IF p_preset <> 'weighted_stages' THEN
+      v_weights := NULL; -- only persist weights when preset is weighted_stages
+    ELSE
+      FOR v_key IN SELECT jsonb_object_keys(p_scoring_weights) LOOP
+        IF NOT (v_key = ANY(v_allowed_stages)) THEN
+          RETURN json_build_object('success', false, 'error', 'Invalid stage in scoring_weights: ' || v_key);
+        END IF;
+        v_val := (p_scoring_weights ->> v_key)::numeric;
+        IF v_val < 0.5 OR v_val > 10 THEN
+          RETURN json_build_object('success', false, 'error', 'Weight for ' || v_key || ' must be 0.5-10');
+        END IF;
+      END LOOP;
+      v_weights := p_scoring_weights;
+    END IF;
+  ELSE
+    -- Preset changed away from weighted_stages → clear custom weights
+    IF p_preset <> 'weighted_stages' THEN
+      v_weights := NULL;
+    ELSE
+      -- Keep existing weights if not sent
+      SELECT scoring_weights INTO v_weights FROM public.boloes WHERE id = p_bolao_id;
+    END IF;
+  END IF;
+
+  UPDATE public.boloes
+    SET scoring_preset = p_preset,
+        scoring_result = v_r,
+        scoring_exact = v_e,
+        scoring_weights = v_weights
+    WHERE id = p_bolao_id;
+
+  RETURN json_build_object(
+    'success', true,
+    'scoring_result', v_r,
+    'scoring_exact', v_e,
+    'scoring_weights', v_weights
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.update_bolao_scoring(uuid, text, int, int, jsonb) TO authenticated;

--- a/supabase/migrations/041_bolao_prediction_deadline.sql
+++ b/supabase/migrations/041_bolao_prediction_deadline.sql
@@ -1,0 +1,208 @@
+-- ============================================================
+-- BOLÃO: Prediction deadline modes
+-- Owner chooses ON CREATION between:
+--   'per_match'        (default) — deadline = kickoff of that match
+--   'per_round'        — deadline = kickoff of the first match in the stage
+--   'tournament_start' — deadline = kickoff of the first match of the Cup
+-- Immutable after creation (locked into the bolao's rules).
+-- Manual `is_closed` flag remains orthogonal — closing freezes all predictions.
+-- ============================================================
+
+-- 1. Add column (default per_match for backward compat)
+ALTER TABLE public.boloes
+  ADD COLUMN IF NOT EXISTS prediction_deadline_mode text
+    NOT NULL DEFAULT 'per_match'
+    CHECK (prediction_deadline_mode IN ('per_match','per_round','tournament_start'));
+
+COMMENT ON COLUMN public.boloes.prediction_deadline_mode IS
+  'When predictions close: per_match, per_round (first match of the stage), or tournament_start (first match of the Cup). Set on creation, immutable after.';
+
+-- 2. Deadline helper — returns timestamptz deadline for a given (bolao, match)
+CREATE OR REPLACE FUNCTION public.get_prediction_deadline(
+  p_bolao_id uuid,
+  p_match_id int
+) RETURNS timestamptz
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_mode text;
+  v_stage text;
+  v_deadline timestamptz;
+BEGIN
+  SELECT prediction_deadline_mode INTO v_mode
+  FROM public.boloes WHERE id = p_bolao_id;
+  IF v_mode IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  IF v_mode = 'per_match' THEN
+    SELECT (match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo'
+      INTO v_deadline
+    FROM public.wc_matches WHERE id = p_match_id;
+  ELSIF v_mode = 'per_round' THEN
+    SELECT stage INTO v_stage
+    FROM public.wc_matches WHERE id = p_match_id;
+    IF v_stage IS NULL THEN RETURN NULL; END IF;
+    SELECT MIN((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+      INTO v_deadline
+    FROM public.wc_matches WHERE stage = v_stage;
+  ELSIF v_mode = 'tournament_start' THEN
+    SELECT MIN((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+      INTO v_deadline
+    FROM public.wc_matches;
+  END IF;
+
+  RETURN v_deadline;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_prediction_deadline(uuid, int) TO authenticated;
+
+-- 3. RPC: submit a single prediction with server-side deadline check
+CREATE OR REPLACE FUNCTION public.submit_bolao_prediction(
+  p_bolao_id uuid,
+  p_match_id int,
+  p_predicted_home_score int,
+  p_predicted_away_score int
+) RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_is_closed boolean;
+  v_deadline timestamptz;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.bolao_members
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+  ) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member');
+  END IF;
+
+  SELECT is_closed INTO v_is_closed FROM public.boloes WHERE id = p_bolao_id;
+  IF v_is_closed THEN
+    RETURN json_build_object('success', false, 'error', 'Inscrições fechadas');
+  END IF;
+
+  v_deadline := public.get_prediction_deadline(p_bolao_id, p_match_id);
+  IF v_deadline IS NOT NULL AND now() >= v_deadline THEN
+    RETURN json_build_object(
+      'success', false,
+      'error', 'Prazo de palpite encerrado',
+      'deadline', v_deadline
+    );
+  END IF;
+
+  IF p_predicted_home_score < 0 OR p_predicted_away_score < 0
+     OR p_predicted_home_score > 20 OR p_predicted_away_score > 20 THEN
+    RETURN json_build_object('success', false, 'error', 'Placar inválido (0-20)');
+  END IF;
+
+  INSERT INTO public.bolao_predictions
+    (bolao_id, user_id, match_id, predicted_home_score, predicted_away_score)
+  VALUES
+    (p_bolao_id, v_user_id, p_match_id, p_predicted_home_score, p_predicted_away_score)
+  ON CONFLICT (bolao_id, user_id, match_id) DO UPDATE
+    SET predicted_home_score = EXCLUDED.predicted_home_score,
+        predicted_away_score = EXCLUDED.predicted_away_score,
+        updated_at = now();
+
+  RETURN json_build_object('success', true);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.submit_bolao_prediction(uuid, int, int, int) TO authenticated;
+
+-- 4. RPC: batch submit (used when mode = tournament_start or per_round)
+CREATE OR REPLACE FUNCTION public.batch_submit_bolao_predictions(
+  p_bolao_id uuid,
+  p_predictions jsonb
+) RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_is_closed boolean;
+  v_mode text;
+  v_deadline timestamptz;
+  v_saved int := 0;
+  v_skipped int := 0;
+  v_pred jsonb;
+  v_match_id int;
+  v_home int;
+  v_away int;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.bolao_members
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+  ) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member');
+  END IF;
+
+  SELECT is_closed, prediction_deadline_mode INTO v_is_closed, v_mode
+  FROM public.boloes WHERE id = p_bolao_id;
+  IF v_is_closed THEN
+    RETURN json_build_object('success', false, 'error', 'Inscrições fechadas');
+  END IF;
+
+  FOR v_pred IN SELECT * FROM jsonb_array_elements(p_predictions) LOOP
+    v_match_id := (v_pred ->> 'match_id')::int;
+    v_home := (v_pred ->> 'home')::int;
+    v_away := (v_pred ->> 'away')::int;
+
+    IF v_match_id IS NULL OR v_home IS NULL OR v_away IS NULL THEN
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+    IF v_home < 0 OR v_away < 0 OR v_home > 20 OR v_away > 20 THEN
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+
+    v_deadline := public.get_prediction_deadline(p_bolao_id, v_match_id);
+    IF v_deadline IS NOT NULL AND now() >= v_deadline THEN
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+
+    INSERT INTO public.bolao_predictions
+      (bolao_id, user_id, match_id, predicted_home_score, predicted_away_score)
+    VALUES
+      (p_bolao_id, v_user_id, v_match_id, v_home, v_away)
+    ON CONFLICT (bolao_id, user_id, match_id) DO UPDATE
+      SET predicted_home_score = EXCLUDED.predicted_home_score,
+          predicted_away_score = EXCLUDED.predicted_away_score,
+          updated_at = now();
+    v_saved := v_saved + 1;
+  END LOOP;
+
+  RETURN json_build_object('success', true, 'saved', v_saved, 'skipped', v_skipped);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.batch_submit_bolao_predictions(uuid, jsonb) TO authenticated;
+
+-- 5. Tighten RLS on bolao_predictions: client-side upsert still allowed only
+--    through the RPCs above, which enforce deadline. Existing policies remain
+--    for SELECT; for INSERT/UPDATE, drop permissive policy if any and rely on
+--    SECURITY DEFINER RPC. (No-op if policies are already restrictive.)
+--
+--    NOTE: If your current RLS lets authenticated users INSERT/UPDATE directly,
+--    the deadline check is bypassed. The frontend should switch to the RPCs.

--- a/supabase/migrations/042_bolao_update_deadline_mode_rpc.sql
+++ b/supabase/migrations/042_bolao_update_deadline_mode_rpc.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- BOLÃO: RPC to update prediction_deadline_mode after creation
+-- Owner-only. Moved from creation form to settings panel.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.update_bolao_deadline_mode(
+  p_bolao_id uuid,
+  p_mode text
+) RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_user_id uuid;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.boloes WHERE id = p_bolao_id AND owner_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not the owner');
+  END IF;
+  IF p_mode NOT IN ('per_match','per_round','tournament_start') THEN
+    RETURN json_build_object('success', false, 'error', 'Invalid mode');
+  END IF;
+
+  UPDATE public.boloes
+    SET prediction_deadline_mode = p_mode
+    WHERE id = p_bolao_id;
+
+  RETURN json_build_object('success', true, 'prediction_deadline_mode', p_mode);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.update_bolao_deadline_mode(uuid, text) TO authenticated;

--- a/supabase/migrations/043_bolao_get_user_boloes_deadline_mode.sql
+++ b/supabase/migrations/043_bolao_get_user_boloes_deadline_mode.sql
@@ -1,0 +1,117 @@
+-- ============================================================
+-- BOLÃO: expor prediction_deadline_mode em get_user_boloes
+-- Onda 1 — Deadline visibility (badge na home precisa do modo).
+-- ============================================================
+
+-- DROP necessário porque o RETURNS TABLE muda (nova coluna no fim).
+DROP FUNCTION IF EXISTS public.get_user_boloes(uuid);
+
+CREATE OR REPLACE FUNCTION public.get_user_boloes(p_user_id uuid DEFAULT NULL::uuid)
+ RETURNS TABLE(id uuid, name text, description text, invite_code text, is_premium boolean, is_closed boolean, max_participants integer, owner_id uuid, owner_name text, member_count bigint, user_rank integer, user_points integer, user_predictions bigint, pending_predictions bigint, has_champion_prediction boolean, created_at timestamp with time zone, prediction_deadline_mode text)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id uuid := COALESCE(p_user_id, auth.uid());
+BEGIN
+  RETURN QUERY
+  WITH
+    my_boloes AS (
+      SELECT b.*
+      FROM boloes b
+      JOIN bolao_members bm ON bm.bolao_id = b.id AND bm.user_id = v_user_id
+      ORDER BY b.created_at DESC
+    ),
+    member_counts AS (
+      SELECT bm.bolao_id, COUNT(*) AS cnt
+      FROM bolao_members bm
+      WHERE bm.bolao_id IN (SELECT mb.id FROM my_boloes mb)
+      GROUP BY bm.bolao_id
+    ),
+    user_stats AS (
+      SELECT
+        bp.bolao_id,
+        COALESCE(SUM(bp.points_earned), 0)::integer AS total_points,
+        COUNT(*) AS pred_count
+      FROM bolao_predictions bp
+      WHERE bp.user_id = v_user_id
+        AND bp.bolao_id IN (SELECT mb.id FROM my_boloes mb)
+      GROUP BY bp.bolao_id
+    ),
+    future_matches AS (
+      SELECT COUNT(*) AS cnt
+      FROM wc_matches m
+      WHERE m.is_finished = false AND m.home_team_code != 'TBD'
+    ),
+    covered_future AS (
+      SELECT bp.bolao_id, COUNT(*) AS cnt
+      FROM bolao_predictions bp
+      JOIN wc_matches m ON m.id = bp.match_id
+      WHERE bp.user_id = v_user_id
+        AND bp.bolao_id IN (SELECT mb.id FROM my_boloes mb)
+        AND m.is_finished = false
+        AND m.home_team_code != 'TBD'
+      GROUP BY bp.bolao_id
+    ),
+    champion_preds AS (
+      SELECT sp.bolao_id
+      FROM bolao_special_predictions sp
+      WHERE sp.user_id = v_user_id
+        AND sp.prediction_type = 'champion'
+        AND sp.bolao_id IN (SELECT mb.id FROM my_boloes mb)
+    ),
+    boloes_with_points AS (
+      SELECT DISTINCT bp.bolao_id
+      FROM bolao_predictions bp
+      WHERE bp.bolao_id IN (SELECT mb.id FROM my_boloes mb)
+        AND bp.points_earned IS NOT NULL AND bp.points_earned > 0
+    ),
+    user_ranks AS (
+      SELECT
+        bwp.bolao_id,
+        COALESCE((
+          SELECT ranking.rk
+          FROM (
+            SELECT bm3.user_id,
+                   RANK() OVER (ORDER BY COALESCE(SUM(bp2.points_earned), 0) DESC) AS rk
+            FROM bolao_members bm3
+            LEFT JOIN bolao_predictions bp2
+              ON bp2.bolao_id = bm3.bolao_id AND bp2.user_id = bm3.user_id
+            WHERE bm3.bolao_id = bwp.bolao_id
+            GROUP BY bm3.user_id
+          ) ranking
+          WHERE ranking.user_id = v_user_id
+        ), 1)::integer AS user_rank
+      FROM boloes_with_points bwp
+    )
+  SELECT
+    mb.id,
+    mb.name,
+    mb.description,
+    mb.invite_code,
+    mb.is_premium,
+    mb.is_closed,
+    mb.max_participants,
+    mb.owner_id,
+    COALESCE(u.raw_user_meta_data->>'full_name', u.email)::text AS owner_name,
+    COALESCE(mc.cnt, 0)                                             AS member_count,
+    COALESCE(ur.user_rank, 1)                                       AS user_rank,
+    COALESCE(us.total_points, 0)                                    AS user_points,
+    COALESCE(us.pred_count, 0)                                      AS user_predictions,
+    ((SELECT cnt FROM future_matches) - COALESCE(cf.cnt, 0))        AS pending_predictions,
+    (cp.bolao_id IS NOT NULL)                                       AS has_champion_prediction,
+    mb.created_at,
+    mb.prediction_deadline_mode
+  FROM my_boloes mb
+  LEFT JOIN auth.users u          ON u.id = mb.owner_id
+  LEFT JOIN member_counts mc      ON mc.bolao_id = mb.id
+  LEFT JOIN user_stats us         ON us.bolao_id = mb.id
+  LEFT JOIN covered_future cf     ON cf.bolao_id = mb.id
+  LEFT JOIN champion_preds cp     ON cp.bolao_id = mb.id
+  LEFT JOIN user_ranks ur         ON ur.bolao_id = mb.id
+  ORDER BY mb.created_at DESC;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_user_boloes(uuid) TO authenticated;


### PR DESCRIPTION
## Resumo

Primeira onda do plano de UX/CRO documentado em [docs/bolao-audit-and-implementation-plan.md](docs/bolao-audit-and-implementation-plan.md). Foco em **problemas P0** que sangravam acessibilidade e queimavam conversão no fluxo do Bolão Copa 2026.

**Branch base:** `feature/bolao-copa-2026` (este PR depende do trabalho prévio: pesos por fase customizáveis + prazo de palpites + auditoria UX, no commit `798c452`).

---

## O que muda na percepção do usuário

| Antes | Depois |
|---|---|
| Botões pequenos demais (32–38px) — dedo erra em mobile | Tudo em 44px (mínimo WCAG) |
| Quando esse palpite fecha mesmo? | Badge na home + header com countdown ao vivo |
| Criei o bolão, e agora? | Card destacado puxando pra compartilhar |
| Cliquei 2 vezes em "Criar Premium" → cobrança duplicada | Tela trava no primeiro click |
| Paguei R$19,90 e nada mudou (caí no admin) | Modal celebrativo com features desbloqueadas |
| Webhook atrasou → bolão ainda free, sem explicação | Overlay "Confirmando pagamento... 30s" com fallback |
| Emojis misturados com SVG icons | Lucide consistente em todo lugar |

---

## Bloco A — Touch targets + acessibilidade

**Componentes ajustados:**
- `NumberStepper`: botões `±` de 24–28px → 36–44px (size sm/md), focus rings, spinners nativos do browser removidos
- `BolaoHome`: botões "Criar"/"Entrar" 38px → 44px; "Criar" mostra texto também em mobile (estava `hidden sm:inline`); placeholder do input de código exemplifica formato (`ABC12345`)
- `BolaoDetail`: botão Settings 32px → 44px; tabs com `role=tablist`, `role=tab`, `aria-selected`, `aria-controls`, `focus-visible`
- `BolaoPalpites`: botão voltar 32px → 44px com `aria-label`
- `MatchPredictionCard`: inputs de placar 32×40px → 44×48px com `aria-label` dinâmico (`Placar BRA mandante` / `Placar MEX visitante`) e `inputMode="numeric"` (mobile abre teclado numérico)
- `BolaoShareButton`: variants compact/icon agora `h-11` com aria-labels, `aria-expanded`, `aria-haspopup`, dropdown com `role=menu/menuitem`, **ESC fecha**
- `ChampionPickModal`: search h-11; team buttons com `aria-pressed`/label; rodapé com botões h-11
- `SpecialPredictionsSection`: search h-10; team buttons aria-pressed/label; **chip "remover team" virou button semântico** com aria-label `"Remover {team}"` (antes era só `title="Clique para remover"`)
- `BolaoAdminPanel`: toggles (Champion / Special / Multiplicador por fase) com hit-area 44×44, `aria-pressed`, `aria-label`

**Acessibilidade ganhada:** screen readers agora anunciam estado de toggles, tabs, e ações dos botões-ícone. Navegação por teclado consistente em todos os modais.

---

## Bloco B — Deadline visibility

**Novo componente:** [src/components/bolao/DeadlineBadge.tsx](src/components/bolao/DeadlineBadge.tsx) — pílula com ícone `Clock` que atualiza a cada 30s. Pulsa vermelho com `AlertCircle` quando faltam < 1h.

**Helpers em `use-bolao.ts`:**
- `getNextDeadline(mode, allMatches, isClosed)` — retorna o próximo prazo de palpite respeitando o modo do bolão
- `formatDeadlineRelative(deadline, now)` — formata adaptativo: `47min` / `2h 15min` / `Hoje 22:00` / `Amanhã 22:00` / `23/04 22:00`
- `isDeadlineUrgent(deadline)` — true se < 1h

**Onde aparece:**
- Cada card de bolão na home (badge inline junto de PREMIUM/Pendentes/Campeão)
- Header do bolão (badge proeminente abaixo da info bar)

**Migration 043** (aplicada em staging): `get_user_boloes` RPC agora retorna `prediction_deadline_mode` — necessário para o badge da home calcular o prazo correto por modo.

---

## Bloco C — Share destacado + lock checkout

**Novo componente:** [src/components/bolao/ShareCallout.tsx](src/components/bolao/ShareCallout.tsx) — card grande com 3 botões (Copiar link / WhatsApp / Telegram) de h-11. Aparece quando `ranking.length <= 1 && !is_closed`. Dispensável via X (sessionStorage por bolão), reaparece em nova aba.

**BolaoDetail:** substituiu o card "Primeiros passos" antigo (que tinha 2 numbered steps) pelo ShareCallout + um card menor "Faça seus palpites" (só quando `myPredictions === 0`).

**Lock checkout:** novo state `checkoutRedirecting` em BolaoHome dispara overlay full-screen `z-[200]` (spinner amarelo + texto "Redirecionando para pagamento. Não feche essa janela") que **previne o duplo click** e qualquer interação com a página enquanto redireciona pra Stripe. Cobre os 2 fluxos (dynamic checkout + fallback payment link).

---

## Bloco D — Welcome Premium pós-pagamento + webhook loading

**Novo componente:** [src/components/bolao/PremiumWelcomeModal.tsx](src/components/bolao/PremiumWelcomeModal.tsx) — modal celebrativo com Crown gradient amarelo + 5 features desbloqueadas (Participantes ilimitados, Pontuação custom, Palpites especiais, Multiplicador 5x, Logo/cor). Animação stagger 100ms por item. 2 CTAs:
- **"Convidar amigos agora"** (primário, scroll pro topo onde está o ShareCallout)
- **"Configurar pontuação e palpites especiais"** (secundário, abre admin panel)

**Webhook polling:** refactor do useEffect de `?success=true` em BolaoDetail:
1. Se `bolao.is_premium = true` ao chegar → abre modal direto e limpa URL
2. Se `bolao.is_premium = false` → entra em `awaitingWebhook`, faz polling a cada 4s invalidando a query (max 8 tentativas = ~32s)
3. Quando `is_premium` flipa pra true → abre modal automaticamente
4. Após timeout sem flip → overlay fallback "Pagamento sendo processado, você receberá email" com botão de continuar

**Substituiu o `setShowAdmin(true)` automático pós-pagamento** que queimava o momento emocional jogando o user direto numa tela de configurações.

---

## Cleanup de ícones

- `BolaoRankingTable`: medals (1, 2, 3) emojis substituídos por Trophy/Medal/Award (Lucide). Componente `RankBadge` novo com aria-label "1 lugar" / "2 lugar" / "3 lugar". Cores tier-specific (yellow/slate/orange) mantém a hierarquia de pódio.
- `BolaoDetail` "Faça seus palpites": emoji bola substituído por ícone `Target` em círculo azul.
- Skill UI/UX Pro Max regra `no-emoji-icons` agora respeitada em todos os componentes do bolão.

---

## Rollout em produção

**Antes do merge:**
- [x] TypeScript compila sem erros (`npx tsc --noEmit`)
- [x] Migration 043 aplicada em staging (`kpbjuplcwiyrymafhehz`)
- [ ] Migration 043 aplicar em produção (`lavclmlvvfzkblrstojd`) — único arquivo SQL: [supabase/migrations/043_bolao_get_user_boloes_deadline_mode.sql](supabase/migrations/043_bolao_get_user_boloes_deadline_mode.sql)

**Antes do deploy do frontend em prod:**
1. Aplicar migration 043 em prod (DROP + CREATE da função `get_user_boloes`)
2. Smoke test: `SELECT id, name, prediction_deadline_mode FROM public.get_user_boloes();` deve retornar a coluna nova
3. Deploy do frontend

**Sem migration 043 em prod, o `DeadlineBadge` na lista de bolões da home cai no fallback `'per_match'` — funciona em 90% dos casos (modo default), mas mostra prazo impreciso em bolões configurados como `per_round` ou `tournament_start`. Não quebra nada.**

---

## Test plan

- [ ] Touch targets 44x44 em todos os botões dos componentes do bolão (dedo grande no mobile não erra)
- [ ] Tab key navega coerente; ESC fecha modais e dropdowns
- [ ] Screen reader anuncia toggles, tabs e botões-ícone corretamente
- [ ] Badge de deadline aparece na home (cards) e no header do bolão; atualiza ao vivo (espere 30s); pulsa vermelho quando menos de 1h
- [ ] Bolão com 1 membro só -> ShareCallout aparece; clique no X dispensa; F5 não traz de volta; nova aba traz
- [ ] Botão "Criar Premium" -> overlay loading bloqueia duplo-click até o redirect
- [ ] `?success=true` em bolão premium -> modal celebrativo abre, CTAs funcionam
- [ ] `?success=true` em bolão ainda não-premium -> overlay "Confirmando pagamento" com polling
- [ ] Ranking table mostra Trophy/Medal/Award (não mais emojis)
- [ ] "Faça seus palpites" mostra ícone Target (não mais emoji bola)
- [ ] Mobile (375px): nada cortado, sem horizontal scroll, toques funcionam

---

## Próximas ondas

Onda 2 (P1 — fricção): consolidar BolaoPalpites + PredictionsModal, empty states com CTA, auto-save draft, bottom sheet mobile, etc. Ver plano completo em [docs/bolao-audit-and-implementation-plan.md](docs/bolao-audit-and-implementation-plan.md).
