### PR TITLE
fix(bolao): 6 bugs do feedback do Diody (Premium-required em 3 fluxos + 3 bugs UX)

### DIFF
--- a/src/components/bolao/PredictionsList.tsx
+++ b/src/components/bolao/PredictionsList.tsx
@@ -259,28 +259,13 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dateFilter, filterMode]);
 
-  // Auto-avançar pro próximo dia com pendências quando o dia atual ficar completo.
-  // 800ms de delay pra dar tempo do user perceber "✓ Tudo palpitado".
-  // Cancela se user trocar de dia manualmente antes do timer disparar.
-  useEffect(() => {
-    if (filterMode !== 'date' || dateFilter === 'all') return;
-    if (!selectedDayStats) return;
-    if (selectedDayStats.total === 0) return;
-    if (selectedDayStats.palpitated < selectedDayStats.total) return;
-
-    const timer = setTimeout(() => {
-      // Procura próximo dia (após o atual) com ao menos um jogo pendente
-      const currentIndex = dates.indexOf(dateFilter);
-      const nextDate = dates
-        .slice(currentIndex + 1)
-        .find((d) => (pendingByDate.get(d) ?? 0) > 0);
-      if (nextDate) {
-        setDateFilter(nextDate);
-      }
-      // Se não há próximo, fica no dia atual com a mensagem "Tudo palpitado"
-    }, 800);
-    return () => clearTimeout(timer);
-  }, [filterMode, dateFilter, selectedDayStats, dates, pendingByDate]);
+  // Removido: auto-advance pro próximo dia quando o dia atual fica completo.
+  // Motivo (feedback Diody, 18/mai/2026): quando o user clica num dia que JÁ
+  // tem todos palpites preenchidos pra revisar/editar, o effect disparava
+  // depois de 800ms e trocava o filter pro próximo dia pendente — "não dava
+  // pra ficar no dia que já preenchi". A intenção era educada (guiar pro
+  // próximo) mas virou agressiva. Se o user quer pular pra próximo pendente,
+  // ele tem outras formas: botão "Próximo" da sticky bar + chip "só pendentes".
 
   return (
     <>

--- a/src/components/bolao/useQuickPickUndo.ts
+++ b/src/components/bolao/useQuickPickUndo.ts
@@ -61,13 +61,22 @@ export function useQuickPickUndo(bolaoId: string, predictions: BolaoPrediction[]
 
         let deletedCount = 0;
         let failedCount = 0;
+        const failedErrors: string[] = [];
         if (toDelete.length > 0) {
+          // Log detalhado: silenciar com .catch(() => false) escondia bugs
+          // tipo prazo encerrado, auth perdida, RLS, etc. Agora cada falha
+          // vai pro console.error com contexto + acumula mensagem pra toast.
           const results = await Promise.all(
             toDelete.map((id) =>
               bolaoService
                 .deletePrediction(bolaoId, id)
                 .then(() => true)
-                .catch(() => false)
+                .catch((err: unknown) => {
+                  const msg = err instanceof Error ? err.message : String(err);
+                  console.error(`[QuickPickUndo] Falha excluindo match ${id}:`, err);
+                  failedErrors.push(`match ${id}: ${msg}`);
+                  return false;
+                })
             )
           );
           deletedCount = results.filter((r) => r).length;
@@ -102,9 +111,11 @@ export function useQuickPickUndo(bolaoId: string, predictions: BolaoPrediction[]
         ]);
 
         if (failedCount > 0) {
+          // Mostra a primeira mensagem real de erro pro user entender o que rolou
+          const firstError = failedErrors[0] ?? 'erro desconhecido';
           toast({
-            title: 'Desfeito parcialmente',
-            description: `${deletedCount} apagados, ${failedCount} falharam. ${toRestore.length} restaurados.`,
+            title: 'Não consegui desfazer todos',
+            description: `${deletedCount} apagados, ${failedCount} falharam. Causa: ${firstError}`,
             variant: 'destructive',
           });
         } else {

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -23,10 +23,16 @@ export function Toaster() {
     <ToastProvider>
       <ToastViewport />
       {toasts.map(function ({ id, title, description, action, variant, className, ...props }) {
+        // Em /bolao usamos paleta light "Direção A". Cores LITERAIS (#hex)
+        // em vez de CSS vars (var(--ink)) porque o portal do Radix renderiza
+        // no body — fora do escopo de `.theme-bolao` do BolaoLayout, então
+        // var(--ink) pode resolver pra undefined dependendo do browser
+        // (especialmente iOS Safari mobile em system light mode), resultando
+        // em texto invisível ("branco em branco").
         const themeClass = isBolao
           ? variant === 'destructive'
-            ? 'theme-bolao !bg-status-danger !border-status-danger !text-white'
-            : 'theme-bolao !bg-white !border-line !text-ink shadow-md'
+            ? '!bg-[#b91c1c] !border-[#b91c1c] !text-white'
+            : '!bg-white !border-[#e3e6e0] !text-[#1a1d1a] shadow-md'
           : ''
         return (
           <Toast
@@ -38,7 +44,7 @@ export function Toaster() {
             <div className="grid gap-1">
               {title && <ToastTitle>{title}</ToastTitle>}
               {description && (
-                <ToastDescription className={isBolao && variant !== 'destructive' ? 'text-ink-2' : undefined}>
+                <ToastDescription className={isBolao && variant !== 'destructive' ? '!text-[#4a4f48]' : undefined}>
                   {description}
                 </ToastDescription>
               )}

--- a/supabase/migrations/044_bolao_liberar_premium_features.sql
+++ b/supabase/migrations/044_bolao_liberar_premium_features.sql
@@ -1,0 +1,322 @@
+-- ============================================================
+-- BUGS DO REVIEW DO DIODY — Liberar features que eram Premium pra Free
+-- ============================================================
+-- PR #140 do Vitor (Onda 6) decidiu liberar TODAS as features pra Free:
+-- pontuação custom, multiplicador, palpites especiais, logo, cores,
+-- heatmap, versus. Só o limite de participantes muda (Free 20 / Premium 9999).
+--
+-- Mas o backend (RPCs) continuou bloqueando com 'Premium required'. Diody
+-- testando em prod viu erro em 3 fluxos:
+--   - Selecionar finalista        → toggle_special_prediction
+--   - Trocar logo                 → update_bolao_theme
+--   - Salvar pontuação custom     → update_bolao_scoring
+--
+-- + 2 funções que também tinham check Premium e merecem ser liberadas:
+--   - get_my_team_heatmap (stats por time)
+--   - get_versus_stats    (comparação 1×1)
+--
+-- Esta migration recria as 5 funções SEM o IF NOT is_premium THEN error.
+-- ============================================================
+
+-- ─── toggle_special_prediction ──────────────────────────────
+-- Toggle palpite especial (finalist/semifinalist/quarterfinalist/round_of_32).
+-- Validações: autenticado, membro do bolão, tipo válido, máx picks por tipo.
+-- SEM check Premium.
+CREATE OR REPLACE FUNCTION public.toggle_special_prediction(
+  p_bolao_id uuid,
+  p_prediction_type text,
+  p_team_code text
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id uuid;
+  v_max_picks int;
+  v_current_count int;
+  v_exists boolean;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+
+  IF p_prediction_type NOT IN ('finalist', 'semifinalist', 'quarterfinalist', 'round_of_32') THEN
+    RETURN json_build_object('success', false, 'error', 'Invalid prediction type');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+  ) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member');
+  END IF;
+
+  -- SEM check Premium — Diody decisão: liberar pra Free também.
+
+  v_max_picks := CASE p_prediction_type
+    WHEN 'finalist'        THEN 2
+    WHEN 'semifinalist'    THEN 4
+    WHEN 'quarterfinalist' THEN 8
+    WHEN 'round_of_32'     THEN 16
+    ELSE 4
+  END;
+
+  SELECT EXISTS(
+    SELECT 1 FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+      AND prediction_type = p_prediction_type AND predicted_team_code = p_team_code
+  ) INTO v_exists;
+
+  IF v_exists THEN
+    DELETE FROM bolao_special_predictions
+      WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+        AND prediction_type = p_prediction_type AND predicted_team_code = p_team_code;
+    RETURN json_build_object('success', true, 'action', 'removed');
+  ELSE
+    SELECT COUNT(*) INTO v_current_count
+    FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = p_prediction_type;
+
+    IF v_current_count >= v_max_picks THEN
+      RETURN json_build_object('success', false, 'error', 'Max picks reached', 'max', v_max_picks);
+    END IF;
+
+    INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_team_code)
+      VALUES (p_bolao_id, v_user_id, p_prediction_type, p_team_code);
+    RETURN json_build_object('success', true, 'action', 'added', 'count', v_current_count + 1);
+  END IF;
+END;
+$function$;
+
+-- ─── update_bolao_scoring ───────────────────────────────────
+-- Dono altera pontuação (preset + valores + pesos por fase).
+-- SEM check Premium.
+CREATE OR REPLACE FUNCTION public.update_bolao_scoring(
+  p_bolao_id uuid,
+  p_preset text,
+  p_scoring_result integer DEFAULT NULL::integer,
+  p_scoring_exact integer DEFAULT NULL::integer,
+  p_scoring_weights jsonb DEFAULT NULL::jsonb
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+DECLARE
+  v_user_id uuid;
+  v_r int; v_e int;
+  v_weights jsonb;
+  v_allowed_stages text[] := ARRAY['group','round_of_32','round_of_16','quarter','semi','third_place','final'];
+  v_key text;
+  v_val numeric;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.boloes WHERE id = p_bolao_id AND owner_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not the owner');
+  END IF;
+
+  -- SEM check Premium — PR #140 liberou pontuação custom pra Free.
+
+  IF p_preset = 'standard' THEN
+    v_r := 1; v_e := 3;
+  ELSIF p_preset = 'classic' THEN
+    v_r := 1; v_e := 5;
+  ELSIF p_preset = 'weighted_stages' THEN
+    v_r := COALESCE(p_scoring_result, 1);
+    v_e := COALESCE(p_scoring_exact, 3);
+  ELSIF p_preset = 'custom' THEN
+    IF p_scoring_result IS NULL OR p_scoring_exact IS NULL THEN
+      RETURN json_build_object('success', false, 'error', 'Custom preset requires scoring values');
+    END IF;
+    v_r := p_scoring_result; v_e := p_scoring_exact;
+  ELSE
+    RETURN json_build_object('success', false, 'error', 'Invalid preset');
+  END IF;
+
+  IF v_r < 1 OR v_r > 10 THEN
+    RETURN json_build_object('success', false, 'error', 'scoring_result must be 1-10');
+  END IF;
+  IF v_e < 1 OR v_e > 20 THEN
+    RETURN json_build_object('success', false, 'error', 'scoring_exact must be 1-20');
+  END IF;
+
+  IF p_scoring_weights IS NOT NULL THEN
+    IF p_preset <> 'weighted_stages' THEN
+      v_weights := NULL;
+    ELSE
+      FOR v_key IN SELECT jsonb_object_keys(p_scoring_weights) LOOP
+        IF NOT (v_key = ANY(v_allowed_stages)) THEN
+          RETURN json_build_object('success', false, 'error', 'Invalid stage in scoring_weights: ' || v_key);
+        END IF;
+        v_val := (p_scoring_weights ->> v_key)::numeric;
+        IF v_val < 0.5 OR v_val > 10 THEN
+          RETURN json_build_object('success', false, 'error', 'Weight for ' || v_key || ' must be 0.5-10');
+        END IF;
+      END LOOP;
+      v_weights := p_scoring_weights;
+    END IF;
+  ELSE
+    IF p_preset <> 'weighted_stages' THEN
+      v_weights := NULL;
+    ELSE
+      SELECT scoring_weights INTO v_weights FROM public.boloes WHERE id = p_bolao_id;
+    END IF;
+  END IF;
+
+  UPDATE public.boloes
+    SET scoring_preset = p_preset,
+        scoring_result = v_r,
+        scoring_exact = v_e,
+        scoring_weights = v_weights
+    WHERE id = p_bolao_id;
+
+  RETURN json_build_object(
+    'success', true,
+    'scoring_result', v_r,
+    'scoring_exact', v_e,
+    'scoring_weights', v_weights
+  );
+END;
+$function$;
+
+-- ─── update_bolao_theme ─────────────────────────────────────
+-- Dono altera cor + logo do bolão.
+-- SEM check Premium.
+CREATE OR REPLACE FUNCTION public.update_bolao_theme(
+  p_bolao_id uuid,
+  p_color text DEFAULT NULL::text,
+  p_logo_url text DEFAULT NULL::text
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $function$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM boloes WHERE id = p_bolao_id AND owner_id = auth.uid()) THEN
+    RETURN json_build_object('success', false, 'error', 'Not the owner');
+  END IF;
+
+  -- SEM check Premium — PR #140 liberou customização pra Free.
+
+  UPDATE boloes
+    SET custom_color      = COALESCE(p_color, custom_color),
+        custom_banner_url = COALESCE(p_logo_url, custom_banner_url)
+    WHERE id = p_bolao_id;
+  RETURN json_build_object('success', true);
+END;
+$function$;
+
+-- ─── get_my_team_heatmap ────────────────────────────────────
+-- Heatmap por time: quantos palpites + acertos pra cada seleção.
+-- SEM check Premium.
+CREATE OR REPLACE FUNCTION public.get_my_team_heatmap(p_bolao_id uuid)
+RETURNS TABLE(team_code text, team_name text, matches_predicted integer, matches_finished integer, exact_scores integer, correct_results integer, total_points integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+DECLARE
+  v_user_id uuid;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN RETURN; END IF;
+
+  -- SEM check Premium — stats avançadas liberadas pra todos.
+
+  IF NOT EXISTS (SELECT 1 FROM public.bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id) THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH all_codes AS (
+    SELECT DISTINCT m.home_team_code AS code, m.home_team AS name
+    FROM public.bolao_predictions bp
+    JOIN public.wc_matches m ON m.id = bp.match_id
+    WHERE bp.bolao_id = p_bolao_id AND bp.user_id = v_user_id
+      AND m.home_team_code <> 'TBD'
+    UNION
+    SELECT DISTINCT m.away_team_code, m.away_team
+    FROM public.bolao_predictions bp
+    JOIN public.wc_matches m ON m.id = bp.match_id
+    WHERE bp.bolao_id = p_bolao_id AND bp.user_id = v_user_id
+      AND m.away_team_code <> 'TBD'
+  ),
+  involved_predictions AS (
+    SELECT
+      ac.code,
+      ac.name,
+      bp.points_earned,
+      m.is_finished,
+      b.scoring_exact
+    FROM all_codes ac
+    JOIN public.wc_matches m ON (m.home_team_code = ac.code OR m.away_team_code = ac.code)
+    JOIN public.bolao_predictions bp ON bp.match_id = m.id AND bp.user_id = v_user_id AND bp.bolao_id = p_bolao_id
+    JOIN public.boloes b ON b.id = bp.bolao_id
+  )
+  SELECT
+    ip.code::text,
+    ip.name::text,
+    COUNT(*)::int,
+    COUNT(*) FILTER (WHERE ip.is_finished)::int,
+    COUNT(*) FILTER (WHERE ip.is_finished AND ip.points_earned >= ip.scoring_exact)::int,
+    COUNT(*) FILTER (WHERE ip.is_finished AND ip.points_earned > 0)::int,
+    COALESCE(SUM(ip.points_earned), 0)::int
+  FROM involved_predictions ip
+  GROUP BY ip.code, ip.name
+  ORDER BY total_points DESC, exact_scores DESC;
+END;
+$function$;
+
+-- ─── get_versus_stats ───────────────────────────────────────
+-- Comparação 1×1 entre user e oponente.
+-- SEM check Premium.
+CREATE OR REPLACE FUNCTION public.get_versus_stats(p_bolao_id uuid, p_opponent_user_id uuid)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+DECLARE
+  v_user_id uuid;
+  v_my_stats jsonb;
+  v_opp_stats jsonb;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN RETURN json_build_object('error', 'Not authenticated'); END IF;
+
+  -- SEM check Premium — comparação 1×1 liberada pra todos.
+
+  IF NOT EXISTS (SELECT 1 FROM public.bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id) THEN
+    RETURN json_build_object('error', 'Not a member');
+  END IF;
+
+  WITH stats AS (
+    SELECT
+      bp.user_id,
+      COALESCE(SUM(bp.points_earned), 0)::int AS total_points,
+      COUNT(*) FILTER (WHERE bp.points_earned >= b.scoring_exact)::int AS exact_scores,
+      COUNT(*) FILTER (WHERE bp.points_earned > 0)::int AS correct_results,
+      COUNT(*)::int AS total_predictions
+    FROM public.bolao_predictions bp
+    JOIN public.boloes b ON b.id = bp.bolao_id
+    WHERE bp.bolao_id = p_bolao_id
+      AND bp.user_id IN (v_user_id, p_opponent_user_id)
+    GROUP BY bp.user_id
+  )
+  SELECT
+    (SELECT to_jsonb(s) FROM stats s WHERE s.user_id = v_user_id),
+    (SELECT to_jsonb(s) FROM stats s WHERE s.user_id = p_opponent_user_id)
+  INTO v_my_stats, v_opp_stats;
+
+  RETURN json_build_object(
+    'me', COALESCE(v_my_stats, '{}'::jsonb),
+    'opponent', COALESCE(v_opp_stats, '{}'::jsonb)
+  );
+END;
+$function$;


### PR DESCRIPTION
## TL;DR

6 bugs identificados pelo Diody testando em prod hoje (18/mai). Mix de **3 bugs de backend** (RPCs com check Premium que não deveria existir — PR #140 já tinha decidido liberar tudo pra Free) + **3 bugs de frontend** (toast branco-em-branco, navegação por dia travada, log silencioso no undo).

## Bugs corrigidos

### 1. "Premium required" ao selecionar finalista
`toggle_special_prediction` tinha `IF NOT is_premium THEN error 'Premium required'`. PR #140 decidiu liberar palpites especiais (finalista, semifinalista, quartas, R32) pra Free, mas o backend não foi atualizado.

**Fix:** migration `044` recria a função sem o check Premium.

### 2. "Premium required" ao trocar logo
`update_bolao_theme` mesmo padrão. PR #140 liberou customização pra Free.

**Fix:** migration `044` remove o check.

### 3. "Premium required" ao salvar pontuação custom
`update_bolao_scoring` mesmo padrão. PR #140 liberou pontuação custom pra Free.

**Fix:** migration `044` remove o check.

### 4. Caixinha de info Quick Pick com fundo branco e letra branca (ilegível)
O `Toaster` aplicava `!text-ink !border-line !bg-white` que dependem de CSS vars (`var(--ink)`) definidas só em `.theme-bolao`. O portal do Radix Toast renderiza no body — fora do escopo de `BolaoLayout`. Em iOS Safari mobile com system light mode, vars custom às vezes não resolvem.

**Fix:** trocar pra cores literais (`#1a1d1a`, `#e3e6e0`, etc.) que sempre funcionam, independente de scope CSS.

### 5. Não consigo ficar num dia já preenchido
`PredictionsList` tinha um `useEffect` que disparava 800ms depois do user clicar num dia completo e trocava pro próximo dia pendente automaticamente. Intenção era educada ("guia pro próximo") mas virou agressiva: impede revisar/editar dias completos.

**Fix:** remover o auto-advance. Se o user quer pular, ele tem outras opções (botão "Próximo" da sticky bar + chip "só pendentes").

### 6. Quick Pick "Desfazer" não desfaz
Investigação não identificou root cause definitivo. Possíveis causas: silent fail em `Promise.all` com `.catch(() => false)` que escondia o erro real.

**Fix:** logging detalhado — agora cada falha vai pro `console.error` com contexto + a primeira mensagem de erro real aparece no toast. Próxima reprodução vai dar a info exata pra corrigir.

## Bonus

Migration 044 também remove check Premium de `get_my_team_heatmap` e `get_versus_stats` (stats avançadas) — seguindo a mesma decisão do PR #140 de liberar tudo pra Free.

## Após merge

1. **Aplicar migration `044_bolao_liberar_premium_features.sql`** em prod (via SQL Editor)
2. **Frontend deploy automático** via Vercel pega os fixes de Toaster, PredictionsList e useQuickPickUndo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
