### PR TITLE
fix(og-bolao): index.ts -> index.tsx pra desbloquear deploy da edge function

### DIFF
--- a/supabase/functions/og-bolao/index.tsx
+++ b/supabase/functions/og-bolao/index.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource https://esm.sh/react@18.2.0 */
 // @ts-nocheck — Deno edge function. TS check rodado pelo deploy do Supabase.
 //
 // OG image dinâmica pra bolão.


### PR DESCRIPTION
## Bug

Deploy de `og-bolao` falhou com:

```
Failed to bundle the function (reason: The module's source code could not be parsed:
Expected '>', got 'style' at file:///tmp/.../source/index.ts:52:11)
```

## Causa

A função gera OG image dinâmica via `og_edge` (Satori) e tem JSX inline (`<div style={{...}}>`).
Mas o arquivo é `.ts` — Deno só parseia JSX em `.tsx`.

## Fix

- `git mv index.ts → index.tsx` (preserva histórico)
- Adiciona pragma `/** @jsxImportSource https://esm.sh/react@18.2.0 */` no topo
  pra garantir resolução do React 18 que `og_edge` espera

## Como deployar depois desse merge

```bash
supabase functions deploy og-bolao --project-ref <prod>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)