### PR TITLE
fix(nav): libera o botão Bolão Copa 2026 na AnalyticsNav

### DIFF
--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -38,7 +38,7 @@ import {
  *
  * Pra liberar: setar pra `true`.
  */
-const SHOW_BOLAO_NAV_ITEM = false;
+const SHOW_BOLAO_NAV_ITEM = true;
 
 /**
  * Visual variant da nav.


### PR DESCRIPTION
## O que muda
Libera o botão **"Bolão Copa 2026"** na `AnalyticsNav` (o header real, ao lado de Análises/Betinho), trocando `SHOW_BOLAO_NAV_ITEM` de `false` → `true`.

## Contexto
O botão já existia na AnalyticsNav, escondido por uma flag temporária (`SHOW_BOLAO_NAV_ITEM=false`) pra testar `/bolao` via URL direta antes de expor pros usuários gerais. Agora libera.

> Obs: o #166 tinha adicionado o Bolão na `MainNav` por engano — essa só aparece em Dashboard/PlayerSelection. O header de fato é a AnalyticsNav, corrigido aqui.

## Teste
- `tsc --noEmit` limpo (EXIT=0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)