### PR TITLE
fix(bolao): tela preta após criar bolão (lazy chunk stale) + a11y CreateBolaoModal (develop → main)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,38 +17,44 @@ import PremiumRoute from "./components/PremiumRoute";
 import { PostHogPageView } from "./components/PostHogPageView";
 import { EnvironmentBanner } from "./components/EnvironmentBanner";
 import Footer from "./components/Footer";
+import { lazyWithRetry } from "./lib/lazy-with-retry";
 
-// Lazy-loaded pages (not critical for first paint)
-const Betinho = React.lazy(() => import("./pages/Betinho"));
-const Onboarding = React.lazy(() => import("./pages/Onboarding"));
-const DashboardTest = React.lazy(() => import("./pages/DashboardTest"));
-const Bets = React.lazy(() => import("./pages/Bets"));
-const Bankroll = React.lazy(() => import("./pages/Bankroll"));
-const BettingDashboard = React.lazy(() => import("./pages/BettingDashboard"));
-const PlayerSelectionTest = React.lazy(() => import("./pages/PlayerSelectionTest"));
-const PlayerSelection = React.lazy(() => import("./pages/PlayerSelection"));
-const Analysis = React.lazy(() => import("./pages/Analysis"));
-const Waitlist = React.lazy(() => import("./pages/Waitlist"));
-const Paywall = React.lazy(() => import("./pages/Paywall"));
-const PaywallDashboard = React.lazy(() => import("./pages/PaywallDashboard"));
-const PaywallPlatform = React.lazy(() => import("./pages/PaywallPlatform"));
-const NotFound = React.lazy(() => import("./pages/NotFound"));
-const ComoUsar = React.lazy(() => import("./pages/ComoUsar"));
-const Games = React.lazy(() => import("./pages/Games"));
-const GameDetail = React.lazy(() => import("./pages/GameDetail"));
-const Settings = React.lazy(() => import("./pages/Settings"));
-const Report = React.lazy(() => import("./pages/Report"));
-const SharePage = React.lazy(() => import("./pages/SharePage"));
-const Analise360List = React.lazy(() => import("./pages/Analise360List"));
-const Analise360Detail = React.lazy(() => import("./pages/Analise360Detail"));
-const HomeNBA = React.lazy(() => import("./pages/HomeNBA"));
-const BolaoEntry = React.lazy(() => import("./pages/BolaoEntry"));
-const BolaoHome = React.lazy(() => import("./pages/BolaoHome"));
-const BolaoDetail = React.lazy(() => import("./pages/BolaoDetail"));
-const BolaoPalpites = React.lazy(() => import("./pages/BolaoPalpites"));
-const BolaoJoin = React.lazy(() => import("./pages/BolaoJoin"));
-const BolaoWelcome = React.lazy(() => import("./pages/BolaoWelcome"));
-const BolaoLP = React.lazy(() => import("./pages/BolaoLP"));
+// Lazy-loaded pages (not critical for first paint).
+// Usa `lazyWithRetry` em vez de `React.lazy` direto pra detectar falha de
+// chunk após deploy (hash dos chunks muda, navegador com versão antiga
+// cacheada tenta carregar chunk inexistente -> "Failed to fetch dynamically
+// imported module" -> tela branca). Helper força reload uma vez por sessão
+// pra pegar build novo.
+const Betinho = lazyWithRetry(() => import("./pages/Betinho"));
+const Onboarding = lazyWithRetry(() => import("./pages/Onboarding"));
+const DashboardTest = lazyWithRetry(() => import("./pages/DashboardTest"));
+const Bets = lazyWithRetry(() => import("./pages/Bets"));
+const Bankroll = lazyWithRetry(() => import("./pages/Bankroll"));
+const BettingDashboard = lazyWithRetry(() => import("./pages/BettingDashboard"));
+const PlayerSelectionTest = lazyWithRetry(() => import("./pages/PlayerSelectionTest"));
+const PlayerSelection = lazyWithRetry(() => import("./pages/PlayerSelection"));
+const Analysis = lazyWithRetry(() => import("./pages/Analysis"));
+const Waitlist = lazyWithRetry(() => import("./pages/Waitlist"));
+const Paywall = lazyWithRetry(() => import("./pages/Paywall"));
+const PaywallDashboard = lazyWithRetry(() => import("./pages/PaywallDashboard"));
+const PaywallPlatform = lazyWithRetry(() => import("./pages/PaywallPlatform"));
+const NotFound = lazyWithRetry(() => import("./pages/NotFound"));
+const ComoUsar = lazyWithRetry(() => import("./pages/ComoUsar"));
+const Games = lazyWithRetry(() => import("./pages/Games"));
+const GameDetail = lazyWithRetry(() => import("./pages/GameDetail"));
+const Settings = lazyWithRetry(() => import("./pages/Settings"));
+const Report = lazyWithRetry(() => import("./pages/Report"));
+const SharePage = lazyWithRetry(() => import("./pages/SharePage"));
+const Analise360List = lazyWithRetry(() => import("./pages/Analise360List"));
+const Analise360Detail = lazyWithRetry(() => import("./pages/Analise360Detail"));
+const HomeNBA = lazyWithRetry(() => import("./pages/HomeNBA"));
+const BolaoEntry = lazyWithRetry(() => import("./pages/BolaoEntry"));
+const BolaoHome = lazyWithRetry(() => import("./pages/BolaoHome"));
+const BolaoDetail = lazyWithRetry(() => import("./pages/BolaoDetail"));
+const BolaoPalpites = lazyWithRetry(() => import("./pages/BolaoPalpites"));
+const BolaoJoin = lazyWithRetry(() => import("./pages/BolaoJoin"));
+const BolaoWelcome = lazyWithRetry(() => import("./pages/BolaoWelcome"));
+const BolaoLP = lazyWithRetry(() => import("./pages/BolaoLP"));
 
 const queryClient = new QueryClient();
 

