### PR TITLE
fix(bolao): 4 bloqueantes do stripe-webhook (review do PR #140)

### DIFF
--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -9,6 +9,25 @@ const stripe = new Stripe(Deno.env.get('STRIPE_SECRET_KEY') || '', {
 
 const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SIGNING_SECRET') || '';
 
+/**
+ * Gera invite_code compatível com `bolao.service.ts > generateInviteCode`:
+ * alfabeto custom sem caracteres ambíguos (I/O/0/1), sempre 6 chars.
+ *
+ * Substitui o `Math.random().toString(36).substring(2, 8).toUpperCase()` antigo
+ * que (B4 do PR #140 review):
+ *   1. Podia produzir <6 chars (Math.random dando valor com poucos dígitos)
+ *   2. Tinha alfabeto diferente do gerado pelo frontend (caracteres ambíguos)
+ *   3. Não tinha retry em colisão de UNIQUE
+ */
+function generateInviteCode(): string {
+  const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // sem I/O/0/1
+  let code = '';
+  for (let i = 0; i < 6; i++) {
+    code += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return code;
+}
+
 serve(async (req) => {
   console.log('[Webhook] Request received');
   console.log('[Webhook] Method:', req.method);
@@ -113,12 +132,31 @@ serve(async (req) => {
           (session.mode === 'payment' && bolaoId && isUuid(bolaoId));
 
         if (isBolaoPayment && bolaoId) {
-          // Check if bolão already exists (old flow: created before payment)
+          // B1 — Hijack protection: bolaoId vem de metadata.bolaoId OU
+          // client_reference_id, ambos controlados pelo cliente. UUIDs vazam
+          // em links de convite. Sem validar ownership, atacante pode pagar
+          // R$ 19,90 passando bolaoId de outro user e promover bolão alheio.
+          // SELECT inclui owner_id pra checar antes do UPDATE.
           const { data: existingBolao } = await supabase
             .from('boloes')
-            .select('id')
+            .select('id, owner_id')
             .eq('id', bolaoId)
             .maybeSingle();
+
+          if (existingBolao && userId && existingBolao.owner_id !== userId) {
+            console.error('[Webhook] ⚠️ HIJACK ATTEMPT: payer is not bolao owner', {
+              bolaoId,
+              payingUser: userId,
+              actualOwner: existingBolao.owner_id,
+              sessionId: session.id,
+            });
+            // Retorna 200 pra Stripe NÃO retentar (não é erro do nosso lado,
+            // é fraude do atacante). Marcamos no body pra log/auditoria.
+            return new Response(
+              JSON.stringify({ received: true, hijack_attempt: true }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } }
+            );
+          }
 
           if (existingBolao) {
             // Old flow: bolão was created before payment — just upgrade it
@@ -135,42 +173,82 @@ serve(async (req) => {
             // New flow: create the bolão now (user paid without prior creation)
             const bolaoName = session.metadata?.bolaoName || 'Bolão Copa 2026';
             const bolaoDescription = session.metadata?.bolaoDescription || null;
-            const inviteCode = Math.random().toString(36).substring(2, 8).toUpperCase();
 
-            const { error: createError } = await supabase.from('boloes').insert({
-              id: bolaoId,
-              owner_id: userId || null,
-              name: bolaoName,
-              description: bolaoDescription,
-              invite_code: inviteCode,
-              is_premium: true,
-              max_participants: 9999,
-            });
+            // B4 — Retry on collision: invite_code é UNIQUE em boloes.
+            // Se a primeira tentativa colidir, regenera e tenta de novo.
+            // Max 3 tentativas pra evitar loop. Sucesso garante 1 INSERT atômico.
+            let createError: { code?: string; message?: string } | null = null;
+            let attempts = 0;
+            const MAX_ATTEMPTS = 3;
 
-            if (createError) {
-              console.error('[Webhook] Error creating premium bolão:', createError);
-            } else {
-              console.log('[Webhook] ✅ Premium bolão created:', bolaoId);
+            while (attempts < MAX_ATTEMPTS) {
+              const inviteCode = generateInviteCode();
+              const { error } = await supabase.from('boloes').insert({
+                id: bolaoId,
+                owner_id: userId || null,
+                name: bolaoName,
+                description: bolaoDescription,
+                invite_code: inviteCode,
+                is_premium: true,
+                max_participants: 9999,
+              });
+
+              if (!error) {
+                createError = null;
+                console.log('[Webhook] ✅ Premium bolão created:', bolaoId, 'invite:', inviteCode);
+                break;
+              }
+
+              // 23505 = unique_violation (Postgres). Verifica se foi
+              // invite_code que colidiu (pode ser id, mas id é UUID pré-gerado
+              // e não deveria colidir; se colidir, é bug maior — não retry).
+              const isInviteCollision =
+                error.code === '23505' &&
+                (error.message?.includes('invite_code') ?? false);
+
+              if (!isInviteCollision) {
+                createError = error;
+                console.error('[Webhook] Error creating premium bolão:', error);
+                break;
+              }
+
+              attempts++;
+              console.warn(`[Webhook] invite_code collision (attempt ${attempts}/${MAX_ATTEMPTS}), regenerating`);
+            }
+
+            if (!createError && attempts < MAX_ATTEMPTS) {
               // Add owner as member
               if (userId) {
-                await supabase.from('bolao_members').insert({
+                const { error: memberError } = await supabase.from('bolao_members').insert({
                   bolao_id: bolaoId,
                   user_id: userId,
                   role: 'owner',
                 });
+                if (memberError) {
+                  // Bolão criado mas membership falhou — bug funcional silencioso
+                  // (dono fica sem acesso). Log loud pra investigação manual.
+                  console.error('[Webhook] ⚠️ Bolão created but owner membership failed', {
+                    bolaoId, userId, error: memberError,
+                  });
+                }
               }
+            } else if (attempts >= MAX_ATTEMPTS) {
+              console.error('[Webhook] ❌ Failed to create bolão after 3 invite_code collisions', { bolaoId });
             }
           }
 
-          // Record the purchase
+          // Record the purchase — upsert por stripe_session_id pra idempotência
+          // (B2: Stripe retenta eventos. Sem upsert, 2 entregas = 2 rows.)
           if (userId) {
-            const { error: subError } = await supabase.from('bolao_subscriptions').insert({
-              user_id: userId,
-              bolao_id: bolaoId,
-              type: 'bolao_premium',
-              stripe_session_id: session.id,
-              status: 'active',
-            });
+            const { error: subError } = await supabase
+              .from('bolao_subscriptions')
+              .upsert({
+                user_id: userId,
+                bolao_id: bolaoId,
+                type: 'bolao_premium',
+                stripe_session_id: session.id,
+                status: 'active',
+              }, { onConflict: 'stripe_session_id' });
             if (subError) console.error('[Webhook] Error recording purchase:', subError);
             else console.log('[Webhook] Purchase recorded for user:', userId);
           }

--- a/supabase/migrations/042_bolao_subscriptions_unique_session.sql
+++ b/supabase/migrations/042_bolao_subscriptions_unique_session.sql
@@ -1,0 +1,27 @@
+-- ============================================================
+-- B2 — Idempotência do webhook Stripe via UNIQUE(stripe_session_id)
+-- ============================================================
+-- Bug do PR #140 review: bolao_subscriptions sem UNIQUE em stripe_session_id.
+-- Stripe retenta eventos quando o webhook responde com 5xx/timeout —
+-- sem UNIQUE, duas entregas da mesma session geram duas rows = inconsistência
+-- contábil + double-charge ghost.
+--
+-- Fix: PARTIAL UNIQUE INDEX em stripe_session_id WHERE NOT NULL.
+-- Permite múltiplas rows com NULL (legacy / não-Stripe) mas garante 1:1
+-- pra sessões reais do Stripe.
+-- ============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'bolao_subscriptions_stripe_session_id_unique'
+  ) THEN
+    CREATE UNIQUE INDEX bolao_subscriptions_stripe_session_id_unique
+      ON public.bolao_subscriptions (stripe_session_id)
+      WHERE stripe_session_id IS NOT NULL;
+  END IF;
+END
+$$;

--- a/supabase/migrations/043_bolao_delete_complete_cascade.sql
+++ b/supabase/migrations/043_bolao_delete_complete_cascade.sql
@@ -1,0 +1,69 @@
+-- ============================================================
+-- B3 — delete_bolao com cascade completo + transação atômica
+-- ============================================================
+-- Bug do PR #140 review: a versão anterior do delete_bolao fazia DELETE manual
+-- em 4 tabelas (special_predictions, predictions, members, boloes) sem
+-- BEGIN/EXCEPTION. Se um DELETE intermediário falhasse, o estado ficava
+-- inconsistente (membros/palpites apagados mas bolão preservado).
+--
+-- Além disso, não cobria bolao_insights e bolao_subscriptions.
+--
+-- Fix:
+--   - Confia no FK cascade (já configurado no baseline):
+--     * bolao_members         ON DELETE CASCADE
+--     * bolao_predictions     ON DELETE CASCADE
+--     * bolao_special_predictions ON DELETE CASCADE
+--     * bolao_insights        ON DELETE CASCADE
+--     * bolao_subscriptions   ON DELETE SET NULL (preserva histórico contábil)
+--   - Wrap em BEGIN...EXCEPTION pra rollback atômico em caso de erro
+--   - Em caso de falha, retorna JSON com erro descritivo em vez de propagar exception
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.delete_bolao(p_bolao_id uuid)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id  uuid;
+  v_owner_id uuid;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Não autenticado');
+  END IF;
+
+  SELECT owner_id INTO v_owner_id
+    FROM boloes
+   WHERE id = p_bolao_id;
+
+  IF v_owner_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Bolão não encontrado');
+  END IF;
+
+  IF v_owner_id <> v_user_id THEN
+    RETURN json_build_object('success', false, 'error', 'Apenas o dono pode excluir o bolão');
+  END IF;
+
+  -- Bloco atômico: se o DELETE falhar (ex: FK orphan inesperado, constraint
+  -- check, etc.), faz rollback automático do bloco e retorna erro estruturado
+  -- em vez de propagar exception pro client (RLS / RPC ficaria broken).
+  BEGIN
+    -- DELETE em boloes dispara CASCADE em tudo que tem FK CASCADE,
+    -- e SET NULL em bolao_subscriptions.bolao_id.
+    DELETE FROM boloes WHERE id = p_bolao_id;
+
+    RETURN json_build_object('success', true);
+
+  EXCEPTION WHEN OTHERS THEN
+    -- Log no postgres log + retorno estruturado
+    RAISE WARNING '[delete_bolao] Falha excluindo % (user %): %',
+      p_bolao_id, v_user_id, SQLERRM;
+    RETURN json_build_object(
+      'success', false,
+      'error', 'Erro ao excluir: ' || SQLERRM
+    );
+  END;
+END;
+$function$;


### PR DESCRIPTION
## TL;DR

Resolve os **4 bloqueantes** identificados no review crítico do PR #140 (`docs/pr-140-review.md`, 08/mai/2026) no fluxo Stripe `bolao_premium`. Depois desse PR mergeado + 2 migrations aplicadas em prod + redeploy do `stripe-webhook`, o bolão Premium fica seguro pra liberar.

## Bloqueantes corrigidos

### B1 — Hijack protection no webhook

**Antes:** o handler de `checkout.session.completed` para `bolao_premium` buscava `select('id').eq('id', bolaoId)` e dava UPDATE em `is_premium=true` sem validar ownership. `bolaoId` vem de `metadata.bolaoId` OU `client_reference_id`, ambos **controlados pelo cliente**. UUIDs vazam em links de convite. **Atacante podia pagar R$ 19,90 com `bolaoId` de outro user e promover bolão alheio a Premium**, registrando ainda uma row em `bolao_subscriptions` com `user_id` do atacante e `bolao_id` da vítima.

**Agora:** SELECT inclui `owner_id`. Se `existingBolao.owner_id !== userId`:
- Retorna 200 (Stripe não retenta — não é erro nosso) com `hijack_attempt: true` no body
- `console.error` com contexto pra audit: `{ bolaoId, payingUser, actualOwner, sessionId }`

### B2 — Idempotência via UNIQUE(stripe_session_id)

Nova migration `042_bolao_subscriptions_unique_session.sql`:

**Antes:** `bolao_subscriptions` sem UNIQUE em `stripe_session_id`. Stripe retenta eventos em 5xx/timeout — 2 entregas = 2 rows = inconsistência contábil.

**Agora:** PARTIAL UNIQUE INDEX em `stripe_session_id WHERE NOT NULL` (permite múltiplos NULL pra rows legacy) + INSERT no webhook trocado por `upsert({ ... }, { onConflict: 'stripe_session_id' })`.

### B3 — delete_bolao com cascade completo + transação

Nova migration `043_bolao_delete_complete_cascade.sql`:

**Antes:** DELETE manual em 4 tabelas (`bolao_special_predictions`, `bolao_predictions`, `bolao_members`, `boloes`) sem `BEGIN/EXCEPTION`. Se um intermediário falhasse, ficava estado zumbi (filhos apagados, bolão preservado). Também não cobria `bolao_insights` nem `bolao_subscriptions`.

**Agora:**
- Confia no FK CASCADE já configurado no baseline:
  - `bolao_members`, `bolao_predictions`, `bolao_special_predictions`, `bolao_insights`: `ON DELETE CASCADE`
  - `bolao_subscriptions.bolao_id`: `ON DELETE SET NULL` (preserva histórico contábil)
- DELETE simplificado pra só `DELETE FROM boloes` — cascade FK cuida do resto
- Wrap em `BEGIN ... EXCEPTION WHEN OTHERS THEN` pra rollback atômico + retorno JSON estruturado

### B4 — invite_code consistente + retry on collision

**Antes:** `Math.random().toString(36).substring(2, 8).toUpperCase()` podia produzir <6 chars (Math.random com poucos dígitos significativos) + alfabeto divergente do frontend (com caracteres ambíguos como I/O/0/1) + sem retry on collision.

**Agora:** função `generateInviteCode()` replica `bolao.service.ts` (alfabeto `ABCDEFGHJKLMNPQRSTUVWXYZ23456789`, 6 chars sempre) + loop de retry de 3 tentativas detectando Postgres `23505` em `invite_code` (vs `id`, que é UUID pré-gerado).

## Bonus

Log loud quando `bolao_members.insert` (owner como member) falhar — antes era bug funcional silencioso onde o dono pagava Premium mas ficava sem acesso.

## Migrations a aplicar em prod

| # | Arquivo | O que faz |
|---|---|---|
| 1 | `042_bolao_subscriptions_unique_session.sql` | PARTIAL UNIQUE INDEX |
| 2 | `043_bolao_delete_complete_cascade.sql` | `CREATE OR REPLACE FUNCTION delete_bolao` |

## Redeploy edge function

```
supabase functions deploy stripe-webhook --project-ref <prod>
```

Ou via UI Dashboard, colar o novo `stripe-webhook/index.ts`.

## Validação

- ✅ `tsc --noEmit` passou
- ⚠️ Hijack test recomendado em staging: criar bolão Free no user A, copiar UUID, fazer checkout `bolao_premium` no user B com `bolaoId` do A → confirmar que webhook não promove bolão de A (log mostra hijack_attempt)
- ⚠️ Idempotência test: disparar `checkout.session.completed` 2x pra mesma session → confirmar 1 row em `bolao_subscriptions`
- ⚠️ Delete cascade test: criar bolão Premium com Stripe → registrar `bolao_subscriptions` → excluir bolão → confirmar `bolao_id` virou NULL em `bolao_subscriptions` (preserva contábil)

## Próximo após esse PR

Depois de aplicado + validado:
- Flippar `SHOW_BOLAO_NAV_ITEM = true` no `AnalyticsNav.tsx` pra liberar bolão pros users

🤖 Generated with [Claude Code](https://claude.com/claude-code)
