### PR TITLE
feat(bolao): aba "Pendentes" pra achar palpites que faltam + fix leitura special predictions

### DIFF
--- a/docs/bolao-deploy-runbook.md
+++ b/docs/bolao-deploy-runbook.md
@@ -63,6 +63,15 @@ SELECT vault.create_secret('<x-cron-secret>', 'ingest_wc_cron_secret', 'x-cron-s
 SELECT vault.create_secret('https://<PROJECT_REF>.supabase.co/functions/v1/ingest-wc-scores', 'ingest_wc_url', 'URL da função');
 ```
 
+## Componente: settlement dos prêmios de jogador (M4)
+- Migration `052` — `resolve_player_awards()` (pontua palpites vs `wc_player_awards`, idempotente).
+- `ingest-wc-topscorer` — **pós-final**: resolve o artilheiro automático (desempate gols→assists→min)
+  + chama resolve. `POST /functions/v1/ingest-wc-topscorer` (header `x-cron-secret`).
+- `set-player-award` — **noite da final**: registra vencedor de júri (goleiro/craque/revelação) ou
+  força o artilheiro. `POST /functions/v1/set-player-award` body `{award_type, player_id}` (header `x-cron-secret`).
+- Operação na noite da final: rodar `ingest-wc-topscorer` (artilheiro) + 3× `set-player-award` (júri).
+- Prod (além do já listado): aplicar migration 052; deploy de `ingest-wc-topscorer` + `set-player-award`.
+
 ## Log de execução
 - 2026-06-01 — migrations 046/047 aplicadas no **staging** (validadas). Função `ingest-wc-scores`
   escrita.
@@ -71,3 +80,7 @@ SELECT vault.create_secret('https://<PROJECT_REF>.supabase.co/functions/v1/inges
   Cron via pg_net também 200. Falta só validar com jogo finalizado real.
 - 2026-06-01 — **M2 elencos no staging:** migration 049 (wc_players) + deploy `ingest-wc-squads`.
   Run = 48 times, 1381 jogadores, 167 goleiros, 0 erros. birth_date pendente (profiles).
+- 2026-06-01 — **M2 birth_date:** `enrich-wc-players` rodado: 1323/1381 com data, 77 elegíveis Revelação.
+- 2026-06-01 — **M3 completo:** migrations 050 (schema) + 051 (RPCs); frontend PlayerAwardsSection +
+  admin (toggles/pontos). tsc limpo. **M4:** migration 052 (resolve, testado acerto=10/erro=0) +
+  `ingest-wc-topscorer` (artilheiro auto) + `set-player-award` (júri/manual) deployadas no staging.

--- a/docs/bolao-deploy-runbook.md
+++ b/docs/bolao-deploy-runbook.md
@@ -36,8 +36,9 @@ Robô que lê o placar da API-Sports e atualiza o bolão. Migrations já aplicad
 - [ ] Secrets `API_SPORTS_KEY` (idealmente chave backend nova) + `CRON_SECRET` (pode ser outro valor) — **Diody**.
 - [ ] Vault: `ingest_wc_cron_secret` + `ingest_wc_url` (URL com o ref de prod) — via SQL.
 - [ ] Aplicar migrations 046, 047, 048, 049 em prod — **Diody/Claude** (via migration, regra anti-drift).
-- [ ] Deploy das funções `ingest-wc-scores`, `ingest-wc-squads` **e** `enrich-wc-players` em prod.
-- [ ] Rodar `ingest-wc-squads` 1x → depois `enrich-wc-players` em loop (birth_date) + smoke test do `ingest-wc-scores`.
+- [ ] Criar bucket público `wc-player-photos` (storage.buckets).
+- [ ] Deploy: `ingest-wc-scores`, `ingest-wc-squads`, `enrich-wc-players`, `mirror-wc-photos`, `ingest-wc-topscorer`, `set-player-award`.
+- [ ] Rodar `ingest-wc-squads` → `enrich-wc-players` (loop) → `mirror-wc-photos` (loop) + smoke test do `ingest-wc-scores`.
 - [ ] Cron já vem da migration 048 (lê Vault) — conferir `cron.job`.
 
 ## Componente: ingestão de elencos (`ingest-wc-squads` + `enrich-wc-players`)
@@ -47,7 +48,11 @@ Popula `wc_players` (migration 049). Disparadas **sob demanda** (sem cron). Reus
    ⚠️ Squads = pool nacional amplo (~1381 no staging), não os 26 finais. Re-rodar perto da convocação.
 2. `POST /functions/v1/enrich-wc-players` (body `{after, batch}`, em loop até `done`) — preenche
    `birth_date` via `players/profiles`. Necessário pro filtro de Revelação. Staging: 1323/1381
-   preenchidos, 77 elegíveis (≥2005). **Fotos já vêm no squads** (URL do CDN da API, sem download).
+   preenchidos, 77 elegíveis (≥2005).
+3. `POST /functions/v1/mirror-wc-photos` (body `{after, batch}`, em loop até `done`) — baixa as
+   fotos da api-sports e sobe no bucket **`wc-player-photos`** (público), reescrevendo `photo_url`
+   pro nosso Storage. **Necessário** porque a api-sports bloqueia hotlink no navegador (a imagem só
+   carrega server-side). Pré-req: criar o bucket público. Staging: 1381/1381 espelhadas.
 
 ### Como setar os secrets no painel (passo a passo)
 1. Acessar https://supabase.com/dashboard/project/kpbjuplcwiyrymafhehz/settings/functions

--- a/docs/bolao-deploy-runbook.md
+++ b/docs/bolao-deploy-runbook.md
@@ -1,0 +1,50 @@
+# Bolão — Runbook de Deploy (staging → produção)
+
+> Registro vivo de tudo que precisa ser feito **fora do código** (secrets, deploy de edge
+> functions, cron) pra ligar a ingestão de dados do bolão. Objetivo: produção vira só "seguir
+> a lista". Atualizar a cada passo.
+>
+> ⚠️ **Nunca commitar valores de secret aqui.** Só os *nomes* e de onde tirar o valor.
+>
+> Ambientes (ver memória `feedback_supabase_environments`):
+> - **staging** = `kpbjuplcwiyrymafhehz`
+> - **produção** = `lavclmlvvfzkblrstojd`
+
+## Componente: ingestão de placar (`ingest-wc-scores`)
+
+Robô que lê o placar da API-Sports e atualiza o bolão. Migrations já aplicadas: `046_wc_team_map`,
+`047_wc_matches_api_fixture_id`. Código: `supabase/functions/ingest-wc-scores/`.
+
+### Secrets necessários (Edge Functions)
+| Nome | Valor (de onde tirar) |
+|---|---|
+| `API_SPORTS_KEY` | chave da API-Sports. Por ora = o mesmo valor de `VITE_API_SPORTS_KEY` no `.env.local`. **Migrar pra chave backend dedicada depois da renovação.** |
+| `CRON_SECRET` | string aleatória (hex 48). Gerada por nós; guardada só no painel + aqui no chat. Serve pra só o nosso agendador conseguir acordar o robô. |
+
+### Checklist por ambiente
+
+**Staging** (`kpbjuplcwiyrymafhehz`)
+- [ ] Secrets `API_SPORTS_KEY` e `CRON_SECRET` setados no painel — **Diody** (Dashboard → Project Settings → Edge Functions → Manage secrets / Add new secret).
+- [ ] Deploy da função `ingest-wc-scores` — **Claude (via MCP)**.
+- [ ] Habilitar extensões `pg_cron` + `pg_net` e agendar o job (migration) — **Claude (via MCP)**.
+- [ ] Smoke test: forçar/checar 1 jogo e confirmar placar + pontos — **Claude + Diody**.
+
+**Produção** (`lavclmlvvfzkblrstojd`) — só depois do staging validado
+- [ ] Renovar assinatura API-Sports (vence **11/jun/2026**) — **Diody**.
+- [ ] Secrets `API_SPORTS_KEY` (idealmente chave backend nova) + `CRON_SECRET` (pode ser outro valor) — **Diody**.
+- [ ] Aplicar migrations 046 + 047 em prod — **Diody** (via migration, conforme regra anti-drift).
+- [ ] Deploy da função em prod.
+- [ ] Agendar cron em prod.
+- [ ] Smoke test em prod.
+
+### Como setar os secrets no painel (passo a passo)
+1. Acessar https://supabase.com/dashboard/project/kpbjuplcwiyrymafhehz/settings/functions
+   (ou: Dashboard → escolher projeto → ⚙️ Project Settings → **Edge Functions** → seção **Secrets**).
+2. **Add new secret** → Name: `API_SPORTS_KEY` → Value: (valor passado no chat) → salvar.
+3. **Add new secret** → Name: `CRON_SECRET` → Value: (valor passado no chat) → salvar.
+4. Avisar o Claude que está feito → ele faz o deploy + cron.
+
+## Log de execução
+_(preencher conforme avança)_
+- 2026-06-01 — migrations 046/047 aplicadas no **staging** (validadas). Função `ingest-wc-scores`
+  escrita (sem deploy). Aguardando secrets no staging pra deploy + cron.

--- a/docs/bolao-deploy-runbook.md
+++ b/docs/bolao-deploy-runbook.md
@@ -36,16 +36,18 @@ Robô que lê o placar da API-Sports e atualiza o bolão. Migrations já aplicad
 - [ ] Secrets `API_SPORTS_KEY` (idealmente chave backend nova) + `CRON_SECRET` (pode ser outro valor) — **Diody**.
 - [ ] Vault: `ingest_wc_cron_secret` + `ingest_wc_url` (URL com o ref de prod) — via SQL.
 - [ ] Aplicar migrations 046, 047, 048, 049 em prod — **Diody/Claude** (via migration, regra anti-drift).
-- [ ] Deploy das funções `ingest-wc-scores` **e** `ingest-wc-squads` em prod.
-- [ ] Rodar `ingest-wc-squads` 1x (popular elencos) + smoke test do `ingest-wc-scores`.
+- [ ] Deploy das funções `ingest-wc-scores`, `ingest-wc-squads` **e** `enrich-wc-players` em prod.
+- [ ] Rodar `ingest-wc-squads` 1x → depois `enrich-wc-players` em loop (birth_date) + smoke test do `ingest-wc-scores`.
 - [ ] Cron já vem da migration 048 (lê Vault) — conferir `cron.job`.
 
-## Componente: ingestão de elencos (`ingest-wc-squads`)
-Popula `wc_players` (migration 049) com os elencos. Disparada **sob demanda** (não tem cron):
-rodar quando a FIFA confirmar os 26, e re-rodar se mudar. Reusa os secrets do `ingest-wc-scores`.
-Chamada: `POST /functions/v1/ingest-wc-squads` com header `x-cron-secret`.
-⚠️ Squads = pool nacional amplo (~1381 jogadores no staging), não os 26 finais.
-TODO: enriquecer `birth_date` via `players/profiles` (só necessário pro filtro de Melhor Jovem).
+## Componente: ingestão de elencos (`ingest-wc-squads` + `enrich-wc-players`)
+Popula `wc_players` (migration 049). Disparadas **sob demanda** (sem cron). Reusam os secrets do
+`ingest-wc-scores`. Ordem:
+1. `POST /functions/v1/ingest-wc-squads` (header `x-cron-secret`) — nome/posição/número/foto.
+   ⚠️ Squads = pool nacional amplo (~1381 no staging), não os 26 finais. Re-rodar perto da convocação.
+2. `POST /functions/v1/enrich-wc-players` (body `{after, batch}`, em loop até `done`) — preenche
+   `birth_date` via `players/profiles`. Necessário pro filtro de Revelação. Staging: 1323/1381
+   preenchidos, 77 elegíveis (≥2005). **Fotos já vêm no squads** (URL do CDN da API, sem download).
 
 ### Como setar os secrets no painel (passo a passo)
 1. Acessar https://supabase.com/dashboard/project/kpbjuplcwiyrymafhehz/settings/functions

--- a/docs/bolao-deploy-runbook.md
+++ b/docs/bolao-deploy-runbook.md
@@ -34,10 +34,18 @@ Robô que lê o placar da API-Sports e atualiza o bolão. Migrations já aplicad
 **Produção** (`lavclmlvvfzkblrstojd`) — só depois do staging validado
 - [ ] Renovar assinatura API-Sports (vence **11/jun/2026**) — **Diody**.
 - [ ] Secrets `API_SPORTS_KEY` (idealmente chave backend nova) + `CRON_SECRET` (pode ser outro valor) — **Diody**.
-- [ ] Aplicar migrations 046 + 047 em prod — **Diody** (via migration, conforme regra anti-drift).
-- [ ] Deploy da função em prod.
-- [ ] Agendar cron em prod.
-- [ ] Smoke test em prod.
+- [ ] Vault: `ingest_wc_cron_secret` + `ingest_wc_url` (URL com o ref de prod) — via SQL.
+- [ ] Aplicar migrations 046, 047, 048, 049 em prod — **Diody/Claude** (via migration, regra anti-drift).
+- [ ] Deploy das funções `ingest-wc-scores` **e** `ingest-wc-squads` em prod.
+- [ ] Rodar `ingest-wc-squads` 1x (popular elencos) + smoke test do `ingest-wc-scores`.
+- [ ] Cron já vem da migration 048 (lê Vault) — conferir `cron.job`.
+
+## Componente: ingestão de elencos (`ingest-wc-squads`)
+Popula `wc_players` (migration 049) com os elencos. Disparada **sob demanda** (não tem cron):
+rodar quando a FIFA confirmar os 26, e re-rodar se mudar. Reusa os secrets do `ingest-wc-scores`.
+Chamada: `POST /functions/v1/ingest-wc-squads` com header `x-cron-secret`.
+⚠️ Squads = pool nacional amplo (~1381 jogadores no staging), não os 26 finais.
+TODO: enriquecer `birth_date` via `players/profiles` (só necessário pro filtro de Melhor Jovem).
 
 ### Como setar os secrets no painel (passo a passo)
 1. Acessar https://supabase.com/dashboard/project/kpbjuplcwiyrymafhehz/settings/functions
@@ -59,3 +67,5 @@ SELECT vault.create_secret('https://<PROJECT_REF>.supabase.co/functions/v1/inges
 - 2026-06-01 — **staging ligado ponta a ponta:** secrets (painel + Vault), deploy da função,
   migration 048 (pg_cron `*/5` + pg_net lendo Vault). Smoke test 200 OK (72 fixtures, 0 sem-link).
   Cron via pg_net também 200. Falta só validar com jogo finalizado real.
+- 2026-06-01 — **M2 elencos no staging:** migration 049 (wc_players) + deploy `ingest-wc-squads`.
+  Run = 48 times, 1381 jogadores, 167 goleiros, 0 erros. birth_date pendente (profiles).

--- a/docs/bolao-deploy-runbook.md
+++ b/docs/bolao-deploy-runbook.md
@@ -23,11 +23,13 @@ Robô que lê o placar da API-Sports e atualiza o bolão. Migrations já aplicad
 
 ### Checklist por ambiente
 
-**Staging** (`kpbjuplcwiyrymafhehz`)
-- [ ] Secrets `API_SPORTS_KEY` e `CRON_SECRET` setados no painel — **Diody** (Dashboard → Project Settings → Edge Functions → Manage secrets / Add new secret).
-- [ ] Deploy da função `ingest-wc-scores` — **Claude (via MCP)**.
-- [ ] Habilitar extensões `pg_cron` + `pg_net` e agendar o job (migration) — **Claude (via MCP)**.
-- [ ] Smoke test: forçar/checar 1 jogo e confirmar placar + pontos — **Claude + Diody**.
+**Staging** (`kpbjuplcwiyrymafhehz`) — ✅ CONCLUÍDO 2026-06-01
+- [x] Secrets `API_SPORTS_KEY` e `CRON_SECRET` setados no painel — Diody.
+- [x] Vault: `ingest_wc_cron_secret` + `ingest_wc_url` (via SQL, não versionado).
+- [x] Deploy da função `ingest-wc-scores` (version 1, verify_jwt=false) — Claude (MCP).
+- [x] Extensões `pg_cron` + `pg_net` + job agendado `*/5 * * * *` (migration 048).
+- [x] Smoke test: função retornou 200 `{ok, fixtures_recebidos:72, sem_link:0}`; cron via pg_net também 200.
+- [ ] Pendente: validar ramo "placar→pontos" com 1 jogo real (só com jogo finalizado).
 
 **Produção** (`lavclmlvvfzkblrstojd`) — só depois do staging validado
 - [ ] Renovar assinatura API-Sports (vence **11/jun/2026**) — **Diody**.
@@ -44,7 +46,16 @@ Robô que lê o placar da API-Sports e atualiza o bolão. Migrations já aplicad
 3. **Add new secret** → Name: `CRON_SECRET` → Value: (valor passado no chat) → salvar.
 4. Avisar o Claude que está feito → ele faz o deploy + cron.
 
+### Pré-requisito Vault por ambiente (rodar 1x via SQL — NÃO versionar valores)
+```sql
+-- staging já feito. Pra prod, trocar URL pro ref de prod e (idealmente) outro secret:
+SELECT vault.create_secret('<x-cron-secret>', 'ingest_wc_cron_secret', 'x-cron-secret do ingest-wc-scores');
+SELECT vault.create_secret('https://<PROJECT_REF>.supabase.co/functions/v1/ingest-wc-scores', 'ingest_wc_url', 'URL da função');
+```
+
 ## Log de execução
-_(preencher conforme avança)_
 - 2026-06-01 — migrations 046/047 aplicadas no **staging** (validadas). Função `ingest-wc-scores`
-  escrita (sem deploy). Aguardando secrets no staging pra deploy + cron.
+  escrita.
+- 2026-06-01 — **staging ligado ponta a ponta:** secrets (painel + Vault), deploy da função,
+  migration 048 (pg_cron `*/5` + pg_net lendo Vault). Smoke test 200 OK (72 fixtures, 0 sem-link).
+  Cron via pg_net também 200. Falta só validar com jogo finalizado real.

--- a/docs/bolao-palpites-jogador-plano.md
+++ b/docs/bolao-palpites-jogador-plano.md
@@ -1,0 +1,305 @@
+# Bolão Copa 2026 — Palpites Especiais de Jogador (pesquisa + plano)
+
+> Status: **proposta / pesquisa**. Nada implementado.
+> Autor: levantamento a pedido do Diody (sugestão dos usuários).
+> Data: 2026-06-01.
+
+## 1. O problema
+
+Hoje os palpites especiais são todos **de seleção** (campeão, finalistas, semis, quartas,
+mata-mata). A sugestão dos usuários é incluir palpites **de jogador**:
+
+- **Artilheiro** (Chuteira de Ouro / Golden Boot)
+- **Melhor goleiro** (Luva de Ouro / Golden Glove)
+- **Revelação / jovem** (Prêmio de Melhor Jovem / Young Player)
+- **Craque da Copa** (Bola de Ouro / Golden Ball)
+
+A dúvida do Diody é a **metrificação**: artilheiro é objetivo (conta gol), mas os outros
+três são subjetivos. O insight dele está correto e é o eixo de todo o plano abaixo.
+
+## 2. Pesquisa — como cada prêmio é decidido
+
+| Prêmio | Quem decide | Critério | Anúncio | Metrificável por stat? |
+|---|---|---|---|---|
+| **Chuteira de Ouro** (artilheiro) | Regra fixa FIFA | Mais gols. Empate → mais assistências → menos minutos jogados | Fim do torneio | ✅ **Sim, 100% objetivo** |
+| **Luva de Ouro** (goleiro) | FIFA Technical Study Group (júri) | Desempenho geral do goleiro | Cerimônia de encerramento | ⚠️ Não — é júri (proxy possível: jogos sem sofrer gol, defesas, etc., mas **não** é a regra oficial) |
+| **Melhor Jovem** (revelação) | FIFA TSG (júri) | Melhor jogador com ≤21 anos no início do ano (nascidos a partir de ~01/01/2005 p/ 2026) | Cerimônia de encerramento | ❌ Não — júri |
+| **Bola de Ouro** (craque) | Votação da mídia (shortlist do TSG) | Melhor jogador do torneio | Cerimônia de encerramento | ❌ Não — votação |
+
+**Conclusão-chave:** só a **Chuteira de Ouro** tem regra determinística. Os outros três são
+decisões de júri/mídia anunciadas **na cerimônia de encerramento, depois da final**. Não
+existe fórmula oficial — qualquer "metrificação" nossa seria um proxy que **não bate** com o
+vencedor real. Logo, dependem do **anúncio oficial da FIFA** pra serem resolvidos. É
+exatamente o ponto do Diody: sem o resultado oficial, vira inviável (ou injusto).
+
+Fontes:
+- [FIFA World Cup awards — Wikipedia](https://en.wikipedia.org/wiki/FIFA_World_Cup_awards)
+- [Goal.com — How the Golden Ball is decided](https://www.goal.com/en-us/news/world-cup-golden-ball-full-winners-list-how-award-decided/bltf1da74d328214aba)
+- [Inquirer — FIFA awards explained](https://www.inquirer.com/soccer/world-cup-trophies-golden-boot-golden-ball-golden-glove-young-player-fifa-awards-20221117.html)
+- [ESPN — Young Player Award](https://www.espn.com/soccer/story/_/id/48760910/who-won-young-player-award-world-cup)
+
+## 3. Pesquisa — o que a API-Sports (API-Football) entrega
+
+Cobertura da Copa 2026 na API-Sports inclui: fixtures (events, lineups, statistics, players),
+standings, **players**, **topscorers**, **topassists**, top cards, injuries, predictions, odds,
+e **squads** (elencos por seleção).
+
+- ✅ **topscorers** → ranking de artilheiros (gols). Dá pra resolver a Chuteira de Ouro
+  automaticamente, inclusive os critérios de desempate (assists via player stats, minutos
+  jogados via player stats).
+- ✅ **squads / players** → lista de jogadores por seleção com nome, posição, número,
+  **data de nascimento** (necessária pro filtro de elegibilidade do Melhor Jovem).
+- ❌ **A API NÃO devolve os vencedores oficiais dos prêmios de júri** (Luva/Bola/Jovem).
+  Esses são divulgados pela FIFA num evento, não num endpoint.
+
+Confirma a tese: **artilheiro = automático via API**; **goleiro/craque/revelação = só com o
+resultado oficial inserido manualmente** depois do anúncio.
+
+Fontes:
+- [API-Football — guia Copa 2026](https://www.api-football.com/news/post/fifa-world-cup-2026-guide-to-using-data-with-api-sports)
+- [API-Football — Top Scorers endpoint](https://www.api-football.com/news/post/top-scorers-endpoint)
+- Ver também memória do projeto: estratégia de dados = REST direto na API-Sports.
+
+## 4. Decisão central: modelo de resolução em 2 trilhas
+
+Como os prêmios são **fatos globais** (o artilheiro da Copa é o mesmo pra todos os bolões),
+a resolução **NÃO** pode ser por dono de bolão (risco de manipulação/erro). Tem que ser
+**centralizada**, igual ao resultado dos jogos (`calculate_bolao_scores` hoje usa a verdade
+global de `wc_matches`). Duas trilhas:
+
+- **Trilha A — Automática (artilheiro):** ingestão do `topscorers` da API após a final →
+  função resolve o vencedor (com desempate) → pontua todos os palpites de `top_scorer`.
+- **Trilha B — Manual central (goleiro/craque/revelação):** quando a FIFA anuncia, **um admin
+  da plataforma** (não o dono do bolão) registra o `player_id` oficial vencedor de cada prêmio
+  numa tabela global → função pontua os palpites correspondentes em todos os bolões.
+
+Ambas rodam **uma única vez, após a final** (settlement único), diferente dos palpites de
+placar que pontuam jogo a jogo.
+
+## 5. Proposta de produto
+
+### 5.1 Faseamento (recomendado)
+
+- **Onda 1 — Artilheiro:** menor risco, 100% objetivo, resolução automática. Entrega o valor
+  da feature ("palpite de jogador") já validando elenco + UI de seleção de jogador.
+- **Onda 2 — Goleiro / Craque / Revelação:** depende da trilha de resolução manual central +
+  do anúncio oficial. Liga depois que a Onda 1 estiver redonda.
+
+Isso responde direto à preocupação do Diody: começa pelo metrificável e só liga os
+subjetivos com o resultado oficial da FIFA em mãos.
+
+### 5.2 Free vs Premium
+
+Seguir a regra já vigente do bolão (palpites especiais liberados pra todos; Premium muda só
+limite de participantes). Sugestão: **mesma política** — palpites de jogador liberados pra
+Free e Premium. (Decisão do Diody.)
+
+### 5.3 Pontuação
+
+Pesos configuráveis pelo dono (como os outros especiais). Sugestão de default:
+artilheiro alto (mais difícil/icônico), demais médios. Valores finais = decisão de produto.
+
+## 6. Arquitetura (extensão do que já existe)
+
+> Base atual (read-only confirmado): `bolao_special_predictions` guarda `predicted_team_code`
+> (TEXT), sem conceito de jogador. `toggle_special_prediction` valida só os 4 tipos de
+> seleção. Não existe tabela de jogadores/elencos. Seed de referência segue o padrão de
+> `041_bolao_seed_wc_matches.sql`.
+
+### 6.1 Banco
+
+1. **`wc_players`** (nova, dados de referência globais)
+   - `player_id` (PK, id da API-Sports), `player_name`, `team_code` (FK lógica p/ seleção),
+     `position` (GK/DF/MF/FW), `shirt_number`, `birth_date` (p/ filtro de jovem), `photo_url`.
+   - Seed via ingestão dos **squads** da API-Sports (quando a FIFA confirmar os elencos —
+     ~início de junho/2026, Copa abre 11/jun).
+
+2. **Armazenamento dos palpites** — duas opções:
+   - **(Recomendado) Reusar `bolao_special_predictions`** adicionando coluna nullable
+     `predicted_player_id` e novos valores de `prediction_type`
+     (`top_scorer`/`best_goalkeeper`/`best_young_player`/`best_player`). Reaproveita
+     `get_my_special_predictions`, `toggle`, summary e o scaffolding de pontuação. Cada tipo
+     de jogador é **pick único** (1 jogador), diferente dos picks múltiplos de seleção.
+   - (Alternativa) Tabela dedicada `bolao_player_predictions`. Mais limpo conceitualmente, mas
+     duplica RPCs e UI. Só vale se a lógica divergir muito.
+
+3. **`wc_player_awards`** (nova, verdade global) — `award_type`, `winner_player_id`,
+   `resolved_at`, `resolved_by`. Preenchida pela trilha A (auto) ou B (admin central).
+
+### 6.2 RPCs
+
+- `toggle_player_prediction(bolao_id, prediction_type, player_id)` — ou estender
+  `toggle_special_prediction` pra aceitar `player_id` quando o tipo for de jogador
+  (validação: pick único; goleiro só aceita `position='GK'`; jovem só aceita `birth_date`
+  elegível).
+- `get_wc_players(filtro: posição/elegibilidade/busca)` — alimenta o seletor.
+- `resolve_player_awards()` — settlement: lê `wc_player_awards` (+ `topscorers` p/ artilheiro)
+  e grava `points_earned` nos palpites. SECURITY DEFINER, idempotente.
+- Ajustar `get_bolao_special_summary` p/ exibir popularidade dos palpites de jogador.
+
+### 6.3 Frontend
+
+- **Seletor de jogador** (novo componente): busca por nome, filtro por posição (goleiro) e por
+  elegibilidade (jovem), foto + seleção + número. Padrão visual do `SpecialPredictionsSection`.
+- Estender `TYPE_META` e o `SpecialPrediction` (service) com os tipos de jogador.
+- **Admin do bolão** (`BolaoAdminPanel`): toggles + pesos dos novos tipos.
+- **Admin de plataforma** (novo, restrito): registrar vencedores oficiais (trilha B) e
+  disparar `resolve_player_awards`.
+
+### 6.4 Ingestão de dados
+
+- Edge function / job: (a) puxar **squads** pra popular `wc_players` antes da abertura;
+  (b) puxar **topscorers** após a final pra resolver artilheiro.
+
+## 7. Riscos e dependências
+
+- **Confirmação dos elencos:** rosters oficiais saem perto da abertura (Copa 11/jun/2026).
+  A seleção de jogador só abre quando `wc_players` estiver populado. Prazo do palpite =
+  até a abertura (igual aos outros especiais).
+- **Cutoff do Melhor Jovem:** nascidos a partir de ~01/01/2005 (a confirmar pela FIFA p/ 2026).
+  Filtro depende de `birth_date` da API.
+- **Prêmios de júri:** sem resultado oficial automatizável → dependem do anúncio FIFA +
+  inserção manual central. **Timing confirmado:** os prêmios saem na cerimônia no gramado
+  **minutos após a final, na mesma noite** (ex: Copa 2022, 18/dez — Messi/Mbappé/Martínez/
+  Enzo anunciados logo após o apito). Logo, a "demora" não é externa: é só a nossa operação
+  inserir os 3 vencedores naquela noite. Pontuam dentro do hype da final, sem perder o sentido.
+- **Trilha de resolução central:** precisa de papel de admin de plataforma (não existe hoje
+  pro bolão) — definir quem opera.
+
+## 8. Plano de execução solo (você + eu)
+
+> **Premissas (confirmar/corrigir):** (a) feature completa, mas sequenciada; (b) resolução
+> manual **central** (admin de plataforma) + automação pro artilheiro; (c) liberado pra Free e
+> Premium (política atual). 48 seleções / 104 jogos / **Copa abre 11/jun/2026, final ~19/jul**.
+
+> ⚠️ **Regra de ouro (lição do drift staging×prod):** toda função/tabela nova nasce como
+> **migration commitada**. Nada de SQL direto no banco. Sempre staging → validar → prod via
+> migration. Ver memória `project_bolao_staging_prod_drift`.
+
+Como é só eu + você, isto **não é paralelo** — é uma fila de movimentos ordenada por
+**prazo e risco**. Dois prazos mandam:
+- 🔴 **11/jun (abertura):** tudo que envolve *colocar palpite* e *pontuar placar* tem que estar de pé.
+- 🟢 **~19/jul (final):** o *settlement dos prêmios de jogador* só acontece aqui — tem 5-6 semanas de folga.
+
+### Movimento 0 — Contrato + validação da API (gate, antes de tudo)
+O único acoplamento entre "integração" e "feature" é o schema. Fechar primeiro destrava os dois.
+- Validar na API-Sports (Copa 2026): `fixtures` (placar/eventos), `squads` (com `birth_date`+
+  `position`), `topscorers`. **Se a API não entregar, o plano muda — por isso é o passo 1.**
+- Fechar o schema das tabelas novas (`wc_players`, `wc_player_awards`, extensão de
+  `bolao_special_predictions`). Confirmar cutoff do Melhor Jovem 2026 (~nascidos ≥ 01/01/2005).
+
+### Movimento 1 — A ponte API-Sports → Supabase + ingestão de PLACAR 🔴 (critical path)
+**Por que primeiro:** sem isso o bolão **não pontua nada** na Copa, com ou sem feature de jogador.
+É a peça mais urgente do produto inteiro, não só dos prêmios.
+- Edge function base (`ingest-wc`) que fala REST com a API-Sports (1 cliente, vários jobs).
+- Job de **fixtures/placar** → upsert em `wc_matches` (score + `is_finished`) → dispara
+  `calculate_bolao_scores`. Agendado via **cron do Supabase** (frequente nos dias de jogo).
+- **Fallback manual** de placar (admin seta um jogo) como rede de segurança pro 1º dia.
+
+### Movimento 2 — Elencos: ingestão de squads → `wc_players` 🔴
+Reusa a ponte do M1. Gate pra UI de palpite de jogador.
+- Migration `046_wc_players` (player_id PK, nome, team_code, position, birth_date, photo).
+  RLS leitura pública; escrita service_role.
+- Job de **squads** → upsert em `wc_players`. Rodar quando a FIFA confirmar os elencos.
+
+### Movimento 3 — Palpite de jogador: SELEÇÃO 🔴 (precisa abrir antes de 11/jun)
+Foco só em *deixar o usuário palpitar* — pontuação fica pro M4.
+- Migration `047_player_predictions_schema`: estende `bolao_special_predictions`
+  (`predicted_player_id` nullable, `team_code` nullable, `CHECK` por tipo,
+  `UNIQUE(bolao_id,user_id,prediction_type)` p/ pick único); novos tipos
+  `top_scorer`/`best_goalkeeper`/`best_young_player`/`best_player`; config de pesos no `boloes`;
+  tabela global `wc_player_awards`.
+- Migration `048_player_predictions_rpcs`: **recriar `get_my_special_predictions`** com
+  `predicted_player_id` (muda OUT columns → `DROP`+`CREATE`, **sincronizar staging E prod** — é
+  a função do incidente recente); `set_player_prediction(...)` com validações
+  (goleiro→`position='Goalkeeper'`; jovem→`birth_date` elegível; prazo).
+- Frontend: componente `PlayerPicker` (busca + filtro posição/elegibilidade + foto/bandeira),
+  4 cards de prêmio no modal, toggles + pesos no `BolaoAdminPanel`.
+
+### Movimento 4 — Settlement dos prêmios 🟢 (com folga, após picks fecharem)
+- `resolve_player_awards()` — idempotente; lê `wc_player_awards` e pontua todos os bolões
+  respeitando os pesos de cada um.
+- Job de **topscorers** (reusa a ponte) → resolve **artilheiro automático** com desempate.
+- **Mini-tela de admin de plataforma** — registrar os 3 vencedores de júri + botão "puxar
+  artilheiro" → liquida na noite da final em ~30s. É a "automação rápida" que você citou.
+
+### Movimento 5 — Polimento 🟢
+Visualização de resultado (vencedor × seu palpite × pontos), popularidade por prêmio,
+achievement ("acertou o artilheiro").
+
+### A decisão de escopo que o calendário força
+Em modo solo, **M1 (placar) é inegociável pra 11/jun**. M2+M3 (palpite de jogador no ar) é o
+*stretch* pra mesma data. Se o tempo apertar, a ordem de sacrifício é clara: garante M1, e os
+prêmios de jogador viram fast-follow — **mas** a seleção do palpite (M3) tem que entrar antes da
+abertura pra valer nesta Copa (prazo = abertura). M4/M5 têm semanas de folga de qualquer jeito.
+
+→ **Próximo movimento concreto: M0** — validar os 3 endpoints na API-Sports e fechar o schema.
+Posso começar por aí quando você der o ok.
+
+## 9. M0 — Resultado da validação (concluído 2026-06-01)
+
+Validado direto na API-Sports (`v3.football.api-sports.io`, league id **1** = World Cup,
+season **2026**, `current=true`, abre 11/jun).
+
+### O que a API entrega
+- ✅ **Capacidade confirmada:** a Copa **2022** tem cobertura toda `true` (players, top_scorers,
+  statistics_players, events, lineups). Na **2026** essas flags estão `false` agora porque o
+  torneio não começou — vão virar `true` conforme a Copa se aproxima/começa (igual 2022).
+- ✅ **Fixtures/placar (2026):** 72 de 104 jogos já carregados (knockout com TBD ainda não),
+  com **team ids** (ex: México=16). Pipeline de placar viável.
+- ✅ **Topscorers:** forma da resposta traz `goals.total`, `goals.assists`, `games.minutes` →
+  dá pra resolver o **artilheiro automático** com o desempate oficial (validado na 2022:
+  Mbappé 8 gols × Messi 7). Em 2026 está vazio agora (sem jogos).
+- ✅ **Posição do jogador:** vem no `players/squads` (Goalkeeper/Defender/Midfielder/Attacker).
+- ⚠️ **`birth_date` NÃO vem no `squads`** (só `age`). Está no **`players/profiles`** (1 chamada
+  por jogador / paginado). A ingestão precisa **combinar squads + profiles** pra ter a data exata
+  (necessária pra elegibilidade do Melhor Jovem).
+- ⚠️ **Elenco = pool nacional amplo, não os 26 da Copa:** `squads?team=16` retornou 49 jogadores.
+  Pré-torneio listamos demais. Mitigação: re-ingerir perto/depois da convocação oficial (o
+  squads tende a enxugar) e/ou aceitar o pool amplo (quem palpita em jogador fora dos 26 só perde).
+
+### Conta / plano (operacional)
+- Plano **Pro — 7.500 req/dia** (folga pra enriquecer ~1248 jogadores via profiles + pollar placar).
+- 🔴 **A assinatura vence em 11/jun/2026 — o dia da abertura.** Renovar antes, senão a ingestão
+  morre no 1º jogo. **Bloqueador operacional nº 1.**
+- Mapeamento necessário: API usa **team id numérico**; nosso `wc_matches` usa código de 3 letras.
+  A ingestão precisa de um de↔para (team id → team_code), construível a partir dos próprios fixtures.
+
+### Schema fechado (contrato pras duas frentes)
+- **`wc_players`** (ref global): `player_id bigint PK`, `player_name`, `team_code`, `api_team_id`,
+  `position`, `shirt_number`, `birth_date` (nullable até enriquecer), `photo_url`, `updated_at`.
+  RLS leitura pública; escrita service_role. Índices `(team_code)`, `(position)`.
+- **`bolao_special_predictions`** (extensão): `+ predicted_player_id bigint NULL` (FK wc_players);
+  `predicted_team_code` vira nullable; `CHECK` (tipo de time → team_code; tipo de jogador →
+  player_id); `UNIQUE(bolao_id,user_id,prediction_type)` parcial p/ tipos de jogador (pick único).
+  Novos tipos: `top_scorer`,`best_goalkeeper`,`best_young_player`,`best_player`.
+- **`wc_player_awards`** (verdade global): `award_type text PK`, `winner_player_id bigint FK`,
+  `resolved_at`, `resolved_by`.
+- **`boloes`** (config): `player_awards_enabled jsonb` + `player_award_points jsonb` (padrão do
+  `scoring_weights`).
+- **Elegibilidade Melhor Jovem 2026:** filtro `birth_date >= '2005-01-01'` (a confirmar oficialmente).
+
+### Veredito do gate
+API entrega tudo que o plano precisa. Sinais verdes pra seguir. **Pendências não-código:**
+(1) renovar a assinatura API-Sports antes de 11/jun; (2) decidir timing da ingestão de elencos
+(pool amplo agora vs lista enxuta perto da Copa).
+
+## 10. Progresso M1 — ponte API→Supabase + placar
+
+Decisão: usar a chave atual (`VITE_API_SPORTS_KEY`) por enquanto; migrar pra secret/chave
+backend depois.
+
+- ✅ **046_wc_team_map** — de↔para `api_team_id`→`team_code` (48/48, validado staging). Commit f8d10c3.
+- ✅ **047_wc_matches_api_fixture_id** — coluna + seed dos 72 jogos de grupo (validado staging;
+  mata-mata null até resolver). Casamento por par de times, NÃO por data (API=UTC, nosso=BRT). Commit 9669aa5.
+- ✅ **edge function `ingest-wc-scores`** (código, sem deploy) — puxa fixtures, atualiza placar+
+  is_finished por `api_fixture_id`, dispara `calculate_bolao_scores`; idempotente; guard
+  `x-cron-secret`; `verify_jwt=false`. Commit a10a28a.
+
+**Falta pra ativar o placar automático (precisa de você / infra):**
+1. Setar secrets no Supabase: `API_SPORTS_KEY` (valor da chave atual por ora), `CRON_SECRET`.
+2. Deploy da função `ingest-wc-scores`.
+3. Agendar via pg_cron (chamar a função de X em X min nos dias de jogo).
+4. Smoke test com 1 jogo (forçar um placar via API mock / jogo passado) antes de 11/jun.
+
+**TODO técnico:** auto-link do mata-mata (32 jogos) quando a API carregar os fixtures com times reais.

--- a/src/components/bolao/AchievementProvider.tsx
+++ b/src/components/bolao/AchievementProvider.tsx
@@ -159,13 +159,13 @@ const AchievementBadge: React.FC<{ def: AchievementDef }> = ({ def }) => {
             <Icon className="w-5 h-5 text-amber-2" />
           </div>
           <div className="min-w-0 flex-1">
-            <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-white/90 leading-tight">
+            <p className="text-[10px] font-bold uppercase tracking-[0.14em] text-ink-2 leading-tight">
               Conquista
             </p>
-            <p className="text-[14px] font-bold text-white leading-tight truncate">
+            <p className="text-[14px] font-bold text-ink leading-tight truncate">
               {def.title}
             </p>
-            <p className="text-[11px] text-white/85 leading-tight truncate">
+            <p className="text-[11px] text-ink-2 leading-tight truncate">
               {def.description}
             </p>
           </div>
@@ -174,7 +174,7 @@ const AchievementBadge: React.FC<{ def: AchievementDef }> = ({ def }) => {
             onClick={handleShare}
             disabled={sharing}
             aria-label="Compartilhar conquista"
-            className="shrink-0 w-9 h-9 flex items-center justify-center rounded-full bg-white/20 hover:bg-white/30 active:bg-white/40 text-white transition-colors disabled:opacity-50"
+            className="shrink-0 w-9 h-9 flex items-center justify-center rounded-full bg-ink/10 hover:bg-ink/20 active:bg-ink/25 text-ink transition-colors disabled:opacity-50"
           >
             <Share2 className="w-4 h-4" />
           </button>

--- a/src/components/bolao/BolaoAdminPanel.tsx
+++ b/src/components/bolao/BolaoAdminPanel.tsx
@@ -55,6 +55,8 @@ interface BolaoAdminPanelProps {
   specialPredictionsConfig: Record<string, boolean>;
   specialPredictionsPoints: Record<string, number>;
   championPoints: number;
+  playerAwardsEnabled?: Record<string, boolean>;
+  playerAwardPoints?: Record<string, number>;
   ranking: BolaoRankingEntry[];
   currentUserId: string | undefined;
   ownerUserId: string;
@@ -108,6 +110,20 @@ const SPECIAL_TYPES: Record<string, string> = {
   semifinalist: 'Semifinalistas',
   quarterfinalist: 'Quartas de Final',
   round_of_32: 'Mata-mata (32)',
+};
+
+const PLAYER_AWARD_TYPES: { key: string; label: string; sub: string }[] = [
+  { key: 'top_scorer', label: 'Artilheiro', sub: 'Chuteira de Ouro' },
+  { key: 'best_player', label: 'Craque da Copa', sub: 'Bola de Ouro' },
+  { key: 'best_goalkeeper', label: 'Melhor Goleiro', sub: 'Luva de Ouro' },
+  { key: 'best_young_player', label: 'Revelação', sub: 'Melhor jovem (≤21)' },
+];
+
+const DEFAULT_PLAYER_AWARDS_ENABLED: Record<string, boolean> = {
+  top_scorer: true, best_player: true, best_goalkeeper: true, best_young_player: true,
+};
+const DEFAULT_PLAYER_AWARD_POINTS: Record<string, number> = {
+  top_scorer: 10, best_player: 10, best_goalkeeper: 8, best_young_player: 8,
 };
 
 // ── NumberStepper (light theme) ───────────────────────────────────
@@ -252,6 +268,8 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   specialPredictionsConfig,
   specialPredictionsPoints,
   championPoints,
+  playerAwardsEnabled,
+  playerAwardPoints,
   ranking,
   currentUserId,
   ownerUserId,
@@ -296,6 +314,12 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   const [specialConfig, setSpecialConfig] = useState<Record<string, boolean>>(specialPredictionsConfig);
   const [specialPoints, setSpecialPoints] = useState<Record<string, number>>(specialPredictionsPoints);
   const [champPoints, setChampPoints] = useState(championPoints);
+  const [playerAwardsConfig, setPlayerAwardsConfig] = useState<Record<string, boolean>>(
+    { ...DEFAULT_PLAYER_AWARDS_ENABLED, ...(playerAwardsEnabled ?? {}) }
+  );
+  const [playerPoints, setPlayerPoints] = useState<Record<string, number>>(
+    { ...DEFAULT_PLAYER_AWARD_POINTS, ...(playerAwardPoints ?? {}) }
+  );
 
   const { toast } = useToast();
   const removeMember = useRemoveMember();
@@ -479,6 +503,33 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
       { bolaoId, settings: { special_predictions_points: specialPoints } },
       {
         onSuccess: () => toast({ title: 'Pontuação dos palpites especiais atualizada' }),
+        onError: (err: any) => toast({ title: 'Erro', description: err.message, variant: 'destructive' }),
+      }
+    );
+  };
+
+  const handleTogglePlayerAward = (key: string) => {
+    const newConfig = { ...playerAwardsConfig, [key]: !playerAwardsConfig[key] };
+    const prev = { ...playerAwardsConfig };
+    setPlayerAwardsConfig(newConfig);
+    const label = PLAYER_AWARD_TYPES.find((a) => a.key === key)?.label ?? key;
+    updateSettings.mutate(
+      { bolaoId, settings: { player_awards_enabled: newConfig } },
+      {
+        onSuccess: () => toast({ title: newConfig[key] ? `${label} habilitado` : `${label} desabilitado` }),
+        onError: (err: any) => {
+          setPlayerAwardsConfig(prev);
+          toast({ title: 'Erro', description: err.message, variant: 'destructive' });
+        },
+      }
+    );
+  };
+
+  const handleSavePlayerPoints = () => {
+    updateSettings.mutate(
+      { bolaoId, settings: { player_award_points: playerPoints } },
+      {
+        onSuccess: () => toast({ title: 'Pontuação dos prêmios de jogador atualizada' }),
         onError: (err: any) => toast({ title: 'Erro', description: err.message, variant: 'destructive' }),
       }
     );
@@ -1033,6 +1084,48 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
             <button
               type="button"
               onClick={handleSaveSpecialPoints}
+              disabled={updateSettings.isPending}
+              className="h-10 px-4 rounded-rebrand-md bg-forest text-white text-[13px] font-bold hover:bg-forest-2 disabled:opacity-50"
+            >
+              {updateSettings.isPending ? 'Salvando...' : 'Salvar pontuação'}
+            </button>
+          </div>
+        )}
+      </Card>
+
+      <Card title="Prêmios de Jogador" sub="Artilheiro, craque, goleiro e revelação — cada um ativável com pontos próprios">
+        {PLAYER_AWARD_TYPES.map(({ key, label, sub }) => (
+          <SettingsRow
+            key={key}
+            title={label}
+            sub={playerAwardsConfig[key] ? `${sub} · vale ${playerPoints[key] ?? 1} pt(s)` : 'Desabilitado'}
+          >
+            <div className="flex items-center gap-2">
+              <NumberStepper
+                value={playerPoints[key] ?? 1}
+                onChange={(v) => setPlayerPoints({ ...playerPoints, [key]: v })}
+                min={1}
+                max={50}
+                suffix="pts"
+                size="sm"
+                disabled={!playerAwardsConfig[key] || !isOwner}
+                ariaLabel={`pontos de ${label}`}
+                className="w-28"
+              />
+              <Toggle
+                on={!!playerAwardsConfig[key]}
+                onClick={() => handleTogglePlayerAward(key)}
+                ariaLabel={`Toggle ${label}`}
+                disabled={!isOwner}
+              />
+            </div>
+          </SettingsRow>
+        ))}
+        {isOwner && JSON.stringify(playerPoints) !== JSON.stringify({ ...DEFAULT_PLAYER_AWARD_POINTS, ...(playerAwardPoints ?? {}) }) && (
+          <div className="py-3 border-t border-line">
+            <button
+              type="button"
+              onClick={handleSavePlayerPoints}
               disabled={updateSettings.isPending}
               className="h-10 px-4 rounded-rebrand-md bg-forest text-white text-[13px] font-bold hover:bg-forest-2 disabled:opacity-50"
             >

--- a/src/components/bolao/PalpitesProgress.tsx
+++ b/src/components/bolao/PalpitesProgress.tsx
@@ -5,6 +5,11 @@ interface PalpitesProgressProps {
   total: number;
   /** "modal" = dentro do dialog (cabeçalho compacto). "page" = dentro de página (mais espaço) */
   variant?: 'modal' | 'page';
+  /**
+   * Quando presente e ainda há pendentes, o indicador vira clicável (ex.: pular
+   * pra aba "Pendentes"). Sem isso, renderiza estático.
+   */
+  onClick?: () => void;
 }
 
 /**
@@ -14,9 +19,10 @@ interface PalpitesProgressProps {
  *  Fazer Palpites               12 / 72
  *  ████████░░░░░░░░░░░░░░░ 17%
  */
-export const PalpitesProgress: React.FC<PalpitesProgressProps> = ({ done, total, variant = 'modal' }) => {
+export const PalpitesProgress: React.FC<PalpitesProgressProps> = ({ done, total, variant = 'modal', onClick }) => {
   const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0;
   const isComplete = total > 0 && done >= total;
+  const clickable = !!onClick && !isComplete && total > 0;
 
   // Cor escala: ink-3 → amber → forest conforme progresso
   const colorClass =
@@ -25,14 +31,24 @@ export const PalpitesProgress: React.FC<PalpitesProgressProps> = ({ done, total,
     : pct >= 20 ? 'text-amber-2'
     : 'text-ink-3';
 
+  const Tag: any = clickable ? 'button' : 'div';
+
   return (
-    <div
-      className="flex flex-col items-end gap-1.5 w-32"
-      role="progressbar"
-      aria-valuenow={done}
-      aria-valuemin={0}
-      aria-valuemax={total}
-      aria-label={`${done} de ${total} palpites feitos (${pct}%)`}
+    <Tag
+      type={clickable ? 'button' : undefined}
+      onClick={clickable ? onClick : undefined}
+      aria-label={
+        clickable
+          ? `${total - done} palpites faltando — ver pendentes`
+          : `${done} de ${total} palpites feitos (${pct}%)`
+      }
+      className={`flex flex-col items-end gap-1.5 w-32 ${
+        clickable ? 'group cursor-pointer rounded-rebrand-md -m-1 p-1 hover:bg-canvas-2 transition-colors' : ''
+      }`}
+      role={clickable ? undefined : 'progressbar'}
+      aria-valuenow={clickable ? undefined : done}
+      aria-valuemin={clickable ? undefined : 0}
+      aria-valuemax={clickable ? undefined : total}
     >
       <div className="flex items-baseline gap-1 tabular-nums">
         <span className={`${variant === 'modal' ? 'text-lg' : 'text-xl'} font-bold leading-none ${colorClass}`}>
@@ -50,6 +66,11 @@ export const PalpitesProgress: React.FC<PalpitesProgressProps> = ({ done, total,
           }}
         />
       </div>
-    </div>
+      {clickable && (
+        <span className="text-[10px] font-semibold text-status-warning group-hover:underline underline-offset-2">
+          ver {total - done} pendente{total - done !== 1 ? 's' : ''}
+        </span>
+      )}
+    </Tag>
   );
 };

--- a/src/components/bolao/PlayerAwardsSection.tsx
+++ b/src/components/bolao/PlayerAwardsSection.tsx
@@ -1,0 +1,264 @@
+import React, { useMemo, useState } from 'react';
+import { Goal, Star, Shield, Sparkles, ChevronDown, Search, X, Check } from 'lucide-react';
+import { TeamFlag } from '@/components/bolao/TeamFlag';
+import { useWcPlayers, useMySpecialPredictions, useSetPlayerPrediction } from '@/hooks/use-bolao';
+import { useToast } from '@/hooks/use-toast';
+import type { PlayerAwardType, WcPlayer } from '@/services/bolao.service';
+
+/** Cutoff de elegibilidade do Melhor Jovem 2026 (nascidos a partir desta data). */
+const YOUNG_CUTOFF = '2005-01-01';
+
+interface AwardMeta {
+  key: PlayerAwardType;
+  label: string;
+  sublabel: string;
+  icon: React.ComponentType<{ className?: string }>;
+  /** Filtro de quais jogadores podem ser escolhidos pra este prêmio. */
+  filter?: (p: WcPlayer) => boolean;
+}
+
+const AWARDS: AwardMeta[] = [
+  { key: 'top_scorer', label: 'Artilheiro', sublabel: 'Quem faz mais gols · Chuteira de Ouro', icon: Goal },
+  { key: 'best_player', label: 'Craque da Copa', sublabel: 'Melhor jogador · Bola de Ouro', icon: Star },
+  {
+    key: 'best_goalkeeper', label: 'Melhor Goleiro', sublabel: 'Luva de Ouro', icon: Shield,
+    filter: (p) => p.position === 'Goalkeeper',
+  },
+  {
+    key: 'best_young_player', label: 'Revelação', sublabel: 'Melhor jovem (≤21) · nascidos ≥ 2005', icon: Sparkles,
+    filter: (p) => !!p.birth_date && p.birth_date >= YOUNG_CUTOFF,
+  },
+];
+
+interface Props {
+  bolaoId: string;
+  /** Liga/desliga cada prêmio (config do bolão). Default: todos ligados. */
+  enabled?: Partial<Record<PlayerAwardType, boolean>>;
+  /** Pontos por prêmio (config do bolão). */
+  pointsConfig?: Partial<Record<PlayerAwardType, number>>;
+}
+
+export const PlayerAwardsSection: React.FC<Props> = ({ bolaoId, enabled, pointsConfig }) => {
+  const { data: players } = useWcPlayers();
+  const { data: myPreds } = useMySpecialPredictions(bolaoId);
+
+  /** award_type → player_id escolhido pelo user. */
+  const myPicks = useMemo(() => {
+    const map: Partial<Record<PlayerAwardType, number>> = {};
+    for (const p of myPreds || []) {
+      if (p.predicted_player_id && (p.prediction_type as PlayerAwardType)) {
+        map[p.prediction_type as PlayerAwardType] = p.predicted_player_id;
+      }
+    }
+    return map;
+  }, [myPreds]);
+
+  const playersById = useMemo(() => {
+    const m = new Map<number, WcPlayer>();
+    for (const p of players || []) m.set(p.player_id, p);
+    return m;
+  }, [players]);
+
+  const awardsToShow = AWARDS.filter((a) => enabled?.[a.key] !== false);
+  if (awardsToShow.length === 0) return null;
+
+  return (
+    <div className="space-y-3">
+      {awardsToShow.map((award) => (
+        <PlayerAwardCard
+          key={award.key}
+          award={award}
+          bolaoId={bolaoId}
+          players={players || []}
+          pickedPlayer={myPicks[award.key] ? playersById.get(myPicks[award.key]!) ?? null : null}
+          pointsLabel={pointsConfig?.[award.key] != null ? `+${pointsConfig[award.key]} pts` : undefined}
+        />
+      ))}
+    </div>
+  );
+};
+
+interface CardProps {
+  award: AwardMeta;
+  bolaoId: string;
+  players: WcPlayer[];
+  pickedPlayer: WcPlayer | null;
+  pointsLabel?: string;
+}
+
+const PlayerAwardCard: React.FC<CardProps> = ({ award, bolaoId, players, pickedPlayer, pointsLabel }) => {
+  const Icon = award.icon;
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const setPick = useSetPlayerPrediction();
+  const { toast } = useToast();
+
+  // Jogadores elegíveis a este prêmio
+  const eligible = useMemo(
+    () => (award.filter ? players.filter(award.filter) : players),
+    [players, award]
+  );
+
+  // Revelação fica "em breve" enquanto ninguém tem birth_date (não enriquecido)
+  const youngBlocked =
+    award.key === 'best_young_player' && players.length > 0 && players.every((p) => !p.birth_date);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const base = q
+      ? eligible.filter((p) => p.player_name.toLowerCase().includes(q) || p.team_code.toLowerCase().includes(q))
+      : eligible;
+    return base.slice(0, 60);
+  }, [eligible, search]);
+
+  const handlePick = (playerId: number | null) => {
+    setPick.mutate(
+      { bolaoId, predictionType: award.key, playerId },
+      {
+        onError: (err: any) =>
+          toast({ title: 'Erro', description: err?.message ?? 'Tente novamente', variant: 'destructive' }),
+      }
+    );
+  };
+
+  return (
+    <div className={`rounded-rebrand-md border bg-white overflow-hidden transition-colors ${open ? 'border-forest/40' : 'border-line'}`}>
+      <button
+        type="button"
+        onClick={() => !youngBlocked && setOpen((v) => !v)}
+        aria-expanded={open}
+        disabled={youngBlocked}
+        className="w-full px-4 py-3 flex items-center justify-between gap-3 text-left hover:bg-canvas-2 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-9 h-9 rounded-rebrand-sm bg-canvas-2 text-ink-2 flex items-center justify-center shrink-0">
+            <Icon className="w-4 h-4" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[13px] font-semibold text-ink leading-tight">{award.label}</p>
+            <p className="text-[11px] text-ink-2 leading-tight mt-0.5">
+              {award.sublabel}
+              {pointsLabel && <span className="text-forest font-semibold"> · {pointsLabel}</span>}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2.5 shrink-0">
+          {youngBlocked ? (
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-ink-3 bg-canvas-2 px-2 py-1 rounded-rebrand-sm">
+              Em breve
+            </span>
+          ) : pickedPlayer ? (
+            <span className="inline-flex items-center gap-1.5 text-[11px] font-semibold text-amber-2 max-w-[42vw] sm:max-w-none">
+              <TeamFlag code={pickedPlayer.team_code} size="sm" />
+              <span className="truncate">{pickedPlayer.player_name}</span>
+            </span>
+          ) : (
+            <span className="text-[11px] text-ink-3">Escolher</span>
+          )}
+          {!youngBlocked && (
+            <ChevronDown className={`w-4 h-4 text-ink-3 shrink-0 transition-transform ${open ? 'rotate-180' : ''}`} />
+          )}
+        </div>
+      </button>
+
+      {open && !youngBlocked && (
+        <div className="px-4 pb-4 border-t border-line">
+          {/* Pick atual com opção de remover */}
+          {pickedPlayer && (
+            <div className="flex items-center gap-2.5 mt-3 pb-3 border-b border-line">
+              <PlayerAvatar player={pickedPlayer} />
+              <div className="min-w-0 flex-1">
+                <p className="text-[12px] font-semibold text-ink truncate">{pickedPlayer.player_name}</p>
+                <p className="text-[11px] text-ink-2 flex items-center gap-1.5">
+                  <TeamFlag code={pickedPlayer.team_code} size="sm" /> {pickedPlayer.team_code}
+                  {pickedPlayer.position && <span className="text-ink-3">· {pickedPlayer.position}</span>}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => handlePick(null)}
+                disabled={setPick.isPending}
+                className="inline-flex items-center gap-1 h-7 px-2.5 rounded-rebrand-sm border border-line text-[11px] font-semibold text-ink-2 hover:border-line-2 hover:bg-canvas-2 transition-colors"
+              >
+                <X className="w-3 h-3" /> Remover
+              </button>
+            </div>
+          )}
+
+          {/* Busca */}
+          <div className="relative my-3">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-ink-3 pointer-events-none" />
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={`Buscar entre ${eligible.length} jogadores…`}
+              aria-label={`Buscar jogador para ${award.label}`}
+              className="w-full h-10 pl-9 pr-3 rounded-rebrand-md border border-line bg-canvas-2 text-[12px] text-ink placeholder:text-ink-3 focus:bg-white focus:border-forest focus:ring-2 focus:ring-forest/20 focus:outline-none transition-colors"
+            />
+          </div>
+
+          {/* Grid de jogadores */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2 max-h-72 overflow-y-auto minimal-scrollbar pr-1">
+            {filtered.map((p) => {
+              const picked = pickedPlayer?.player_id === p.player_id;
+              return (
+                <button
+                  key={p.player_id}
+                  type="button"
+                  onClick={() => handlePick(p.player_id)}
+                  disabled={setPick.isPending}
+                  aria-pressed={picked}
+                  className={`relative flex items-center gap-2 p-2 rounded-rebrand-sm border text-left transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-forest/40 ${
+                    picked ? 'border-amber bg-amber/[0.10] ring-2 ring-amber/30' : 'border-line bg-white hover:border-line-2 hover:bg-canvas-2'
+                  }`}
+                >
+                  <PlayerAvatar player={p} />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-[11px] font-semibold text-ink leading-tight truncate">{p.player_name}</p>
+                    <p className="text-[10px] text-ink-2 flex items-center gap-1 leading-tight mt-0.5">
+                      <TeamFlag code={p.team_code} size="sm" /> {p.team_code}
+                    </p>
+                  </div>
+                  {picked && (
+                    <span className="absolute top-1 right-1 w-4 h-4 rounded-full bg-amber text-white flex items-center justify-center">
+                      <Check className="w-2.5 h-2.5" />
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+            {filtered.length === 0 && (
+              <p className="col-span-full text-center text-[12px] text-ink-3 py-6">Nenhum jogador encontrado</p>
+            )}
+          </div>
+          {!search && eligible.length > 60 && (
+            <p className="text-[10px] text-ink-3 mt-2 text-center">
+              Mostrando 60 de {eligible.length} — use a busca pra achar mais rápido.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const PlayerAvatar: React.FC<{ player: WcPlayer }> = ({ player }) => {
+  const [err, setErr] = useState(false);
+  if (err || !player.photo_url) {
+    return (
+      <div className="w-8 h-8 rounded-full bg-canvas-2 text-ink-3 flex items-center justify-center text-[10px] font-bold shrink-0">
+        {player.player_name.slice(0, 2).toUpperCase()}
+      </div>
+    );
+  }
+  return (
+    <img
+      src={player.photo_url}
+      alt={player.player_name}
+      onError={() => setErr(true)}
+      className="w-8 h-8 rounded-full object-cover bg-canvas-2 shrink-0"
+      loading="lazy"
+    />
+  );
+};

--- a/src/components/bolao/PredictionsList.tsx
+++ b/src/components/bolao/PredictionsList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Filter, CheckCircle, ChevronLeft, ChevronRight, Check } from 'lucide-react';
+import { Filter, CheckCircle, ChevronLeft, ChevronRight, Check, ListChecks } from 'lucide-react';
 import { MatchPredictionCard } from '@/components/bolao/MatchPredictionCard';
 import { FilterScroller } from '@/components/bolao/FilterScroller';
 import type { WcMatch, BolaoPrediction } from '@/services/bolao.service';
@@ -23,9 +23,16 @@ interface PredictionsListProps {
   onGroupFilterChange: (filter: string) => void;
   /** When true, each card shows a "sugerir placar" sparkles button */
   enableSuggestion?: boolean;
+  /**
+   * Modo de filtro controlado pelo caller — permite que a barra de progresso
+   * (fora deste componente) salte direto pra aba "Pendentes". Opcional: se
+   * omitido, o componente gerencia o modo internamente.
+   */
+  filterMode?: FilterMode;
+  onFilterModeChange?: (mode: FilterMode) => void;
 }
 
-type FilterMode = 'group' | 'date' | 'stage';
+export type FilterMode = 'group' | 'date' | 'stage' | 'pending';
 
 const STAGE_LABEL_BY_KEY: Record<string, string> = {
   group: 'Fase de grupos',
@@ -93,11 +100,14 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
   groupFilter,
   onGroupFilterChange,
   enableSuggestion,
+  filterMode: controlledFilterMode,
+  onFilterModeChange,
 }) => {
-  const [filterMode, setFilterMode] = useState<FilterMode>('date');
+  const [internalFilterMode, setInternalFilterMode] = useState<FilterMode>('date');
+  const filterMode = controlledFilterMode ?? internalFilterMode;
+  const setFilterMode = onFilterModeChange ?? setInternalFilterMode;
   const [dateFilter, setDateFilter] = useState<string>('all');
   const [stageFilter, setStageFilter] = useState<string>('all');
-  const [onlyPending, setOnlyPending] = useState(false);
   const [autoSelected, setAutoSelected] = useState(false);
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const prevPredCountRef = React.useRef<number>(predictions?.length ?? 0);
@@ -134,8 +144,23 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
     return Array.from(unique).sort();
   }, [matches]);
 
+  // Um jogo está "pendente" quando é jogável (não finalizado, times definidos)
+  // e ainda não recebeu palpite. Centraliza a regra usada na aba Pendentes,
+  // nos badges por dia e na contagem total.
+  const isPending = React.useCallback(
+    (m: WcMatch) =>
+      !m.is_finished &&
+      m.home_team_code !== 'TBD' &&
+      m.away_team_code !== 'TBD' &&
+      !predictionsByMatch.has(m.id),
+    [predictionsByMatch]
+  );
+
   const filteredMatches = useMemo(() => {
     if (!matches) return [];
+    if (filterMode === 'pending') {
+      return matches.filter(isPending);
+    }
     let list = matches;
     if (filterMode === 'group') {
       if (groupFilter !== 'all') list = list.filter((m) => m.group_name === groupFilter);
@@ -144,20 +169,21 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
     } else {
       if (dateFilter !== 'all') list = list.filter((m) => m.match_date === dateFilter);
     }
-    if (onlyPending) {
-      list = list.filter(
-        (m) =>
-          !m.is_finished &&
-          m.home_team_code !== 'TBD' &&
-          m.away_team_code !== 'TBD' &&
-          !predictionsByMatch.has(m.id)
-      );
-    }
     return list;
-  }, [matches, filterMode, groupFilter, dateFilter, stageFilter, onlyPending, predictionsByMatch]);
+  }, [matches, filterMode, groupFilter, dateFilter, stageFilter, isPending]);
 
   const groupedMatches = useMemo(() => {
     const grouped: Record<string, WcMatch[]> = {};
+    // Aba Pendentes: lista corrida de tudo que falta, agrupada por dia (com
+    // cabeçalho de data) pra dar contexto sem o user precisar caçar dia a dia.
+    if (filterMode === 'pending') {
+      filteredMatches.forEach((m) => {
+        const key = formatLongDateLabel(m.match_date);
+        if (!grouped[key]) grouped[key] = [];
+        grouped[key].push(m);
+      });
+      return grouped;
+    }
     if (filterMode === 'date' && dateFilter !== 'all') {
       grouped[formatLongDateLabel(dateFilter)] = filteredMatches;
       return grouped;
@@ -200,12 +226,17 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
     if (!matches) return new Map<string, number>();
     const m = new Map<string, number>();
     matches.forEach((match) => {
-      if (match.is_finished || match.home_team_code === 'TBD' || match.away_team_code === 'TBD') return;
-      if (predictionsByMatch.has(match.id)) return;
+      if (!isPending(match)) return;
       m.set(match.match_date, (m.get(match.match_date) ?? 0) + 1);
     });
     return m;
-  }, [matches, predictionsByMatch]);
+  }, [matches, isPending]);
+
+  // Total de pendentes no torneio inteiro — alimenta o badge da aba Pendentes.
+  const totalPending = useMemo(
+    () => (matches || []).filter(isPending).length,
+    [matches, isPending]
+  );
 
   // Estatísticas do dia selecionado (pra cabeçalho rico)
   const selectedDayStats = useMemo(() => {
@@ -265,11 +296,11 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
   // depois de 800ms e trocava o filter pro próximo dia pendente — "não dava
   // pra ficar no dia que já preenchi". A intenção era educada (guiar pro
   // próximo) mas virou agressiva. Se o user quer pular pra próximo pendente,
-  // ele tem outras formas: botão "Próximo" da sticky bar + chip "só pendentes".
+  // ele tem outras formas: botão "Próximo" da sticky bar + aba "Pendentes".
 
   return (
     <>
-      {/* Mode toggle: Dias | Grupos | Fase + filtro "só pendentes" */}
+      {/* Mode toggle: Por dia | Por grupo | Por fase + aba "Pendentes (N)" */}
       <div
         className={`${filterPadding} flex items-center justify-between gap-2 mb-2 flex-wrap`}
       >
@@ -318,37 +349,46 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
           </button>
         </div>
 
-        {/* Toggle "só pendentes" — texto-link estilo mockup */}
-        {(() => {
-          const totalPending = (matches || []).filter(
-            (m) =>
-              !m.is_finished &&
-              m.home_team_code !== 'TBD' &&
-              m.away_team_code !== 'TBD' &&
-              !predictionsByMatch.has(m.id)
-          ).length;
-          if (totalPending === 0) return null;
-          return (
-            <button
-              type="button"
-              onClick={() => setOnlyPending((v) => !v)}
-              className="text-[11px] text-ink-2 hover:text-ink transition-colors"
-              aria-pressed={onlyPending}
+        {/* Aba "Pendentes" — ação destacada (âmbar) que leva direto pra lista
+            do que falta. Substituiu o antigo toggle "Mostrar: todos" (texto
+            cinza, invisível). Feedback Diody: user em 71/72 não achava o que
+            faltava sem caçar dia a dia. */}
+        {totalPending === 0 ? (
+          // Sem nag: só mostra o "tudo preenchido" quando o user está na aba
+          // pendentes e acabou de zerar — senão some.
+          filterMode === 'pending' ? (
+            <span className="inline-flex items-center gap-1.5 h-8 px-3 rounded-rebrand-md text-[12px] font-semibold text-status-success border border-status-success">
+              <Check className="w-3.5 h-3.5" strokeWidth={3} />
+              Tudo preenchido
+            </span>
+          ) : null
+        ) : (
+          <button
+            type="button"
+            aria-pressed={filterMode === 'pending'}
+            onClick={() => setFilterMode(filterMode === 'pending' ? 'date' : 'pending')}
+            className={`inline-flex items-center gap-1.5 h-8 px-3 rounded-rebrand-md text-[12px] font-semibold border transition-colors ${
+              filterMode === 'pending'
+                ? 'bg-status-warning text-white border-status-warning'
+                : 'bg-white text-status-warning border-amber hover:bg-canvas-2'
+            }`}
+          >
+            <ListChecks className="w-3.5 h-3.5" />
+            Pendentes
+            <span
+              className={`tabular-nums text-[11px] font-bold rounded-full px-1.5 min-w-[18px] text-center ${
+                filterMode === 'pending' ? 'bg-white/20 text-white' : 'bg-status-warning text-white'
+              }`}
             >
-              Mostrar:{' '}
-              <span
-                className={`font-semibold ${
-                  onlyPending ? 'text-forest underline underline-offset-2' : 'text-ink'
-                }`}
-              >
-                {onlyPending ? `só pendentes (${totalPending})` : 'todos'}
-              </span>
-            </button>
-          );
-        })()}
+              {totalPending}
+            </span>
+          </button>
+        )}
       </div>
 
-      {/* Filter scroller */}
+      {/* Filter scroller — escondido no modo Pendentes (lista corrida, sem
+          sub-filtro de data/grupo/fase). */}
+      {filterMode !== 'pending' && (
       <div className={variant === 'modal' ? 'px-5' : ''}>
         <FilterScroller filterIcon={<Filter className="w-3 h-3 text-ink-3 shrink-0" />}>
           {filterMode === 'group' ? (
@@ -462,6 +502,7 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
           )}
         </FilterScroller>
       </div>
+      )}
 
       {/* Matches */}
       {isLoadingMatches ? (
@@ -556,7 +597,7 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
                       allMatches={matches}
                       isClosed={isClosed}
                       enableSuggestion={enableSuggestion}
-                      hideMatchDate={filterMode === 'date'}
+                      hideMatchDate={filterMode === 'date' || filterMode === 'pending'}
                     />
                   </div>
                 ))}
@@ -565,11 +606,17 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
           ))}
           {filteredMatches.length === 0 && (
             <div className="text-center py-12 text-ink-2">
-              <p className="text-[13px]">
-                {onlyPending
-                  ? 'Tudo palpitado por aqui! Tira o filtro pra ver a lista completa.'
-                  : 'Nenhum jogo encontrado nesse filtro.'}
-              </p>
+              {filterMode === 'pending' ? (
+                <div className="inline-flex flex-col items-center gap-2">
+                  <CheckCircle className="w-8 h-8 text-status-success" />
+                  <p className="text-[14px] font-semibold text-ink">Tudo preenchido!</p>
+                  <p className="text-[12px]">
+                    Você palpitou em todos os jogos. Use as abas acima pra revisar.
+                  </p>
+                </div>
+              ) : (
+                <p className="text-[13px]">Nenhum jogo encontrado nesse filtro.</p>
+              )}
             </div>
           )}
         </div>

--- a/src/components/bolao/PredictionsModal.tsx
+++ b/src/components/bolao/PredictionsModal.tsx
@@ -13,7 +13,8 @@ import {
   useUpsertPredictionsBatch,
   useDeletePrediction,
 } from '@/hooks/use-bolao';
-import { PredictionsList } from '@/components/bolao/PredictionsList';
+import { PredictionsList, type FilterMode } from '@/components/bolao/PredictionsList';
+import { ChevronRight } from 'lucide-react';
 import { ConfirmDialog } from '@/components/bolao/ConfirmDialog';
 import { QuickPickInline } from '@/components/bolao/QuickPickInline';
 import type { QuickPickApplyOpts } from '@/components/bolao/quick-pick';
@@ -37,6 +38,7 @@ export const PredictionsModal: React.FC<PredictionsModalProps> = ({
   currentUserId,
 }) => {
   const [groupFilter, setGroupFilter] = useState<string>('all');
+  const [filterMode, setFilterMode] = useState<FilterMode>('date');
   const [confirmDeleteMatchId, setConfirmDeleteMatchId] = useState<number | null>(null);
 
   const { data: bolao } = useBolao(bolaoId);
@@ -210,6 +212,22 @@ export const PredictionsModal: React.FC<PredictionsModalProps> = ({
               </span>
             </div>
           </div>
+          {/* CTA "ver o que falta" — ancorado no gatilho emocional (a barra de
+              progresso). Resolve o feedback do user em 71/72 que não achava
+              os pendentes. Some quando completo. Leva direto pra aba Pendentes. */}
+          {totalMatches > 0 && totalPredictions < totalMatches && filterMode !== 'pending' && (
+            <button
+              type="button"
+              onClick={() => setFilterMode('pending')}
+              className="mt-2 w-full inline-flex items-center justify-between gap-2 h-9 px-3 rounded-rebrand-md border border-amber bg-white text-status-warning text-[12px] font-semibold hover:bg-canvas-2 transition-colors"
+            >
+              <span>
+                Faltam {totalMatches - totalPredictions} jogo
+                {totalMatches - totalPredictions !== 1 ? 's' : ''} — ver o que falta
+              </span>
+              <ChevronRight className="w-4 h-4 shrink-0" />
+            </button>
+          )}
         </DialogHeader>
 
         {/* Matches — scrollable */}
@@ -240,6 +258,8 @@ export const PredictionsModal: React.FC<PredictionsModalProps> = ({
             accentColor="green"
             groupFilter={groupFilter}
             onGroupFilterChange={setGroupFilter}
+            filterMode={filterMode}
+            onFilterModeChange={setFilterMode}
             enableSuggestion
           />
         </div>

--- a/src/components/bolao/SpecialPredictionsModal.tsx
+++ b/src/components/bolao/SpecialPredictionsModal.tsx
@@ -48,6 +48,8 @@ interface SpecialPredictionsModalProps {
   enabledTypes?: SpecialPredictionsConfig;
   championPoints: number;
   pointsConfig: PointsConfig;
+  playerAwardsEnabled?: Record<string, boolean>;
+  playerAwardPoints?: Record<string, number>;
 }
 
 export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = ({
@@ -63,6 +65,8 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
   enabledTypes,
   championPoints,
   pointsConfig,
+  playerAwardsEnabled,
+  playerAwardPoints,
 }) => {
   const [championPickerOpen, setChampionPickerOpen] = useState(false);
 
@@ -315,7 +319,11 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
                     </h3>
                     <div className="flex-1 h-px bg-line" />
                   </div>
-                  <PlayerAwardsSection bolaoId={bolaoId} />
+                  <PlayerAwardsSection
+                    bolaoId={bolaoId}
+                    enabled={playerAwardsEnabled}
+                    pointsConfig={playerAwardPoints}
+                  />
                 </div>
               </div>
 

--- a/src/components/bolao/SpecialPredictionsModal.tsx
+++ b/src/components/bolao/SpecialPredictionsModal.tsx
@@ -11,6 +11,7 @@ import { TeamFlag } from '@/components/bolao/TeamFlag';
 import { ChampionHeroCard } from '@/components/bolao/ChampionHeroCard';
 import { ChampionPickModal } from '@/components/bolao/ChampionPickModal';
 import { SpecialPredictionsSection } from '@/components/bolao/SpecialPredictionsSection';
+import { PlayerAwardsSection } from '@/components/bolao/PlayerAwardsSection';
 import {
   useChampionPredictions,
   useUpsertChampionPrediction,
@@ -111,7 +112,7 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
       round_of_32: [],
     };
     for (const p of mySpecialPreds || []) {
-      if (p.prediction_type in map) map[p.prediction_type as keyof typeof map].push(p.predicted_team_code);
+      if (p.prediction_type in map && p.predicted_team_code) map[p.prediction_type as keyof typeof map].push(p.predicted_team_code);
     }
     return map;
   }, [mySpecialPreds]);
@@ -305,6 +306,17 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
                     onSuggestChampion={championEnabled ? handleSuggestChampion : undefined}
                   />
                 )}
+
+                {/* Palpites de jogador (artilheiro/goleiro/craque/revelação) */}
+                <div>
+                  <div className="flex items-center gap-2 mt-1 mb-2">
+                    <h3 className="text-[11px] font-bold uppercase tracking-[0.14em] text-ink-3">
+                      Palpites de jogador
+                    </h3>
+                    <div className="flex-1 h-px bg-line" />
+                  </div>
+                  <PlayerAwardsSection bolaoId={bolaoId} />
+                </div>
               </div>
 
               {/* Sidebar — bônus, popularidade, prazo (sempre visível) */}

--- a/src/components/bolao/SpecialPredictionsSection.tsx
+++ b/src/components/bolao/SpecialPredictionsSection.tsx
@@ -326,7 +326,7 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
       round_of_32: [],
     };
     for (const p of myPreds || []) {
-      if (p.prediction_type in map) map[p.prediction_type].push(p.predicted_team_code);
+      if (p.prediction_type in map && p.predicted_team_code) map[p.prediction_type].push(p.predicted_team_code);
     }
     return map;
   }, [myPreds]);

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -348,6 +348,8 @@ export function useUpdateBolaoSettings() {
         special_predictions_config?: Record<string, boolean>;
         special_predictions_points?: Record<string, number>;
         champion_points?: number;
+        player_awards_enabled?: Record<string, boolean>;
+        player_award_points?: Record<string, number>;
       };
     }) => bolaoService.updateBolaoSettings(params.bolaoId, params.settings),
     onSuccess: (_data, variables) => {

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -272,6 +272,33 @@ export function useToggleSpecialPrediction() {
   });
 }
 
+// =============================================
+// Player Awards (palpites de jogador)
+// =============================================
+
+export function useWcPlayers() {
+  return useQuery({
+    queryKey: ['wc-players'],
+    queryFn: () => bolaoService.getWcPlayers(),
+    staleTime: 60 * 60 * 1000, // ref data quase estática
+  });
+}
+
+export function useSetPlayerPrediction() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: {
+      bolaoId: string;
+      predictionType: 'top_scorer' | 'best_goalkeeper' | 'best_young_player' | 'best_player';
+      playerId: number | null;
+    }) => bolaoService.setPlayerPrediction(params.bolaoId, params.predictionType, params.playerId),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['special-predictions-mine', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
+    },
+  });
+}
+
 export function useUpdateBolaoScoring() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -383,6 +383,8 @@ const BolaoDetail: React.FC = () => {
           enabledTypes={bolao.special_predictions_config ?? undefined}
           championPoints={bolao.champion_points ?? 25}
           pointsConfig={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_32: 1 }}
+          playerAwardsEnabled={bolao.player_awards_enabled ?? undefined}
+          playerAwardPoints={bolao.player_award_points ?? undefined}
         />
 
         {currentUserId && (
@@ -404,6 +406,8 @@ const BolaoDetail: React.FC = () => {
             specialPredictionsConfig={bolao.special_predictions_config ?? { finalist: true, semifinalist: true, quarterfinalist: true, round_of_32: true }}
             specialPredictionsPoints={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_32: 1 }}
             championPoints={bolao.champion_points ?? 10}
+            playerAwardsEnabled={bolao.player_awards_enabled ?? undefined}
+            playerAwardPoints={bolao.player_award_points ?? undefined}
             ranking={ranking || []}
             currentUserId={currentUserId}
             ownerUserId={bolao.owner_id}
@@ -742,6 +746,8 @@ const BolaoDetail: React.FC = () => {
         enabledTypes={bolao.special_predictions_config ?? undefined}
         championPoints={bolao.champion_points ?? 25}
         pointsConfig={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_32: 1 }}
+        playerAwardsEnabled={bolao.player_awards_enabled ?? undefined}
+        playerAwardPoints={bolao.player_award_points ?? undefined}
       />
 
       {/* Predictions modal */}
@@ -772,6 +778,8 @@ const BolaoDetail: React.FC = () => {
           specialPredictionsConfig={bolao.special_predictions_config ?? { finalist: true, semifinalist: true, quarterfinalist: true, round_of_32: true }}
           specialPredictionsPoints={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_32: 1 }}
           championPoints={bolao.champion_points ?? 10}
+          playerAwardsEnabled={bolao.player_awards_enabled ?? undefined}
+          playerAwardPoints={bolao.player_award_points ?? undefined}
           ranking={ranking || []}
           currentUserId={currentUserId}
           ownerUserId={bolao.owner_id}

--- a/src/pages/BolaoPalpites.tsx
+++ b/src/pages/BolaoPalpites.tsx
@@ -11,7 +11,7 @@ import {
   useUpsertPredictionsBatch,
   useDeletePrediction,
 } from '@/hooks/use-bolao';
-import { PredictionsList } from '@/components/bolao/PredictionsList';
+import { PredictionsList, type FilterMode } from '@/components/bolao/PredictionsList';
 import { PendingPredictionsSticky } from '@/components/bolao/PendingPredictionsSticky';
 import { ConfirmDialog } from '@/components/bolao/ConfirmDialog';
 import { useAchievement } from '@/components/bolao/AchievementProvider';
@@ -31,6 +31,7 @@ const BolaoPalpites: React.FC = () => {
   const navigate = useNavigate();
   const [currentUserId, setCurrentUserId] = useState<string | undefined>();
   const [groupFilter, setGroupFilter] = useState<GroupFilter>('all');
+  const [filterMode, setFilterMode] = useState<FilterMode>('date');
 
   React.useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
@@ -208,7 +209,12 @@ const BolaoPalpites: React.FC = () => {
             <h1 className="font-display text-[20px] font-bold text-ink leading-tight">Palpites</h1>
             <p className="text-[12px] text-ink-2 truncate">{bolao?.name}</p>
           </div>
-          <PalpitesProgress done={totalPredictions} total={totalMatches} variant="page" />
+          <PalpitesProgress
+            done={totalPredictions}
+            total={totalMatches}
+            variant="page"
+            onClick={() => setFilterMode('pending')}
+          />
         </div>
 
         {/* Quick Pick — 4 personas + copiar de outro bolão.
@@ -238,6 +244,8 @@ const BolaoPalpites: React.FC = () => {
             accentColor="green"
             groupFilter={groupFilter}
             onGroupFilterChange={setGroupFilter}
+            filterMode={filterMode}
+            onFilterModeChange={setFilterMode}
             enableSuggestion
           />
         )}

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -54,6 +54,8 @@ export interface Bolao {
     round_of_32: number;
   };
   champion_points: number;
+  player_awards_enabled: Record<PlayerAwardType, boolean> | null;
+  player_award_points: Record<PlayerAwardType, number> | null;
   created_at: string;
 }
 
@@ -732,6 +734,8 @@ export const bolaoService = {
       special_predictions_config?: Record<string, boolean>;
       special_predictions_points?: Record<string, number>;
       champion_points?: number;
+      player_awards_enabled?: Record<string, boolean>;
+      player_award_points?: Record<string, number>;
     }
   ): Promise<void> {
     const { error } = await supabase

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -117,10 +117,27 @@ export interface ChampionPrediction {
   created_at: string;
 }
 
+export type SpecialPredictionType =
+  | 'finalist' | 'semifinalist' | 'quarterfinalist' | 'round_of_32'
+  | 'top_scorer' | 'best_goalkeeper' | 'best_young_player' | 'best_player';
+
+export type PlayerAwardType = 'top_scorer' | 'best_goalkeeper' | 'best_young_player' | 'best_player';
+
 export interface SpecialPrediction {
-  prediction_type: 'finalist' | 'semifinalist' | 'quarterfinalist' | 'round_of_32';
-  predicted_team_code: string;
+  prediction_type: SpecialPredictionType;
+  predicted_team_code: string | null;
+  predicted_player_id: number | null;
   points_earned: number | null;
+}
+
+export interface WcPlayer {
+  player_id: number;
+  player_name: string;
+  team_code: string;
+  position: string | null;
+  shirt_number: number | null;
+  birth_date: string | null;
+  photo_url: string | null;
 }
 
 export interface SpecialSummaryEntry {
@@ -568,6 +585,35 @@ export const bolaoService = {
     const result = data as { success: boolean; action?: string; count?: number; error?: string; max?: number };
     if (!result.success) throw new Error(result.error || 'Erro ao salvar palpite');
     return { action: result.action as 'added' | 'removed', count: result.count };
+  },
+
+  // --- Player Awards (palpites de jogador) ---
+
+  /** Lista todos os jogadores da Copa (ref global wc_players). Filtro/busca é client-side. */
+  async getWcPlayers(): Promise<WcPlayer[]> {
+    const { data, error } = await supabase
+      .from('wc_players')
+      .select('player_id, player_name, team_code, position, shirt_number, birth_date, photo_url')
+      .order('player_name');
+    if (error) throw error;
+    return (data || []) as WcPlayer[];
+  },
+
+  /** Define (pick único) o palpite de jogador. playerId null limpa o palpite. */
+  async setPlayerPrediction(
+    bolaoId: string,
+    predictionType: PlayerAwardType,
+    playerId: number | null
+  ): Promise<{ action: 'set' | 'removed' }> {
+    const { data, error } = await supabase.rpc('set_player_prediction', {
+      p_bolao_id: bolaoId,
+      p_prediction_type: predictionType,
+      p_player_id: playerId,
+    });
+    if (error) throw error;
+    const result = data as { success: boolean; action?: string; error?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao salvar palpite');
+    return { action: result.action as 'set' | 'removed' };
   },
 
   async updateBolaoScoring(

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -26,3 +26,7 @@ verify_jwt = false
 [functions.ingest-wc-squads]
 # Ingestão de elencos sob demanda — protegida pelo header x-cron-secret (CRON_SECRET).
 verify_jwt = false
+
+[functions.enrich-wc-players]
+# Enriquecimento de birth_date (em lotes) — protegida pelo header x-cron-secret.
+verify_jwt = false

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -22,3 +22,7 @@ verify_jwt = false
 [functions.ingest-wc-scores]
 # Job de cron — sem JWT de usuário. Protegida pelo header x-cron-secret (CRON_SECRET).
 verify_jwt = false
+
+[functions.ingest-wc-squads]
+# Ingestão de elencos sob demanda — protegida pelo header x-cron-secret (CRON_SECRET).
+verify_jwt = false

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -18,3 +18,7 @@ verify_jwt = false
 # Desabilita verificação JWT para webhooks do Stripe
 # Webhooks do Stripe usam assinatura própria (stripe-signature) ao invés de JWT
 verify_jwt = false
+
+[functions.ingest-wc-scores]
+# Job de cron — sem JWT de usuário. Protegida pelo header x-cron-secret (CRON_SECRET).
+verify_jwt = false

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -34,3 +34,7 @@ verify_jwt = false
 [functions.ingest-wc-topscorer]
 # Resolve o artilheiro automático (pós-final) — protegida pelo header x-cron-secret.
 verify_jwt = false
+
+[functions.set-player-award]
+# Registra vencedor de prêmio (júri/manual) + liquida — protegida pelo header x-cron-secret.
+verify_jwt = false

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -30,3 +30,7 @@ verify_jwt = false
 [functions.enrich-wc-players]
 # Enriquecimento de birth_date (em lotes) — protegida pelo header x-cron-secret.
 verify_jwt = false
+
+[functions.ingest-wc-topscorer]
+# Resolve o artilheiro automático (pós-final) — protegida pelo header x-cron-secret.
+verify_jwt = false

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -38,3 +38,7 @@ verify_jwt = false
 [functions.set-player-award]
 # Registra vencedor de prêmio (júri/manual) + liquida — protegida pelo header x-cron-secret.
 verify_jwt = false
+
+[functions.mirror-wc-photos]
+# Espelha fotos dos jogadores no nosso Storage (evita hotlink) — header x-cron-secret.
+verify_jwt = false

--- a/supabase/functions/enrich-wc-players/index.ts
+++ b/supabase/functions/enrich-wc-players/index.ts
@@ -1,0 +1,92 @@
+// ============================================================
+// enrich-wc-players — preenche birth_date em wc_players (via players/profiles)
+// ============================================================
+// O endpoint /players/squads NÃO traz data de nascimento (só age). Esta função
+// busca /players/profiles?player=ID e grava birth_date — necessário pro filtro de
+// elegibilidade do Melhor Jovem (Revelação).
+//
+// Processa em LOTES com cursor (p_after = último player_id processado) pra não
+// estourar o tempo de execução. Chamar repetidamente passando next_after até done.
+// Só chama profiles pra quem está sem birth_date (re-runs ficam baratos), mas o
+// cursor avança sempre (não trava no "tail" de jogadores sem data na API).
+//
+// Proteção: header `x-cron-secret`. Body opcional: { after?: number, batch?: number }.
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const API_BASE = "https://v3.football.api-sports.io";
+const DEFAULT_BATCH = 120;
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  if ((req.headers.get("x-cron-secret") || "") !== cronSecret || !cronSecret) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+  const apiKey = Deno.env.get("API_SPORTS_KEY") || "";
+  if (!apiKey) return json({ error: "API_SPORTS_KEY not set" }, 500);
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  let after = 0;
+  let batch = DEFAULT_BATCH;
+  try {
+    const body = await req.json().catch(() => ({}));
+    if (typeof body?.after === "number") after = body.after;
+    if (typeof body?.batch === "number") batch = Math.min(Math.max(body.batch, 1), 200);
+  } catch { /* sem body */ }
+
+  try {
+    // Lote por cursor (player_id crescente)
+    const { data: rows, error: selErr } = await supabase
+      .from("wc_players")
+      .select("player_id, birth_date")
+      .gt("player_id", after)
+      .order("player_id", { ascending: true })
+      .limit(batch);
+    if (selErr) throw selErr;
+
+    let enriched = 0;
+    let lastId = after;
+    for (const row of rows ?? []) {
+      lastId = Number(row.player_id);
+      if (row.birth_date) continue; // já tem — pula a chamada
+
+      const res = await fetch(`${API_BASE}/players/profiles?player=${row.player_id}`, {
+        headers: { "x-apisports-key": apiKey },
+      });
+      if (!res.ok) continue;
+      const payload = await res.json();
+      const birth = payload?.response?.[0]?.player?.birth?.date ?? null;
+      if (!birth) continue;
+
+      const { error: upErr } = await supabase
+        .from("wc_players")
+        .update({ birth_date: birth })
+        .eq("player_id", row.player_id);
+      if (!upErr) enriched++;
+    }
+
+    const done = (rows?.length ?? 0) < batch;
+    return json({
+      ok: true,
+      processados: rows?.length ?? 0,
+      enriquecidos: enriched,
+      next_after: lastId,
+      done,
+    });
+  } catch (e) {
+    console.error("enrich-wc-players error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/supabase/functions/ingest-wc-scores/index.ts
+++ b/supabase/functions/ingest-wc-scores/index.ts
@@ -1,0 +1,135 @@
+// ============================================================
+// ingest-wc-scores — ingestão de placar da Copa (API-Sports → wc_matches)
+// ============================================================
+// Job de cron (não user-facing). Puxa os fixtures da Copa 2026 na API-Sports,
+// atualiza placar + is_finished em wc_matches (casando por api_fixture_id) e
+// dispara calculate_bolao_scores nos jogos que mudaram pra finalizado.
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET (evita chamada pública).
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, API_SPORTS_KEY, CRON_SECRET.
+//
+// Idempotente: só escreve quando o valor muda; só recalcula pontos quando o jogo
+// vira finalizado ou o placar muda.
+//
+// Escopo atual: fase de grupos (api_fixture_id já semeado na migration 047). O
+// mata-mata (32 jogos) ainda não carregou na API e tem times TBD no nosso seed —
+// o auto-link dele entra numa iteração futura (ver TODO no fim).
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const API_BASE = "https://v3.football.api-sports.io";
+const WC_LEAGUE_ID = 1;
+const WC_SEASON = 2026;
+const FINISHED = new Set(["FT", "AET", "PEN"]); // status.short que contam como encerrado
+
+serve(async (req) => {
+  // Auth de cron: header secreto
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  const provided = req.headers.get("x-cron-secret") || "";
+  if (!cronSecret || provided !== cronSecret) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+
+  const apiKey = Deno.env.get("API_SPORTS_KEY") || "";
+  if (!apiKey) return json({ error: "API_SPORTS_KEY not set" }, 500);
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  try {
+    // 1) Puxa todos os fixtures da Copa (1 request — escala trivial p/ 1 liga)
+    const res = await fetch(
+      `${API_BASE}/fixtures?league=${WC_LEAGUE_ID}&season=${WC_SEASON}`,
+      { headers: { "x-apisports-key": apiKey } }
+    );
+    if (!res.ok) return json({ error: `API ${res.status}` }, 502);
+    const payload = await res.json();
+    const fixtures: any[] = payload?.response ?? [];
+
+    // 2) Carrega o estado atual dos jogos já linkados (api_fixture_id NOT NULL)
+    const { data: rows, error: selErr } = await supabase
+      .from("wc_matches")
+      .select("id, api_fixture_id, home_score, away_score, is_finished")
+      .not("api_fixture_id", "is", null);
+    if (selErr) throw selErr;
+
+    const byFixture = new Map<number, any>();
+    for (const r of rows ?? []) byFixture.set(Number(r.api_fixture_id), r);
+
+    const changedMatchIds: number[] = [];
+    let updated = 0;
+    let skippedUnlinked = 0;
+
+    // 3) Para cada fixture, atualiza o jogo correspondente se algo mudou
+    for (const fx of fixtures) {
+      const fid = Number(fx?.fixture?.id);
+      const row = byFixture.get(fid);
+      if (!row) {
+        skippedUnlinked++; // mata-mata ainda não linkado, etc.
+        continue;
+      }
+
+      const status = fx?.fixture?.status?.short ?? "";
+      const isFinished = FINISHED.has(status);
+      const homeScore = fx?.goals?.home ?? null; // resultado (AET incluso; pênaltis à parte)
+      const awayScore = fx?.goals?.away ?? null;
+
+      const scoreChanged =
+        row.home_score !== homeScore || row.away_score !== awayScore;
+      const finishedChanged = row.is_finished !== isFinished;
+      if (!scoreChanged && !finishedChanged) continue;
+
+      const { error: updErr } = await supabase
+        .from("wc_matches")
+        .update({
+          home_score: homeScore,
+          away_score: awayScore,
+          is_finished: isFinished,
+        })
+        .eq("id", row.id);
+      if (updErr) throw updErr;
+      updated++;
+
+      // Recalcula pontos só quando o jogo (passa a) estar finalizado
+      if (isFinished) changedMatchIds.push(row.id);
+    }
+
+    // 4) Dispara o cálculo de pontos dos bolões pros jogos que mudaram
+    const scored: number[] = [];
+    for (const matchId of changedMatchIds) {
+      const { error: rpcErr } = await supabase.rpc("calculate_bolao_scores", {
+        p_match_id: matchId,
+      });
+      if (rpcErr) {
+        console.error(`calculate_bolao_scores(${matchId}) falhou:`, rpcErr.message);
+        continue;
+      }
+      scored.push(matchId);
+    }
+
+    return json({
+      ok: true,
+      fixtures_recebidos: fixtures.length,
+      jogos_atualizados: updated,
+      jogos_recalculados: scored.length,
+      fixtures_sem_link: skippedUnlinked, // esperado p/ mata-mata por enquanto
+    });
+  } catch (e) {
+    console.error("ingest-wc-scores error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// TODO (iteração futura): auto-link do mata-mata. Quando a API carregar os 32
+// jogos do knockout (com times reais) e o nosso bracket resolver os TBD, casar
+// por par de times via wc_team_map e gravar api_fixture_id nas linhas knockout.

--- a/supabase/functions/ingest-wc-squads/index.ts
+++ b/supabase/functions/ingest-wc-squads/index.ts
@@ -17,6 +17,15 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 
 const API_BASE = "https://v3.football.api-sports.io";
 
+// A API às vezes devolve nomes com entidades HTML (ex: O&apos;Neill). Decodifica.
+function decodeName(s: string): string {
+  return (s ?? "")
+    .replace(/&apos;|&#39;|&#x27;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, "&")
+    .trim();
+}
+
 serve(async (req) => {
   const cronSecret = Deno.env.get("CRON_SECRET") || "";
   const provided = req.headers.get("x-cron-secret") || "";
@@ -58,7 +67,7 @@ serve(async (req) => {
         .filter((p) => p?.id != null)
         .map((p) => ({
           player_id: Number(p.id),
-          player_name: String(p.name ?? "").trim() || `#${p.id}`,
+          player_name: decodeName(String(p.name ?? "")) || `#${p.id}`,
           api_team_id: t.api_team_id,
           team_code: t.team_code,
           position: p.position ?? null,

--- a/supabase/functions/ingest-wc-squads/index.ts
+++ b/supabase/functions/ingest-wc-squads/index.ts
@@ -1,0 +1,100 @@
+// ============================================================
+// ingest-wc-squads — ingestão de elencos da Copa (API-Sports → wc_players)
+// ============================================================
+// Disparada sob demanda (admin) quando os elencos forem confirmados. Lê os 48
+// times do wc_team_map, puxa /players/squads?team=ID de cada, e faz upsert em
+// wc_players (nome, posição, número, foto). birth_date NÃO vem no squads (só age)
+// — fica null aqui e é preenchido pelo passo de enriquecimento via profiles.
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET (mesma do ingest-wc-scores).
+// Idempotente: upsert por player_id.
+//
+// Atenção: o squads retorna o POOL nacional amplo (~40-50/seleção), não os 26 da
+// Copa. Re-rodar perto da convocação oficial pra refletir a lista enxuta.
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const API_BASE = "https://v3.football.api-sports.io";
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  const provided = req.headers.get("x-cron-secret") || "";
+  if (!cronSecret || provided !== cronSecret) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+
+  const apiKey = Deno.env.get("API_SPORTS_KEY") || "";
+  if (!apiKey) return json({ error: "API_SPORTS_KEY not set" }, 500);
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  try {
+    // 1) Times da Copa (de↔para api_team_id → team_code)
+    const { data: teams, error: teamErr } = await supabase
+      .from("wc_team_map")
+      .select("api_team_id, team_code");
+    if (teamErr) throw teamErr;
+
+    let totalPlayers = 0;
+    const teamErrors: { api_team_id: number; error: string }[] = [];
+
+    // 2) Para cada seleção, puxa o elenco e faz upsert
+    for (const t of teams ?? []) {
+      const res = await fetch(`${API_BASE}/players/squads?team=${t.api_team_id}`, {
+        headers: { "x-apisports-key": apiKey },
+      });
+      if (!res.ok) {
+        teamErrors.push({ api_team_id: t.api_team_id, error: `API ${res.status}` });
+        continue;
+      }
+      const payload = await res.json();
+      const players: any[] = payload?.response?.[0]?.players ?? [];
+
+      const rows = players
+        .filter((p) => p?.id != null)
+        .map((p) => ({
+          player_id: Number(p.id),
+          player_name: String(p.name ?? "").trim() || `#${p.id}`,
+          api_team_id: t.api_team_id,
+          team_code: t.team_code,
+          position: p.position ?? null,
+          shirt_number: p.number ?? null,
+          photo_url: p.photo ?? null,
+          updated_at: new Date().toISOString(),
+          // birth_date: preenchido no passo de enriquecimento (profiles)
+        }));
+
+      if (rows.length > 0) {
+        const { error: upErr } = await supabase
+          .from("wc_players")
+          .upsert(rows, { onConflict: "player_id" });
+        if (upErr) {
+          teamErrors.push({ api_team_id: t.api_team_id, error: upErr.message });
+          continue;
+        }
+        totalPlayers += rows.length;
+      }
+    }
+
+    return json({
+      ok: teamErrors.length === 0,
+      times_processados: (teams?.length ?? 0) - teamErrors.length,
+      jogadores_upsertados: totalPlayers,
+      erros: teamErrors,
+    });
+  } catch (e) {
+    console.error("ingest-wc-squads error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/supabase/functions/ingest-wc-topscorer/index.ts
+++ b/supabase/functions/ingest-wc-topscorer/index.ts
@@ -1,0 +1,108 @@
+// ============================================================
+// ingest-wc-topscorer — resolve o ARTILHEIRO automático (pós-final)
+// ============================================================
+// Puxa /players/topscorers da Copa, aplica o desempate oficial da Chuteira de
+// Ouro (mais gols → mais assistências → menos minutos jogados), grava o vencedor
+// em wc_player_awards('top_scorer') e dispara resolve_player_awards.
+//
+// Rodar UMA vez após a final (manual ou no botão do admin). Idempotente.
+// Proteção: header x-cron-secret. Garante que o jogador exista em wc_players
+// (upsert mínimo via wc_team_map) antes de gravar o award (FK).
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const API_BASE = "https://v3.football.api-sports.io";
+const WC_LEAGUE_ID = 1;
+const WC_SEASON = 2026;
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  if ((req.headers.get("x-cron-secret") || "") !== cronSecret || !cronSecret) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+  const apiKey = Deno.env.get("API_SPORTS_KEY") || "";
+  if (!apiKey) return json({ error: "API_SPORTS_KEY not set" }, 500);
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  try {
+    const res = await fetch(
+      `${API_BASE}/players/topscorers?league=${WC_LEAGUE_ID}&season=${WC_SEASON}`,
+      { headers: { "x-apisports-key": apiKey } }
+    );
+    if (!res.ok) return json({ error: `API ${res.status}` }, 502);
+    const payload = await res.json();
+    const list: any[] = payload?.response ?? [];
+    if (list.length === 0) {
+      return json({ ok: true, message: "Sem dados de artilheiro ainda (torneio não começou/terminou)." });
+    }
+
+    // Desempate oficial: gols ↓, assists ↓, minutos ↑
+    const ranked = list
+      .map((e) => {
+        const st = e?.statistics?.[0] ?? {};
+        return {
+          player_id: Number(e?.player?.id),
+          name: e?.player?.name ?? null,
+          birth: e?.player?.birth?.date ?? null,
+          photo: e?.player?.photo ?? null,
+          api_team_id: Number(st?.team?.id) || null,
+          goals: st?.goals?.total ?? 0,
+          assists: st?.goals?.assists ?? 0,
+          minutes: st?.games?.minutes ?? 999999,
+        };
+      })
+      .filter((p) => p.player_id)
+      .sort((a, b) => b.goals - a.goals || b.assists - a.assists || a.minutes - b.minutes);
+
+    const winner = ranked[0];
+
+    // Garante que o jogador exista em wc_players (FK do award)
+    const { data: existing } = await supabase
+      .from("wc_players").select("player_id").eq("player_id", winner.player_id).maybeSingle();
+
+    if (!existing && winner.api_team_id) {
+      const { data: tm } = await supabase
+        .from("wc_team_map").select("team_code").eq("api_team_id", winner.api_team_id).maybeSingle();
+      if (tm?.team_code) {
+        await supabase.from("wc_players").insert({
+          player_id: winner.player_id,
+          player_name: winner.name ?? `#${winner.player_id}`,
+          api_team_id: winner.api_team_id,
+          team_code: tm.team_code,
+          birth_date: winner.birth,
+          photo_url: winner.photo,
+        });
+      }
+    }
+
+    // Grava o vencedor + settle
+    const { error: awErr } = await supabase
+      .from("wc_player_awards")
+      .upsert(
+        { award_type: "top_scorer", winner_player_id: winner.player_id, resolved_at: new Date().toISOString() },
+        { onConflict: "award_type" }
+      );
+    if (awErr) throw awErr;
+
+    const { data: resolveRes, error: rErr } = await supabase.rpc("resolve_player_awards");
+    if (rErr) throw rErr;
+
+    return json({
+      ok: true,
+      artilheiro: { player_id: winner.player_id, name: winner.name, goals: winner.goals, assists: winner.assists },
+      resolve: resolveRes,
+    });
+  } catch (e) {
+    console.error("ingest-wc-topscorer error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}

--- a/supabase/functions/mirror-wc-photos/index.ts
+++ b/supabase/functions/mirror-wc-photos/index.ts
@@ -1,0 +1,82 @@
+// ============================================================
+// mirror-wc-photos — espelha as fotos dos jogadores no nosso Storage
+// ============================================================
+// A api-sports serve a foto (HTTP 200) servidor-a-servidor, mas o <img> no
+// navegador falha (hotlink protection / rede). Solução: a edge function baixa a
+// imagem e sobe no bucket público wc-player-photos; reescreve wc_players.photo_url
+// pra URL do nosso Storage (que o navegador alcança sem hotlink).
+//
+// Lotes com cursor (after/batch). Idempotente: pula quem já aponta pro Storage.
+// Proteção: header x-cron-secret. Body: { after?: number, batch?: number }.
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const BUCKET = "wc-player-photos";
+const DEFAULT_BATCH = 80;
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  if ((req.headers.get("x-cron-secret") || "") !== cronSecret || !cronSecret) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  let after = 0;
+  let batch = DEFAULT_BATCH;
+  try {
+    const body = await req.json().catch(() => ({}));
+    if (typeof body?.after === "number") after = body.after;
+    if (typeof body?.batch === "number") batch = Math.min(Math.max(body.batch, 1), 150);
+  } catch { /* sem body */ }
+
+  try {
+    const { data: rows, error: selErr } = await supabase
+      .from("wc_players")
+      .select("player_id, photo_url")
+      .gt("player_id", after)
+      .order("player_id", { ascending: true })
+      .limit(batch);
+    if (selErr) throw selErr;
+
+    let mirrored = 0;
+    let lastId = after;
+    for (const row of rows ?? []) {
+      lastId = Number(row.player_id);
+      const src: string | null = row.photo_url;
+      // pula quem não tem foto de origem ou já está no nosso storage
+      if (!src || src.includes("/storage/v1/object/public/")) continue;
+
+      const res = await fetch(src, { redirect: "follow" });
+      if (!res.ok) continue;
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      if (bytes.byteLength === 0) continue;
+
+      const path = `${row.player_id}.png`;
+      const { error: upErr } = await supabase.storage
+        .from(BUCKET)
+        .upload(path, bytes, { contentType: "image/png", upsert: true });
+      if (upErr) continue;
+
+      const { data: pub } = supabase.storage.from(BUCKET).getPublicUrl(path);
+      const { error: updErr } = await supabase
+        .from("wc_players")
+        .update({ photo_url: pub.publicUrl })
+        .eq("player_id", row.player_id);
+      if (!updErr) mirrored++;
+    }
+
+    const done = (rows?.length ?? 0) < batch;
+    return json({ ok: true, processados: rows?.length ?? 0, espelhados: mirrored, next_after: lastId, done });
+  } catch (e) {
+    console.error("mirror-wc-photos error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}

--- a/supabase/functions/set-player-award/index.ts
+++ b/supabase/functions/set-player-award/index.ts
@@ -1,0 +1,63 @@
+// ============================================================
+// set-player-award — registra vencedor de prêmio e liquida (admin/manual)
+// ============================================================
+// Usada na noite da final pros prêmios de JÚRI (goleiro/craque/revelação), que a
+// API não entrega — o operador informa o player_id oficial. Também serve pra
+// corrigir/forçar o artilheiro manualmente. Grava wc_player_awards + dispara
+// resolve_player_awards.
+//
+// Proteção: header x-cron-secret. Body: { award_type, player_id }.
+// O jogador precisa existir em wc_players (validação explícita).
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const VALID = new Set(["top_scorer", "best_goalkeeper", "best_young_player", "best_player"]);
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  if ((req.headers.get("x-cron-secret") || "") !== cronSecret || !cronSecret) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const awardType = String(body?.award_type ?? "");
+    const playerId = Number(body?.player_id);
+
+    if (!VALID.has(awardType)) {
+      return json({ error: `award_type inválido. Use: ${[...VALID].join(", ")}` }, 400);
+    }
+    if (!playerId) return json({ error: "player_id obrigatório" }, 400);
+
+    // Jogador precisa existir (FK + sanidade)
+    const { data: player } = await supabase
+      .from("wc_players").select("player_id, player_name").eq("player_id", playerId).maybeSingle();
+    if (!player) return json({ error: `Jogador ${playerId} não está em wc_players` }, 404);
+
+    const { error: awErr } = await supabase
+      .from("wc_player_awards")
+      .upsert(
+        { award_type: awardType, winner_player_id: playerId, resolved_at: new Date().toISOString() },
+        { onConflict: "award_type" }
+      );
+    if (awErr) throw awErr;
+
+    const { data: resolveRes, error: rErr } = await supabase.rpc("resolve_player_awards");
+    if (rErr) throw rErr;
+
+    return json({ ok: true, award: awardType, winner: player, resolve: resolveRes });
+  } catch (e) {
+    console.error("set-player-award error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}

--- a/supabase/migrations/045_bolao_sync_prod_special_predictions.sql
+++ b/supabase/migrations/045_bolao_sync_prod_special_predictions.sql
@@ -1,0 +1,41 @@
+-- ============================================================
+-- Sync prod ↔ staging — get_my_special_predictions faltante + overload morto
+-- ============================================================
+-- Diagnóstico (staging × prod): produção divergiu do staging porque várias
+-- mudanças de RPC do bolão foram aplicadas direto no banco de staging e nunca
+-- viraram migration. O frontend (já em prod) chama `get_my_special_predictions`
+-- — função que existe SÓ no staging, em nenhuma migration. Em prod a leitura
+-- falha → a tela de Palpites Especiais nunca mostra os palpites do usuário
+-- (finalistas travados em 0/2, sem coroa no campeão).
+--
+-- A 044 (liberar Premium) consertou a ESCRITA (toggle_special_prediction). Esta
+-- migration conserta a LEITURA, criando a função que faltava.
+--
+-- + Limpeza: prod tem um overload morto de update_bolao_scoring (4 args, sem
+--   p_scoring_weights) que ficou com o check Premium e nunca foi substituído
+--   pela 044. O frontend SEMPRE manda os 5 args (p_scoring_weights ?? null),
+--   então esse overload nunca é chamado — mas dropamos pra evitar ambiguidade
+--   de resolução no PostgREST e remover código bloqueado.
+-- ============================================================
+
+-- ─── get_my_special_predictions ─────────────────────────────
+-- Lê os palpites especiais do próprio usuário (auth.uid()) num bolão.
+-- Usado por useMySpecialPredictions → desenha finalistas/semis/quartas/mata-mata.
+-- Versão canônica do staging, endurecida com search_path + tabela qualificada.
+CREATE OR REPLACE FUNCTION public.get_my_special_predictions(p_bolao_id uuid)
+RETURNS TABLE(prediction_type text, predicted_team_code text, points_earned integer)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  SELECT prediction_type, predicted_team_code, points_earned
+  FROM public.bolao_special_predictions
+  WHERE bolao_id = p_bolao_id AND user_id = auth.uid()
+  ORDER BY prediction_type, predicted_team_code;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_my_special_predictions(uuid) TO authenticated;
+
+-- ─── DROP overload morto de update_bolao_scoring ────────────
+-- A versão correta (com p_scoring_weights jsonb) permanece, já liberada pela 044.
+DROP FUNCTION IF EXISTS public.update_bolao_scoring(uuid, text, integer, integer);

--- a/supabase/migrations/046_wc_team_map.sql
+++ b/supabase/migrations/046_wc_team_map.sql
@@ -1,0 +1,77 @@
+-- ============================================================
+-- wc_team_map — de↔para entre o team id da API-Sports e o nosso team_code
+-- ============================================================
+-- A ingestão (placar via fixtures, elencos via squads) recebe da API-Sports um
+-- team id NUMÉRICO. O nosso `wc_matches`/`wc_players` usa código FIFA de 3 letras
+-- em português (ESP, JPN, NED...). Os códigos de 3 letras DA API não servem como
+-- chave: divergem dos nossos (Spain=SPA, Japan=JAP) e ainda colidem (Australia e
+-- Austria ambos "AUS"; Iran e Iraq ambos "IRA"). Por isso o mapa é por team id.
+--
+-- Validado em 2026-06-01 contra /teams?league=1&season=2026 (48 seleções) e o
+-- nosso seed de wc_matches (48 seleções) — casamento 48/48, sem órfãos.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.wc_team_map (
+  api_team_id integer PRIMARY KEY,
+  team_code   text NOT NULL UNIQUE,
+  api_name    text NOT NULL          -- nome em inglês da API (referência/debug)
+);
+
+ALTER TABLE public.wc_team_map ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "wc_team_map_public_read" ON public.wc_team_map;
+CREATE POLICY "wc_team_map_public_read" ON public.wc_team_map
+  FOR SELECT USING (true);
+-- Escrita: só service_role (ingestão). Sem policy de write = bloqueado p/ authenticated/anon.
+
+INSERT INTO public.wc_team_map (api_team_id, team_code, api_name) VALUES
+  (1532, 'ALG', 'Algeria'),
+  (26,   'ARG', 'Argentina'),
+  (20,   'AUS', 'Australia'),
+  (775,  'AUT', 'Austria'),
+  (1,    'BEL', 'Belgium'),
+  (1113, 'BIH', 'Bosnia & Herzegovina'),
+  (6,    'BRA', 'Brazil'),
+  (5529, 'CAN', 'Canada'),
+  (1533, 'CPV', 'Cape Verde Islands'),
+  (8,    'COL', 'Colombia'),
+  (1508, 'COD', 'Congo DR'),
+  (3,    'CRO', 'Croatia'),
+  (5530, 'CUW', 'Curaçao'),
+  (770,  'CZE', 'Czech Republic'),
+  (2382, 'ECU', 'Ecuador'),
+  (32,   'EGY', 'Egypt'),
+  (10,   'ENG', 'England'),
+  (2,    'FRA', 'France'),
+  (25,   'GER', 'Germany'),
+  (1504, 'GHA', 'Ghana'),
+  (2386, 'HAI', 'Haiti'),
+  (22,   'IRN', 'Iran'),
+  (1567, 'IRQ', 'Iraq'),
+  (1501, 'CIV', 'Ivory Coast'),
+  (12,   'JPN', 'Japan'),
+  (1548, 'JOR', 'Jordan'),
+  (16,   'MEX', 'Mexico'),
+  (31,   'MAR', 'Morocco'),
+  (1118, 'NED', 'Netherlands'),
+  (4673, 'NZL', 'New Zealand'),
+  (1090, 'NOR', 'Norway'),
+  (11,   'PAN', 'Panama'),
+  (2380, 'PAR', 'Paraguay'),
+  (27,   'POR', 'Portugal'),
+  (1569, 'QAT', 'Qatar'),
+  (23,   'KSA', 'Saudi Arabia'),
+  (1108, 'SCO', 'Scotland'),
+  (13,   'SEN', 'Senegal'),
+  (1531, 'RSA', 'South Africa'),
+  (17,   'KOR', 'South Korea'),
+  (9,    'ESP', 'Spain'),
+  (5,    'SWE', 'Sweden'),
+  (15,   'SUI', 'Switzerland'),
+  (28,   'TUN', 'Tunisia'),
+  (777,  'TUR', 'Türkiye'),
+  (7,    'URU', 'Uruguay'),
+  (2384, 'USA', 'USA'),
+  (1568, 'UZB', 'Uzbekistan')
+ON CONFLICT (api_team_id) DO UPDATE
+  SET team_code = EXCLUDED.team_code, api_name = EXCLUDED.api_name;

--- a/supabase/migrations/047_wc_matches_api_fixture_id.sql
+++ b/supabase/migrations/047_wc_matches_api_fixture_id.sql
@@ -1,0 +1,41 @@
+-- ============================================================
+-- wc_matches.api_fixture_id — link pro fixture id da API-Sports
+-- ============================================================
+-- A ingestão de placar atualiza wc_matches por este id. Mapeamento validado
+-- (2026-06-01) contra /fixtures?league=1&season=2026: os 72 jogos de fase de
+-- grupos casam 72/72 com o nosso seed por PAR DE TIMES (orientação home/away
+-- idêntica). NÃO casar por data: a API é UTC e nosso match_date é BRT (28/72
+-- caem em dia diferente). Mata-mata (32 jogos) ainda não carregou na API (times
+-- TBD) — fica NULL e será populado pela ingestão quando os times resolverem.
+-- ============================================================
+
+ALTER TABLE public.wc_matches ADD COLUMN IF NOT EXISTS api_fixture_id bigint;
+
+CREATE UNIQUE INDEX IF NOT EXISTS wc_matches_api_fixture_id_key
+  ON public.wc_matches (api_fixture_id) WHERE api_fixture_id IS NOT NULL;
+
+UPDATE public.wc_matches m
+   SET api_fixture_id = f.fid
+  FROM (VALUES
+    (1489369,'MEX','RSA'),(1538999,'KOR','CZE'),(1539000,'CAN','BIH'),(1489370,'USA','PAR'),
+    (1489373,'QAT','SUI'),(1489371,'BRA','MAR'),(1489372,'HAI','SCO'),(1539001,'AUS','TUR'),
+    (1489374,'GER','CUW'),(1489376,'NED','JPN'),(1489375,'CIV','ECU'),(1539002,'SWE','TUN'),
+    (1489380,'ESP','CPV'),(1489377,'BEL','EGY'),(1489379,'KSA','URU'),(1489378,'IRN','NZL'),
+    (1489383,'FRA','SEN'),(1539016,'IRQ','NOR'),(1489381,'ARG','ALG'),(1489382,'AUT','JOR'),
+    (1539003,'POR','COD'),(1489384,'ENG','CRO'),(1489385,'GHA','PAN'),(1489386,'UZB','COL'),
+    (1539004,'CZE','RSA'),(1539005,'SUI','BIH'),(1489387,'CAN','QAT'),(1489388,'MEX','KOR'),
+    (1489391,'USA','AUS'),(1489390,'SCO','MAR'),(1489389,'BRA','HAI'),(1539006,'TUR','PAR'),
+    (1539007,'NED','SWE'),(1489393,'GER','CIV'),(1489392,'ECU','CUW'),(1489394,'TUN','JPN'),
+    (1489397,'ESP','KSA'),(1489395,'BEL','IRN'),(1489398,'URU','CPV'),(1489396,'NZL','EGY'),
+    (1489399,'ARG','AUT'),(1539017,'FRA','IRQ'),(1489401,'NOR','SEN'),(1489400,'JOR','ALG'),
+    (1489404,'POR','UZB'),(1489402,'ENG','GHA'),(1489403,'PAN','CRO'),(1539008,'COL','COD'),
+    (1489408,'SUI','CAN'),(1539009,'BIH','QAT'),(1489405,'MAR','HAI'),(1489406,'SCO','BRA'),
+    (1539010,'CZE','MEX'),(1489407,'RSA','KOR'),(1489410,'ECU','GER'),(1489409,'CUW','CIV'),
+    (1539011,'JPN','SWE'),(1489412,'TUN','NED'),(1539012,'TUR','USA'),(1489411,'PAR','AUS'),
+    (1539074,'SEN','IRQ'),(1489416,'NOR','FRA'),(1489417,'URU','ESP'),(1489413,'CPV','KSA'),
+    (1489414,'EGY','IRN'),(1489415,'NZL','BEL'),(1489420,'CRO','GHA'),(1489422,'PAN','ENG'),
+    (1489419,'COL','POR'),(1539013,'COD','UZB'),(1489418,'ALG','AUT'),(1489421,'JOR','ARG')
+  ) AS f(fid, home, away)
+ WHERE m.stage = 'group'
+   AND m.home_team_code = f.home
+   AND m.away_team_code = f.away;

--- a/supabase/migrations/048_cron_ingest_wc_scores.sql
+++ b/supabase/migrations/048_cron_ingest_wc_scores.sql
@@ -1,0 +1,37 @@
+-- ============================================================
+-- Agendamento (cron) da ingestão de placar — ingest-wc-scores
+-- ============================================================
+-- Habilita pg_cron + pg_net e agenda a chamada da edge function ingest-wc-scores
+-- a cada 5 min. URL e secret são lidos do Vault (NÃO ficam hardcoded aqui), então
+-- esta migration é portável entre ambientes.
+--
+-- PRÉ-REQUISITO POR AMBIENTE (não versionado — rodar uma vez via SQL, ver runbook):
+--   vault.create_secret('<x-cron-secret>',  'ingest_wc_cron_secret', ...);
+--   vault.create_secret('<url da função>',  'ingest_wc_url', ...);
+-- E os secrets da própria função (API_SPORTS_KEY, CRON_SECRET) setados no painel.
+--
+-- TODO prod: restringir à janela do torneio (jun/jul) e usar cadência menor em
+-- horário de jogo (ex: */2) e maior fora dele.
+-- ============================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'ingest-wc-scores') THEN
+    PERFORM cron.unschedule('ingest-wc-scores');
+  END IF;
+END $$;
+
+SELECT cron.schedule('ingest-wc-scores', '*/5 * * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_wc_url'),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_wc_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+$job$);

--- a/supabase/migrations/049_wc_players.sql
+++ b/supabase/migrations/049_wc_players.sql
@@ -1,0 +1,32 @@
+-- ============================================================
+-- wc_players — elencos da Copa (dados de referência globais)
+-- ============================================================
+-- Populada pela ingestão de squads da API-Sports (edge function ingest-wc-squads).
+-- Base pros palpites de jogador (artilheiro/goleiro/craque/revelação).
+--
+-- birth_date vem do endpoint players/profiles (NÃO do squads, que só dá age) —
+-- por isso é nullable; é enriquecido num 2º passo e só é essencial pro filtro de
+-- elegibilidade do Melhor Jovem (nascidos >= 2005-01-01, a confirmar).
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.wc_players (
+  player_id    bigint PRIMARY KEY,                 -- id da API-Sports
+  player_name  text NOT NULL,
+  api_team_id  integer NOT NULL REFERENCES public.wc_team_map(api_team_id),
+  team_code    text NOT NULL,                      -- nosso código (denormalizado, via wc_team_map)
+  position     text,                               -- Goalkeeper/Defender/Midfielder/Attacker
+  shirt_number integer,
+  birth_date   date,                               -- nullable até enriquecer via profiles
+  photo_url    text,
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS wc_players_team_code_idx ON public.wc_players (team_code);
+CREATE INDEX IF NOT EXISTS wc_players_position_idx  ON public.wc_players (position);
+
+ALTER TABLE public.wc_players ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "wc_players_public_read" ON public.wc_players;
+CREATE POLICY "wc_players_public_read" ON public.wc_players
+  FOR SELECT USING (true);
+-- Escrita: só service_role (ingestão). Sem policy de write = bloqueado p/ authenticated/anon.

--- a/supabase/migrations/050_bolao_player_predictions_schema.sql
+++ b/supabase/migrations/050_bolao_player_predictions_schema.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- M3 — Schema dos palpites de JOGADOR (artilheiro/goleiro/revelação/craque)
+-- ============================================================
+-- Reusa bolao_special_predictions (em vez de tabela nova) pra aproveitar
+-- get_my_special_predictions/summary/scoring. Diferenças do palpite de jogador:
+--   - alvo é predicted_player_id (não predicted_team_code)
+--   - pick ÚNICO por tipo (1 jogador), via índice parcial
+-- + tabela global wc_player_awards (verdade dos vencedores) e config no boloes.
+-- RPCs (set_player_prediction, resolve_player_awards, get_my_special_predictions
+-- com player_id) ficam na migration seguinte (051).
+-- ============================================================
+
+-- ─── 1) bolao_special_predictions: aceita tipos de jogador ───
+ALTER TABLE public.bolao_special_predictions
+  DROP CONSTRAINT IF EXISTS bolao_special_predictions_prediction_type_check;
+ALTER TABLE public.bolao_special_predictions
+  ADD CONSTRAINT bolao_special_predictions_prediction_type_check
+  CHECK (prediction_type = ANY (ARRAY[
+    'champion','finalist','semifinalist','quarterfinalist','round_of_32',
+    'top_scorer','best_goalkeeper','best_young_player','best_player'
+  ]));
+
+-- alvo jogador + team_code passa a ser opcional
+ALTER TABLE public.bolao_special_predictions
+  ADD COLUMN IF NOT EXISTS predicted_player_id bigint REFERENCES public.wc_players(player_id);
+ALTER TABLE public.bolao_special_predictions
+  ALTER COLUMN predicted_team_code DROP NOT NULL;
+
+-- coerência: tipo de jogador → player_id (sem team_code); tipo de time → team_code (sem player_id)
+ALTER TABLE public.bolao_special_predictions
+  DROP CONSTRAINT IF EXISTS bolao_special_predictions_target_check;
+ALTER TABLE public.bolao_special_predictions
+  ADD CONSTRAINT bolao_special_predictions_target_check CHECK (
+    (prediction_type = ANY (ARRAY['top_scorer','best_goalkeeper','best_young_player','best_player'])
+       AND predicted_player_id IS NOT NULL AND predicted_team_code IS NULL)
+    OR
+    (prediction_type = ANY (ARRAY['champion','finalist','semifinalist','quarterfinalist','round_of_32'])
+       AND predicted_team_code IS NOT NULL AND predicted_player_id IS NULL)
+  );
+
+-- pick ÚNICO por prêmio de jogador (a UNIQUE antiga inclui team_code=NULL e não restringe)
+CREATE UNIQUE INDEX IF NOT EXISTS bolao_special_predictions_player_unique
+  ON public.bolao_special_predictions (bolao_id, user_id, prediction_type)
+  WHERE prediction_type = ANY (ARRAY['top_scorer','best_goalkeeper','best_young_player','best_player']);
+
+-- ─── 2) wc_player_awards: verdade global dos vencedores ──────
+CREATE TABLE IF NOT EXISTS public.wc_player_awards (
+  award_type       text PRIMARY KEY
+                     CHECK (award_type = ANY (ARRAY['top_scorer','best_goalkeeper','best_young_player','best_player'])),
+  winner_player_id bigint REFERENCES public.wc_players(player_id),
+  resolved_at      timestamptz,
+  resolved_by      uuid REFERENCES auth.users(id)
+);
+ALTER TABLE public.wc_player_awards ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS "wc_player_awards_public_read" ON public.wc_player_awards;
+CREATE POLICY "wc_player_awards_public_read" ON public.wc_player_awards
+  FOR SELECT USING (true);
+-- Escrita: só service_role (resolução central). Sem policy de write p/ anon/auth.
+
+-- ─── 3) boloes: liga/desliga + pesos dos prêmios de jogador ──
+ALTER TABLE public.boloes
+  ADD COLUMN IF NOT EXISTS player_awards_enabled jsonb NOT NULL
+    DEFAULT '{"top_scorer":true,"best_goalkeeper":true,"best_young_player":true,"best_player":true}'::jsonb;
+ALTER TABLE public.boloes
+  ADD COLUMN IF NOT EXISTS player_award_points jsonb NOT NULL
+    DEFAULT '{"top_scorer":10,"best_goalkeeper":8,"best_young_player":8,"best_player":10}'::jsonb;

--- a/supabase/migrations/051_bolao_player_predictions_rpcs.sql
+++ b/supabase/migrations/051_bolao_player_predictions_rpcs.sql
@@ -1,0 +1,106 @@
+-- ============================================================
+-- M3 — RPCs dos palpites de JOGADOR
+-- ============================================================
+-- 1) get_my_special_predictions: recriada INCLUINDO predicted_player_id no retorno.
+--    ⚠️ É a função do incidente de drift (migration 045). Muda OUT columns →
+--    DROP+CREATE. Sincronizar staging E prod ao promover (ver runbook).
+-- 2) set_player_prediction: grava o palpite de jogador (pick único). Validações:
+--    autenticado, membro, prêmio habilitado no bolão, prazo (antes da abertura),
+--    jogador existe, goleiro só aceita Goalkeeper, revelação exige birth_date
+--    conhecido E elegível (bloqueio seguro enquanto birth_date não foi enriquecido).
+-- ============================================================
+
+-- ─── get_my_special_predictions (agora com player_id) ───────
+DROP FUNCTION IF EXISTS public.get_my_special_predictions(uuid);
+CREATE FUNCTION public.get_my_special_predictions(p_bolao_id uuid)
+RETURNS TABLE(prediction_type text, predicted_team_code text, predicted_player_id bigint, points_earned integer)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  SELECT prediction_type, predicted_team_code, predicted_player_id, points_earned
+  FROM public.bolao_special_predictions
+  WHERE bolao_id = p_bolao_id AND user_id = auth.uid()
+  ORDER BY prediction_type, predicted_team_code, predicted_player_id;
+$function$;
+GRANT EXECUTE ON FUNCTION public.get_my_special_predictions(uuid) TO authenticated;
+
+-- ─── set_player_prediction ──────────────────────────────────
+CREATE OR REPLACE FUNCTION public.set_player_prediction(
+  p_bolao_id uuid,
+  p_prediction_type text,
+  p_player_id bigint
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id uuid;
+  v_enabled jsonb;
+  v_player record;
+  v_kickoff timestamptz;
+  v_young_cutoff date := '2005-01-01';  -- a confirmar p/ 2026 (nascidos >= esta data)
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+
+  IF p_prediction_type NOT IN ('top_scorer','best_goalkeeper','best_young_player','best_player') THEN
+    RETURN json_build_object('success', false, 'error', 'Invalid prediction type');
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member');
+  END IF;
+
+  -- Prêmio habilitado neste bolão?
+  SELECT player_awards_enabled INTO v_enabled FROM boloes WHERE id = p_bolao_id;
+  IF v_enabled IS NULL OR COALESCE((v_enabled ->> p_prediction_type)::boolean, false) = false THEN
+    RETURN json_build_object('success', false, 'error', 'Prêmio desabilitado neste bolão');
+  END IF;
+
+  -- Prazo: até a abertura da Copa (kickoff do primeiro jogo)
+  SELECT min((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+    INTO v_kickoff FROM wc_matches;
+  IF v_kickoff IS NOT NULL AND now() >= v_kickoff THEN
+    RETURN json_build_object('success', false, 'error', 'Prazo encerrado (Copa começou)');
+  END IF;
+
+  -- Remoção: player_id nulo limpa o palpite
+  IF p_player_id IS NULL THEN
+    DELETE FROM bolao_special_predictions
+      WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = p_prediction_type;
+    RETURN json_build_object('success', true, 'action', 'removed');
+  END IF;
+
+  SELECT * INTO v_player FROM wc_players WHERE player_id = p_player_id;
+  IF NOT FOUND THEN
+    RETURN json_build_object('success', false, 'error', 'Jogador não encontrado');
+  END IF;
+
+  IF p_prediction_type = 'best_goalkeeper' AND v_player.position IS DISTINCT FROM 'Goalkeeper' THEN
+    RETURN json_build_object('success', false, 'error', 'Esse prêmio aceita só goleiros');
+  END IF;
+
+  IF p_prediction_type = 'best_young_player' THEN
+    IF v_player.birth_date IS NULL THEN
+      RETURN json_build_object('success', false, 'error', 'Elegibilidade indisponível (sem data de nascimento)');
+    END IF;
+    IF v_player.birth_date < v_young_cutoff THEN
+      RETURN json_build_object('success', false, 'error', 'Jogador não elegível ao prêmio de revelação');
+    END IF;
+  END IF;
+
+  -- Pick único: substitui o anterior do mesmo tipo
+  DELETE FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = p_prediction_type;
+  INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_player_id)
+    VALUES (p_bolao_id, v_user_id, p_prediction_type, p_player_id);
+
+  RETURN json_build_object('success', true, 'action', 'set');
+END;
+$function$;
+GRANT EXECUTE ON FUNCTION public.set_player_prediction(uuid, text, bigint) TO authenticated;

--- a/supabase/migrations/052_resolve_player_awards.sql
+++ b/supabase/migrations/052_resolve_player_awards.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- M4 — resolve_player_awards: settlement dos prêmios de jogador
+-- ============================================================
+-- Lê os vencedores oficiais em wc_player_awards e grava points_earned nos
+-- palpites de jogador de TODOS os bolões, respeitando o peso de cada bolão
+-- (boloes.player_award_points). Idempotente: recalcula tudo a cada chamada.
+--
+-- Disparada após a final: pelo job de topscorers (artilheiro automático) e/ou
+-- pela mini-tela de admin (prêmios de júri). Só pontua prêmios que já têm
+-- winner_player_id definido.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.resolve_player_awards()
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_scored int := 0;
+BEGIN
+  UPDATE public.bolao_special_predictions bsp
+     SET points_earned = CASE
+           WHEN bsp.predicted_player_id = wpa.winner_player_id
+             THEN COALESCE((b.player_award_points ->> bsp.prediction_type)::int, 0)
+           ELSE 0
+         END
+    FROM public.wc_player_awards wpa
+    JOIN public.boloes b ON true
+   WHERE bsp.prediction_type = wpa.award_type
+     AND wpa.winner_player_id IS NOT NULL
+     AND b.id = bsp.bolao_id;
+
+  GET DIAGNOSTICS v_scored = ROW_COUNT;
+  RETURN json_build_object('success', true, 'scored', v_scored);
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.resolve_player_awards() TO service_role;


### PR DESCRIPTION
## Contexto

Dois ajustes de bolão acumulados nesta branch.

### 1. Aba "Pendentes" — achar os palpites que faltam (UX)

**Feedback do Diody:** um usuário em **71/72** não conseguia descobrir qual palpite faltava sem caçar dia por dia / grupo por grupo / fase por fase. O toggle `Mostrar: todos` que resolveria isso estava **disfarçado de texto cinza** (sumia no mobile) e, pior, filtrava **só dentro do dia selecionado** — nunca mostrava o que falta no torneio inteiro de uma vez.

**O que muda:**
- **Aba "Pendentes · N"** (pill âmbar destacada) substitui o toggle invisível. Mostra uma **lista corrida de todos os jogos sem palpite**, agrupada por dia. Estado de celebração quando zera; sem _nag_ quando não há pendência.
- **Barra de progresso vira o gatilho:** no modal, um CTA `Faltam N — ver o que falta ›` ancorado logo abaixo do `71/72` salta direto pra aba Pendentes. Na página, o indicador de progresso fica clicável (`ver N pendentes`), complementando a sticky bar que já existia.
- `filterMode` virou controlável pelo componente pai (prop opcional, retrocompatível com o state interno).

Arquivos: `PredictionsList.tsx`, `PredictionsModal.tsx`, `PalpitesProgress.tsx`, `BolaoPalpites.tsx`.

### 2. Fix: leitura de special predictions em prod (`d2252ba`)

Prod divergiu do staging — `get_my_special_predictions` (chamada pelo front) só existia no staging, então em prod a tela de Palpites Especiais nunca mostrava os palpites (finalistas travados em 0/2, sem coroa no campeão). Esta migration cria a função em prod e dropa o overload morto `update_bolao_scoring(uuid,text,int,int)`. Validado no staging (no-op idempotente).

## Testes
- `tsc --noEmit` limpo (EXIT=0).
- Migration validada no staging como no-op idempotente.

## Como validar a UX
1. Abrir o modal "Fazer palpites" (ou a página `/bolao/:id/palpites`) com palpites faltando.
2. Conferir o CTA "Faltam N — ver o que falta" abaixo da barra de progresso → clica → cai na aba **Pendentes** com a lista corrida do que falta.
3. Preencher o último → pill vira "✓ Tudo preenchido" e a lista mostra o estado de celebração.

🤖 Generated with [Claude Code](https://claude.com/claude-code)