### PR TITLE
feat(bolao): Onda 3 UX — sair, zerar palpite, achievements, bandeiras, skeletons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AchievementProvider } from "@/components/bolao/AchievementProvider";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import LandingEcossistema from "./pages/LandingEcossistema";
 import Landing from "./pages/Landing";
@@ -56,6 +57,7 @@ const LazyFallback = () => (
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
+      <AchievementProvider>
       <Toaster />
       <Sonner />
       <BrowserRouter>
@@ -175,6 +177,7 @@ const App = () => (
           <Footer />
         </Suspense>
       </BrowserRouter>
+      </AchievementProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/bolao/AchievementProvider.tsx
+++ b/src/components/bolao/AchievementProvider.tsx
@@ -1,0 +1,141 @@
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { Trophy, Target, Medal, Star, Flame, Award } from 'lucide-react';
+
+/**
+ * Sistema de conquistas (achievements) estilo Xbox/PlayStation.
+ *
+ * Como funciona:
+ *  1. Componentes consumidores chamam `useAchievement().unlock(id, ...)`.
+ *  2. O Provider mantém uma fila e mostra um badge flutuante por 3.5s.
+ *  3. Cada achievement é registrado em localStorage pra evitar repetir.
+ *
+ * Como adicionar conquistas novas:
+ *  - Adicionar entry em ACHIEVEMENTS abaixo
+ *  - Chamar `unlock('achievement-id')` no momento certo
+ *
+ * Visual: drop-in do topo, badge dourado, ícone + nome + descrição.
+ * Respeita prefers-reduced-motion (sem animação se usuário prefere parado).
+ */
+
+type AchievementId =
+  | 'first-prediction'
+  | 'first-exact-score'
+  | 'reached-podium'
+  | 'all-group-stage-done'
+  | 'champion-picked'
+  | 'streak-5-correct'
+  | 'first-special-pick'
+  | 'all-finalists-picked';
+
+interface AchievementDef {
+  id: AchievementId;
+  title: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+  /** Persistir no localStorage (achievements grandes, "uma vez na vida") */
+  persistent?: boolean;
+}
+
+const ACHIEVEMENTS: Record<AchievementId, AchievementDef> = {
+  'first-prediction':       { id: 'first-prediction',      title: 'Primeiro palpite',          description: 'Você está no jogo',                icon: Target,  persistent: true },
+  'first-exact-score':      { id: 'first-exact-score',     title: 'Cravou o placar!',          description: 'Acertou um placar exato',          icon: Flame,   persistent: true },
+  'reached-podium':         { id: 'reached-podium',        title: 'No pódio',                  description: 'Top 3 no ranking',                 icon: Medal,   persistent: true },
+  'all-group-stage-done':   { id: 'all-group-stage-done',  title: 'Fase de grupos completa',   description: 'Palpitou todos os 48 jogos',       icon: Award,   persistent: true },
+  'champion-picked':        { id: 'champion-picked',       title: 'Apostou alto',              description: 'Escolheu o campeão',               icon: Trophy,  persistent: true },
+  'streak-5-correct':       { id: 'streak-5-correct',      title: 'Sequência de 5',            description: 'Acertou 5 palpites seguidos',      icon: Star,    persistent: true },
+  'first-special-pick':     { id: 'first-special-pick',    title: 'Olho de águia',             description: 'Primeira aposta em palpite especial', icon: Star,   persistent: true },
+  'all-finalists-picked':   { id: 'all-finalists-picked',  title: 'Aposta final',              description: 'Escolheu seus 2 finalistas',       icon: Trophy,  persistent: true },
+};
+
+const STORAGE_PREFIX = 'achievement_unlocked_';
+
+interface QueueItem {
+  uid: number; // unique render key
+  def: AchievementDef;
+}
+
+interface AchievementContextValue {
+  unlock: (id: AchievementId, scopeKey?: string) => void;
+}
+
+const AchievementContext = createContext<AchievementContextValue | null>(null);
+
+export const AchievementProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [queue, setQueue] = useState<QueueItem[]>([]);
+  const [counter, setCounter] = useState(0);
+
+  const unlock = useCallback((id: AchievementId, scopeKey?: string) => {
+    const def = ACHIEVEMENTS[id];
+    if (!def) return;
+
+    if (def.persistent) {
+      const key = STORAGE_PREFIX + id + (scopeKey ? '_' + scopeKey : '');
+      try {
+        if (localStorage.getItem(key) === '1') return; // já desbloqueado
+        localStorage.setItem(key, '1');
+      } catch {
+        // localStorage indisponível — ainda mostra o badge
+      }
+    }
+
+    setCounter(c => c + 1);
+    setQueue(q => [...q, { uid: Date.now() + Math.random(), def }]);
+  }, []);
+
+  // Auto-dismiss after 3.5s
+  useEffect(() => {
+    if (queue.length === 0) return;
+    const head = queue[0];
+    const timer = setTimeout(() => {
+      setQueue(q => q.filter(item => item.uid !== head.uid));
+    }, 3500);
+    return () => clearTimeout(timer);
+  }, [queue]);
+
+  const current = queue[0];
+
+  return (
+    <AchievementContext.Provider value={{ unlock }}>
+      {children}
+      {current && <AchievementBadge key={current.uid} def={current.def} />}
+    </AchievementContext.Provider>
+  );
+};
+
+export function useAchievement(): AchievementContextValue {
+  const ctx = useContext(AchievementContext);
+  if (!ctx) {
+    // Fallback silencioso fora do provider — não quebra app
+    return { unlock: () => {} };
+  }
+  return ctx;
+}
+
+// Badge visual — drop-in animation, fixed top-center
+const AchievementBadge: React.FC<{ def: AchievementDef }> = ({ def }) => {
+  const Icon = def.icon;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed top-4 left-1/2 -translate-x-1/2 z-[200] pointer-events-none animate-achievement-drop motion-reduce:animate-none"
+    >
+      <div className="flex items-center gap-3 pl-2 pr-4 py-2 rounded-full border border-yellow-500/50 bg-gradient-to-r from-yellow-600/95 via-yellow-500/95 to-yellow-400/95 shadow-2xl shadow-yellow-500/30 backdrop-blur-sm min-w-[280px] max-w-[90vw]">
+        <div className="w-10 h-10 rounded-full bg-terminal-bg/90 border border-yellow-300/40 flex items-center justify-center shrink-0">
+          <Icon className="w-5 h-5 text-yellow-300" />
+        </div>
+        <div className="min-w-0">
+          <p className="text-[10px] font-bold uppercase tracking-widest text-yellow-100/80 leading-tight">
+            Conquista
+          </p>
+          <p className="text-sm font-bold text-terminal-bg leading-tight truncate">
+            {def.title}
+          </p>
+          <p className="text-[11px] text-terminal-bg/80 leading-tight truncate">
+            {def.description}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/bolao/BolaoAdminPanel.tsx
+++ b/src/components/bolao/BolaoAdminPanel.tsx
@@ -39,6 +39,7 @@ import {
   useBolaoStats,
 } from '@/hooks/use-bolao';
 import { useToast } from '@/hooks/use-toast';
+import { ToastAction } from '@/components/ui/toast';
 import type { BolaoRankingEntry } from '@/services/bolao.service';
 
 interface BolaoAdminPanelProps {
@@ -235,7 +236,10 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   ownerUserId,
   predictionDeadlineMode,
 }) => {
-  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
+  // Soft-removed members: userId → { timer, userName }. Mostrados como
+  // ocultos na lista; após 5s o RPC é executado, com possibilidade de undo.
+  const pendingRemovalsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const [pendingRemovedIds, setPendingRemovedIds] = useState<Set<string>>(new Set());
   const [specialExpanded, setSpecialExpanded] = useState(false);
   const [upgradeLoading, setUpgradeLoading] = useState(false);
   // When user clicks a deadline mode and there are existing predictions,
@@ -271,24 +275,61 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
 
   if (currentUserId !== ownerUserId) return null;
 
+  // Padrão UX moderno (Gmail-style): clique imediato esconde o membro da lista
+  // e mostra toast com botão "Desfazer". Após 5s sem undo, executa o RPC.
   const handleRemove = (userId: string, userName: string) => {
-    if (confirmRemove !== userId) {
-      setConfirmRemove(userId);
-      return;
-    }
-    removeMember.mutate(
-      { bolaoId, userId },
-      {
-        onSuccess: () => {
-          toast({ title: `${userName} removido do bolão` });
-          setConfirmRemove(null);
-        },
-        onError: (err: any) => {
-          toast({ title: 'Erro', description: err.message, variant: 'destructive' });
-          setConfirmRemove(null);
-        },
-      }
-    );
+    // Já está em remoção pendente? ignora cliques duplos
+    if (pendingRemovalsRef.current.has(userId)) return;
+
+    setPendingRemovedIds(prev => {
+      const next = new Set(prev);
+      next.add(userId);
+      return next;
+    });
+
+    const undo = () => {
+      const timer = pendingRemovalsRef.current.get(userId);
+      if (timer) clearTimeout(timer);
+      pendingRemovalsRef.current.delete(userId);
+      setPendingRemovedIds(prev => {
+        const next = new Set(prev);
+        next.delete(userId);
+        return next;
+      });
+    };
+
+    const timer = setTimeout(() => {
+      pendingRemovalsRef.current.delete(userId);
+      removeMember.mutate(
+        { bolaoId, userId },
+        {
+          onSuccess: () => {
+            // Mantém escondido (já confirmado server-side)
+          },
+          onError: (err: any) => {
+            // Reverte UI (membro reaparece) + toast de erro
+            setPendingRemovedIds(prev => {
+              const next = new Set(prev);
+              next.delete(userId);
+              return next;
+            });
+            toast({ title: 'Erro ao remover', description: err.message, variant: 'destructive' });
+          },
+        }
+      );
+    }, 5000);
+
+    pendingRemovalsRef.current.set(userId, timer);
+
+    toast({
+      title: `${userName} removido`,
+      description: 'Você pode desfazer em 5s',
+      action: (
+        <ToastAction altText="Desfazer remoção" onClick={undo}>
+          Desfazer
+        </ToastAction>
+      ),
+    });
   };
 
   const handleToggleClose = () => {
@@ -1139,44 +1180,37 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
               <span className="text-[10px] opacity-30 ml-auto">{ranking.length}</span>
             </div>
             <div className="space-y-1.5 max-h-48 overflow-y-auto minimal-scrollbar">
-              {ranking.map((member) => {
-                const isOwner = member.user_id === ownerUserId;
-                const isConfirming = confirmRemove === member.user_id;
-                return (
-                  <div
-                    key={member.user_id}
-                    className="flex items-center gap-3 py-2 px-3 rounded border border-terminal-border-subtle bg-terminal-dark-gray/20"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm font-medium truncate">
-                        {member.user_name || member.user_email}
-                      </p>
-                      <p className="text-[10px] opacity-40">
-                        {member.total_points} pts · {member.total_predictions} palpites
-                      </p>
+              {ranking
+                .filter(m => !pendingRemovedIds.has(m.user_id))
+                .map((member) => {
+                  const isOwner = member.user_id === ownerUserId;
+                  return (
+                    <div
+                      key={member.user_id}
+                      className="flex items-center gap-3 py-2 px-3 rounded border border-terminal-border-subtle bg-terminal-dark-gray/20"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium truncate">
+                          {member.user_name || member.user_email}
+                        </p>
+                        <p className="text-[10px] opacity-40">
+                          {member.total_points} pts · {member.total_predictions} palpites
+                        </p>
+                      </div>
+                      {isOwner ? (
+                        <span className="text-[10px] text-terminal-green font-bold shrink-0">Criador</span>
+                      ) : (
+                        <button
+                          onClick={() => handleRemove(member.user_id, member.user_name || member.user_email)}
+                          aria-label={`Remover ${member.user_name || member.user_email} do bolão`}
+                          className="shrink-0 flex items-center gap-1 text-[10px] font-bold transition-colors px-2 h-9 rounded border border-terminal-border opacity-60 hover:opacity-100 hover:border-terminal-red/40 hover:text-terminal-red hover:bg-terminal-red/5"
+                        >
+                          <UserX className="w-3 h-3" /> Remover
+                        </button>
+                      )}
                     </div>
-                    {isOwner ? (
-                      <span className="text-[10px] text-terminal-green font-bold shrink-0">Criador</span>
-                    ) : (
-                      <button
-                        onClick={() => handleRemove(member.user_id, member.user_name || member.user_email)}
-                        disabled={removeMember.isPending}
-                        className={`shrink-0 flex items-center gap-1 text-[10px] font-bold transition-colors px-2 py-1 rounded border ${
-                          isConfirming
-                            ? 'border-terminal-red/60 text-terminal-red bg-terminal-red/10'
-                            : 'border-terminal-border opacity-50 hover:opacity-80 hover:border-terminal-red/40 hover:text-terminal-red'
-                        }`}
-                      >
-                        {isConfirming ? (
-                          <><AlertTriangle className="w-2.5 h-2.5" /> Confirmar</>
-                        ) : (
-                          <><UserX className="w-2.5 h-2.5" /> Remover</>
-                        )}
-                      </button>
-                    )}
-                  </div>
-                );
-              })}
+                  );
+                })}
             </div>
           </div>
         </div>

--- a/src/components/bolao/ChampionPickModal.tsx
+++ b/src/components/bolao/ChampionPickModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { Trophy, Search, Check, X } from 'lucide-react';
 import {
   Dialog,
@@ -8,6 +8,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { TeamFlag } from '@/components/bolao/TeamFlag';
 import type { WcMatch } from '@/services/bolao.service';
 
 interface Team {
@@ -49,6 +50,12 @@ export const ChampionPickModal: React.FC<ChampionPickModalProps> = ({
 }) => {
   const [selected, setSelected] = useState<string | null>(currentPick);
   const [search, setSearch] = useState('');
+
+  // Sync `selected` quando `currentPick` muda no parent (ex: outro user
+  // altera, ou quando o modal reabre depois de salvar)
+  useEffect(() => {
+    if (open) setSelected(currentPick);
+  }, [open, currentPick]);
 
   const teams = useMemo(() => extractTeams(matches), [matches]);
 
@@ -142,8 +149,7 @@ export const ChampionPickModal: React.FC<ChampionPickModalProps> = ({
                         <Check className="w-2 h-2 text-terminal-bg" />
                       </div>
                     )}
-                    {/* Flag placeholder */}
-                    <div className="w-8 h-5 rounded-sm bg-terminal-border-subtle/40 border border-terminal-border-subtle/30 shrink-0" />
+                    <TeamFlag code={team.code} size="md" />
                     <div className="text-center w-full">
                       <p
                         className={`text-[11px] font-bold ${isSelected ? 'text-yellow-400' : 'text-terminal-text'}`}

--- a/src/components/bolao/ConfirmDialog.tsx
+++ b/src/components/bolao/ConfirmDialog.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'default' | 'destructive';
+  onConfirm: () => void;
+  isLoading?: boolean;
+}
+
+/**
+ * ConfirmDialog reusável pra ações destrutivas/irreversíveis.
+ *
+ * Usado em: sair do bolão, zerar palpite, remover membro (futuro).
+ *
+ * UX: variante destructive deixa o botão de confirmar vermelho pra
+ * sinalizar irreversibilidade. Foco inicial no botão Cancelar (mais
+ * seguro — Enter não dispara ação destrutiva por engano).
+ */
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Confirmar',
+  cancelLabel = 'Cancelar',
+  variant = 'default',
+  onConfirm,
+  isLoading,
+}) => {
+  const isDestructive = variant === 'destructive';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={`bg-terminal-bg max-w-md ${
+          isDestructive ? 'border-terminal-red/40' : 'border-terminal-border'
+        }`}
+      >
+        <DialogHeader>
+          <DialogTitle className={`flex items-center gap-2 ${isDestructive ? 'text-terminal-red' : ''}`}>
+            {isDestructive && <AlertTriangle className="w-5 h-5" />}
+            {title}
+          </DialogTitle>
+        </DialogHeader>
+
+        {description && (
+          <div className="text-sm opacity-80 leading-relaxed">{description}</div>
+        )}
+
+        <div className="flex justify-end gap-2 mt-2">
+          <Button
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+            className="h-11 px-4"
+            // Foco inicial fica aqui — Enter aciona Cancelar (mais seguro)
+            autoFocus
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            onClick={onConfirm}
+            disabled={isLoading}
+            className={`h-11 px-4 font-bold ${
+              isDestructive
+                ? 'bg-terminal-red text-terminal-bg hover:bg-terminal-red/90'
+                : 'bg-terminal-blue text-terminal-bg hover:bg-terminal-blue/90'
+            }`}
+          >
+            {isLoading ? 'Processando...' : confirmLabel}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/bolao/MatchPredictionCard.tsx
+++ b/src/components/bolao/MatchPredictionCard.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { Lock, Check } from 'lucide-react';
+import React, { useState, useEffect, useRef } from 'react';
+import { Lock, Check, MoreVertical, Trash2 } from 'lucide-react';
 import type { WcMatch, BolaoPrediction } from '@/services/bolao.service';
 import { isMatchLocked, isMatchPredictionLocked, computeMatchDeadline } from '@/hooks/use-bolao';
 import { readDraft, writeDraft, clearDraft } from '@/components/bolao/useDraftPrediction';
@@ -8,6 +8,8 @@ interface MatchPredictionCardProps {
   match: WcMatch;
   prediction?: BolaoPrediction;
   onSave: (matchId: number, homeScore: number, awayScore: number) => void;
+  /** Optional — when present, shows menu with "Apagar palpite" option */
+  onDelete?: (matchId: number) => void;
   isSaving?: boolean;
   // Bolão id for localStorage draft key (optional for backward compat)
   bolaoId?: string;
@@ -21,6 +23,7 @@ export const MatchPredictionCard: React.FC<MatchPredictionCardProps> = ({
   match,
   prediction,
   onSave,
+  onDelete,
   isSaving,
   bolaoId,
   deadlineMode,
@@ -44,14 +47,43 @@ export const MatchPredictionCard: React.FC<MatchPredictionCardProps> = ({
   const [homeScore, setHomeScore] = useState<string>(initialHome);
   const [awayScore, setAwayScore] = useState<string>(initialAway);
   const [saved, setSaved] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
 
-  // Sync from server when prediction arrives (e.g., after upsert success)
+  // Close menu on outside click + ESC
   useEffect(() => {
+    if (!menuOpen) return;
+    const onClick = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [menuOpen]);
+
+  // Sync from server when prediction arrives (after upsert success) OR
+  // when prediction is deleted (clear inputs + draft, volta ao estado vazio).
+  // Track previous prediction via ref pra distinguir "carregou agora" de "foi deletado".
+  const prevPredictionRef = useRef<BolaoPrediction | undefined>(prediction);
+  useEffect(() => {
+    const hadBefore = !!prevPredictionRef.current;
     if (prediction) {
       setHomeScore(prediction.predicted_home_score.toString());
       setAwayScore(prediction.predicted_away_score.toString());
+    } else if (hadBefore) {
+      // Prediction existia e sumiu → foi deletada
+      setHomeScore('');
+      setAwayScore('');
+      if (bolaoId) clearDraft(bolaoId, match.id);
     }
-  }, [prediction]);
+    prevPredictionRef.current = prediction;
+  }, [prediction, bolaoId, match.id]);
 
   // Derived: there's an unsaved draft whenever the current values diverge
   // from the server (or no server value yet but user typed something).
@@ -158,6 +190,39 @@ export const MatchPredictionCard: React.FC<MatchPredictionCardProps> = ({
           <span className="text-[10px] opacity-50">
             {dateStr} {timeStr}
           </span>
+          {onDelete && hasPrediction && !locked && !match.is_finished && (
+            <div ref={menuRef} className="relative">
+              <button
+                type="button"
+                onClick={() => setMenuOpen(v => !v)}
+                aria-label="Mais opções do palpite"
+                aria-expanded={menuOpen}
+                aria-haspopup="menu"
+                className="w-8 h-8 flex items-center justify-center rounded text-terminal-text/40 hover:text-terminal-text/90 hover:bg-terminal-gray/30 transition-colors"
+              >
+                <MoreVertical className="w-4 h-4" />
+              </button>
+              {menuOpen && (
+                <div
+                  role="menu"
+                  className="absolute right-0 top-full mt-1 z-30 w-44 rounded-lg border border-terminal-border bg-terminal-dark-gray shadow-xl overflow-hidden"
+                >
+                  <button
+                    role="menuitem"
+                    type="button"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onDelete(match.id);
+                    }}
+                    className="w-full flex items-center gap-2 px-3 py-2.5 text-left text-sm text-terminal-red hover:bg-terminal-red/10 focus:bg-terminal-red/10 focus:outline-none transition-colors"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                    Apagar palpite
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
       {/* Custom deadline indicator — only show when deadline differs from kickoff */}

--- a/src/components/bolao/PredictionsList.tsx
+++ b/src/components/bolao/PredictionsList.tsx
@@ -13,6 +13,8 @@ interface PredictionsListProps {
   isClosed?: boolean;
   deadlineMode?: 'per_match' | 'per_round' | 'tournament_start';
   onSave: (matchId: number, homeScore: number, awayScore: number) => void;
+  /** Optional — when present, shows "Apagar palpite" menu in each card */
+  onDelete?: (matchId: number) => void;
   /** "page" = vertical layout pra rota dedicada; "modal" = compactado */
   variant?: 'page' | 'modal';
   /** Cor do filtro ativo — green pra page, blue pra modal */
@@ -36,6 +38,7 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
   isClosed,
   deadlineMode,
   onSave,
+  onDelete,
   variant = 'page',
   accentColor = 'green',
   groupFilter,
@@ -127,6 +130,7 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
                       match={match}
                       prediction={predictionsByMatch.get(match.id)}
                       onSave={onSave}
+                      onDelete={onDelete}
                       isSaving={isSavingPrediction}
                       bolaoId={bolaoId}
                       deadlineMode={deadlineMode}

--- a/src/components/bolao/PredictionsModal.tsx
+++ b/src/components/bolao/PredictionsModal.tsx
@@ -10,8 +10,11 @@ import {
   useWcMatches,
   useBolaoPredictions,
   useUpsertPrediction,
+  useDeletePrediction,
 } from '@/hooks/use-bolao';
 import { PredictionsList } from '@/components/bolao/PredictionsList';
+import { ConfirmDialog } from '@/components/bolao/ConfirmDialog';
+import { useAchievement } from '@/components/bolao/AchievementProvider';
 import { useToast } from '@/hooks/use-toast';
 
 interface PredictionsModalProps {
@@ -28,14 +31,18 @@ export const PredictionsModal: React.FC<PredictionsModalProps> = ({
   currentUserId,
 }) => {
   const [groupFilter, setGroupFilter] = useState<string>('all');
+  const [confirmDeleteMatchId, setConfirmDeleteMatchId] = useState<number | null>(null);
 
   const { data: bolao } = useBolao(bolaoId);
   const { data: matches, isLoading } = useWcMatches();
   const { data: predictions } = useBolaoPredictions(bolaoId, currentUserId);
   const upsertPrediction = useUpsertPrediction();
+  const deletePrediction = useDeletePrediction();
   const { toast } = useToast();
+  const { unlock } = useAchievement();
 
   const handleSave = (matchId: number, homeScore: number, awayScore: number) => {
+    const wasFirstPrediction = (predictions?.length ?? 0) === 0;
     upsertPrediction.mutate(
       {
         bolao_id: bolaoId,
@@ -46,12 +53,31 @@ export const PredictionsModal: React.FC<PredictionsModalProps> = ({
       {
         onSuccess: () => {
           toast({ title: 'Palpite salvo', description: `${homeScore} x ${awayScore}` });
+          if (wasFirstPrediction) unlock('first-prediction', bolaoId);
         },
         onError: (err: any) => {
           toast({ title: 'Erro ao salvar palpite', description: err?.message ?? 'Tente novamente', variant: 'destructive' });
         },
       }
     );
+  };
+
+  const handleDeleteRequest = (matchId: number) => {
+    setConfirmDeleteMatchId(matchId);
+  };
+
+  const performDelete = () => {
+    if (confirmDeleteMatchId == null) return;
+    const matchId = confirmDeleteMatchId;
+    deletePrediction.mutate(
+      { bolao_id: bolaoId, match_id: matchId },
+      {
+        onSuccess: () => toast({ title: 'Palpite apagado' }),
+        onError: (err: any) =>
+          toast({ title: 'Erro ao apagar', description: err?.message ?? 'Tente novamente', variant: 'destructive' }),
+      }
+    );
+    setConfirmDeleteMatchId(null);
   };
 
   const totalMatches = matches?.filter((m) => !m.is_finished && m.home_team_code !== 'TBD').length || 0;
@@ -83,12 +109,25 @@ export const PredictionsModal: React.FC<PredictionsModalProps> = ({
             isClosed={bolao?.is_closed}
             deadlineMode={bolao?.prediction_deadline_mode ?? 'per_match'}
             onSave={handleSave}
+            onDelete={handleDeleteRequest}
             variant="modal"
             accentColor="blue"
             groupFilter={groupFilter}
             onGroupFilterChange={setGroupFilter}
           />
         </div>
+
+        {/* Confirmação ao apagar palpite */}
+        <ConfirmDialog
+          open={confirmDeleteMatchId !== null}
+          onOpenChange={(o) => !o && setConfirmDeleteMatchId(null)}
+          title="Apagar este palpite?"
+          description="O palpite vai voltar ao estado vazio (- x -). Você pode palpitar de novo enquanto o prazo estiver aberto."
+          confirmLabel="Apagar"
+          variant="destructive"
+          onConfirm={performDelete}
+          isLoading={deletePrediction.isPending}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/src/components/bolao/SpecialPredictionsSection.tsx
+++ b/src/components/bolao/SpecialPredictionsSection.tsx
@@ -1,5 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Crown, Lock, ChevronDown, ChevronUp, Check, Search, X } from 'lucide-react';
+import { TeamFlag } from '@/components/bolao/TeamFlag';
+import { useAchievement } from '@/components/bolao/AchievementProvider';
 import {
   useMySpecialPredictions,
   useSpecialSummary,
@@ -51,6 +53,7 @@ const PickPanel: React.FC<PickPanelProps> = ({ type, bolaoId, myPicks, summaryCo
   const [open, setOpen] = useState(false);
   const toggle = useToggleSpecialPrediction();
   const { toast } = useToast();
+  const { unlock } = useAchievement();
 
   const filtered = useMemo(() => {
     if (!search) return teams;
@@ -64,9 +67,17 @@ const PickPanel: React.FC<PickPanelProps> = ({ type, bolaoId, myPicks, summaryCo
       toast({ title: `Máximo de ${max} times para ${label}`, variant: 'destructive' });
       return;
     }
+    // Captura estado antes do save pra detectar primeira pick + finalistas completos
+    const wasFirstAnyPick = myPicks.length === 0;
+    const willCompleteFinalists = type === 'finalist' && !isPicked && myPicks.length + 1 >= max;
+
     toggle.mutate(
       { bolaoId, predictionType: type, teamCode: code },
       {
+        onSuccess: () => {
+          if (wasFirstAnyPick) unlock('first-special-pick', bolaoId);
+          if (willCompleteFinalists) unlock('all-finalists-picked', bolaoId);
+        },
         onError: (err: any) => toast({ title: 'Erro', description: err.message, variant: 'destructive' }),
       }
     );
@@ -147,7 +158,8 @@ const PickPanel: React.FC<PickPanelProps> = ({ type, bolaoId, myPicks, summaryCo
                       <Check className="w-2 h-2 text-terminal-bg" />
                     </div>
                   )}
-                  <span className="font-mono font-bold text-xs">{team.code}</span>
+                  <TeamFlag code={team.code} size="sm" />
+                  <span className="font-mono font-bold text-xs mt-0.5">{team.code}</span>
                   <span className="text-[10px] opacity-60 leading-tight text-center line-clamp-1">{team.name}</span>
                   {count > 0 && totalMembers > 1 && (
                     <span className="text-[9px] opacity-40 tabular-nums">{count} pick{count !== 1 ? 's' : ''}</span>

--- a/src/components/bolao/TeamFlag.tsx
+++ b/src/components/bolao/TeamFlag.tsx
@@ -1,11 +1,78 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-/** Placeholder for team flag/crest — will be replaced with actual image later */
-export function TeamFlag({ code }: { code: string }) {
+/**
+ * Mapeia códigos FIFA (3 letras, ex: BRA, ARG) para ISO 3166-1 alpha-2
+ * (2 letras, lowercase, ex: br, ar) — formato esperado pelo flagcdn.com.
+ *
+ * Cobre os 48 países da Copa do Mundo 2026 + alguns outros comuns.
+ */
+const FIFA_TO_ISO: Record<string, string> = {
+  // Anfitriões
+  USA: 'us', CAN: 'ca', MEX: 'mx',
+  // CONMEBOL
+  ARG: 'ar', BRA: 'br', URU: 'uy', PAR: 'py', PER: 'pe', COL: 'co', CHI: 'cl', ECU: 'ec', BOL: 'bo', VEN: 've',
+  // UEFA
+  FRA: 'fr', GER: 'de', ENG: 'gb-eng', ESP: 'es', POR: 'pt', NED: 'nl', BEL: 'be', ITA: 'it', CRO: 'hr',
+  POL: 'pl', SUI: 'ch', DEN: 'dk', SWE: 'se', NOR: 'no', AUT: 'at', UKR: 'ua', SRB: 'rs', CZE: 'cz',
+  TUR: 'tr', SCO: 'gb-sct', WAL: 'gb-wls', NIR: 'gb-nir', IRL: 'ie', HUN: 'hu', ROU: 'ro', GRE: 'gr',
+  RUS: 'ru', SVK: 'sk', SVN: 'si', BIH: 'ba', BUL: 'bg', BLR: 'by', ALB: 'al', MNE: 'me',
+  MKD: 'mk', LUX: 'lu', ISL: 'is', FIN: 'fi', LVA: 'lv', LTU: 'lt', EST: 'ee', MDA: 'md',
+  KOS: 'xk', ARM: 'am', AZE: 'az', GEO: 'ge', KAZ: 'kz',
+  // CONCACAF
+  CRC: 'cr', PAN: 'pa', HON: 'hn', JAM: 'jm', SLV: 'sv', GUA: 'gt', HAI: 'ht', TRI: 'tt',
+  CUW: 'cw', SUR: 'sr', GUY: 'gy', BAR: 'bb', GRN: 'gd', NCA: 'ni',
+  // CAF (África)
+  MAR: 'ma', SEN: 'sn', TUN: 'tn', ALG: 'dz', EGY: 'eg', NGA: 'ng', GHA: 'gh', CMR: 'cm', CIV: 'ci',
+  RSA: 'za', MLI: 'ml', BFA: 'bf', BEN: 'bj', GAB: 'ga', CPV: 'cv', COD: 'cd', ANG: 'ao', UGA: 'ug',
+  KEN: 'ke', ZAM: 'zm', ZIM: 'zw', ETH: 'et', SUD: 'sd', MOZ: 'mz', LBY: 'ly', MAD: 'mg', TOG: 'tg',
+  // AFC (Ásia)
+  JPN: 'jp', KOR: 'kr', AUS: 'au', IRN: 'ir', KSA: 'sa', QAT: 'qa', UAE: 'ae', UZB: 'uz', IRQ: 'iq',
+  SYR: 'sy', JOR: 'jo', LIB: 'lb', PRK: 'kp', CHN: 'cn', THA: 'th', VIE: 'vn', PHI: 'ph', MAS: 'my',
+  // OFC (Oceania)
+  NZL: 'nz', SOL: 'sb',
+};
+
+interface TeamFlagProps {
+  code: string;
+  /** Tamanho preset — default w-5 h-3.5 (~20×14) */
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+const SIZE_CLASSES = {
+  sm: 'w-5 h-3.5',
+  md: 'w-7 h-5',
+  lg: 'w-10 h-7',
+};
+
+/**
+ * Bandeira de seleção. Usa flagcdn.com (CDN público, free) com fallback
+ * pra placeholder cinza se o código FIFA não mapeia ou se a imagem falha.
+ */
+export function TeamFlag({ code, size = 'sm', className = '' }: TeamFlagProps) {
+  const [errored, setErrored] = useState(false);
+  const isoCode = FIFA_TO_ISO[code?.toUpperCase()];
+  const sizeClass = SIZE_CLASSES[size];
+
+  if (!isoCode || errored) {
+    return (
+      <div
+        className={`${sizeClass} rounded-sm bg-terminal-border-subtle/40 border border-terminal-border-subtle/60 shrink-0 ${className}`}
+        title={code}
+        aria-label={`Bandeira de ${code} (não disponível)`}
+      />
+    );
+  }
+
   return (
-    <div
-      className="w-5 h-3.5 rounded-sm bg-terminal-border-subtle/40 border border-terminal-border-subtle/60 shrink-0 overflow-hidden"
+    <img
+      src={`https://flagcdn.com/w40/${isoCode}.png`}
+      srcSet={`https://flagcdn.com/w40/${isoCode}.png 1x, https://flagcdn.com/w80/${isoCode}.png 2x`}
+      alt={`Bandeira de ${code}`}
       title={code}
+      onError={() => setErrored(true)}
+      loading="lazy"
+      className={`${sizeClass} rounded-sm border border-terminal-border-subtle/40 shrink-0 object-cover ${className}`}
     />
   );
 }

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -122,6 +122,18 @@ export function useUpsertPrediction() {
   });
 }
 
+export function useDeletePrediction() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { bolao_id: string; match_id: number }) =>
+      bolaoService.deletePrediction(params.bolao_id, params.match_id),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['bolao-predictions', variables.bolao_id] });
+      queryClient.invalidateQueries({ queryKey: ['bolao-ranking', variables.bolao_id] });
+    },
+  });
+}
+
 export function useUpsertPredictionsBatch() {
   const queryClient = useQueryClient();
 

--- a/src/index.css
+++ b/src/index.css
@@ -344,3 +344,48 @@ All colors MUST be HSL.
 .recharts-rectangle.recharts-tooltip-cursor {
   fill: transparent !important;
 }
+
+/* Achievement badge: drop in from top with bounce, hold ~2.5s, slide up out */
+@keyframes achievement-drop {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -120%) scale(0.92);
+  }
+  10% {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1.04);
+  }
+  18% {
+    transform: translate(-50%, 0) scale(1);
+  }
+  82% {
+    opacity: 1;
+    transform: translate(-50%, 0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -120%) scale(0.92);
+  }
+}
+
+.animate-achievement-drop {
+  animation: achievement-drop 3.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-achievement-drop {
+    animation: none !important;
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  /* Reduz drasticamente animações para usuários sensíveis (vestibular).
+     Mantém transições rápidas mas remove pulse/bounce/spin demorados. */
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -14,6 +14,7 @@ import {
   Settings,
   Target,
   AlertCircle,
+  LogOut,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -24,6 +25,7 @@ import {
   useBolaoPredictions,
   useChampionPredictions,
   useUpsertChampionPrediction,
+  useLeaveBolao,
   computeMatchDeadline,
 } from '@/hooks/use-bolao';
 import { BolaoRankingTable } from '@/components/bolao/BolaoRankingTable';
@@ -38,6 +40,8 @@ import { DeadlineBadge } from '@/components/bolao/DeadlineBadge';
 import { ShareCallout } from '@/components/bolao/ShareCallout';
 import { PremiumWelcomeModal } from '@/components/bolao/PremiumWelcomeModal';
 import { BolaoBottomNav } from '@/components/bolao/BolaoBottomNav';
+import { ConfirmDialog } from '@/components/bolao/ConfirmDialog';
+import { useAchievement } from '@/components/bolao/AchievementProvider';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import type { WcMatch, BolaoRankingEntry } from '@/services/bolao.service';
@@ -158,10 +162,26 @@ const BolaoDetail: React.FC = () => {
   const location = useLocation();
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const leaveBolao = useLeaveBolao();
+  const { unlock } = useAchievement();
+
+  const handleLeaveBolao = () => {
+    if (!id) return;
+    leaveBolao.mutate(id, {
+      onSuccess: () => {
+        toast({ title: 'Você saiu do bolão' });
+        navigate('/bolao');
+      },
+      onError: (err: any) => {
+        toast({ title: 'Erro ao sair', description: err?.message ?? 'Tente novamente', variant: 'destructive' });
+      },
+    });
+  };
   const [activeTab, setActiveTab] = useState<Tab>('ranking');
   const [currentUserId, setCurrentUserId] = useState<string | undefined>();
   const [showAdmin, setShowAdmin] = useState(false);
   const [showPremiumWelcome, setShowPremiumWelcome] = useState(false);
+  const [confirmLeaveOpen, setConfirmLeaveOpen] = useState(false);
   // Webhook polling state: true = ?success=true detectado mas is_premium ainda false
   const [awaitingWebhook, setAwaitingWebhook] = useState(false);
   const [webhookTimedOut, setWebhookTimedOut] = useState(false);
@@ -177,10 +197,10 @@ const BolaoDetail: React.FC = () => {
   const [specialPredictionsOpen, setSpecialPredictionsOpen] = useState(false);
 
   const { data: bolao, isLoading: loadingBolao } = useBolao(id);
-  const { data: ranking } = useBolaoRanking(id);
+  const { data: ranking, isLoading: loadingRanking } = useBolaoRanking(id);
   const { data: matches } = useWcMatches();
   const { data: myPredictions } = useBolaoPredictions(id, currentUserId);
-  const { data: championPredictions } = useChampionPredictions(id);
+  const { data: championPredictions, isLoading: loadingChampions } = useChampionPredictions(id);
   const upsertChampion = useUpsertChampionPrediction();
 
   // ── Handle query params: Stripe success + auto-open settings ──────
@@ -237,11 +257,60 @@ const BolaoDetail: React.FC = () => {
     [championPredictions, currentUserId]
   );
 
+  // Achievement: usuário escolheu campeão (uma vez)
+  useEffect(() => {
+    if (id && myChampionPick) unlock('champion-picked', id);
+  }, [id, myChampionPick, unlock]);
+
+  // Achievement: usuário entrou no top 3 (uma vez)
+  useEffect(() => {
+    if (!id || !ranking || !currentUserId) return;
+    const me = ranking.find(r => r.user_id === currentUserId);
+    if (!me) return;
+    // Só conta pódio quando há concorrência (>=3 membros) e o user está em rank 1-3
+    if (ranking.length >= 3 && me.rank <= 3 && me.total_points > 0) {
+      unlock('reached-podium', id);
+    }
+  }, [id, ranking, currentUserId, unlock]);
+
+  // Achievement: usuário cravou primeiro placar exato (uma vez)
+  // points_earned == scoring_exact significa placar exato (resto é 0 ou scoring_result)
+  useEffect(() => {
+    if (!id || !myPredictions || !bolao) return;
+    const exactScoreHit = myPredictions.some(
+      p => p.points_earned != null && p.points_earned >= bolao.scoring_exact
+    );
+    if (exactScoreHit) unlock('first-exact-score', id);
+  }, [id, myPredictions, bolao, unlock]);
+
+  // Achievement: completou todos os palpites da fase de grupos
+  useEffect(() => {
+    if (!id || !matches || !myPredictions) return;
+    const groupMatches = matches.filter(m => m.stage === 'group' && m.home_team_code !== 'TBD');
+    if (groupMatches.length === 0) return;
+    const palpitatedGroupIds = new Set(
+      myPredictions
+        .filter(p => groupMatches.some(g => g.id === p.match_id))
+        .map(p => p.match_id)
+    );
+    if (palpitatedGroupIds.size >= groupMatches.length) {
+      unlock('all-group-stage-done', id);
+    }
+  }, [id, matches, myPredictions, unlock]);
+
   const handleChampionConfirm = (teamCode: string) => {
     if (!id) return;
     upsertChampion.mutate(
       { bolaoId: id, teamCode },
-      { onSuccess: () => setChampionModalOpen(false) }
+      {
+        onSuccess: () => {
+          setChampionModalOpen(false);
+          toast({ title: 'Palpite de campeão salvo', description: teamCode });
+        },
+        onError: (err: any) => {
+          toast({ title: 'Erro ao salvar campeão', description: err?.message ?? 'Tente novamente', variant: 'destructive' });
+        },
+      }
     );
   };
 
@@ -346,27 +415,54 @@ const BolaoDetail: React.FC = () => {
   const sidebarContent = (
     <>
       {/* 1. Palpites dos Jogos */}
-      <div className="terminal-container p-4 border-terminal-blue/20 bg-terminal-blue/[0.03]">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-2 min-w-0">
-            <ClipboardList className="w-4 h-4 text-terminal-blue shrink-0" />
-            <div className="min-w-0">
-              <p className="text-[10px] font-bold uppercase tracking-wider text-terminal-blue">
-                Palpites dos Jogos
-              </p>
-              <p className="text-xs opacity-50">
-                {myPredictions?.length || 0} feitos · {matches?.filter((m) => !m.is_finished && m.home_team_code !== 'TBD').length || 0} disponíveis
-              </p>
+      {(() => {
+        const made = myPredictions?.length ?? 0;
+        const total = totalAvailableMatches;
+        const pct = total > 0 ? Math.round((made / total) * 100) : 0;
+        const complete = total > 0 && made >= total;
+        return (
+          <div className="terminal-container p-4 border-terminal-blue/20 bg-terminal-blue/[0.03]">
+            <div className="flex items-center justify-between gap-3 mb-2">
+              <div className="flex items-center gap-2 min-w-0">
+                <ClipboardList className="w-4 h-4 text-terminal-blue shrink-0" />
+                <div className="min-w-0">
+                  <p className="text-[10px] font-bold uppercase tracking-wider text-terminal-blue">
+                    Palpites dos Jogos
+                  </p>
+                  <p className="text-xs opacity-60">
+                    <span className="font-bold text-terminal-text tabular-nums">{made}</span>
+                    <span className="opacity-60"> / </span>
+                    <span className="opacity-80 tabular-nums">{total}</span>
+                    <span className="opacity-50"> palpites · {pct}%</span>
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={() => setPredictionsModalOpen(true)}
+                className="text-[10px] font-bold text-terminal-blue hover:text-terminal-blue/80 shrink-0 border border-terminal-blue/30 rounded px-2 py-1 hover:bg-terminal-blue/10 transition-colors"
+              >
+                {complete ? 'Revisar' : 'Fazer palpites →'}
+              </button>
+            </div>
+            {/* Progress bar — azul a cinza, completa em verde */}
+            <div
+              className="h-1.5 rounded-full bg-terminal-border-subtle overflow-hidden"
+              role="progressbar"
+              aria-valuenow={pct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${made} de ${total} palpites feitos`}
+            >
+              <div
+                className={`h-full transition-all duration-500 ${
+                  complete ? 'bg-terminal-green' : 'bg-terminal-blue'
+                }`}
+                style={{ width: `${pct}%` }}
+              />
             </div>
           </div>
-          <button
-            onClick={() => setPredictionsModalOpen(true)}
-            className="text-[10px] font-bold text-terminal-blue hover:text-terminal-blue/80 shrink-0 border border-terminal-blue/30 rounded px-2 py-1 hover:bg-terminal-blue/10 transition-colors"
-          >
-            Fazer palpites →
-          </button>
-        </div>
-      </div>
+        );
+      })()}
 
       {/* 2. Palpite de Campeão */}
       {(bolao.champion_enabled ?? true) && <div className="terminal-container p-4 border-yellow-500/20 bg-yellow-500/[0.03]">
@@ -399,6 +495,16 @@ const BolaoDetail: React.FC = () => {
             {myChampionPick ? 'Alterar' : 'Escolher →'}
           </button>
         </div>
+
+        {loadingChampions && !championPredictions && (
+          <div className="mt-3 pt-3 border-t border-yellow-500/10">
+            <div className="flex flex-wrap gap-1.5">
+              {[1, 2, 3].map(i => (
+                <div key={i} className="h-5 w-12 rounded bg-yellow-500/10 animate-pulse" />
+              ))}
+            </div>
+          </div>
+        )}
 
         {championPredictions && championPredictions.length > 0 && (
           <div className="mt-3 pt-3 border-t border-yellow-500/10">
@@ -519,7 +625,7 @@ const BolaoDetail: React.FC = () => {
               inviteCode={bolao.invite_code}
               variant="compact"
             />
-            {currentUserId && currentUserId === bolao.owner_id && (
+            {currentUserId && currentUserId === bolao.owner_id ? (
               <Button
                 variant="ghost"
                 onClick={() => setShowAdmin(true)}
@@ -529,7 +635,18 @@ const BolaoDetail: React.FC = () => {
                 <Settings className="w-4 h-4" />
                 <span className="hidden sm:inline">Configurações</span>
               </Button>
-            )}
+            ) : currentUserId ? (
+              <Button
+                variant="ghost"
+                onClick={() => setConfirmLeaveOpen(true)}
+                aria-label="Sair do bolão"
+                className="gap-1.5 text-xs opacity-50 hover:opacity-100 hover:text-terminal-red h-11 px-3"
+                title="Sair do bolão"
+              >
+                <LogOut className="w-4 h-4" />
+                <span className="hidden sm:inline">Sair</span>
+              </Button>
+            ) : null}
           </div>
         </div>
 
@@ -539,10 +656,23 @@ const BolaoDetail: React.FC = () => {
             <Users className="w-3 h-3" />
             {ranking?.length || 0} participantes
           </span>
-          <span className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={async () => {
+              try {
+                await navigator.clipboard.writeText(bolao.invite_code);
+                toast({ title: 'Código copiado', description: bolao.invite_code });
+              } catch {
+                toast({ title: 'Erro ao copiar', variant: 'destructive' });
+              }
+            }}
+            aria-label={`Copiar código de convite ${bolao.invite_code}`}
+            title="Clique para copiar"
+            className="flex items-center gap-1 hover:opacity-100 hover:text-terminal-blue transition-colors cursor-pointer"
+          >
             <Hash className="w-3 h-3" />
-            {bolao.invite_code}
-          </span>
+            <span className="font-mono">{bolao.invite_code}</span>
+          </button>
           <span>
             {bolao.scoring_result} pt resultado / {bolao.scoring_exact} pts placar
             {bolao.scoring_preset === 'weighted_stages' && (
@@ -681,15 +811,23 @@ const BolaoDetail: React.FC = () => {
                     )}
                   </div>
                 )}
-                <BolaoRankingTable
-                  ranking={ranking || []}
-                  currentUserId={currentUserId}
-                  onInviteFriends={() => {
-                    // Scroll to top so user sees the ShareCallout (rendered at the top
-                    // when ranking.length <= 1).
-                    window.scrollTo({ top: 0, behavior: 'smooth' });
-                  }}
-                />
+                {loadingRanking && !ranking ? (
+                  <div className="space-y-1.5">
+                    {[1, 2, 3, 4].map(i => (
+                      <div key={i} className="h-14 rounded bg-terminal-dark-gray/30 animate-pulse" />
+                    ))}
+                  </div>
+                ) : (
+                  <BolaoRankingTable
+                    ranking={ranking || []}
+                    currentUserId={currentUserId}
+                    onInviteFriends={() => {
+                      // Scroll to top so user sees the ShareCallout (rendered at the top
+                      // when ranking.length <= 1).
+                      window.scrollTo({ top: 0, behavior: 'smooth' });
+                    }}
+                  />
+                )}
               </div>
             )}
 
@@ -924,6 +1062,30 @@ const BolaoDetail: React.FC = () => {
           </div>
         </div>
       )}
+
+      {/* ── Sair do bolão (apenas não-owner) ── */}
+      <ConfirmDialog
+        open={confirmLeaveOpen}
+        onOpenChange={setConfirmLeaveOpen}
+        title="Sair do bolão?"
+        description={
+          <>
+            <p className="mb-2">
+              Você não vai mais aparecer no ranking de <strong>{bolao.name}</strong>.
+            </p>
+            <p className="text-xs opacity-70">
+              Seus palpites já feitos serão removidos. Pra voltar, precisa do código de convite novamente.
+            </p>
+          </>
+        }
+        confirmLabel="Sair do bolão"
+        variant="destructive"
+        onConfirm={() => {
+          handleLeaveBolao();
+          setConfirmLeaveOpen(false);
+        }}
+        isLoading={leaveBolao.isPending}
+      />
     </div>
   );
 };

--- a/src/pages/BolaoPalpites.tsx
+++ b/src/pages/BolaoPalpites.tsx
@@ -8,9 +8,12 @@ import {
   useWcMatches,
   useBolaoPredictions,
   useUpsertPrediction,
+  useDeletePrediction,
 } from '@/hooks/use-bolao';
 import { PredictionsList } from '@/components/bolao/PredictionsList';
 import { PendingPredictionsSticky } from '@/components/bolao/PendingPredictionsSticky';
+import { ConfirmDialog } from '@/components/bolao/ConfirmDialog';
+import { useAchievement } from '@/components/bolao/AchievementProvider';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 
@@ -32,15 +35,40 @@ const BolaoPalpites: React.FC = () => {
   const { data: matches, isLoading: loadingMatches } = useWcMatches();
   const { data: predictions } = useBolaoPredictions(id, currentUserId);
   const upsertPrediction = useUpsertPrediction();
+  const deletePrediction = useDeletePrediction();
   const { toast } = useToast();
+  const { unlock } = useAchievement();
+  const [confirmDeleteMatchId, setConfirmDeleteMatchId] = useState<number | null>(null);
 
   const predictionsByMatch = useMemo(
     () => new Map((predictions || []).map((p) => [p.match_id, p])),
     [predictions]
   );
 
+  const handleDeleteRequest = (matchId: number) => {
+    setConfirmDeleteMatchId(matchId);
+  };
+
+  const performDelete = () => {
+    if (!id || confirmDeleteMatchId == null) return;
+    const matchId = confirmDeleteMatchId;
+    deletePrediction.mutate(
+      { bolao_id: id, match_id: matchId },
+      {
+        onSuccess: () => {
+          toast({ title: 'Palpite apagado' });
+        },
+        onError: (err: any) => {
+          toast({ title: 'Erro ao apagar', description: err?.message ?? 'Tente novamente', variant: 'destructive' });
+        },
+      }
+    );
+    setConfirmDeleteMatchId(null);
+  };
+
   const handleSave = (matchId: number, homeScore: number, awayScore: number) => {
     if (!id) return;
+    const wasFirstPrediction = (predictions?.length ?? 0) === 0;
     upsertPrediction.mutate(
       {
         bolao_id: id,
@@ -51,6 +79,7 @@ const BolaoPalpites: React.FC = () => {
       {
         onSuccess: () => {
           toast({ title: 'Palpite salvo', description: `${homeScore} x ${awayScore}` });
+          if (wasFirstPrediction) unlock('first-prediction', id);
         },
         onError: (err: any) => {
           toast({ title: 'Erro ao salvar palpite', description: err?.message ?? 'Tente novamente', variant: 'destructive' });
@@ -123,6 +152,7 @@ const BolaoPalpites: React.FC = () => {
             isClosed={bolao?.is_closed}
             deadlineMode={bolao?.prediction_deadline_mode ?? 'per_match'}
             onSave={handleSave}
+            onDelete={handleDeleteRequest}
             variant="page"
             accentColor="green"
             groupFilter={groupFilter}
@@ -130,6 +160,18 @@ const BolaoPalpites: React.FC = () => {
           />
         )}
       </div>
+
+      {/* Confirmação ao apagar palpite */}
+      <ConfirmDialog
+        open={confirmDeleteMatchId !== null}
+        onOpenChange={(open) => !open && setConfirmDeleteMatchId(null)}
+        title="Apagar este palpite?"
+        description="O palpite vai voltar ao estado vazio (- x -). Você pode palpitar de novo enquanto o prazo estiver aberto."
+        confirmLabel="Apagar"
+        variant="destructive"
+        onConfirm={performDelete}
+        isLoading={deletePrediction.isPending}
+      />
     </div>
   );
 };

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -407,6 +407,16 @@ export const bolaoService = {
     return { prediction_deadline_mode: result.prediction_deadline_mode };
   },
 
+  async deletePrediction(bolaoId: string, matchId: number): Promise<void> {
+    const { data, error } = await supabase.rpc('delete_bolao_prediction', {
+      p_bolao_id: bolaoId,
+      p_match_id: matchId,
+    });
+    if (error) throw error;
+    const result = data as { success: boolean; error?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao apagar palpite');
+  },
+
   async getPredictionDeadline(bolaoId: string, matchId: number): Promise<string | null> {
     const { data, error } = await supabase.rpc('get_prediction_deadline', {
       p_bolao_id: bolaoId,

--- a/supabase/migrations/044_bolao_delete_prediction.sql
+++ b/supabase/migrations/044_bolao_delete_prediction.sql
@@ -1,0 +1,57 @@
+-- ============================================================
+-- BOLÃO: deletar palpite individual
+-- Permite o usuário "zerar" um palpite, removendo-o completamente.
+-- O card volta ao estado vazio ("- x -"), não persiste como 0/0.
+-- Aplica as mesmas validações de submit (deadline + is_closed).
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.delete_bolao_prediction(
+  p_bolao_id uuid,
+  p_match_id int
+) RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_is_closed boolean;
+  v_deadline timestamptz;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.bolao_members
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+  ) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member');
+  END IF;
+
+  SELECT is_closed INTO v_is_closed FROM public.boloes WHERE id = p_bolao_id;
+  IF v_is_closed THEN
+    RETURN json_build_object('success', false, 'error', 'Inscrições fechadas');
+  END IF;
+
+  -- Mesma regra de deadline do submit_bolao_prediction
+  v_deadline := public.get_prediction_deadline(p_bolao_id, p_match_id);
+  IF v_deadline IS NOT NULL AND now() >= v_deadline THEN
+    RETURN json_build_object(
+      'success', false,
+      'error', 'Prazo de palpite encerrado',
+      'deadline', v_deadline
+    );
+  END IF;
+
+  DELETE FROM public.bolao_predictions
+   WHERE bolao_id = p_bolao_id
+     AND user_id = v_user_id
+     AND match_id = p_match_id;
+
+  RETURN json_build_object('success', true);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.delete_bolao_prediction(uuid, int) TO authenticated;


### PR DESCRIPTION
## Resumo

Terceira onda do plano de UX/CRO documentado em [docs/bolao-audit-and-implementation-plan.md](docs/bolao-audit-and-implementation-plan.md). Foco em **P2 (Qualidade)** + completude de features que faltavam.

**Branch base:** `feature/bolao-onda2-ux` (depende da Onda 2 que está em PR #136).

---

## O que muda na percepção do usuário

| Antes | Depois |
|---|---|
| Não consigo sair de bolão de amigo (só dono pode me tirar) | Botão "Sair" no header com confirmação |
| Palpitei errado — só dá pra editar, não apagar | Menu 3 pontos no card → "Apagar palpite" volta ao estado vazio |
| Owner remove membro sem volta — clique errado é tragédia | Toast com botão "Desfazer" por 5s, padrão Gmail-style |
| Palpitar é frio — sem reconhecimento | Achievement badge dourado estilo Xbox em milestones |
| "X feitos · Y disponíveis" — passivo | Barra de progresso azul → verde com aria-valuenow |
| Tela vazia enquanto carrega ranking/champion | Skeletons pulsantes |
| Código de convite só pra leitura | 1 clique copia + toast |
| Champion Pick com retângulo cinza no lugar da bandeira | Bandeiras reais via flagcdn.com (100+ países) |
| Animações continuam rolando pra quem prefere parado | `prefers-reduced-motion` global → 0.01ms |
| Salvei campeão e nada aconteceu visualmente | Toast "Palpite de campeão salvo · BRA" |

---

## Bloco A — Ações que faltavam

### Sair do bolão
- Botão `LogOut` no header (não-owner). Em mobile: só ícone.
- ConfirmDialog vermelho explicando que palpites serão removidos
- Foco inicial em "Cancelar" (Enter cancela, mais seguro)

### Zerar palpite
- **Migration 044**: novo RPC `delete_bolao_prediction` com mesma validação de deadline + `is_closed` do submit
- Menu 3 pontos no card (só aparece se há palpite, não locked, não finished)
- ConfirmDialog "Apagar palpite" → palpite some, inputs voltam a `- x -`
- **Bug fix**: card limpa rascunho local automaticamente quando prediction desaparece (useRef pra trackear previous; antes deixava badge "Rascunho" zumbi)

### Undo no remover membro (admin panel)
- Padrão Gmail-style: clique 1x esconde da UI imediatamente + toast com **"Desfazer"** por 5s
- Sem undo, RPC executa server-side
- Cliques duplos rápidos no mesmo membro são ignorados
- Substitui o padrão antigo "click 1 = confirmar / click 2 = remove"

### `<ConfirmDialog>` reusável (componente novo)
Variants `default` / `destructive`. Foco automático no Cancelar pra Enter ser seguro.

---

## Bloco B — Achievement system

**Componente novo:** [src/components/bolao/AchievementProvider.tsx](src/components/bolao/AchievementProvider.tsx)

Provider global com fila de notificações. Drop-down do topo, badge dourado com ícone+título+descrição. **8 conquistas registradas**:

| ID | Título | Quando dispara |
|---|---|---|
| `first-prediction` | Primeiro palpite | 1ª prediction salva no bolão |
| `first-exact-score` | Cravou o placar | `points_earned >= scoring_exact` em qualquer match |
| `reached-podium` | No pódio | Top 3 com 3+ membros e jogos finalizados |
| `all-group-stage-done` | Fase de grupos completa | Palpitou todos os 48 jogos de grupo |
| `champion-picked` | Apostou alto | Escolheu campeão |
| `first-special-pick` | Olho de águia | 1ª pick especial qualquer (finalista/semi/quartas/r32) |
| `all-finalists-picked` | Aposta final | Completou os 2 finalistas |
| `streak-5-correct` | Sequência de 5 | Reservado pra futuro (5 acertos seguidos) |

**Persistência**: cada conquista grava em `localStorage` com key `achievement_unlocked_<id>_<bolaoId>` — não dispara 2× pro mesmo user/bolão.

**Animação**: drop-down do topo com bounce (cubic-bezier), 3.5s total. Respeita `prefers-reduced-motion`.

### Barra de progresso visual
Card "Palpites dos Jogos" agora tem barra fina azul → verde quando 100%. Inclui `aria-valuenow` pra screen readers.

---

## Bloco C — Loading skeletons

- **Ranking tab**: 4 linhas pulsantes durante `useBolaoRanking`
- **Champion sidebar card**: 3 chips pulsantes durante `useChampionPredictions`
- **BolaoStatsPanel**: já tinha (mantido)

---

## Bloco D — Polimento

### Invite code clicável
Hash + código na info bar agora é botão. 1 clique → `navigator.clipboard.writeText()` + toast. `aria-label` "Copiar código de convite XYZ".

### Bandeiras reais
**Componente refactorado:** [src/components/bolao/TeamFlag.tsx](src/components/bolao/TeamFlag.tsx)

- Mapeamento FIFA (3 letras) → ISO 3166-1 alpha-2 (2 letras)
- 100+ países cobertos em todas as confederações: CONMEBOL, UEFA (+países pequenos como BIH, MNE, MKD, ALB), CONCACAF (+CUW, SUR), CAF (+CPV, COD, ANG, KEN), AFC, OFC
- Fonte: `flagcdn.com` (CDN público, free, alta resolução)
- Fallback graceful pro placeholder cinza original em 2 casos: código não mapeado, ou imagem falha de carregar
- Sizes preset: `sm` (5×3.5), `md` (7×5), `lg` (10×7)
- Aplicado em **ChampionPickModal** e **SpecialPredictionsSection**

---

## Bloco E — Acessibilidade avançada

### `prefers-reduced-motion` global
Regra CSS aplicada em `*` reduz `animation-duration` e `transition-duration` pra `0.01ms` e `scroll-behavior` pra `auto`. Quem ativou "Reduzir movimento" no SO não tem mais vertigem com animações.

### Aria-labels novos
LogOut, MoreVertical (menu), Hash (invite code), Star toggles, achievement badges (`role="status"` + `aria-live="polite"`).

---

## Fixes pós-validação manual

Bugs reportados e corrigidos antes do commit:

1. **Apagar palpite deixava "Rascunho" zumbi** — useEffect só sincronizava quando `prediction` existia. Fix: `useRef` pra trackear previous; quando `prediction` desaparece, limpa inputs + draft do localStorage.
2. **Salvar campeão sem feedback** — `handleChampionConfirm` agora dispara toast em success E error.
3. **Modal Champion não atualizava ao reabrir** — `useState(currentPick)` só inicializava no mount. Fix: `useEffect(() => setSelected(currentPick), [open, currentPick])`.
4. **Bandeiras faltando** (BIH, CUW, CPV, COD) — adicionei +20 países no mapping.
5. **Special Predictions sem bandeiras** — adicionei `<TeamFlag>` acima do código em cada team button.
6. **2 achievements novos** pros Especiais por solicitação do usuário.

---

## Rollout em produção

**Antes do merge:**
- [x] TypeScript compila sem erros
- [x] 44 testes da Onda 2 ainda passando
- [x] Servidor local roda sem erros de runtime
- [x] Migration 044 aplicada em staging
- [ ] Onda 1 (#135) e Onda 2 (#136) precisam estar mergeadas antes desta

**Antes do deploy do frontend em prod:**
- Aplicar **migration 044** em prod (`lavclmlvvfzkblrstojd`): único arquivo SQL [supabase/migrations/044_bolao_delete_prediction.sql](supabase/migrations/044_bolao_delete_prediction.sql)
- Smoke test: `SELECT public.delete_bolao_prediction('bolao-id', 1);` deve retornar `{success: false, error: 'Not authenticated'}` ou similar (depende do contexto)

---

## Test plan

### UX manual
- [ ] Sair do bolão (não-owner) → ConfirmDialog → confirma → redireciona pra `/bolao`
- [ ] Apagar palpite → ConfirmDialog → confirma → inputs voltam pra vazio, sem "Rascunho" zumbi
- [ ] Remover membro → toast com Desfazer → cliquei undo → membro reaparece
- [ ] Achievement aparece na primeira ação correspondente
- [ ] Achievement não aparece na segunda vez (persistido)
- [ ] Barra de progresso atualiza em tempo real
- [ ] Skeletons aparecem em refresh com network throttle
- [ ] Código de convite copia ao clicar
- [ ] Bandeiras reais em Champion Pick e Special Predictions
- [ ] DevTools → emulate prefers-reduced-motion → animações somem

### Automatizados (já passando)
- [x] `npm run test:run` → 44/44 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
