### PR TITLE
feat(auth): revamp IDV bolão + fix redirect pós-login/signup

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -4,14 +4,42 @@ import { useTranslation } from "react-i18next";
 import { usePostHog } from "@posthog/react";
 import { createClient } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { BarChart3, Trophy } from "lucide-react";
+import { Trophy, Users, Sparkles, Check } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { LanguageToggle } from "@/components/LanguageToggle";
+
+/**
+ * Determina pra onde redirecionar o user após login/signup bem-sucedido.
+ *
+ * 1. Se houver `location.state.from` (ProtectedRoute setou — ex: link de
+ *    convite, deep link), respeita. Mantém compatibilidade com fluxos que
+ *    dependem disso (BolaoLP `/bolao/comecar` passa `state.from`).
+ * 2. Default = `/bolao`. Antes era `/onboarding`; mudado pra bolão por
+ *    decisão do produto (Diody): bolão vira a porta de entrada padrão
+ *    pós-cadastro, todos caem na home do bolão.
+ *
+ * Bug histórico que esta função corrige: `handleSignUp` ignorava
+ * `state.from` (hard-coded `/onboarding`), então quem vinha da LP do bolão
+ * via signup caía no onboarding em vez do bolão.
+ */
+function getRedirectTarget(
+  state: unknown,
+  fallback: string = "/bolao"
+): string {
+  const from = (state as { from?: { pathname?: string; search?: string } } | null)?.from;
+  if (
+    from?.pathname &&
+    from.pathname.startsWith("/") &&
+    !from.pathname.startsWith("//") // proteção contra open redirect
+  ) {
+    return from.pathname + (from.search || "");
+  }
+  return fallback;
+}
 
 const Auth = () => {
   const navigate = useNavigate();
@@ -27,7 +55,7 @@ const Auth = () => {
   const [referralCode, setReferralCode] = useState("");
   const [phoneCountryCode, setPhoneCountryCode] = useState("+55");
   const [phoneNumber, setPhoneNumber] = useState("");
-  
+
   const supabase = createClient();
 
   // Detecta se o usuario chegou aqui por um link de convite de bolao
@@ -51,52 +79,27 @@ const Auth = () => {
     setLoading(true);
 
     try {
-      const { error } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      });
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
 
       if (error) {
-        toast({
-          title: "Error",
-          description: error.message,
-          variant: "destructive",
-        });
-      } else {
-        // Get user data for PostHog identify
-        const { data: { user } } = await supabase.auth.getUser();
-        
-        if (user && posthog) {
-          // Identify user in PostHog
-          posthog.identify(user.id, {
-            email: user.email,
-            name: user.user_metadata?.name || user.email?.split('@')[0],
-          });
-          
-          // Track sign-in event
-          posthog.capture('signed_in', {
-            email: user.email,
-            method: 'email',
-          });
-        }
-        
-        toast({
-          title: "Success",
-          description: "Welcome back!",
-        });
-        const from = (location.state as { from?: { pathname?: string; search?: string } })?.from;
-        if (from?.pathname && from.pathname.startsWith("/") && !from.pathname.startsWith("//")) {
-          navigate(from.pathname + (from.search || ""));
-        } else {
-          navigate("/onboarding");
-        }
+        toast({ title: "Erro", description: error.message, variant: "destructive" });
+        return;
       }
+
+      const { data: { user } } = await supabase.auth.getUser();
+
+      if (user && posthog) {
+        posthog.identify(user.id, {
+          email: user.email,
+          name: user.user_metadata?.name || user.email?.split('@')[0],
+        });
+        posthog.capture('signed_in', { email: user.email, method: 'email' });
+      }
+
+      toast({ title: "Bem-vindo de volta!" });
+      navigate(getRedirectTarget(location.state));
     } catch (error) {
-      toast({
-        title: "Error",
-        description: "An unexpected error occurred",
-        variant: "destructive",
-      });
+      toast({ title: "Erro", description: "Ocorreu um erro inesperado", variant: "destructive" });
     } finally {
       setLoading(false);
     }
@@ -104,312 +107,411 @@ const Auth = () => {
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (password !== confirmPassword) {
-      toast({
-        title: "Error",
-        description: "Passwords do not match",
-        variant: "destructive",
-      });
+      toast({ title: "Erro", description: "As senhas não conferem", variant: "destructive" });
       return;
     }
 
     const cleanPhone = phoneNumber.replace(/\D/g, '');
     if (cleanPhone.length < 8) {
-      toast({
-        title: "Error",
-        description: "Informe um telefone válido",
-        variant: "destructive",
-      });
+      toast({ title: "Erro", description: "Informe um telefone válido", variant: "destructive" });
       return;
     }
 
     setLoading(true);
 
     try {
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-      });
+      const { error } = await supabase.auth.signUp({ email, password });
 
       if (error) {
-        toast({
-          title: "Error",
-          description: error.message,
-          variant: "destructive",
-        });
-      } else {
-        // Get the newly created user
-        const { data: { user } } = await supabase.auth.getUser();
-        if (user) {
-          const normalizedReferralCode = referralCode.trim() ? referralCode.toUpperCase().trim() : null;
-          const whatsappNumber = phoneCountryCode.replace(/\D/g, '') + cleanPhone;
-          const userData: any = {
-            id: user.id,
-            email: user.email!,
-            name: name,
-            referred_by: normalizedReferralCode,
-            whatsapp_number: whatsappNumber,
-          };
+        toast({ title: "Erro", description: error.message, variant: "destructive" });
+        return;
+      }
 
-          // Create user record in our users table
-          const { error: userError } = await supabase
-            .from('users')
-            .insert(userData);
-          
-          if (userError) {
-            console.error('Error creating user record:', userError);
-            toast({
-              title: "Error",
-              description: "Failed to create user record",
-              variant: "destructive",
-            });
-          } else if (normalizedReferralCode && userData.referred_by) {
-            // Create referral record - find referrer by code
-            try {
-              // Find referrer by code
-              const { data: referrerData, error: referrerError } = await supabase
-                .from('users')
-                .select('id')
-                .eq('referral_code', normalizedReferralCode)
-                .single();
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        const normalizedReferralCode = referralCode.trim() ? referralCode.toUpperCase().trim() : null;
+        const whatsappNumber = phoneCountryCode.replace(/\D/g, '') + cleanPhone;
+        const userData: any = {
+          id: user.id,
+          email: user.email!,
+          name,
+          referred_by: normalizedReferralCode,
+          whatsapp_number: whatsappNumber,
+        };
 
-              if (!referrerError && referrerData && referrerData.id !== user.id) {
-                // Insert into referrals table
-                await supabase
-                  .from('referrals')
-                  .insert({
-                    referrer_id: referrerData.id,
-                    referred_id: user.id,
-                    referral_code: normalizedReferralCode
-                  });
-              }
-            } catch (err) {
-              // Silent fail - referral code is already saved in referred_by
-              console.error('Error creating referral record:', err);
+        const { error: userError } = await supabase.from('users').insert(userData);
+
+        if (userError) {
+          console.error('Error creating user record:', userError);
+          toast({ title: "Erro", description: "Falha ao criar registro de usuário", variant: "destructive" });
+        } else if (normalizedReferralCode) {
+          try {
+            const { data: referrerData, error: referrerError } = await supabase
+              .from('users')
+              .select('id')
+              .eq('referral_code', normalizedReferralCode)
+              .single();
+
+            if (!referrerError && referrerData && referrerData.id !== user.id) {
+              await supabase.from('referrals').insert({
+                referrer_id: referrerData.id,
+                referred_id: user.id,
+                referral_code: normalizedReferralCode,
+              });
             }
-          }
-          
-          // Identify user in PostHog and track sign-up event
-          if (posthog) {
-            const referralProperties = normalizedReferralCode ? { referred_by_code: normalizedReferralCode } : {};
-            posthog.identify(user.id, {
-              email: user.email,
-              name: name || user.email?.split('@')[0],
-              ...referralProperties,
-            });
-            
-            posthog.capture('signed_up', {
-              email: user.email,
-              name: name,
-              method: 'email',
-              ...referralProperties,
-            });
-          }
-          
-          // Track CompleteRegistration event in Meta Pixel
-          if (typeof window !== 'undefined' && (window as any).fbq) {
-            (window as any).fbq('track', 'CompleteRegistration');
+          } catch (err) {
+            console.error('Error creating referral record:', err);
           }
         }
-        
-        toast({
-          title: "Success",
-          description: "Account created! Please check your email to verify your account.",
-        });
-        
-        // Redirect to onboarding after successful signup
-        navigate("/onboarding");
+
+        if (posthog) {
+          const referralProperties = normalizedReferralCode
+            ? { referred_by_code: normalizedReferralCode }
+            : {};
+          posthog.identify(user.id, {
+            email: user.email,
+            name: name || user.email?.split('@')[0],
+            ...referralProperties,
+          });
+          posthog.capture('signed_up', {
+            email: user.email,
+            name,
+            method: 'email',
+            ...referralProperties,
+          });
+        }
+
+        if (typeof window !== 'undefined' && (window as any).fbq) {
+          (window as any).fbq('track', 'CompleteRegistration');
+        }
       }
+
+      toast({ title: "Conta criada!", description: "Você já pode começar a usar a plataforma." });
+      // Fix: antes era hard-coded /onboarding, ignorando state.from. Agora
+      // respeita o redirect target (ex: vindo da LP do bolão).
+      navigate(getRedirectTarget(location.state));
     } catch (error) {
-      toast({
-        title: "Error",
-        description: "An unexpected error occurred",
-        variant: "destructive",
-      });
+      toast({ title: "Erro", description: "Ocorreu um erro inesperado", variant: "destructive" });
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center p-4">
-      <div className="w-full max-w-md space-y-6">
-        <div className="flex items-center justify-between">
+    // theme-bolao no root pra ativar CSS vars (--canvas, --forest, --ink, etc.)
+    // mesmo fora do BolaoLayout (Auth tem rota /auth, não /bolao/*).
+    <div className="theme-bolao min-h-screen bg-canvas flex flex-col">
+      {/* Topbar minimalista */}
+      <header className="border-b border-line bg-white">
+        <div className="max-w-screen-xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <BarChart3 className="h-8 w-8 text-primary" />
-            <span className="text-xl font-bold text-foreground">Smartbetting</span>
+            <div className="w-7 h-7 rounded-rebrand-sm bg-forest text-white grid place-items-center">
+              <Trophy className="w-4 h-4" />
+            </div>
+            <span className="font-display text-[15px] font-bold text-ink">Smartbetting</span>
           </div>
           <LanguageToggle />
         </div>
+      </header>
 
-        {/* Banner contextual quando o usuario chegou por invite de bolao */}
-        {fromBolaoInvite && (
-          <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-4">
+      {/* Conteúdo principal: split em md+ (hero left + form right), single column mobile */}
+      <div className="flex-1 grid grid-cols-1 lg:grid-cols-[1.1fr_1fr] max-w-screen-xl mx-auto w-full">
+        {/* ─── Hero (esquerda no desktop, esconde no mobile pra economizar scroll) ─── */}
+        <aside className="hidden lg:flex bg-forest text-white p-12 xl:p-16 flex-col justify-between relative overflow-hidden">
+          {/* decorações atmosféricas */}
+          <div className="absolute -right-32 -top-32 w-96 h-96 rounded-full bg-amber/10 pointer-events-none" aria-hidden />
+          <div className="absolute -left-20 bottom-20 w-72 h-72 rounded-full bg-amber/5 pointer-events-none" aria-hidden />
+
+          <div className="relative z-10">
+            <div className="text-[12px] uppercase tracking-[0.18em] font-semibold opacity-70 mb-3">
+              Bolão · Copa do Mundo 2026
+            </div>
+            <h1 className="font-display text-[42px] xl:text-[52px] leading-[1.05] font-extrabold mb-5 tracking-tight">
+              Reúne a galera.<br />
+              Palpita os 104 jogos.<br />
+              <span className="text-amber">Vê quem manja mais.</span>
+            </h1>
+            <p className="text-[15px] opacity-80 leading-relaxed max-w-[420px]">
+              Cria seu bolão em 30 segundos, compartilha no zap, e leva a galera junto. Grátis pra até 20 amigos.
+            </p>
+          </div>
+
+          <div className="relative z-10 space-y-3 max-w-[420px]">
             <div className="flex items-start gap-3">
-              <div className="w-9 h-9 rounded-md bg-amber-500/20 grid place-items-center text-amber-500 shrink-0">
+              <div className="w-8 h-8 rounded-rebrand-sm bg-amber/15 grid place-items-center text-amber shrink-0 mt-0.5">
+                <Users className="w-4 h-4" />
+              </div>
+              <div>
+                <p className="font-display text-[15px] font-bold">Convite com 1 clique</p>
+                <p className="text-[13px] opacity-70">Link direto pro WhatsApp, sem código pra digitar.</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="w-8 h-8 rounded-rebrand-sm bg-amber/15 grid place-items-center text-amber shrink-0 mt-0.5">
+                <Sparkles className="w-4 h-4" />
+              </div>
+              <div>
+                <p className="font-display text-[15px] font-bold">Quick Pick em 1 toque</p>
+                <p className="text-[13px] opacity-70">Não quer palpitar 104 jogos? Preenche tudo automático e edita depois.</p>
+              </div>
+            </div>
+            <div className="flex items-start gap-3">
+              <div className="w-8 h-8 rounded-rebrand-sm bg-amber/15 grid place-items-center text-amber shrink-0 mt-0.5">
                 <Trophy className="w-4 h-4" />
               </div>
               <div>
-                <p className="text-sm font-bold text-foreground leading-tight">
-                  Você foi convidado pro Bolão Copa 2026
-                </p>
-                <p className="text-xs text-muted-foreground mt-1 leading-snug">
-                  Crie sua conta (grátis) ou entre — depois você cai direto no bolão pra fazer seus palpites.
-                </p>
+                <p className="font-display text-[15px] font-bold">Ranking ao vivo</p>
+                <p className="text-[13px] opacity-70">Compartilha imagem do ranking nos Stories e zoeia os amigos.</p>
               </div>
             </div>
           </div>
-        )}
 
-        <Tabs defaultValue={fromBolaoInvite ? "signup" : "signin"} className="w-full">
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="signin">{t("auth.signin")}</TabsTrigger>
-            <TabsTrigger value="signup">{t("auth.signup")}</TabsTrigger>
-          </TabsList>
-          
-          <TabsContent value="signin">
-            <Card>
-              <CardHeader>
-                <CardTitle>{t("auth.signin")}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleSignIn} className="space-y-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="email">{t("auth.email")}</Label>
-                    <Input
-                      id="email"
-                      type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      required
-                    />
+          <div className="relative z-10 text-[11px] opacity-50 mt-8">
+            ✓ 100% gratuito · ✓ Sem cartão · ✓ Sem instalar nada
+          </div>
+        </aside>
+
+        {/* ─── Form (direita no desktop, ocupa toda largura no mobile) ─── */}
+        <main className="flex items-center justify-center p-4 sm:p-8 lg:p-12">
+          <div className="w-full max-w-md">
+            {/* Brand mobile-only (no desktop o hero à esquerda já tem isso) */}
+            <div className="lg:hidden mb-6 text-center">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-rebrand-md bg-forest/10 text-forest mb-3">
+                <Trophy className="w-6 h-6" />
+              </div>
+              <h2 className="font-display text-[24px] font-extrabold text-ink leading-tight">
+                Bolão Copa 2026
+              </h2>
+              <p className="text-[13px] text-ink-2 mt-1">
+                Cria seu bolão em 30 segundos.
+              </p>
+            </div>
+
+            {/* Banner quando o usuario veio de um invite de bolao */}
+            {fromBolaoInvite && (
+              <div className="rounded-rebrand-md border border-amber/40 bg-amber/10 p-4 mb-5">
+                <div className="flex items-start gap-3">
+                  <div className="w-9 h-9 rounded-rebrand-sm bg-amber/20 grid place-items-center text-amber-2 shrink-0">
+                    <Trophy className="w-4 h-4" />
                   </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="password">{t("auth.password")}</Label>
-                    <Input
-                      id="password"
-                      type="password"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <Button type="submit" className="w-full" disabled={loading}>
-                    {loading ? t("loading") : t("auth.signin")}
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
-          </TabsContent>
-          
-          <TabsContent value="signup">
-            <Card>
-              <CardHeader>
-                <CardTitle>{t("auth.signup")}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleSignUp} className="space-y-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="signup-name">Nome Completo</Label>
-                    <Input
-                      id="signup-name"
-                      type="text"
-                      value={name}
-                      onChange={(e) => setName(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="signup-email">{t("auth.email")}</Label>
-                    <Input
-                      id="signup-email"
-                      type="email"
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="signup-password">{t("auth.password")}</Label>
-                    <Input
-                      id="signup-password"
-                      type="password"
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="confirm-password">{t("auth.confirm_password")}</Label>
-                    <Input
-                      id="confirm-password"
-                      type="password"
-                      value={confirmPassword}
-                      onChange={(e) => setConfirmPassword(e.target.value)}
-                      required
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="signup-phone">Telefone</Label>
-                    <div className="flex gap-2">
-                      <Select
-                        value={phoneCountryCode}
-                        onValueChange={setPhoneCountryCode}
-                      >
-                        <SelectTrigger className="w-[100px]">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="+55">🇧🇷 +55</SelectItem>
-                          <SelectItem value="+1">🇺🇸 +1</SelectItem>
-                          <SelectItem value="+54">🇦🇷 +54</SelectItem>
-                          <SelectItem value="+56">🇨🇱 +56</SelectItem>
-                          <SelectItem value="+57">🇨🇴 +57</SelectItem>
-                          <SelectItem value="+351">🇵🇹 +351</SelectItem>
-                          <SelectItem value="+34">🇪🇸 +34</SelectItem>
-                          <SelectItem value="+39">🇮🇹 +39</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <Input
-                        id="signup-phone"
-                        type="tel"
-                        placeholder="(11) 99999-9999"
-                        value={phoneNumber}
-                        onChange={(e) => setPhoneNumber(e.target.value.replace(/\D/g, ''))}
-                        className="flex-1"
-                        required
-                      />
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      Será usado para conectar ao bot no Telegram
+                  <div>
+                    <p className="text-[13px] font-bold text-ink leading-tight">
+                      Você foi convidado pro Bolão Copa 2026
+                    </p>
+                    <p className="text-[12px] text-ink-2 mt-1 leading-snug">
+                      Crie sua conta (grátis) ou entre — depois você cai direto no bolão pra palpitar.
                     </p>
                   </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="referral-code">Código do amigo (opcional)</Label>
-                    <Input
-                      id="referral-code"
-                      type="text"
-                      value={referralCode}
-                      onChange={(e) => setReferralCode(e.target.value.toUpperCase())}
-                      placeholder="ABC123"
-                      maxLength={6}
-                      className="font-mono text-center text-lg tracking-wider"
-                    />
-                    {referralCode && (
-                      <p className="text-xs text-muted-foreground">
-                        Você está se cadastrando com o código de indicação
+                </div>
+              </div>
+            )}
+
+            <Tabs defaultValue={fromBolaoInvite ? "signup" : "signin"} className="w-full">
+              <TabsList className="grid w-full grid-cols-2 bg-canvas-2 p-1 rounded-rebrand-md mb-5">
+                <TabsTrigger
+                  value="signin"
+                  className="rounded-rebrand-sm data-[state=active]:bg-white data-[state=active]:text-forest data-[state=active]:shadow-sm font-semibold text-ink-2 text-[13px]"
+                >
+                  Entrar
+                </TabsTrigger>
+                <TabsTrigger
+                  value="signup"
+                  className="rounded-rebrand-sm data-[state=active]:bg-white data-[state=active]:text-forest data-[state=active]:shadow-sm font-semibold text-ink-2 text-[13px]"
+                >
+                  Criar conta
+                </TabsTrigger>
+              </TabsList>
+
+              {/* ─── SignIn ─── */}
+              <TabsContent value="signin" className="mt-0">
+                <div className="bg-white border border-line rounded-rebrand-xl p-6 sm:p-7 shadow-sm">
+                  <h3 className="font-display text-[20px] font-extrabold text-ink mb-1">
+                    Entrar
+                  </h3>
+                  <p className="text-[13px] text-ink-2 mb-5">
+                    Bom te ver de volta. Coloca os dados aí.
+                  </p>
+                  <form onSubmit={handleSignIn} className="space-y-4">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="email" className="text-[12px] font-semibold text-ink-2 uppercase tracking-wide">
+                        E-mail
+                      </Label>
+                      <Input
+                        id="email"
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                        className="bg-canvas border-line text-ink h-11 rounded-rebrand-md focus-visible:border-forest focus-visible:ring-forest/20"
+                        placeholder="seu@email.com"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="password" className="text-[12px] font-semibold text-ink-2 uppercase tracking-wide">
+                        Senha
+                      </Label>
+                      <Input
+                        id="password"
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        required
+                        className="bg-canvas border-line text-ink h-11 rounded-rebrand-md focus-visible:border-forest focus-visible:ring-forest/20"
+                      />
+                    </div>
+                    <Button
+                      type="submit"
+                      variant="forest"
+                      size="lg"
+                      disabled={loading}
+                      className="w-full rounded-rebrand-md h-11"
+                    >
+                      {loading ? "Entrando..." : "Entrar"}
+                    </Button>
+                  </form>
+                </div>
+              </TabsContent>
+
+              {/* ─── SignUp ─── */}
+              <TabsContent value="signup" className="mt-0">
+                <div className="bg-white border border-line rounded-rebrand-xl p-6 sm:p-7 shadow-sm">
+                  <h3 className="font-display text-[20px] font-extrabold text-ink mb-1">
+                    Criar conta
+                  </h3>
+                  <p className="text-[13px] text-ink-2 mb-5">
+                    Grátis. Sem cartão. Você cria o bolão logo em seguida.
+                  </p>
+                  <form onSubmit={handleSignUp} className="space-y-4">
+                    <div className="space-y-1.5">
+                      <Label htmlFor="signup-name" className="text-[12px] font-semibold text-ink-2 uppercase tracking-wide">
+                        Nome completo
+                      </Label>
+                      <Input
+                        id="signup-name"
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        required
+                        className="bg-canvas border-line text-ink h-11 rounded-rebrand-md focus-visible:border-forest focus-visible:ring-forest/20"
+                        placeholder="Como te chamam"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="signup-email" className="text-[12px] font-semibold text-ink-2 uppercase tracking-wide">
+                        E-mail
+                      </Label>
+                      <Input
+                        id="signup-email"
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                        className="bg-canvas border-line text-ink h-11 rounded-rebrand-md focus-visible:border-forest focus-visible:ring-forest/20"
+                        placeholder="seu@email.com"
+                      />
+                    </div>
+                    <div className="grid grid-cols-2 gap-3">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="signup-password" className="text-[12px] font-semibold text-ink-2 uppercase tracking-wide">
+                          Senha
+                        </Label>
+                        <Input
+                          id="signup-password"
+                          type="password"
+                          value={password}
+                          onChange={(e) => setPassword(e.target.value)}
+                          required
+                          className="bg-canvas border-line text-ink h-11 rounded-rebrand-md focus-visible:border-forest focus-visible:ring-forest/20"
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="confirm-password" className="text-[12px] font-semibold text-ink-2 uppercase tracking-wide">
+                          Confirmar
+                        </Label>
+                        <Input
+                          id="confirm-password"
+                          type="password"
+                          value={confirmPassword}
+                          onChange={(e) => setConfirmPassword(e.target.value)}
+                          required
+                          className="bg-canvas border-line text-ink h-11 rounded-rebrand-md focus-visible:border-forest focus-visible:ring-forest/20"
+                        />
+                      </div>
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="signup-phone" className="text-[12px] font-semibold text-ink-2 uppercase tracking-wide">
+                        Telefone
+                      </Label>
+                      <div className="flex gap-2">
+                        <Select value={phoneCountryCode} onValueChange={setPhoneCountryCode}>
+                          <SelectTrigger className="w-[110px] bg-canvas border-line text-ink h-11 rounded-rebrand-md">
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent className="theme-bolao bg-white border-line text-ink">
+                            <SelectItem value="+55">🇧🇷 +55</SelectItem>
+                            <SelectItem value="+1">🇺🇸 +1</SelectItem>
+                            <SelectItem value="+54">🇦🇷 +54</SelectItem>
+                            <SelectItem value="+56">🇨🇱 +56</SelectItem>
+                            <SelectItem value="+57">🇨🇴 +57</SelectItem>
+                            <SelectItem value="+351">🇵🇹 +351</SelectItem>
+                            <SelectItem value="+34">🇪🇸 +34</SelectItem>
+                            <SelectItem value="+39">🇮🇹 +39</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <Input
+                          id="signup-phone"
+                          type="tel"
+                          placeholder="(11) 99999-9999"
+                          value={phoneNumber}
+                          onChange={(e) => setPhoneNumber(e.target.value.replace(/\D/g, ''))}
+                          className="flex-1 bg-canvas border-line text-ink h-11 rounded-rebrand-md focus-visible:border-forest focus-visible:ring-forest/20"
+                          required
+                        />
+                      </div>
+                      <p className="text-[11px] text-ink-3 mt-0.5">
+                        Pra conectar com o bot do Telegram (opcional).
                       </p>
-                    )}
-                  </div>
-                  <Button type="submit" className="w-full" disabled={loading}>
-                    {loading ? t("loading") : t("auth.signup")}
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="referral-code" className="text-[12px] font-semibold text-ink-2 uppercase tracking-wide">
+                        Código do amigo <span className="text-ink-3 normal-case font-normal">(opcional)</span>
+                      </Label>
+                      <Input
+                        id="referral-code"
+                        type="text"
+                        value={referralCode}
+                        onChange={(e) => setReferralCode(e.target.value.toUpperCase())}
+                        placeholder="ABC123"
+                        maxLength={6}
+                        className="font-mono text-center text-[15px] tracking-wider bg-canvas border-line text-ink h-11 rounded-rebrand-md focus-visible:border-forest focus-visible:ring-forest/20"
+                      />
+                      {referralCode && (
+                        <p className="text-[11px] text-forest font-medium mt-0.5 flex items-center gap-1">
+                          <Check className="w-3 h-3" /> Indicação registrada
+                        </p>
+                      )}
+                    </div>
+                    <Button
+                      type="submit"
+                      variant="forest"
+                      size="lg"
+                      disabled={loading}
+                      className="w-full rounded-rebrand-md h-11"
+                    >
+                      {loading ? "Criando..." : "Criar conta"}
+                    </Button>
+                  </form>
+                </div>
+              </TabsContent>
+            </Tabs>
+
+            <p className="text-[11px] text-ink-3 text-center mt-5">
+              Ao continuar você concorda com os termos de uso.
+            </p>
+          </div>
+        </main>
       </div>
     </div>
   );


### PR DESCRIPTION
## TL;DR

2 mudanças no `Auth.tsx`:

1. **Fix do redirect quebrado** que você reportou — quem vinha da LP fazia signup e caía no `/onboarding` em vez do bolão.
2. **Revamp visual** com IDV do bolão (canvas + forest + amber + ink + font-display).

## Fix do redirect

| Handler | Antes | Agora |
|---|---|---|
| `handleSignIn` | Respeitava `state.from`, fallback `/onboarding` | Respeita `state.from`, fallback **`/bolao`** |
| `handleSignUp` | **Hard-coded `/onboarding`** (bug) | Respeita `state.from`, fallback **`/bolao`** |

Extraído helper `getRedirectTarget(state, fallback)` reusado nos 2 handlers, com proteção contra open redirect (`//`).

**Default mudou de `/onboarding` → `/bolao`** por decisão do produto: todos caem na home do bolão pós-login, salvo `state.from` explícito.

## Revamp visual

- Wrapper root com classe `theme-bolao` pra ativar CSS vars fora do `BolaoLayout`
- **Desktop (lg+):** split 1.1fr / 1fr
  - **Esquerda:** hero forest com proposta de valor ("Reúne a galera / Palpita os 104 jogos / Vê quem manja mais") + 3 features
  - **Direita:** form em card branco `rounded-rebrand-xl` com tabs Entrar / Criar conta
- **Mobile:** single column, hero esconde, brand compacto no topo do form
- Inputs: `bg-canvas border-line`, focus `border-forest ring-forest/20`
- Botões: `variant="forest"`, font-display nos títulos
- Tabs: state-active forest, indicador limpo
- Banner contextual `fromBolaoInvite` re-estilizado com paleta amber

## Test plan

- [ ] Vir da LP `/bolao/comecar` → clicar "Criar grátis" → signup → cai em `/bolao?create=true` (modal abre)
- [ ] Login direto em `/auth` → cai em `/bolao`
- [ ] Login com link de convite `/bolao/entrar/CODE` → após signup cai em `/bolao/entrar/CODE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)