--- a/src/components/bolao/CreateBolaoModal.tsx
+++ b/src/components/bolao/CreateBolaoModal.tsx
@@ -12,7 +12,7 @@ import {
   Palette,
   Flag,
 } from 'lucide-react';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 
 const schema = z.object({
@@ -88,16 +88,21 @@ export const CreateBolaoModal: React.FC<CreateBolaoModalProps> = ({
         // são portados pra fora do DOM tree do BolaoLayout via Radix Portal,
         // então as CSS vars escopadas não chegam sem reaplicar.)
       >
-        {/* Header — pr-12 reserva espaco pro X built-in do DialogContent (top-right) */}
+        {/* Header — pr-12 reserva espaco pro X built-in do DialogContent (top-right).
+            DialogTitle + DialogDescription são necessários pra acessibilidade
+            (Radix avisa em console quando faltam). Renderizam como h2/p com
+            os mesmos estilos visuais. */}
         <div className="flex items-center gap-2.5 px-6 pt-5 pb-4 pr-12 border-b border-line">
           <div className="w-9 h-9 rounded-rebrand-md bg-forest flex items-center justify-center text-amber">
             <Trophy className="w-5 h-5" />
           </div>
           <div>
-            <h2 className="text-[16px] font-bold text-ink leading-tight">Criar bolão</h2>
-            <p className="text-[12px] text-ink-2 leading-tight mt-0.5">
+            <DialogTitle className="text-[16px] font-bold text-ink leading-tight">
+              Criar bolão
+            </DialogTitle>
+            <DialogDescription className="text-[12px] text-ink-2 leading-tight mt-0.5">
               Você é o dono — convida quem quiser depois
-            </p>
+            </DialogDescription>
           </div>
         </div>
 

--- a/src/lib/lazy-with-retry.ts
+++ b/src/lib/lazy-with-retry.ts
@@ -1,0 +1,83 @@
+import React from 'react';
+
+/**
+ * Wrapper de `React.lazy` que detecta falha de fetch de chunk (típico
+ * após deploy novo com hashes de chunks diferentes — chunks antigos
+ * cacheados pelo navegador apontam pra arquivos que não existem mais
+ * no servidor) e força `window.location.reload()` pra pegar o build novo.
+ *
+ * Bug original: user com tab aberta há horas, deploy entra em prod, hash
+ * dos chunks mudam. User clica em algo que dispara lazy load → "Failed to
+ * fetch dynamically imported module" → tela branca/preta.
+ *
+ * Estratégia:
+ *   1. Tenta carregar normalmente
+ *   2. Se erro casar com `Failed to fetch dynamically imported module`
+ *      (ou padrões similares em outros browsers), seta uma flag em
+ *      sessionStorage e força reload
+ *   3. A flag previne loop infinito: se já tentou reload nessa sessão
+ *      e ainda falha, propaga o erro (vai pro ErrorBoundary ou tela de
+ *      erro genérica)
+ *
+ * Uso:
+ *   const BolaoWelcome = lazyWithRetry(() => import('./pages/BolaoWelcome'));
+ */
+export function lazyWithRetry<T extends React.ComponentType<unknown>>(
+  factory: () => Promise<{ default: T }>
+): React.LazyExoticComponent<T> {
+  return React.lazy(async () => {
+    const sessionKey = '__lazy-reload-attempted__';
+
+    try {
+      const mod = await factory();
+      // Sucesso: limpa a flag pra próximo deploy começar limpo
+      try {
+        sessionStorage.removeItem(sessionKey);
+      } catch {
+        // sessionStorage pode falhar em modo privado — ignora
+      }
+      return mod;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const isChunkLoadError =
+        msg.includes('Failed to fetch dynamically imported module') ||
+        msg.includes('Importing a module script failed') ||
+        msg.includes("error loading dynamically imported module") ||
+        msg.includes("Loading chunk");
+
+      if (!isChunkLoadError) {
+        // Outro tipo de erro (sintaxe, runtime no módulo, etc.) — propaga
+        throw err;
+      }
+
+      // Anti-loop: se já tentou reload nessa sessão, desiste e propaga
+      let alreadyTried = false;
+      try {
+        alreadyTried = sessionStorage.getItem(sessionKey) === '1';
+      } catch {
+        // sessionStorage inacessível — força propagação pra evitar loop
+        throw err;
+      }
+
+      if (alreadyTried) {
+        // Já tentamos reload uma vez nessa sessão e ainda falhou —
+        // problema persistente (CDN broken, browser corrupto, etc.).
+        // Propaga pra ErrorBoundary mostrar mensagem útil.
+        throw err;
+      }
+
+      try {
+        sessionStorage.setItem(sessionKey, '1');
+      } catch {
+        // ignora — vamos tentar reload mesmo assim
+      }
+
+      window.location.reload();
+
+      // Reload é assíncrono no browser. Retornamos uma Promise que nunca
+      // resolve pra impedir React de re-renderizar com erro enquanto a
+      // navegação acontece.
+      return new Promise<{ default: T }>(() => {});
+    }
+  });
+}


### PR DESCRIPTION
Sobe pra produção o PR #160 já mergeado em develop.

## TL;DR

Resolve bug crítico: users criam bolão e caem em **tela preta** porque o lazy chunk `BolaoWelcome` apontava pra arquivo deletado do CDN após deploy novo.

## Fix

- Helper `lazyWithRetry` em `src/lib/lazy-with-retry.ts` detecta erro de fetch de chunk e força reload uma vez por sessão (anti-loop com sessionStorage)
- Aplicado em todos os 31 lazy imports do `App.tsx` — previne o mesmo bug em qualquer outra página lazy
- Bonus: `CreateBolaoModal` agora usa `DialogTitle`+`DialogDescription` (remove warning de a11y do Radix)

## Após merge

Frontend deploy automático via Vercel. Users que estiverem com tab aberta no momento podem ver 1 reload silencioso — comportamento desejado pra carregar versão nova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)