### PR TITLE
feat(bolão): chaveamento clicável + prazos configuráveis dos especiais + edição de descrição

### DIFF
--- a/src/components/bolao/BolaoAdminPanel.tsx
+++ b/src/components/bolao/BolaoAdminPanel.tsx
@@ -43,6 +43,7 @@ interface BolaoAdminPanelProps {
   onOpenChange: (open: boolean) => void;
   bolaoId: string;
   bolaoName?: string;
+  bolaoDescription?: string | null;
   isClosed: boolean;
   isPremium: boolean;
   scoringPreset: string | null;
@@ -257,6 +258,7 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   onOpenChange,
   bolaoId,
   bolaoName,
+  bolaoDescription,
   isClosed,
   isPremium,
   scoringPreset,
@@ -297,6 +299,8 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   // Edição inline do nome do bolão
   const [editingName, setEditingName] = useState(false);
   const [nameDraft, setNameDraft] = useState(bolaoName ?? '');
+  const [editingDesc, setEditingDesc] = useState(false);
+  const [descDraft, setDescDraft] = useState(bolaoDescription ?? '');
 
   // Scoring state — toggles permitem desativar uma categoria. Quando OFF,
   // salva 0 no banco; o valor "ultimo ligado" fica em customResult/customExact
@@ -560,6 +564,26 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
     );
   };
 
+  const handleSaveDesc = () => {
+    const trimmed = descDraft.trim();
+    if (trimmed === (bolaoDescription ?? '').trim()) {
+      setEditingDesc(false);
+      return;
+    }
+    updateSettings.mutate(
+      { bolaoId, settings: { description: trimmed || null } },
+      {
+        onSuccess: () => {
+          toast({ title: 'Descrição atualizada' });
+          setEditingDesc(false);
+        },
+        onError: (err: any) => {
+          toast({ title: 'Erro ao atualizar descrição', description: err.message, variant: 'destructive' });
+        },
+      }
+    );
+  };
+
   const handleLogoFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -682,6 +706,71 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
                     setEditingName(true);
                   }}
                   className="h-9 px-3 rounded-rebrand-md text-[12px] font-semibold text-ink-2 border border-line hover:border-line-2 hover:bg-canvas-2 hover:text-ink inline-flex items-center gap-1.5 transition-colors"
+                >
+                  <Pencil className="w-3.5 h-3.5" />
+                  Editar
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="py-4 border-b border-line">
+          <p className="text-[13px] font-semibold text-ink leading-tight mb-1">Descrição do bolão</p>
+          {editingDesc ? (
+            <div className="mt-2 space-y-2">
+              <textarea
+                value={descDraft}
+                onChange={(e) => setDescDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Escape') {
+                    setDescDraft(bolaoDescription ?? '');
+                    setEditingDesc(false);
+                  }
+                }}
+                maxLength={280}
+                rows={3}
+                autoFocus
+                placeholder="Ex: bolão da firma — o campeão paga a pizza 🍕"
+                aria-label="Descrição do bolão"
+                className="w-full px-3 py-2 rounded-rebrand-md border border-line bg-white text-[13px] text-ink focus:border-forest focus:ring-2 focus:ring-forest/20 focus:outline-none resize-none"
+              />
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleSaveDesc}
+                  disabled={updateSettings.isPending}
+                  className="h-9 px-3 rounded-rebrand-md bg-forest text-white text-[12px] font-semibold hover:bg-forest-2 disabled:opacity-50 transition-colors"
+                >
+                  {updateSettings.isPending ? 'Salvando...' : 'Salvar'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDescDraft(bolaoDescription ?? '');
+                    setEditingDesc(false);
+                  }}
+                  disabled={updateSettings.isPending}
+                  className="h-9 px-3 rounded-rebrand-md text-[12px] font-semibold text-ink-2 hover:bg-canvas-2 hover:text-ink disabled:opacity-50 transition-colors"
+                >
+                  Cancelar
+                </button>
+                <span className="text-[10px] text-ink-3 ml-auto tabular-nums">{descDraft.length}/280</span>
+              </div>
+            </div>
+          ) : (
+            <div className="flex items-start justify-between gap-3 mt-1">
+              <p className={`text-[14px] whitespace-pre-line ${bolaoDescription ? 'text-ink' : 'text-ink-3 italic'}`}>
+                {bolaoDescription || 'Sem descrição'}
+              </p>
+              {isOwner && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDescDraft(bolaoDescription ?? '');
+                    setEditingDesc(true);
+                  }}
+                  className="shrink-0 h-9 px-3 rounded-rebrand-md text-[12px] font-semibold text-ink-2 border border-line hover:border-line-2 hover:bg-canvas-2 hover:text-ink inline-flex items-center gap-1.5 transition-colors"
                 >
                   <Pencil className="w-3.5 h-3.5" />
                   Editar

--- a/src/components/bolao/BolaoAdminPanel.tsx
+++ b/src/components/bolao/BolaoAdminPanel.tsx
@@ -36,7 +36,8 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { ToastAction } from '@/components/ui/toast';
 import { ConfirmDialog } from '@/components/bolao/ConfirmDialog';
-import type { BolaoRankingEntry } from '@/services/bolao.service';
+import type { BolaoRankingEntry, WcMatch, SpecialDeadlinesConfig } from '@/services/bolao.service';
+import { specialDeadline } from '@/components/bolao/special-deadlines';
 
 interface BolaoAdminPanelProps {
   open: boolean;
@@ -62,6 +63,10 @@ interface BolaoAdminPanelProps {
   currentUserId: string | undefined;
   ownerUserId: string;
   predictionDeadlineMode: 'per_match' | 'per_day' | 'per_round' | 'per_stage' | 'tournament_start';
+  /** Jogos da Copa — pra exibir os prazos efetivos dos palpites especiais. */
+  matches?: WcMatch[];
+  /** Config atual de prazo dos especiais (preset + overrides). */
+  specialDeadlines?: SpecialDeadlinesConfig | null;
 }
 
 type SectionId = 'geral' | 'pontuacao' | 'prazo' | 'modalidades' | 'membros';
@@ -120,6 +125,51 @@ const PLAYER_AWARD_TYPES: { key: string; label: string; sub: string }[] = [
   { key: 'best_goalkeeper', label: 'Melhor Goleiro', sub: 'Luva de Ouro' },
   { key: 'best_young_player', label: 'Revelação', sub: 'Melhor jovem (≤21)' },
 ];
+
+// Prazo dos palpites especiais — ordem de exibição + de qual flag de modalidade dependem.
+const SPECIAL_DEADLINE_MODES: Record<'rolling' | 'opening', { label: string; description: string }> = {
+  rolling: { label: 'Rolável por rodada', description: 'Cada fase fecha no início da rodada que a decide. Prêmios de jogador na abertura.' },
+  opening: { label: 'Tudo na abertura', description: 'Todos os palpites especiais fecham no primeiro jogo da Copa.' },
+};
+
+type SpecialDeadlineKey =
+  | 'round_of_32' | 'round_of_16' | 'quarterfinalist' | 'semifinalist' | 'finalist' | 'champion'
+  | 'top_scorer' | 'best_player' | 'best_goalkeeper' | 'best_young_player';
+
+const SPECIAL_DEADLINE_ROWS: { key: SpecialDeadlineKey; label: string; group: 'knockout' | 'player' }[] = [
+  { key: 'round_of_32', label: '16 avos', group: 'knockout' },
+  { key: 'round_of_16', label: 'Oitavas', group: 'knockout' },
+  { key: 'quarterfinalist', label: 'Quartas', group: 'knockout' },
+  { key: 'semifinalist', label: 'Semis', group: 'knockout' },
+  { key: 'finalist', label: 'Finalistas', group: 'knockout' },
+  { key: 'champion', label: 'Campeão', group: 'knockout' },
+  { key: 'top_scorer', label: 'Artilheiro', group: 'player' },
+  { key: 'best_player', label: 'Craque', group: 'player' },
+  { key: 'best_goalkeeper', label: 'Goleiro', group: 'player' },
+  { key: 'best_young_player', label: 'Revelação', group: 'player' },
+];
+
+/** Date → "YYYY-MM-DDTHH:mm" em BRT (valor de input datetime-local). */
+function toBrtInputValue(d: Date): string {
+  const p = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Sao_Paulo', year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', hourCycle: 'h23',
+  }).formatToParts(d).reduce((a, x) => { a[x.type] = x.value; return a; }, {} as Record<string, string>);
+  return `${p.year}-${p.month}-${p.day}T${p.hour}:${p.minute}`;
+}
+
+/** "YYYY-MM-DDTHH:mm" (BRT) → ISO com offset -03:00 pra persistir. */
+function brtInputToIso(v: string): string {
+  return `${v}:00-03:00`;
+}
+
+/** Formata um prazo pra exibição curta, ex "28/06 16:00". */
+function fmtDeadlineShort(d: Date | null): string {
+  if (!d) return '—';
+  return new Intl.DateTimeFormat('pt-BR', {
+    timeZone: 'America/Sao_Paulo', day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit',
+  }).format(d).replace(',', '');
+}
 
 const DEFAULT_PLAYER_AWARDS_ENABLED: Record<string, boolean> = {
   top_scorer: true, best_player: true, best_goalkeeper: true, best_young_player: true,
@@ -277,6 +327,8 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   currentUserId,
   ownerUserId,
   predictionDeadlineMode,
+  matches,
+  specialDeadlines,
 }) => {
   const [activeSection, setActiveSection] = useState<SectionId>('geral');
   const contentScrollRef = useRef<HTMLDivElement>(null);
@@ -325,6 +377,15 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   const [playerPoints, setPlayerPoints] = useState<Record<string, number>>(
     { ...DEFAULT_PLAYER_AWARD_POINTS, ...(playerAwardPoints ?? {}) }
   );
+
+  // Prazo dos palpites especiais (preset + overrides por tipo) — salva na hora.
+  const [specialDlMode, setSpecialDlMode] = useState<'rolling' | 'opening'>(specialDeadlines?.mode ?? 'rolling');
+  const [specialDlOverrides, setSpecialDlOverrides] = useState<Record<string, string | null>>(
+    specialDeadlines?.overrides ?? {}
+  );
+  // Linha cujo editor de data está aberto (key) + rascunho do input.
+  const [editingDeadline, setEditingDeadline] = useState<SpecialDeadlineKey | null>(null);
+  const [deadlineDraft, setDeadlineDraft] = useState('');
 
   const { toast } = useToast();
   const removeMember = useRemoveMember();
@@ -511,6 +572,62 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
         onError: (err: any) => toast({ title: 'Erro', description: err.message, variant: 'destructive' }),
       }
     );
+  };
+
+  // ── Prazo dos palpites especiais (salva imediatamente, como o modo dos jogos) ──
+  const persistSpecialDeadlines = (
+    mode: 'rolling' | 'opening',
+    overrides: Record<string, string | null>,
+    successMsg: string
+  ) => {
+    // Remove chaves nulas/vazias pra não inflar o jsonb.
+    const clean: Record<string, string> = {};
+    for (const [k, v] of Object.entries(overrides)) if (v) clean[k] = v;
+    const prevMode = specialDlMode;
+    const prevOverrides = specialDlOverrides;
+    setSpecialDlMode(mode);
+    setSpecialDlOverrides(clean);
+    updateSettings.mutate(
+      { bolaoId, settings: { special_deadlines: { mode, overrides: clean } } },
+      {
+        onSuccess: () => toast({ title: successMsg }),
+        onError: (err: any) => {
+          setSpecialDlMode(prevMode);
+          setSpecialDlOverrides(prevOverrides);
+          toast({ title: 'Erro', description: err.message, variant: 'destructive' });
+        },
+      }
+    );
+  };
+
+  const handleSpecialDlModeChange = (mode: 'rolling' | 'opening') => {
+    if (mode === specialDlMode) return;
+    persistSpecialDeadlines(mode, specialDlOverrides, `Prazo dos especiais: ${SPECIAL_DEADLINE_MODES[mode].label}`);
+  };
+
+  const handleStartEditDeadline = (key: SpecialDeadlineKey) => {
+    const eff = specialDeadline(key, matches ?? [], { mode: specialDlMode, overrides: specialDlOverrides });
+    setDeadlineDraft(eff ? toBrtInputValue(eff) : '');
+    setEditingDeadline(key);
+  };
+
+  const handleSaveDeadlineOverride = (key: SpecialDeadlineKey) => {
+    if (!deadlineDraft) return;
+    const label = SPECIAL_DEADLINE_ROWS.find((r) => r.key === key)?.label ?? key;
+    persistSpecialDeadlines(
+      specialDlMode,
+      { ...specialDlOverrides, [key]: brtInputToIso(deadlineDraft) },
+      `Prazo de ${label} definido`
+    );
+    setEditingDeadline(null);
+  };
+
+  const handleClearDeadlineOverride = (key: SpecialDeadlineKey) => {
+    const label = SPECIAL_DEADLINE_ROWS.find((r) => r.key === key)?.label ?? key;
+    const next = { ...specialDlOverrides };
+    delete next[key];
+    persistSpecialDeadlines(specialDlMode, next, `Prazo de ${label} voltou ao padrão`);
+    setEditingDeadline(null);
   };
 
   const handleTogglePlayerAward = (key: string) => {
@@ -1078,6 +1195,119 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
               </button>
             );
           })}
+        </div>
+      </Card>
+
+      {/* Prazo dos palpites especiais (16 avos…campeão + prêmios de jogador) */}
+      <Card title="Palpites especiais" sub="Quando 16 avos…campeão e os prêmios de jogador fecham">
+        <div className="space-y-2 py-4">
+          {(['rolling', 'opening'] as const).map((mode) => {
+            const active = specialDlMode === mode;
+            const meta = SPECIAL_DEADLINE_MODES[mode];
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => handleSpecialDlModeChange(mode)}
+                disabled={updateSettings.isPending || !isOwner}
+                className={`w-full text-left rounded-rebrand-md border p-3 transition-all disabled:opacity-60 disabled:cursor-not-allowed ${
+                  active ? 'border-forest bg-forest/[0.06] ring-2 ring-forest/15' : 'border-line bg-white hover:border-line-2 hover:bg-canvas-2'
+                }`}
+              >
+                <div className="flex items-start gap-2.5">
+                  <div className={`mt-0.5 w-4 h-4 rounded-full border-2 shrink-0 flex items-center justify-center ${active ? 'border-forest bg-forest' : 'border-line'}`}>
+                    {active && <Check className="w-2.5 h-2.5 text-white" strokeWidth={3} />}
+                  </div>
+                  <div className="min-w-0">
+                    <p className={`text-[13px] font-semibold ${active ? 'text-forest' : 'text-ink'}`}>{meta.label}</p>
+                    <p className="text-[11px] text-ink-2 mt-0.5 leading-snug">{meta.description}</p>
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Ajuste fino: override de data/hora por tipo (só os habilitados) */}
+        <div className="border-t border-line pt-3">
+          <p className="text-[11px] font-semibold text-ink-2 mb-1">Ajustar tipos específicos</p>
+          <p className="text-[11px] text-ink-3 mb-3 leading-snug">
+            Por padrão cada tipo segue o preset acima. Defina uma data pra travar antes ou depois.
+          </p>
+          <div className="space-y-1.5">
+            {SPECIAL_DEADLINE_ROWS.filter((row) => {
+              if (row.key === 'champion') return champEnabled;
+              if (row.group === 'knockout') return !!specialConfig[row.key];
+              return !!playerAwardsConfig[row.key];
+            }).map((row) => {
+              const hasOverride = !!specialDlOverrides[row.key];
+              const eff = specialDeadline(row.key, matches ?? [], { mode: specialDlMode, overrides: specialDlOverrides });
+              const isEditing = editingDeadline === row.key;
+              return (
+                <div key={row.key} className="rounded-rebrand-sm border border-line bg-white">
+                  <div className="flex items-center justify-between gap-2 px-3 py-2">
+                    <div className="min-w-0">
+                      <p className="text-[12px] font-semibold text-ink leading-tight">{row.label}</p>
+                      <p className="text-[11px] text-ink-2 leading-tight mt-0.5 tabular-nums">
+                        {fmtDeadlineShort(eff)}
+                        {hasOverride
+                          ? <span className="text-amber-2 font-semibold"> · ajustado</span>
+                          : <span className="text-ink-3"> · padrão</span>}
+                      </p>
+                    </div>
+                    {isOwner && !isEditing && (
+                      <button
+                        type="button"
+                        onClick={() => handleStartEditDeadline(row.key)}
+                        className="shrink-0 h-8 px-3 rounded-rebrand-sm border border-line text-[12px] font-semibold text-ink-2 hover:border-line-2 hover:bg-canvas-2"
+                      >
+                        {hasOverride ? 'Editar' : 'Definir'}
+                      </button>
+                    )}
+                  </div>
+                  {isEditing && (
+                    <div className="px-3 pb-3 pt-1 border-t border-line flex flex-wrap items-center gap-2">
+                      <input
+                        type="datetime-local"
+                        value={deadlineDraft}
+                        onChange={(e) => setDeadlineDraft(e.target.value)}
+                        aria-label={`Prazo de ${row.label}`}
+                        className="h-9 px-2.5 rounded-rebrand-sm border border-line bg-canvas-2 text-[12px] text-ink focus:bg-white focus:border-forest focus:ring-2 focus:ring-forest/20 focus:outline-none"
+                      />
+                      <span className="text-[10px] text-ink-3">BRT</span>
+                      <div className="flex items-center gap-1.5 ml-auto">
+                        {hasOverride && (
+                          <button
+                            type="button"
+                            onClick={() => handleClearDeadlineOverride(row.key)}
+                            disabled={updateSettings.isPending}
+                            className="h-8 px-2.5 rounded-rebrand-sm border border-line text-[11px] font-semibold text-ink-2 hover:bg-canvas-2 disabled:opacity-50"
+                          >
+                            Restaurar padrão
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => setEditingDeadline(null)}
+                          className="h-8 px-2.5 rounded-rebrand-sm text-[11px] font-semibold text-ink-2 hover:bg-canvas-2"
+                        >
+                          Cancelar
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleSaveDeadlineOverride(row.key)}
+                          disabled={updateSettings.isPending || !deadlineDraft}
+                          className="h-8 px-3 rounded-rebrand-sm bg-forest text-white text-[11px] font-semibold hover:bg-forest-2 disabled:opacity-50"
+                        >
+                          Salvar
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
         </div>
       </Card>
 

--- a/src/components/bolao/BolaoEmptyState.tsx
+++ b/src/components/bolao/BolaoEmptyState.tsx
@@ -218,7 +218,7 @@ export const BolaoEmptyState: React.FC<BolaoEmptyStateProps> = ({
         </div>
 
         {/* ─── Sub-nav: Palpites | Especiais | Tabela | Ranking ─── */}
-        <div className="flex items-center gap-0.5 border-b border-line mb-5 overflow-x-auto -mx-4 px-4 sm:mx-0 sm:px-0 minimal-scrollbar">
+        <div className="flex items-center gap-0.5 border-b border-line mb-5 overflow-x-auto overflow-y-hidden -mx-4 px-4 sm:mx-0 sm:px-0 [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none]">
           {/* Aba "Palpites" — conteúdo principal (hero + convidar) */}
           <button
             type="button"

--- a/src/components/bolao/KnockoutBracket.tsx
+++ b/src/components/bolao/KnockoutBracket.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { Crown } from 'lucide-react';
+import { TeamFlag } from '@/components/bolao/TeamFlag';
+import type { WcMatch } from '@/services/bolao.service';
+import type { ProjectionResult } from '@/components/bolao/group-projection';
+import { resolveBracket, type BracketPicks, type ResolvedMatch, type ResolvedSlot } from '@/components/bolao/bracket';
+
+const STAGE_COLS: { stage: string; label: string }[] = [
+  { stage: 'round_of_32', label: '16 avos' },
+  { stage: 'round_of_16', label: 'Oitavas' },
+  { stage: 'quarter', label: 'Quartas' },
+  { stage: 'semi', label: 'Semis' },
+  { stage: 'final', label: 'Final' },
+];
+
+interface Props {
+  matches: WcMatch[];
+  projection: ProjectionResult;
+  picks: BracketPicks;
+  /** Avança (ou troca) o vencedor de um jogo. Sem isso, render é read-only. */
+  onAdvance?: (match: ResolvedMatch, winnerCode: string) => void;
+  busy?: boolean;
+}
+
+export const KnockoutBracket: React.FC<Props> = ({ matches, projection, picks, onAdvance, busy }) => {
+  const resolved = React.useMemo(
+    () => resolveBracket(matches, projection, picks),
+    [matches, projection, picks]
+  );
+  const byStage = React.useMemo(() => {
+    const map = new Map<string, ResolvedMatch[]>();
+    for (const m of resolved) {
+      if (!map.has(m.stage)) map.set(m.stage, []);
+      map.get(m.stage)!.push(m);
+    }
+    return map;
+  }, [resolved]);
+
+  const champion = resolved.find((m) => m.stage === 'final')?.winner ?? null;
+
+  return (
+    <div className="space-y-3">
+      {champion && (
+        <div className="rounded-rebrand-md border border-amber/40 bg-amber/[0.08] p-3 flex items-center gap-2.5">
+          <Crown className="w-5 h-5 text-amber-2 shrink-0" />
+          <div className="flex items-center gap-2 min-w-0">
+            <TeamFlag code={champion} size="sm" />
+            <span className="text-[13px] font-bold text-ink truncate">Seu campeão: {champion}</span>
+          </div>
+        </div>
+      )}
+
+      <div className="overflow-x-auto minimal-scrollbar pb-2">
+        <div className="flex gap-3 min-w-max">
+          {STAGE_COLS.map(({ stage, label }) => {
+            const list = byStage.get(stage) ?? [];
+            return (
+              <div key={stage} className="flex flex-col gap-2 w-[180px] shrink-0">
+                <p className="text-[10px] uppercase font-bold tracking-[0.12em] text-ink-2 text-center sticky top-0">
+                  {label}
+                </p>
+                <div className="flex flex-col gap-2 justify-around h-full">
+                  {list.map((m) => (
+                    <MatchCard key={m.match_number} match={m} onAdvance={onAdvance} busy={busy} />
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const MatchCard: React.FC<{
+  match: ResolvedMatch;
+  onAdvance?: (m: ResolvedMatch, code: string) => void;
+  busy?: boolean;
+}> = ({ match, onAdvance, busy }) => {
+  return (
+    <div className="rounded-rebrand-sm border border-line bg-white overflow-hidden">
+      <SlotRow slot={match.home} winner={match.winner} match={match} onAdvance={onAdvance} busy={busy} />
+      <div className="h-px bg-line" />
+      <SlotRow slot={match.away} winner={match.winner} match={match} onAdvance={onAdvance} busy={busy} />
+    </div>
+  );
+};
+
+const SlotRow: React.FC<{
+  slot: ResolvedSlot;
+  winner: string | null;
+  match: ResolvedMatch;
+  onAdvance?: (m: ResolvedMatch, code: string) => void;
+  busy?: boolean;
+}> = ({ slot, winner, match, onAdvance, busy }) => {
+  const isWinner = !!slot.code && slot.code === winner;
+  // só clicável quando os dois lados estão resolvidos e há handler
+  const clickable = !!onAdvance && !!slot.code && !!match.home.code && !!match.away.code;
+
+  return (
+    <button
+      type="button"
+      disabled={!clickable || busy}
+      onClick={() => slot.code && onAdvance?.(match, slot.code)}
+      className={`w-full flex items-center gap-1.5 px-2 py-1.5 text-left transition-colors ${
+        isWinner ? 'bg-forest/[0.10]' : 'bg-white'
+      } ${clickable ? 'hover:bg-canvas-2 cursor-pointer' : 'cursor-default'} disabled:cursor-default`}
+    >
+      {slot.code ? (
+        <>
+          <TeamFlag code={slot.code} size="sm" />
+          <span className={`font-mono text-[11px] truncate ${isWinner ? 'font-bold text-forest' : 'text-ink'}`}>
+            {slot.code}
+          </span>
+        </>
+      ) : (
+        <span className="text-[10px] text-ink-3 italic truncate">{slot.label}</span>
+      )}
+    </button>
+  );
+};

--- a/src/components/bolao/PlayerAwardsSection.tsx
+++ b/src/components/bolao/PlayerAwardsSection.tsx
@@ -3,7 +3,8 @@ import { Goal, Star, Shield, Sparkles, ChevronDown, Search, X, Check } from 'luc
 import { TeamFlag } from '@/components/bolao/TeamFlag';
 import { useWcPlayers, useMySpecialPredictions, useSetPlayerPrediction } from '@/hooks/use-bolao';
 import { useToast } from '@/hooks/use-toast';
-import type { PlayerAwardType, WcPlayer } from '@/services/bolao.service';
+import { isSpecialLocked, formatDeadlineLabel } from '@/components/bolao/special-deadlines';
+import type { PlayerAwardType, WcPlayer, WcMatch, SpecialDeadlinesConfig } from '@/services/bolao.service';
 
 /** Cutoff de elegibilidade do Melhor Jovem 2026 (nascidos a partir desta data). */
 const YOUNG_CUTOFF = '2005-01-01';
@@ -36,9 +37,13 @@ interface Props {
   enabled?: Partial<Record<PlayerAwardType, boolean>>;
   /** Pontos por prêmio (config do bolão). */
   pointsConfig?: Partial<Record<PlayerAwardType, number>>;
+  /** Jogos da Copa — pra calcular o prazo (prêmios fecham na abertura). */
+  matches?: WcMatch[];
+  /** Config de prazo dos especiais (preset + overrides). */
+  specialDeadlines?: SpecialDeadlinesConfig | null;
 }
 
-export const PlayerAwardsSection: React.FC<Props> = ({ bolaoId, enabled, pointsConfig }) => {
+export const PlayerAwardsSection: React.FC<Props> = ({ bolaoId, enabled, pointsConfig, matches, specialDeadlines }) => {
   const { data: players } = useWcPlayers();
   const { data: myPreds } = useMySpecialPredictions(bolaoId);
 
@@ -62,6 +67,8 @@ export const PlayerAwardsSection: React.FC<Props> = ({ bolaoId, enabled, pointsC
   const awardsToShow = AWARDS.filter((a) => enabled?.[a.key] !== false);
   if (awardsToShow.length === 0) return null;
 
+  // Por padrão todos fecham na abertura da Copa, mas cada prêmio pode ter
+  // override próprio — então calculamos o prazo por award.
   return (
     <div className="space-y-3">
       {awardsToShow.map((award) => (
@@ -72,6 +79,8 @@ export const PlayerAwardsSection: React.FC<Props> = ({ bolaoId, enabled, pointsC
           players={players || []}
           pickedPlayer={myPicks[award.key] ? playersById.get(myPicks[award.key]!) ?? null : null}
           pointsLabel={pointsConfig?.[award.key] != null ? `+${pointsConfig[award.key]} pts` : undefined}
+          locked={matches ? isSpecialLocked(award.key, matches, specialDeadlines) : false}
+          deadlineLabel={matches ? formatDeadlineLabel(award.key, matches, specialDeadlines) : null}
         />
       ))}
     </div>
@@ -84,9 +93,11 @@ interface CardProps {
   players: WcPlayer[];
   pickedPlayer: WcPlayer | null;
   pointsLabel?: string;
+  locked?: boolean;
+  deadlineLabel?: string | null;
 }
 
-const PlayerAwardCard: React.FC<CardProps> = ({ award, bolaoId, players, pickedPlayer, pointsLabel }) => {
+const PlayerAwardCard: React.FC<CardProps> = ({ award, bolaoId, players, pickedPlayer, pointsLabel, locked, deadlineLabel }) => {
   const Icon = award.icon;
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
@@ -112,6 +123,10 @@ const PlayerAwardCard: React.FC<CardProps> = ({ award, bolaoId, players, pickedP
   }, [eligible, search]);
 
   const handlePick = (playerId: number | null) => {
+    if (locked) {
+      toast({ title: 'Prazo encerrado', description: `Os palpites de ${award.label.toLowerCase()} já fecharam.` });
+      return;
+    }
     setPick.mutate(
       { bolaoId, predictionType: award.key, playerId },
       {
@@ -139,6 +154,11 @@ const PlayerAwardCard: React.FC<CardProps> = ({ award, bolaoId, players, pickedP
             <p className="text-[11px] text-ink-2 leading-tight mt-0.5">
               {award.sublabel}
               {pointsLabel && <span className="text-forest font-semibold"> · {pointsLabel}</span>}
+              {deadlineLabel && (
+                <span className={locked ? 'text-status-danger font-semibold' : 'text-ink-3'}>
+                  {' · '}{locked ? 'encerrado' : deadlineLabel}
+                </span>
+              )}
             </p>
           </div>
         </div>
@@ -177,8 +197,8 @@ const PlayerAwardCard: React.FC<CardProps> = ({ award, bolaoId, players, pickedP
               <button
                 type="button"
                 onClick={() => handlePick(null)}
-                disabled={setPick.isPending}
-                className="inline-flex items-center gap-1 h-7 px-2.5 rounded-rebrand-sm border border-line text-[11px] font-semibold text-ink-2 hover:border-line-2 hover:bg-canvas-2 transition-colors"
+                disabled={setPick.isPending || locked}
+                className="inline-flex items-center gap-1 h-7 px-2.5 rounded-rebrand-sm border border-line text-[11px] font-semibold text-ink-2 hover:border-line-2 hover:bg-canvas-2 transition-colors disabled:opacity-50"
               >
                 <X className="w-3 h-3" /> Remover
               </button>
@@ -207,7 +227,7 @@ const PlayerAwardCard: React.FC<CardProps> = ({ award, bolaoId, players, pickedP
                   key={p.player_id}
                   type="button"
                   onClick={() => handlePick(p.player_id)}
-                  disabled={setPick.isPending}
+                  disabled={setPick.isPending || locked}
                   aria-pressed={picked}
                   className={`relative flex items-center gap-2 p-2 rounded-rebrand-sm border text-left transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-forest/40 ${
                     picked ? 'border-amber bg-amber/[0.10] ring-2 ring-amber/30' : 'border-line bg-white hover:border-line-2 hover:bg-canvas-2'

--- a/src/components/bolao/SpecialPredictionsModal.tsx
+++ b/src/components/bolao/SpecialPredictionsModal.tsx
@@ -19,7 +19,7 @@ import {
   useToggleSpecialPrediction,
 } from '@/hooks/use-bolao';
 import { useToast } from '@/hooks/use-toast';
-import type { WcMatch, ChampionPrediction } from '@/services/bolao.service';
+import type { WcMatch, ChampionPrediction, SpecialDeadlinesConfig } from '@/services/bolao.service';
 
 interface SpecialPredictionsConfig {
   finalist?: boolean;
@@ -52,6 +52,7 @@ interface SpecialPredictionsModalProps {
   pointsConfig: PointsConfig;
   playerAwardsEnabled?: Record<string, boolean>;
   playerAwardPoints?: Record<string, number>;
+  specialDeadlines?: SpecialDeadlinesConfig | null;
 }
 
 export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = ({
@@ -69,6 +70,7 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
   pointsConfig,
   playerAwardsEnabled,
   playerAwardPoints,
+  specialDeadlines,
 }) => {
   const [championPickerOpen, setChampionPickerOpen] = useState(false);
 
@@ -316,6 +318,7 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
                     pointsConfig={pointsConfig}
                     championPick={myChampionPick}
                     onSuggestChampion={championEnabled ? handleSuggestChampion : undefined}
+                    specialDeadlines={specialDeadlines}
                   />
                 )}
 
@@ -331,6 +334,8 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
                     bolaoId={bolaoId}
                     enabled={playerAwardsEnabled}
                     pointsConfig={playerAwardPoints}
+                    matches={matches}
+                    specialDeadlines={specialDeadlines}
                   />
                 </div>
               </div>
@@ -402,12 +407,16 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
                     <div className="rounded-rebrand-md border border-line bg-white p-4">
                       <div className="flex items-center gap-1.5 text-ink-2 mb-1.5">
                         <Clock className="w-3.5 h-3.5" />
-                        <span className="text-[12px] font-semibold">Prazo</span>
+                        <span className="text-[12px] font-semibold">Primeiro prazo</span>
                       </div>
                       <p className="text-[14px] font-bold text-ink leading-tight">{deadline.label}</p>
                       <p className="text-[11px] text-ink-2 mt-0.5">
                         {deadline.passed ? 'Copa iniciada · ' : 'até a abertura da Copa · '}
                         {deadline.dateStr}
+                      </p>
+                      <p className="text-[10px] text-ink-3 mt-2 leading-snug border-t border-line pt-2">
+                        Prêmios de jogador fecham na abertura. Cada fase do mata-mata fecha
+                        no início da rodada que a decide — o prazo aparece em cada card.
                       </p>
                     </div>
                   )}

--- a/src/components/bolao/SpecialPredictionsSection.tsx
+++ b/src/components/bolao/SpecialPredictionsSection.tsx
@@ -8,8 +8,13 @@ import {
   useToggleSpecialPrediction,
   useBolaoPredictions,
   useSetRoundOf32FromProjection,
+  useBracketAdvance,
+  useUpsertChampionPrediction,
 } from '@/hooks/use-bolao';
 import { computeGroupProjection, type PredictionMap } from '@/components/bolao/group-projection';
+import { KnockoutBracket } from '@/components/bolao/KnockoutBracket';
+import { nextStageOf, type BracketPicks, type ResolvedMatch } from '@/components/bolao/bracket';
+import { List, GitFork } from 'lucide-react';
 import type { WcMatch } from '@/services/bolao.service';
 import { useToast } from '@/hooks/use-toast';
 
@@ -379,6 +384,11 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
     );
   };
 
+  // Visualização: lista (cards por fase) ou chaveamento (bracket clicável).
+  const [view, setView] = useState<'lista' | 'bracket'>('lista');
+  const bracketAdvance = useBracketAdvance();
+  const upsertChampion = useUpsertChampionPrediction();
+
   const teams = useMemo(() => extractTeams(matches), [matches]);
 
   const myPicksByType = useMemo(() => {
@@ -460,6 +470,29 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
     round_of_32: `+${pts.round_of_32} pt cada`,
   };
 
+  // Picks no formato do bracket + handler de avanço (clicar no vencedor).
+  const bracketPicks: BracketPicks = {
+    round_of_16: myPicksByType.round_of_16 || [],
+    quarterfinalist: myPicksByType.quarterfinalist || [],
+    semifinalist: myPicksByType.semifinalist || [],
+    finalist: myPicksByType.finalist || [],
+    champion: championPick ?? null,
+  };
+  const bracketBusy = bracketAdvance.isPending || upsertChampion.isPending;
+  const handleAdvance = (match: ResolvedMatch, winnerCode: string) => {
+    const ns = nextStageOf(match.stage);
+    if (!ns) return;
+    const loser = match.home.code === winnerCode ? match.away.code : match.home.code;
+    const onError = (err: any) =>
+      projToast({ title: 'Erro', description: err?.message ?? 'Tente novamente', variant: 'destructive' });
+    if (ns === 'champion') {
+      upsertChampion.mutate({ bolaoId, teamCode: winnerCode }, { onError });
+    } else {
+      bracketAdvance.mutate({ bolaoId, winner: winnerCode, loser: loser ?? '', nextStage: ns }, { onError });
+    }
+  };
+  const canBracket = !!projection?.complete;
+
   // Palpites Especiais agora são liberados pra todo bolão (Free e Premium).
   // A diferença Premium vs Free é APENAS quantidade de participantes (>20).
   return (
@@ -514,6 +547,40 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
         )
       )}
 
+      {/* Toggle Lista | Chaveamento (bracket só com a projeção completa) */}
+      <div className="flex items-center gap-1 p-0.5 rounded-rebrand-md bg-canvas-2 w-fit">
+        <button
+          type="button"
+          onClick={() => setView('lista')}
+          className={`inline-flex items-center gap-1.5 h-8 px-3 rounded-rebrand-sm text-[12px] font-semibold transition-colors ${
+            view === 'lista' ? 'bg-white text-ink shadow-sm' : 'text-ink-2 hover:text-ink'
+          }`}
+        >
+          <List className="w-3.5 h-3.5" /> Lista
+        </button>
+        <button
+          type="button"
+          onClick={() => canBracket && setView('bracket')}
+          disabled={!canBracket}
+          title={canBracket ? undefined : 'Complete os palpites de grupo pra montar o chaveamento'}
+          className={`inline-flex items-center gap-1.5 h-8 px-3 rounded-rebrand-sm text-[12px] font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+            view === 'bracket' ? 'bg-white text-ink shadow-sm' : 'text-ink-2 hover:text-ink'
+          }`}
+        >
+          <GitFork className="w-3.5 h-3.5 rotate-90" /> Chaveamento
+        </button>
+      </div>
+
+      {view === 'bracket' && canBracket && projection ? (
+        <KnockoutBracket
+          matches={matches}
+          projection={projection}
+          picks={bracketPicks}
+          onAdvance={handleAdvance}
+          busy={bracketBusy}
+        />
+      ) : (
+      <>
       {(Object.keys(TYPE_META) as SpecialType[])
         .filter((type) => !enabledTypes || enabledTypes[type] !== false)
         .map((type, idx) => {
@@ -543,6 +610,8 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
             />
           );
         })}
+      </>
+      )}
     </div>
   );
 };

--- a/src/components/bolao/SpecialPredictionsSection.tsx
+++ b/src/components/bolao/SpecialPredictionsSection.tsx
@@ -12,10 +12,11 @@ import {
   useUpsertChampionPrediction,
 } from '@/hooks/use-bolao';
 import { computeGroupProjection, type PredictionMap } from '@/components/bolao/group-projection';
+import { isSpecialLocked, formatDeadlineLabel } from '@/components/bolao/special-deadlines';
 import { KnockoutBracket } from '@/components/bolao/KnockoutBracket';
 import { nextStageOf, type BracketPicks, type ResolvedMatch } from '@/components/bolao/bracket';
 import { List, GitFork } from 'lucide-react';
-import type { WcMatch } from '@/services/bolao.service';
+import type { WcMatch, SpecialDeadlinesConfig } from '@/services/bolao.service';
 import { useToast } from '@/hooks/use-toast';
 
 type SpecialType = 'finalist' | 'semifinalist' | 'quarterfinalist' | 'round_of_16' | 'round_of_32';
@@ -43,6 +44,8 @@ interface Props {
    * não tem campeão definido. Parent pode auto-sugerir esse time como campeão.
    */
   onSuggestChampion?: (teamCode: string) => void;
+  /** Config de prazo dos especiais (preset + overrides) — pra badges e lock. */
+  specialDeadlines?: SpecialDeadlinesConfig | null;
 }
 
 const TYPE_META: Record<
@@ -115,6 +118,10 @@ interface BracketCardProps {
   onAfterAdd?: (teamCode: string) => void;
   /** Label da fase "pai" — mostrado quando o seletor está vazio (pai não preenchido). */
   parentLabel?: string;
+  /** Prazo já encerrado — trava os toggles deste card. */
+  locked?: boolean;
+  /** Rótulo do prazo, ex "fecha 28/06 16h" ou "encerrado". */
+  deadlineLabel?: string | null;
 }
 
 const BracketCard: React.FC<BracketCardProps> = ({
@@ -129,6 +136,8 @@ const BracketCard: React.FC<BracketCardProps> = ({
   championCode,
   defaultOpen,
   onAfterAdd,
+  locked: cardLocked,
+  deadlineLabel,
 }) => {
   const meta = TYPE_META[type];
   const Icon = meta.icon;
@@ -147,6 +156,10 @@ const BracketCard: React.FC<BracketCardProps> = ({
   const isLocked = (code: string) => (pinnedCodes ?? []).includes(code);
 
   const handleToggle = (code: string) => {
+    if (cardLocked) {
+      toast({ title: 'Prazo encerrado', description: `Os palpites de ${meta.label.toLowerCase()} já fecharam.` });
+      return;
+    }
     const isPicked = myPicks.includes(code);
     if (isPicked && isLocked(code)) {
       toast({
@@ -200,6 +213,14 @@ const BracketCard: React.FC<BracketCardProps> = ({
             <p className="text-[13px] font-semibold text-ink leading-tight">{meta.label}</p>
             <p className="text-[11px] text-ink-2 leading-tight mt-0.5">
               {meta.sublabel} · <span className="text-forest font-semibold">{pointsLabel}</span>
+              {deadlineLabel && (
+                <>
+                  {' · '}
+                  <span className={cardLocked ? 'text-status-danger font-semibold' : 'text-ink-3'}>
+                    {cardLocked ? 'encerrado' : deadlineLabel}
+                  </span>
+                </>
+              )}
             </p>
           </div>
         </div>
@@ -288,7 +309,7 @@ const BracketCard: React.FC<BracketCardProps> = ({
                   key={team.code}
                   type="button"
                   onClick={() => handleToggle(team.code)}
-                  disabled={toggle.isPending}
+                  disabled={toggle.isPending || cardLocked}
                   aria-label={`${picked ? 'Remover' : 'Escolher'} ${team.name} para ${meta.label}`}
                   aria-pressed={picked}
                   className={`relative flex flex-col items-center gap-1 p-2.5 min-h-[78px] rounded-rebrand-sm border text-center transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-forest/40 ${
@@ -348,6 +369,7 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
   pointsConfig,
   championPick,
   onSuggestChampion,
+  specialDeadlines,
 }) => {
   const { data: myPreds } = useMySpecialPredictions(bolaoId);
   const { data: summary } = useSpecialSummary(bolaoId);
@@ -390,6 +412,19 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
   const upsertChampion = useUpsertChampionPrediction();
 
   const teams = useMemo(() => extractTeams(matches), [matches]);
+
+  // Prazos por fase (rolável por rodada). Servidor é a autoridade; aqui só
+  // mostramos o prazo e travamos a UI quando passa.
+  const deadlineInfo = useMemo(() => {
+    const types: SpecialType[] = ['round_of_32', 'round_of_16', 'quarterfinalist', 'semifinalist', 'finalist'];
+    const locked: Record<string, boolean> = {};
+    const label: Record<string, string | null> = {};
+    for (const t of types) {
+      locked[t] = isSpecialLocked(t, matches, specialDeadlines);
+      label[t] = formatDeadlineLabel(t, matches, specialDeadlines);
+    }
+    return { locked, label };
+  }, [matches, specialDeadlines]);
 
   const myPicksByType = useMemo(() => {
     const map: Record<string, string[]> = {
@@ -482,6 +517,10 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
   const handleAdvance = (match: ResolvedMatch, winnerCode: string) => {
     const ns = nextStageOf(match.stage);
     if (!ns) return;
+    if (isSpecialLocked(ns, matches, specialDeadlines)) {
+      projToast({ title: 'Prazo encerrado', description: 'Os palpites desta fase já fecharam.' });
+      return;
+    }
     const loser = match.home.code === winnerCode ? match.away.code : match.home.code;
     const onError = (err: any) =>
       projToast({ title: 'Erro', description: err?.message ?? 'Tente novamente', variant: 'destructive' });
@@ -510,9 +549,11 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
                 <button
                   type="button"
                   onClick={() => setConfirmingR32(true)}
-                  className="shrink-0 h-9 px-3.5 rounded-rebrand-md bg-forest text-white text-[12px] font-semibold hover:bg-forest-2 transition-colors"
+                  disabled={deadlineInfo.locked.round_of_32}
+                  title={deadlineInfo.locked.round_of_32 ? 'Prazo dos 16 avos encerrado' : undefined}
+                  className="shrink-0 h-9 px-3.5 rounded-rebrand-md bg-forest text-white text-[12px] font-semibold hover:bg-forest-2 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
                 >
-                  Usar projeção nos 16 avos
+                  {deadlineInfo.locked.round_of_32 ? '16 avos encerrados' : 'Usar projeção nos 16 avos'}
                 </button>
               </div>
             ) : (
@@ -607,6 +648,8 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
               defaultOpen={idx === 0}
               onAfterAdd={(teamCode) => handleAfterAdd(type, teamCode)}
               parentLabel={parent ? TYPE_META[parent].label : undefined}
+              locked={deadlineInfo.locked[type]}
+              deadlineLabel={deadlineInfo.label[type]}
             />
           );
         })}

--- a/src/components/bolao/bracket.test.ts
+++ b/src/components/bolao/bracket.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { parseSlot, matchThirds, resolveBracket, type BracketPicks } from './bracket';
+import type { WcMatch } from '@/services/bolao.service';
+import type { ProjectionResult, GroupProjection } from './group-projection';
+
+// ── Helpers ────────────────────────────────────────────────────────
+function ko(match_number: number, stage: string, home: string, away: string): WcMatch {
+  return {
+    id: match_number, match_number, stage, group_name: null,
+    home_team: home, away_team: away, home_team_code: 'TBD', away_team_code: 'TBD',
+  } as unknown as WcMatch;
+}
+
+/** Monta ProjectionResult a partir de { grupo: [codigos em ordem 1..4] } + terceiros classificados. */
+function projection(groups: Record<string, string[]>, thirdsIn: { code: string; group: string }[]): ProjectionResult {
+  const gps: GroupProjection[] = Object.entries(groups).map(([group, codes]) => ({
+    group,
+    complete: true,
+    standings: codes.map((code, i) => ({
+      code, played: 3, won: 0, drawn: 0, lost: 0, gf: 0, ga: 0, gd: 0, pts: 0,
+      position: i + 1, status: i < 2 ? 'direct' : i === 2 ? 'third_in' : 'out',
+    })),
+  }));
+  return {
+    groups: gps,
+    qualifiers: [],
+    thirdsRanked: thirdsIn.map((t) => ({ code: t.code, group: t.group, in: true })),
+    complete: true,
+  };
+}
+
+const emptyPicks: BracketPicks = { round_of_16: [], quarterfinalist: [], semifinalist: [], finalist: [], champion: null };
+
+// ── Testes ─────────────────────────────────────────────────────────
+describe('parseSlot', () => {
+  it('parseia os 4 tipos de slot', () => {
+    expect(parseSlot('1º Grupo E')).toEqual({ kind: 'group_pos', pos: 1, group: 'E' });
+    expect(parseSlot('2º Grupo B')).toEqual({ kind: 'group_pos', pos: 2, group: 'B' });
+    expect(parseSlot('3º Grupo ABCDF')).toEqual({ kind: 'third', groups: ['A', 'B', 'C', 'D', 'F'] });
+    expect(parseSlot('Vencedor J74')).toEqual({ kind: 'winner', match: 74 });
+    expect(parseSlot('Perdedor J101')).toEqual({ kind: 'loser', match: 101 });
+  });
+});
+
+describe('matchThirds', () => {
+  it('emparelha respeitando grupos permitidos (precisa de backtracking)', () => {
+    // slot1 aceita A ou B; slot2 aceita só A. Atribuição válida: slot2←A3, slot1←B3.
+    const res = matchThirds(
+      [{ matchNumber: 1, groups: ['A', 'B'] }, { matchNumber: 2, groups: ['A'] }],
+      [{ code: 'A3', group: 'A' }, { code: 'B3', group: 'B' }]
+    );
+    expect(res).not.toBeNull();
+    expect(res!.get(2)).toBe('A3');
+    expect(res!.get(1)).toBe('B3');
+  });
+});
+
+describe('resolveBracket', () => {
+  it('resolve 16 avos (grupo + terceiro), vencedor e feeder das oitavas', () => {
+    const matches = [
+      ko(1, 'round_of_32', '1º Grupo A', '2º Grupo B'),
+      ko(2, 'round_of_32', '1º Grupo C', '3º Grupo ABC'),
+      ko(3, 'round_of_16', 'Vencedor J1', 'Vencedor J2'),
+    ];
+    const proj = projection(
+      { A: ['A1', 'A2', 'A3', 'A4'], B: ['B1', 'B2', 'B3', 'B4'], C: ['C1', 'C2', 'C3', 'C4'] },
+      [{ code: 'A3', group: 'A' }]
+    );
+    const picks: BracketPicks = { ...emptyPicks, round_of_16: ['A1', 'C1'], quarterfinalist: ['A1'] };
+    const r = resolveBracket(matches, proj, picks);
+    const byNum = new Map(r.map((m) => [m.match_number, m]));
+
+    expect(byNum.get(1)!.home.code).toBe('A1');
+    expect(byNum.get(1)!.away.code).toBe('B2');
+    expect(byNum.get(1)!.winner).toBe('A1');
+    expect(byNum.get(2)!.away.code).toBe('A3');  // terceiro emparelhado
+    expect(byNum.get(2)!.winner).toBe('C1');
+    // oitavas: participantes = vencedores dos 16 avos
+    expect(byNum.get(3)!.home.code).toBe('A1');
+    expect(byNum.get(3)!.away.code).toBe('C1');
+    expect(byNum.get(3)!.winner).toBe('A1'); // A1 está em quarterfinalist
+  });
+
+  it('resolve final (campeão) e disputa de 3º lugar (perdedores das semis)', () => {
+    const matches = [
+      ko(10, 'semi', '1º Grupo A', '1º Grupo B'),
+      ko(11, 'semi', '1º Grupo C', '1º Grupo D'),
+      ko(12, 'final', 'Vencedor J10', 'Vencedor J11'),
+      ko(13, 'third_place', 'Perdedor J10', 'Perdedor J11'),
+    ];
+    const proj = projection(
+      { A: ['A1', 'A2'], B: ['B1', 'B2'], C: ['C1', 'C2'], D: ['D1', 'D2'] }, []
+    );
+    const picks: BracketPicks = { ...emptyPicks, finalist: ['A1', 'C1'], champion: 'A1' };
+    const r = resolveBracket(matches, proj, picks);
+    const byNum = new Map(r.map((m) => [m.match_number, m]));
+
+    expect(byNum.get(10)!.winner).toBe('A1'); // finalist
+    expect(byNum.get(11)!.winner).toBe('C1');
+    expect(byNum.get(12)!.home.code).toBe('A1');
+    expect(byNum.get(12)!.away.code).toBe('C1');
+    expect(byNum.get(12)!.winner).toBe('A1'); // campeão
+    // 3º lugar = perdedores das semis
+    expect(byNum.get(13)!.home.code).toBe('B1'); // perdedor de J10 (A1 venceu)
+    expect(byNum.get(13)!.away.code).toBe('D1'); // perdedor de J11 (C1 venceu)
+  });
+
+  it('vencedor fica indefinido quando a fase seguinte não decide', () => {
+    const matches = [ko(1, 'round_of_32', '1º Grupo A', '2º Grupo B')];
+    const proj = projection({ A: ['A1', 'A2'], B: ['B1', 'B2'] }, []);
+    const r = resolveBracket(matches, proj, emptyPicks);
+    expect(r[0].winner).toBeNull();
+    expect(r[0].home.code).toBe('A1');
+  });
+});

--- a/src/components/bolao/bracket.ts
+++ b/src/components/bolao/bracket.ts
@@ -114,6 +114,11 @@ const ADVANCERS: Record<string, keyof Omit<BracketPicks, 'champion'> | 'champion
   final: 'champion',
 };
 
+/** Fase de palpite que o vencedor de um jogo desta stage preenche (ou null). */
+export function nextStageOf(stage: string): string | null {
+  return ADVANCERS[stage] ?? null;
+}
+
 /**
  * Resolve o bracket inteiro: participantes de cada jogo + o vencedor deduzido
  * dos palpites especiais. Processa por match_number (feeders referenciam jogos

--- a/src/components/bolao/bracket.ts
+++ b/src/components/bolao/bracket.ts
@@ -1,0 +1,212 @@
+// ============================================================
+// bracket — resolve o chaveamento do mata-mata da Copa 2026
+// ============================================================
+// A estrutura do bracket está no wc_matches (home_team/away_team dos jogos de
+// mata-mata): 16 avos = "1º Grupo E" / "3º Grupo ABCDF"; fases seguintes =
+// "Vencedor J74" / "Perdedor J101". Este motor:
+//   1. parseia os slots;
+//   2. popula os 16 avos a partir da projeção de grupos (1º/2º/3º);
+//   3. emparelha os 8 terceiros classificados aos 8 slots "3º Grupo XXXXX";
+//   4. resolve cada fase usando os palpites especiais (quem avança = quem está
+//      na fase seguinte: round_of_16 → quarter → semi → final → champion).
+// Função PURA (sem React). Ver docs/bolao-projecao-grupos-plano.md.
+// ============================================================
+import type { WcMatch } from '@/services/bolao.service';
+import type { ProjectionResult } from '@/components/bolao/group-projection';
+
+export type SlotRef =
+  | { kind: 'group_pos'; pos: 1 | 2; group: string }
+  | { kind: 'third'; groups: string[] }
+  | { kind: 'winner'; match: number }
+  | { kind: 'loser'; match: number }
+  | { kind: 'unknown'; raw: string };
+
+export interface ResolvedSlot {
+  code: string | null;  // código do time, ou null se ainda não dá pra resolver
+  label: string;        // rótulo curto pra exibir quando não resolvido (ex: "1º E", "Vto J74")
+}
+
+export interface ResolvedMatch {
+  match_number: number;
+  stage: string;
+  home: ResolvedSlot;
+  away: ResolvedSlot;
+  /** Time que o usuário mandou avançar (deduzido dos palpites especiais). */
+  winner: string | null;
+}
+
+export interface BracketPicks {
+  round_of_16: string[];
+  quarterfinalist: string[];
+  semifinalist: string[];
+  finalist: string[];
+  champion: string | null;
+}
+
+const GROUP_POS = /^([12])º\s+Grupo\s+([A-Z])$/i;
+const THIRD = /^3º\s+Grupo\s+([A-Z]+)$/i;
+const WINNER = /^Vencedor\s+J(\d+)$/i;
+const LOSER = /^Perdedor\s+J(\d+)$/i;
+
+export function parseSlot(raw: string): SlotRef {
+  const s = (raw ?? '').trim();
+  let m: RegExpMatchArray | null;
+  if ((m = s.match(GROUP_POS))) return { kind: 'group_pos', pos: Number(m[1]) as 1 | 2, group: m[2].toUpperCase() };
+  if ((m = s.match(THIRD))) return { kind: 'third', groups: m[1].toUpperCase().split('') };
+  if ((m = s.match(WINNER))) return { kind: 'winner', match: Number(m[1]) };
+  if ((m = s.match(LOSER))) return { kind: 'loser', match: Number(m[1]) };
+  return { kind: 'unknown', raw: s };
+}
+
+function shortLabel(ref: SlotRef): string {
+  switch (ref.kind) {
+    case 'group_pos': return `${ref.pos}º ${ref.group}`;
+    case 'third': return `3º (${ref.groups.join('')})`;
+    case 'winner': return `Vto J${ref.match}`;
+    case 'loser': return `Perd. J${ref.match}`;
+    default: return ref.raw;
+  }
+}
+
+/**
+ * Emparelha os 8 terceiros classificados (cada um de um grupo) aos 8 slots
+ * "3º Grupo XXXXX", respeitando os grupos permitidos de cada slot. Backtracking
+ * exato (8×8). Retorna match_number do slot → código do terceiro, ou null se não
+ * houver atribuição válida (não deveria acontecer com 8 terceiros válidos).
+ */
+export function matchThirds(
+  slots: { matchNumber: number; groups: string[] }[],
+  thirds: { code: string; group: string }[]
+): Map<number, string> | null {
+  const result = new Map<number, string>();
+  const usedThird = new Set<number>();
+  // ordena slots pelos mais restritos primeiro (menos terceiros elegíveis) ajuda o backtracking
+  const order = [...slots].sort((a, b) => {
+    const ea = thirds.filter((t) => a.groups.includes(t.group)).length;
+    const eb = thirds.filter((t) => b.groups.includes(t.group)).length;
+    return ea - eb;
+  });
+
+  const solve = (i: number): boolean => {
+    if (i === order.length) return true;
+    const slot = order[i];
+    for (let j = 0; j < thirds.length; j++) {
+      if (usedThird.has(j)) continue;
+      if (!slot.groups.includes(thirds[j].group)) continue;
+      usedThird.add(j);
+      result.set(slot.matchNumber, thirds[j].code);
+      if (solve(i + 1)) return true;
+      usedThird.delete(j);
+      result.delete(slot.matchNumber);
+    }
+    return false;
+  };
+
+  return solve(0) ? result : null;
+}
+
+/** Fase cujos picks definem o vencedor dos jogos de cada stage. */
+const ADVANCERS: Record<string, keyof Omit<BracketPicks, 'champion'> | 'champion'> = {
+  round_of_32: 'round_of_16',
+  round_of_16: 'quarterfinalist',
+  quarter: 'semifinalist',
+  semi: 'finalist',
+  final: 'champion',
+};
+
+/**
+ * Resolve o bracket inteiro: participantes de cada jogo + o vencedor deduzido
+ * dos palpites especiais. Processa por match_number (feeders referenciam jogos
+ * anteriores). Requer projeção completa pros 16 avos.
+ */
+export function resolveBracket(
+  matches: WcMatch[],
+  projection: ProjectionResult,
+  picks: BracketPicks
+): ResolvedMatch[] {
+  const ko = matches
+    .filter((m) => m.stage !== 'group')
+    .sort((a, b) => a.match_number - b.match_number);
+
+  // projeção: grupo → standings ordenadas
+  const groupStandings = new Map(projection.groups.map((g) => [g.group, g.standings]));
+
+  // emparelhamento dos terceiros
+  const thirdSlots = ko
+    .filter((m) => m.stage === 'round_of_32')
+    .map((m) => ({ m, ref: parseSlot(m.away_team) }))
+    .filter((x) => x.ref.kind === 'third')
+    .map((x) => ({ matchNumber: x.m.match_number, groups: (x.ref as { groups: string[] }).groups }));
+  const qualifyingThirds = projection.thirdsRanked
+    .filter((t) => t.in)
+    .map((t) => ({ code: t.code, group: t.group }));
+  const thirdByMatch =
+    thirdSlots.length === qualifyingThirds.length && qualifyingThirds.length > 0
+      ? matchThirds(thirdSlots, qualifyingThirds)
+      : null;
+
+  const sets = {
+    round_of_16: new Set(picks.round_of_16),
+    quarterfinalist: new Set(picks.quarterfinalist),
+    semifinalist: new Set(picks.semifinalist),
+    finalist: new Set(picks.finalist),
+  };
+
+  const byNumber = new Map<number, ResolvedMatch>();
+
+  const resolveRef = (ref: SlotRef): string | null => {
+    switch (ref.kind) {
+      case 'group_pos': {
+        const st = groupStandings.get(ref.group);
+        return st && st[ref.pos - 1] ? st[ref.pos - 1].code : null;
+      }
+      case 'third':
+        // achado pelo emparelhamento (via match_number do slot — resolvido fora)
+        return null;
+      case 'winner':
+        return byNumber.get(ref.match)?.winner ?? null;
+      case 'loser': {
+        const prev = byNumber.get(ref.match);
+        if (!prev || !prev.winner) return null;
+        const a = prev.home.code, b = prev.away.code;
+        return prev.winner === a ? b : prev.winner === b ? a : null;
+      }
+      default:
+        return null;
+    }
+  };
+
+  for (const m of ko) {
+    const homeRef = parseSlot(m.home_team);
+    const awayRef = parseSlot(m.away_team);
+
+    const homeCode =
+      homeRef.kind === 'third' ? thirdByMatch?.get(m.match_number) ?? null : resolveRef(homeRef);
+    const awayCode =
+      awayRef.kind === 'third' ? thirdByMatch?.get(m.match_number) ?? null : resolveRef(awayRef);
+
+    // vencedor = participante presente na fase seguinte (ou campeão)
+    let winner: string | null = null;
+    const adv = ADVANCERS[m.stage];
+    if (adv === 'champion') {
+      winner = picks.champion && (picks.champion === homeCode || picks.champion === awayCode) ? picks.champion : null;
+    } else if (adv) {
+      const set = sets[adv];
+      const inHome = homeCode ? set.has(homeCode) : false;
+      const inAway = awayCode ? set.has(awayCode) : false;
+      if (inHome && !inAway) winner = homeCode;
+      else if (inAway && !inHome) winner = awayCode;
+      // ambos ou nenhum → indefinido (null)
+    }
+
+    byNumber.set(m.match_number, {
+      match_number: m.match_number,
+      stage: m.stage,
+      home: { code: homeCode, label: homeCode ?? shortLabel(homeRef) },
+      away: { code: awayCode, label: awayCode ?? shortLabel(awayRef) },
+      winner,
+    });
+  }
+
+  return ko.map((m) => byNumber.get(m.match_number)!);
+}

--- a/src/components/bolao/special-deadlines.test.ts
+++ b/src/components/bolao/special-deadlines.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { specialDeadline, isSpecialLocked, formatDeadlineLabel } from './special-deadlines';
+import type { WcMatch } from '@/services/bolao.service';
+
+function m(stage: WcMatch['stage'], date: string, time: string): WcMatch {
+  return {
+    stage,
+    match_date: date,
+    match_time_brasilia: time,
+  } as unknown as WcMatch;
+}
+
+// Calendário enxuto: abertura no grupo, depois cada fase do mata-mata.
+const MATCHES: WcMatch[] = [
+  m('group', '2026-06-11', '16:00:00'),
+  m('group', '2026-06-12', '13:00:00'),
+  m('round_of_32', '2026-06-28', '16:00:00'),
+  m('round_of_32', '2026-06-29', '13:00:00'),
+  m('round_of_16', '2026-07-04', '14:00:00'),
+  m('quarter', '2026-07-09', '17:00:00'),
+  m('semi', '2026-07-14', '16:00:00'),
+  m('final', '2026-07-19', '16:00:00'),
+];
+
+const ms = (iso: string) => new Date(iso).getTime();
+
+describe('specialDeadline', () => {
+  it('16 avos e oitavas travam no início do mata-mata (1º round_of_32)', () => {
+    expect(specialDeadline('round_of_32', MATCHES)?.toISOString()).toBe('2026-06-28T19:00:00.000Z');
+    expect(specialDeadline('round_of_16', MATCHES)?.toISOString()).toBe('2026-06-28T19:00:00.000Z');
+  });
+
+  it('cada fase trava no início da fase que a decide', () => {
+    expect(specialDeadline('quarterfinalist', MATCHES)?.toISOString()).toBe('2026-07-04T17:00:00.000Z');
+    expect(specialDeadline('semifinalist', MATCHES)?.toISOString()).toBe('2026-07-09T20:00:00.000Z');
+    expect(specialDeadline('finalist', MATCHES)?.toISOString()).toBe('2026-07-14T19:00:00.000Z');
+    expect(specialDeadline('champion', MATCHES)?.toISOString()).toBe('2026-07-19T19:00:00.000Z');
+  });
+
+  it('prêmios de jogador travam na abertura da Copa (1º jogo de todos)', () => {
+    expect(specialDeadline('top_scorer', MATCHES)?.toISOString()).toBe('2026-06-11T19:00:00.000Z');
+    expect(specialDeadline('best_player', MATCHES)?.toISOString()).toBe('2026-06-11T19:00:00.000Z');
+  });
+
+  it('retorna null sem jogos da fase decisiva', () => {
+    const semFinal = MATCHES.filter((x) => x.stage !== 'final');
+    expect(specialDeadline('champion', semFinal)).toBeNull();
+    expect(specialDeadline('round_of_32', [])).toBeNull();
+  });
+
+  it('mode "opening": tudo trava na abertura da Copa', () => {
+    const cfg = { mode: 'opening' as const };
+    expect(specialDeadline('round_of_32', MATCHES, cfg)?.toISOString()).toBe('2026-06-11T19:00:00.000Z');
+    expect(specialDeadline('champion', MATCHES, cfg)?.toISOString()).toBe('2026-06-11T19:00:00.000Z');
+  });
+
+  it('override por tipo vence o preset', () => {
+    const cfg = { mode: 'rolling' as const, overrides: { champion: '2026-07-15T20:00:00-03:00' } };
+    expect(specialDeadline('champion', MATCHES, cfg)?.toISOString()).toBe('2026-07-15T23:00:00.000Z');
+    // tipos sem override seguem o preset normal
+    expect(specialDeadline('round_of_32', MATCHES, cfg)?.toISOString()).toBe('2026-06-28T19:00:00.000Z');
+  });
+});
+
+describe('isSpecialLocked', () => {
+  it('trava só depois do prazo', () => {
+    expect(isSpecialLocked('champion', MATCHES, undefined, ms('2026-07-19T18:59:00Z'))).toBe(false);
+    expect(isSpecialLocked('champion', MATCHES, undefined, ms('2026-07-19T19:00:00Z'))).toBe(true);
+    expect(isSpecialLocked('top_scorer', MATCHES, undefined, ms('2026-06-12T00:00:00Z'))).toBe(true);
+  });
+
+  it('respeita override ao decidir lock', () => {
+    const cfg = { mode: 'rolling' as const, overrides: { champion: '2026-07-15T20:00:00-03:00' } };
+    expect(isSpecialLocked('champion', MATCHES, cfg, ms('2026-07-15T22:59:00Z'))).toBe(false);
+    expect(isSpecialLocked('champion', MATCHES, cfg, ms('2026-07-15T23:00:00Z'))).toBe(true);
+  });
+});
+
+describe('formatDeadlineLabel', () => {
+  it('mostra data em BRT antes do prazo e "encerrado" depois', () => {
+    expect(formatDeadlineLabel('champion', MATCHES, undefined, ms('2026-06-01T00:00:00Z'))).toBe('fecha 19/07 16h');
+    expect(formatDeadlineLabel('champion', MATCHES, undefined, ms('2026-07-20T00:00:00Z'))).toBe('encerrado');
+  });
+});

--- a/src/components/bolao/special-deadlines.ts
+++ b/src/components/bolao/special-deadlines.ts
@@ -1,0 +1,98 @@
+import type { WcMatch, SpecialDeadlinesConfig } from '@/services/bolao.service';
+
+/**
+ * Prazos dos palpites especiais — espelha a função SQL
+ * `special_prediction_deadline(p_type)` (migration 056). O servidor é a
+ * autoridade; isto é só pra UI mostrar o prazo e travar o card client-side.
+ *
+ * Regra "rolável por rodada": cada palpite trava quando começa a rodada que o
+ * decide. Os prêmios de jogador travam na abertura da Copa (1º jogo de todos).
+ */
+export type SpecialDeadlineType =
+  | 'round_of_32'
+  | 'round_of_16'
+  | 'quarterfinalist'
+  | 'semifinalist'
+  | 'finalist'
+  | 'champion'
+  | 'top_scorer'
+  | 'best_goalkeeper'
+  | 'best_young_player'
+  | 'best_player';
+
+/** Fase cujo PRIMEIRO jogo trava o palpite. `null` → abertura da Copa. */
+const DECIDING_STAGE: Record<SpecialDeadlineType, WcMatch['stage'] | null> = {
+  round_of_32: 'round_of_32', // 16 avos travam no início do mata-mata
+  round_of_16: 'round_of_32', // oitavas são decididas pelos jogos dos 16 avos
+  quarterfinalist: 'round_of_16',
+  semifinalist: 'quarter',
+  finalist: 'semi',
+  champion: 'final',
+  top_scorer: null,
+  best_goalkeeper: null,
+  best_young_player: null,
+  best_player: null,
+};
+
+/** Kickoff em ms (BRT = UTC-3, sem horário de verão desde 2019). */
+function kickoffMs(m: WcMatch): number {
+  return new Date(`${m.match_date}T${m.match_time_brasilia}-03:00`).getTime();
+}
+
+/**
+ * Prazo (Date) do tipo, ou null se ainda não há jogos da fase decisiva.
+ * Espelha o SQL: override por tipo vence; senão segue o preset do `config.mode`
+ * ('opening' = abertura da Copa; 'rolling'/ausente = rodada que decide o tipo).
+ */
+export function specialDeadline(
+  type: SpecialDeadlineType,
+  matches: WcMatch[],
+  config?: SpecialDeadlinesConfig | null
+): Date | null {
+  // 1) Override explícito por tipo vence tudo.
+  const override = config?.overrides?.[type];
+  if (override) {
+    const d = new Date(override);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  if (!matches?.length) return null;
+  // 2) Preset: 'opening' usa todos os jogos; 'rolling' (default) usa a fase decisiva.
+  const mode = config?.mode ?? 'rolling';
+  const stage = mode === 'opening' ? null : DECIDING_STAGE[type];
+  const pool = stage ? matches.filter((m) => m.stage === stage) : matches;
+  const times = pool.map(kickoffMs).filter((t) => Number.isFinite(t));
+  if (!times.length) return null;
+  return new Date(Math.min(...times));
+}
+
+/** true se o prazo já passou (relativo a `now`, default Date.now()). */
+export function isSpecialLocked(
+  type: SpecialDeadlineType,
+  matches: WcMatch[],
+  config?: SpecialDeadlinesConfig | null,
+  now: number = Date.now()
+): boolean {
+  const d = specialDeadline(type, matches, config);
+  return d != null && now >= d.getTime();
+}
+
+/** Rótulo curto pra badge, ex: "fecha 28/06 16h" ou "encerrado". */
+export function formatDeadlineLabel(
+  type: SpecialDeadlineType,
+  matches: WcMatch[],
+  config?: SpecialDeadlinesConfig | null,
+  now: number = Date.now()
+): string | null {
+  const d = specialDeadline(type, matches, config);
+  if (!d) return null;
+  if (now >= d.getTime()) return 'encerrado';
+  const fmt = new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    timeZone: 'America/Sao_Paulo',
+  });
+  // "28/06, 16" → "fecha 28/06 16h"
+  const parts = fmt.format(d).replace(',', '');
+  return `fecha ${parts}h`;
+}

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -299,6 +299,18 @@ export function useSetPlayerPrediction() {
   });
 }
 
+export function useBracketAdvance() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { bolaoId: string; winner: string; loser: string; nextStage: string }) =>
+      bolaoService.bracketAdvance(params.bolaoId, params.winner, params.loser, params.nextStage),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['special-predictions-mine', variables.bolaoId] });
+      queryClient.invalidateQueries({ queryKey: ['champion-predictions', variables.bolaoId] });
+    },
+  });
+}
+
 export function useSetRoundOf32FromProjection() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -367,6 +367,7 @@ export function useUpdateBolaoSettings() {
       bolaoId: string;
       settings: {
         name?: string;
+        description?: string | null;
         champion_enabled?: boolean;
         special_predictions_enabled?: boolean;
         special_predictions_config?: Record<string, boolean>;

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -375,6 +375,7 @@ export function useUpdateBolaoSettings() {
         champion_points?: number;
         player_awards_enabled?: Record<string, boolean>;
         player_award_points?: Record<string, number>;
+        special_deadlines?: import('@/services/bolao.service').SpecialDeadlinesConfig | null;
       };
     }) => bolaoService.updateBolaoSettings(params.bolaoId, params.settings),
     onSuccess: (_data, variables) => {

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -393,6 +393,7 @@ const BolaoDetail: React.FC = () => {
             onOpenChange={setShowAdmin}
             bolaoId={bolao.id}
             bolaoName={bolao.name}
+            bolaoDescription={bolao.description}
             isClosed={bolao.is_closed}
             isPremium={bolao.is_premium}
             scoringPreset={bolao.scoring_preset ?? null}
@@ -765,6 +766,7 @@ const BolaoDetail: React.FC = () => {
           onOpenChange={setShowAdmin}
           bolaoId={bolao.id}
           bolaoName={bolao.name}
+          bolaoDescription={bolao.description}
           isClosed={bolao.is_closed}
           isPremium={bolao.is_premium}
           scoringPreset={bolao.scoring_preset ?? null}

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -385,6 +385,7 @@ const BolaoDetail: React.FC = () => {
           pointsConfig={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}
           playerAwardsEnabled={bolao.player_awards_enabled ?? undefined}
           playerAwardPoints={bolao.player_award_points ?? undefined}
+          specialDeadlines={bolao.special_deadlines ?? null}
         />
 
         {currentUserId && (
@@ -401,6 +402,8 @@ const BolaoDetail: React.FC = () => {
             scoringExact={bolao.scoring_exact}
             scoringWeights={bolao.scoring_weights ?? null}
             predictionDeadlineMode={bolao.prediction_deadline_mode ?? 'per_match'}
+            matches={matches}
+            specialDeadlines={bolao.special_deadlines ?? null}
             customBannerUrl={bolao.custom_banner_url ?? null}
             championEnabled={bolao.champion_enabled ?? true}
             specialPredictionsEnabled={bolao.special_predictions_enabled ?? true}
@@ -749,6 +752,7 @@ const BolaoDetail: React.FC = () => {
         pointsConfig={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}
         playerAwardsEnabled={bolao.player_awards_enabled ?? undefined}
         playerAwardPoints={bolao.player_award_points ?? undefined}
+        specialDeadlines={bolao.special_deadlines ?? null}
       />
 
       {/* Predictions modal */}
@@ -774,6 +778,8 @@ const BolaoDetail: React.FC = () => {
           scoringExact={bolao.scoring_exact}
           scoringWeights={bolao.scoring_weights ?? null}
           predictionDeadlineMode={bolao.prediction_deadline_mode ?? 'per_match'}
+          matches={matches}
+          specialDeadlines={bolao.special_deadlines ?? null}
           customBannerUrl={bolao.custom_banner_url ?? null}
           championEnabled={bolao.champion_enabled ?? true}
           specialPredictionsEnabled={bolao.special_predictions_enabled ?? true}

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -58,7 +58,21 @@ export interface Bolao {
   champion_points: number;
   player_awards_enabled: Record<PlayerAwardType, boolean> | null;
   player_award_points: Record<PlayerAwardType, number> | null;
+  /** Config de prazo dos palpites especiais (presets + override por tipo). null = rolling. */
+  special_deadlines: SpecialDeadlinesConfig | null;
   created_at: string;
+}
+
+/** Preset de prazo dos palpites especiais. */
+export type SpecialDeadlineMode = 'rolling' | 'opening';
+
+/**
+ * Config de prazo dos palpites especiais. `mode` é o preset; `overrides`
+ * sobrescreve a data/hora (ISO timestamptz) de tipos específicos.
+ */
+export interface SpecialDeadlinesConfig {
+  mode: SpecialDeadlineMode;
+  overrides?: Record<string, string | null>;
 }
 
 export interface BolaoMember {
@@ -764,6 +778,7 @@ export const bolaoService = {
       champion_points?: number;
       player_awards_enabled?: Record<string, boolean>;
       player_award_points?: Record<string, number>;
+      special_deadlines?: SpecialDeadlinesConfig | null;
     }
   ): Promise<void> {
     const { error } = await supabase

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -620,6 +620,19 @@ export const bolaoService = {
     return { action: result.action as 'set' | 'removed' };
   },
 
+  /** Avança o vencedor de um confronto do mata-mata (e remove o perdedor das fases adiante). */
+  async bracketAdvance(bolaoId: string, winner: string, loser: string, nextStage: string): Promise<void> {
+    const { data, error } = await supabase.rpc('bracket_advance', {
+      p_bolao_id: bolaoId,
+      p_winner: winner,
+      p_loser: loser,
+      p_next_stage: nextStage,
+    });
+    if (error) throw error;
+    const result = data as { success: boolean; error?: string };
+    if (!result.success) throw new Error(result.error || 'Erro ao avançar no chaveamento');
+  },
+
   /** Auto-preenche os 16 avos (round_of_32) com os 32 códigos projetados. Substitui os atuais. */
   async setRoundOf32FromProjection(bolaoId: string, codes: string[]): Promise<{ count: number }> {
     const { data, error } = await supabase.rpc('set_round_of_32_from_projection', {

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -756,6 +756,7 @@ export const bolaoService = {
     bolaoId: string,
     settings: {
       name?: string;
+      description?: string | null;
       champion_enabled?: boolean;
       special_predictions_enabled?: boolean;
       special_predictions_config?: Record<string, boolean>;

--- a/supabase/migrations/055_bracket_advance.sql
+++ b/supabase/migrations/055_bracket_advance.sql
@@ -1,0 +1,66 @@
+-- ============================================================
+-- bracket_advance — avança/troca o vencedor de um confronto do mata-mata
+-- ============================================================
+-- Usado pelo chaveamento clicável. Ao mandar o `p_winner` avançar num jogo cuja
+-- fase seguinte é `p_next_stage`:
+--   - adiciona o vencedor em p_next_stage (idempotente);
+--   - remove o perdedor de p_next_stage + TODAS as fases mais profundas + campeão
+--     (ele perdeu aqui, não pode estar adiante). Isso invalida picks downstream
+--     quando o usuário troca o vencedor.
+-- O campeão (final) é tratado à parte no front (upsert_champion_prediction).
+-- Atômico. Valida membro + prazo.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.bracket_advance(
+  p_bolao_id uuid,
+  p_winner text,
+  p_loser text,
+  p_next_stage text
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id uuid;
+  v_kickoff timestamptz;
+  v_order text[] := ARRAY['round_of_16','quarterfinalist','semifinalist','finalist'];
+  v_idx int;
+  v_deeper text[];
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Not authenticated');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member');
+  END IF;
+
+  SELECT min((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+    INTO v_kickoff FROM wc_matches;
+  IF v_kickoff IS NOT NULL AND now() >= v_kickoff THEN
+    RETURN json_build_object('success', false, 'error', 'Prazo encerrado (Copa começou)');
+  END IF;
+
+  v_idx := array_position(v_order, p_next_stage);
+  IF v_idx IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'Fase inválida');
+  END IF;
+  v_deeper := v_order[v_idx:array_length(v_order, 1)];  -- a fase + todas as mais profundas
+
+  -- adiciona o vencedor na fase seguinte (idempotente via UNIQUE)
+  INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_team_code)
+    VALUES (p_bolao_id, v_user_id, p_next_stage, p_winner)
+    ON CONFLICT (bolao_id, user_id, prediction_type, predicted_team_code) DO NOTHING;
+
+  -- remove o perdedor desta fase + mais profundas + campeão
+  DELETE FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+      AND predicted_team_code = p_loser
+      AND prediction_type = ANY (v_deeper || ARRAY['champion']);
+
+  RETURN json_build_object('success', true);
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.bracket_advance(uuid, text, text, text) TO authenticated;

--- a/supabase/migrations/056_special_prediction_deadlines.sql
+++ b/supabase/migrations/056_special_prediction_deadlines.sql
@@ -1,0 +1,266 @@
+-- ============================================================
+-- Prazos dos palpites especiais — configuráveis pelo dono do bolão
+-- ============================================================
+-- Modelo "presets + ajuste fino":
+--   boloes.special_deadlines jsonb = {
+--     "mode": "rolling" | "opening",          -- preset (default: rolling)
+--     "overrides": { "<tipo>": "<timestamptz ISO>" | null }  -- vence o preset
+--   }
+--
+-- mode = 'rolling' (padrão, "rolável por rodada"): cada palpite trava quando
+--   começa a rodada que o decide:
+--     16 avos (round_of_32) + Oitavas (round_of_16) → início do mata-mata
+--     Quartas (quarterfinalist) → início das oitavas
+--     Semis (semifinalist)      → início das quartas
+--     Finalistas (finalist)     → início das semis
+--     Campeão (champion)        → a final
+--     Prêmios de jogador        → abertura da Copa
+-- mode = 'opening': tudo trava na abertura da Copa (1º jogo).
+-- overrides[tipo]: data/hora explícita definida pelo dono — vence o preset.
+--
+-- O servidor é a autoridade: os 5 RPCs que gating os especiais consultam
+-- special_prediction_deadline(bolao_id, tipo) antes de gravar.
+-- ============================================================
+
+ALTER TABLE public.boloes ADD COLUMN IF NOT EXISTS special_deadlines jsonb;
+COMMENT ON COLUMN public.boloes.special_deadlines IS
+  'Config de prazo dos palpites especiais: {mode: rolling|opening, overrides: {tipo: timestamptz}}. null = rolling.';
+
+-- Helper: prazo (timestamptz) do tipo para o bolão, considerando override → mode.
+CREATE OR REPLACE FUNCTION public.special_prediction_deadline(p_bolao_id uuid, p_type text)
+RETURNS timestamptz
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_cfg jsonb;
+  v_override text;
+  v_mode text;
+  v_stage text;
+  v_deadline timestamptz;
+BEGIN
+  SELECT special_deadlines INTO v_cfg FROM boloes WHERE id = p_bolao_id;
+
+  -- 1) Override explícito por tipo vence tudo.
+  v_override := v_cfg -> 'overrides' ->> p_type;
+  IF v_override IS NOT NULL AND v_override <> '' THEN
+    RETURN v_override::timestamptz;
+  END IF;
+
+  v_mode := COALESCE(v_cfg ->> 'mode', 'rolling');
+
+  -- 2) Preset "opening": tudo fecha na abertura da Copa.
+  IF v_mode = 'opening' THEN
+    SELECT min((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+      INTO v_deadline FROM wc_matches;
+    RETURN v_deadline;
+  END IF;
+
+  -- 3) Preset "rolling" (padrão): trava no início da rodada que decide o tipo.
+  v_stage := CASE p_type
+    WHEN 'round_of_32'     THEN 'round_of_32'
+    WHEN 'round_of_16'     THEN 'round_of_32'
+    WHEN 'quarterfinalist' THEN 'round_of_16'
+    WHEN 'semifinalist'    THEN 'quarter'
+    WHEN 'finalist'        THEN 'semi'
+    WHEN 'champion'        THEN 'final'
+    ELSE NULL  -- prêmios de jogador → abertura da Copa
+  END;
+
+  IF v_stage IS NULL THEN
+    SELECT min((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+      INTO v_deadline FROM wc_matches;
+  ELSE
+    SELECT min((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+      INTO v_deadline FROM wc_matches WHERE stage = v_stage;
+  END IF;
+  RETURN v_deadline;
+END;
+$function$;
+
+-- ─── toggle_special_prediction (seleção: 16avos..finalistas) ─
+CREATE OR REPLACE FUNCTION public.toggle_special_prediction(
+  p_bolao_id uuid, p_prediction_type text, p_team_code text
+)
+RETURNS json LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id uuid; v_max_picks int; v_current_count int; v_exists boolean; v_deadline timestamptz;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN RETURN json_build_object('success', false, 'error', 'Not authenticated'); END IF;
+  IF p_prediction_type NOT IN ('finalist','semifinalist','quarterfinalist','round_of_16','round_of_32') THEN
+    RETURN json_build_object('success', false, 'error', 'Invalid prediction type'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member'); END IF;
+  v_deadline := special_prediction_deadline(p_bolao_id, p_prediction_type);
+  IF v_deadline IS NOT NULL AND now() >= v_deadline THEN
+    RETURN json_build_object('success', false, 'error', 'Prazo encerrado'); END IF;
+
+  v_max_picks := CASE p_prediction_type
+    WHEN 'finalist' THEN 2 WHEN 'semifinalist' THEN 4 WHEN 'quarterfinalist' THEN 8
+    WHEN 'round_of_16' THEN 16 WHEN 'round_of_32' THEN 32 ELSE 4 END;
+
+  SELECT EXISTS(
+    SELECT 1 FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+      AND prediction_type = p_prediction_type AND predicted_team_code = p_team_code
+  ) INTO v_exists;
+
+  IF v_exists THEN
+    DELETE FROM bolao_special_predictions
+      WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+        AND prediction_type = p_prediction_type AND predicted_team_code = p_team_code;
+    RETURN json_build_object('success', true, 'action', 'removed');
+  ELSE
+    SELECT COUNT(*) INTO v_current_count FROM bolao_special_predictions
+      WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = p_prediction_type;
+    IF v_current_count >= v_max_picks THEN
+      RETURN json_build_object('success', false, 'error', 'Max picks reached', 'max', v_max_picks); END IF;
+    INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_team_code)
+      VALUES (p_bolao_id, v_user_id, p_prediction_type, p_team_code);
+    RETURN json_build_object('success', true, 'action', 'added', 'count', v_current_count + 1);
+  END IF;
+END;
+$function$;
+
+-- ─── set_player_prediction (prêmios de jogador) ─────────────
+CREATE OR REPLACE FUNCTION public.set_player_prediction(
+  p_bolao_id uuid, p_prediction_type text, p_player_id bigint
+)
+RETURNS json LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id uuid; v_enabled jsonb; v_player record; v_deadline timestamptz;
+  v_young_cutoff date := '2005-01-01';
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN RETURN json_build_object('success', false, 'error', 'Not authenticated'); END IF;
+  IF p_prediction_type NOT IN ('top_scorer','best_goalkeeper','best_young_player','best_player') THEN
+    RETURN json_build_object('success', false, 'error', 'Invalid prediction type'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member'); END IF;
+  SELECT player_awards_enabled INTO v_enabled FROM boloes WHERE id = p_bolao_id;
+  IF v_enabled IS NULL OR COALESCE((v_enabled ->> p_prediction_type)::boolean, false) = false THEN
+    RETURN json_build_object('success', false, 'error', 'Prêmio desabilitado neste bolão'); END IF;
+  v_deadline := special_prediction_deadline(p_bolao_id, p_prediction_type);
+  IF v_deadline IS NOT NULL AND now() >= v_deadline THEN
+    RETURN json_build_object('success', false, 'error', 'Prazo encerrado'); END IF;
+
+  IF p_player_id IS NULL THEN
+    DELETE FROM bolao_special_predictions
+      WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = p_prediction_type;
+    RETURN json_build_object('success', true, 'action', 'removed');
+  END IF;
+
+  SELECT * INTO v_player FROM wc_players WHERE player_id = p_player_id;
+  IF NOT FOUND THEN RETURN json_build_object('success', false, 'error', 'Jogador não encontrado'); END IF;
+  IF p_prediction_type = 'best_goalkeeper' AND v_player.position IS DISTINCT FROM 'Goalkeeper' THEN
+    RETURN json_build_object('success', false, 'error', 'Esse prêmio aceita só goleiros'); END IF;
+  IF p_prediction_type = 'best_young_player' THEN
+    IF v_player.birth_date IS NULL THEN
+      RETURN json_build_object('success', false, 'error', 'Elegibilidade indisponível (sem data de nascimento)'); END IF;
+    IF v_player.birth_date < v_young_cutoff THEN
+      RETURN json_build_object('success', false, 'error', 'Jogador não elegível ao prêmio de revelação'); END IF;
+  END IF;
+
+  DELETE FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = p_prediction_type;
+  INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_player_id)
+    VALUES (p_bolao_id, v_user_id, p_prediction_type, p_player_id);
+  RETURN json_build_object('success', true, 'action', 'set');
+END;
+$function$;
+
+-- ─── set_round_of_32_from_projection (16 avos) ──────────────
+CREATE OR REPLACE FUNCTION public.set_round_of_32_from_projection(
+  p_bolao_id uuid, p_codes text[]
+)
+RETURNS json LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id uuid; v_deadline timestamptz; v_count int;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN RETURN json_build_object('success', false, 'error', 'Not authenticated'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member'); END IF;
+  v_deadline := special_prediction_deadline(p_bolao_id, 'round_of_32');
+  IF v_deadline IS NOT NULL AND now() >= v_deadline THEN
+    RETURN json_build_object('success', false, 'error', 'Prazo encerrado'); END IF;
+  IF array_length(p_codes, 1) IS NULL OR array_length(p_codes, 1) > 32 THEN
+    RETURN json_build_object('success', false, 'error', 'Lista inválida (máx 32 seleções)'); END IF;
+  IF EXISTS (
+    SELECT 1 FROM unnest(p_codes) AS c
+    WHERE c NOT IN (
+      SELECT home_team_code FROM wc_matches WHERE home_team_code <> 'TBD'
+      UNION SELECT away_team_code FROM wc_matches WHERE away_team_code <> 'TBD')
+  ) THEN RETURN json_build_object('success', false, 'error', 'Código de seleção inválido'); END IF;
+
+  DELETE FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = 'round_of_32';
+  INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_team_code)
+    SELECT p_bolao_id, v_user_id, 'round_of_32', c FROM unnest(p_codes) AS c;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN json_build_object('success', true, 'count', v_count);
+END;
+$function$;
+
+-- ─── bracket_advance (avanço no chaveamento) ────────────────
+CREATE OR REPLACE FUNCTION public.bracket_advance(
+  p_bolao_id uuid, p_winner text, p_loser text, p_next_stage text
+)
+RETURNS json LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_user_id uuid; v_deadline timestamptz;
+  v_order text[] := ARRAY['round_of_16','quarterfinalist','semifinalist','finalist'];
+  v_idx int; v_deeper text[];
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN RETURN json_build_object('success', false, 'error', 'Not authenticated'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member'); END IF;
+  v_idx := array_position(v_order, p_next_stage);
+  IF v_idx IS NULL THEN RETURN json_build_object('success', false, 'error', 'Fase inválida'); END IF;
+  v_deadline := special_prediction_deadline(p_bolao_id, p_next_stage);
+  IF v_deadline IS NOT NULL AND now() >= v_deadline THEN
+    RETURN json_build_object('success', false, 'error', 'Prazo encerrado'); END IF;
+  v_deeper := v_order[v_idx:array_length(v_order, 1)];
+
+  INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_team_code)
+    VALUES (p_bolao_id, v_user_id, p_next_stage, p_winner)
+    ON CONFLICT (bolao_id, user_id, prediction_type, predicted_team_code) DO NOTHING;
+  DELETE FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id
+      AND predicted_team_code = p_loser
+      AND prediction_type = ANY (v_deeper || ARRAY['champion']);
+  RETURN json_build_object('success', true);
+END;
+$function$;
+
+-- ─── upsert_champion_prediction (campeão) ───────────────────
+CREATE OR REPLACE FUNCTION public.upsert_champion_prediction(p_bolao_id uuid, p_team_code text)
+RETURNS json LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE v_user_id uuid; v_deadline timestamptz;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN RETURN json_build_object('success', false, 'error', 'Not authenticated'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM bolao_members WHERE bolao_id = p_bolao_id AND user_id = v_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'Not a member'); END IF;
+  v_deadline := special_prediction_deadline(p_bolao_id, 'champion');
+  IF v_deadline IS NOT NULL AND now() >= v_deadline THEN
+    RETURN json_build_object('success', false, 'error', 'Prazo encerrado'); END IF;
+  DELETE FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id AND user_id = v_user_id AND prediction_type = 'champion';
+  INSERT INTO bolao_special_predictions (bolao_id, user_id, prediction_type, predicted_team_code)
+    VALUES (p_bolao_id, v_user_id, 'champion', p_team_code);
+  RETURN json_build_object('success', true);
+END;
+$function$;
+
+-- Remove o helper antigo de 1 argumento (substituído pela versão configurável).
+DROP FUNCTION IF EXISTS public.special_prediction_deadline(text);


### PR DESCRIPTION
## Contexto

Empilhado em #165 (Oitavas + projeção). **Base = `fix/bolao-oitavas-round-of-16`** pra manter o diff limpo — só o que é novo aqui.

Stack: #164 (palpites de jogador) → #165 (Oitavas + projeção + funil) → **este PR**.

Fecha as últimas peças dos Palpites Especiais: visualização em chaveamento, edição da descrição do bolão, e **prazos configuráveis por fase** (o pedido principal — o dono decide quando cada palpite fecha).

---

## 1. Chaveamento (bracket) clicável

- **Motor puro** `bracket.ts` (+ testes): resolve os confrontos do mata-mata a partir da projeção de grupos do usuário — `parseSlot`, backtracking pra casar os 8 melhores 3ºs, `resolveBracket`, `nextStageOf`.
- **`KnockoutBracket.tsx`**: render em colunas (16avos → Final). Clicar no vencedor avança a seleção pra próxima fase (cascata e remoção do perdedor das fases posteriores).
- Mantém **as duas visualizações**: toggle **Lista | Chaveamento**. O bracket só fica disponível quando a projeção de grupos está completa; senão cai na lista.
- Backend: migration `055_bracket_advance.sql` (RPC `bracket_advance`).

## 2. Edição da descrição do bolão

- Configurações → Geral → Identificação: textarea (máx 280) com salvar/cancelar inline, via `updateBolaoSettings`.

## 3. Prazos configuráveis dos palpites especiais (presets + ajuste fino)

O dono define **quando cada palpite especial fecha**, em vez de um prazo único.

- Config em `boloes.special_deadlines jsonb`: `{ mode: "rolling" | "opening", overrides: { tipo: timestamptz } }`.
  - **rolling** (padrão): cada palpite trava no início da rodada que o decide — 16avos/oitavas no início do mata-mata, quartas no início das oitavas, semis nas quartas, finalistas nas semis, campeão na final, prêmios de jogador na abertura.
  - **opening**: tudo trava no primeiro jogo da Copa.
  - **overrides[tipo]**: data/hora explícita do dono vence o preset.
- **Migration 056**: helper `special_prediction_deadline(bolao_id, tipo)` (override → mode) consultado pelos **5 RPCs** que gating os especiais (`toggle_special_prediction`, `set_player_prediction`, `set_round_of_32_from_projection`, `bracket_advance`, `upsert_champion_prediction`). **Servidor é a autoridade.**
- **Admin** (Configurações → Prazo de palpites → card "Palpites especiais"): seletor de preset + lista por tipo (só os habilitados) com prazo efetivo, **Definir/Editar** (datetime BRT) e **Restaurar padrão**. Salva na hora.
- **Front**: `special-deadlines.ts` espelha o SQL com testes; badges de prazo e lock nas seções/prêmios refletem a config; sidebar do modal explica o modelo rolável.

## 4. Fix: scrollbar vertical da sub-nav

`overflow-x-auto` fazia o navegador computar `overflow-y: auto`, e a borda + badge causavam ~1px de transbordo → barra vertical fina. Trocado por `overflow-y-hidden` + utilitários que escondem a scrollbar (padrão do `FilterScroller`).

---

## Testes

- ✅ `tsc --noEmit` limpo
- ✅ vitest: 87 testes (engine do bracket, projeção, e `special-deadlines` com casos de override/opening)
- ✅ Playwright E2E no staging:
  - admin salva override de Campeão → toast + "18/07 20:00 · ajustado" → DB persiste → **badge dos 16 avos no modal reflete o override (20/06)** enquanto oitavas/quartas seguem o padrão
  - sub-nav sem scrollbar vertical

## Deploy (prod, pendente)

- Migrations **055** e **056** aplicadas só no **staging** (kpbjuplcwiyrymafhehz). Rodar em produção junto com as do #164/#165.
- `special_deadlines` é nullable → bolões existentes seguem rolling por padrão, sem backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
