### PR TITLE
fix(bolao): palpites especiais consistentes + modo mata-mata por jogo real

### DIFF
--- a/src/components/bolao/BolaoAdminPanel.tsx
+++ b/src/components/bolao/BolaoAdminPanel.tsx
@@ -53,6 +53,7 @@ interface BolaoAdminPanelProps {
   scoringWeights: Record<string, number> | null;
   customBannerUrl: string | null;
   championEnabled: boolean;
+  knockoutRealEnabled: boolean;
   specialPredictionsEnabled: boolean;
   specialPredictionsConfig: Record<string, boolean>;
   specialPredictionsPoints: Record<string, number>;
@@ -317,6 +318,7 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   scoringWeights,
   customBannerUrl,
   championEnabled,
+  knockoutRealEnabled,
   specialPredictionsEnabled,
   specialPredictionsConfig,
   specialPredictionsPoints,
@@ -368,6 +370,7 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
 
   // Modalidades state
   const [champEnabled, setChampEnabled] = useState(championEnabled);
+  const [knockoutReal, setKnockoutReal] = useState(knockoutRealEnabled);
   const [specialConfig, setSpecialConfig] = useState<Record<string, boolean>>(specialPredictionsConfig);
   const [specialPoints, setSpecialPoints] = useState<Record<string, number>>(specialPredictionsPoints);
   const [champPoints, setChampPoints] = useState(championPoints);
@@ -531,6 +534,21 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
         onSuccess: () => toast({ title: newVal ? 'Palpite de campeão habilitado' : 'Palpite de campeão desabilitado' }),
         onError: (err: any) => {
           setChampEnabled(!newVal);
+          toast({ title: 'Erro', description: err.message, variant: 'destructive' });
+        },
+      }
+    );
+  };
+
+  const handleToggleKnockoutReal = () => {
+    const newVal = !knockoutReal;
+    setKnockoutReal(newVal);
+    updateSettings.mutate(
+      { bolaoId, settings: { knockout_real_predictions_enabled: newVal } },
+      {
+        onSuccess: () => toast({ title: newVal ? 'Mata-mata por jogo real habilitado' : 'Mata-mata por jogo real desabilitado' }),
+        onError: (err: any) => {
+          setKnockoutReal(!newVal);
           toast({ title: 'Erro', description: err.message, variant: 'destructive' });
         },
       }
@@ -1371,7 +1389,33 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
         )}
       </Card>
 
+      <Card
+        title="Mata-mata por jogo real"
+        sub="Substitui o funil de projeção: membros palpitam o PLACAR dos jogos reais do mata-mata, liberados conforme os confrontos se definem. O Campeão continua valendo."
+        action={
+          <Toggle
+            on={knockoutReal}
+            onClick={handleToggleKnockoutReal}
+            ariaLabel="Toggle mata-mata por jogo real"
+            disabled={!isOwner}
+          />
+        }
+      >
+        {knockoutReal && (
+          <p className="text-[12px] text-ink-2 leading-snug">
+            Ligado: o funil de projeção abaixo fica desativado e os palpites de
+            placar do mata-mata aparecem na aba de Jogos conforme os confrontos
+            se definem.
+          </p>
+        )}
+      </Card>
+
       <Card title="Palpites Especiais" sub="Cada modalidade pode ser ativada e ter pontos próprios">
+        {knockoutReal && (
+          <p className="text-[12px] text-ink-3 leading-snug pb-2">
+            Desativado enquanto o <span className="font-semibold">mata-mata por jogo real</span> estiver ligado.
+          </p>
+        )}
         {Object.entries(SPECIAL_TYPES).map(([type, label]) => (
           <SettingsRow
             key={type}

--- a/src/components/bolao/SpecialPredictionsModal.tsx
+++ b/src/components/bolao/SpecialPredictionsModal.tsx
@@ -50,6 +50,8 @@ interface SpecialPredictionsModalProps {
   championPoints: number;
   pointsConfig: PointsConfig;
   specialDeadlines?: SpecialDeadlinesConfig | null;
+  /** Modo "mata-mata por jogo real": esconde o funil; placar vai pra aba de Jogos. */
+  knockoutRealMode?: boolean;
 }
 
 export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = ({
@@ -66,6 +68,7 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
   championPoints,
   pointsConfig,
   specialDeadlines,
+  knockoutRealMode,
 }) => {
   const [championPickerOpen, setChampionPickerOpen] = useState(false);
 
@@ -314,6 +317,7 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
                     championPick={myChampionPick}
                     onSuggestChampion={championEnabled ? handleSuggestChampion : undefined}
                     specialDeadlines={specialDeadlines}
+                    knockoutRealMode={knockoutRealMode}
                   />
                 )}
               </div>

--- a/src/components/bolao/SpecialPredictionsSection.tsx
+++ b/src/components/bolao/SpecialPredictionsSection.tsx
@@ -46,6 +46,12 @@ interface Props {
   onSuggestChampion?: (teamCode: string) => void;
   /** Config de prazo dos especiais (preset + overrides) — pra badges e lock. */
   specialDeadlines?: SpecialDeadlinesConfig | null;
+  /**
+   * Modo "mata-mata por jogo real" ligado: esconde o funil de projeção. O
+   * palpite de placar dos jogos reais vai pra aba de Jogos. O palpite de
+   * Campeão continua (é renderizado pelo Modal, fora desta seção).
+   */
+  knockoutRealMode?: boolean;
 }
 
 const TYPE_META: Record<
@@ -370,6 +376,7 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
   championPick,
   onSuggestChampion,
   specialDeadlines,
+  knockoutRealMode,
 }) => {
   const { data: myPreds } = useMySpecialPredictions(bolaoId);
   const { data: summary } = useSpecialSummary(bolaoId);
@@ -531,6 +538,22 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
     }
   };
   const canBracket = !!projection?.complete;
+
+  // Modo "mata-mata por jogo real": o funil de projeção dá lugar ao palpite de
+  // placar nos jogos reais (na aba de Jogos). O Campeão segue no Modal, acima.
+  if (knockoutRealMode) {
+    return (
+      <div className="rounded-rebrand-md border border-line bg-canvas-2 p-3">
+        <p className="text-[12px] text-ink leading-snug">
+          <span className="font-semibold">Mata-mata por jogo real.</span>{' '}
+          Os palpites de placar do mata-mata ficam na aba{' '}
+          <span className="font-semibold">Jogos</span>, liberados conforme os
+          confrontos se definem ao fim da fase de grupos. O palpite de{' '}
+          <span className="font-semibold">Campeão</span> continua aqui em cima.
+        </p>
+      </div>
+    );
+  }
 
   // Palpites Especiais agora são liberados pra todo bolão (Free e Premium).
   // A diferença Premium vs Free é APENAS quantidade de participantes (>20).

--- a/src/components/bolao/SpecialPredictionsSection.tsx
+++ b/src/components/bolao/SpecialPredictionsSection.tsx
@@ -627,7 +627,16 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
         .map((type, idx) => {
           // Funil: cada fase só lista os times escolhidos na fase anterior (pai).
           // União com os picks próprios garante que picks legados sempre apareçam.
-          const parent = PARENT_STAGE[type];
+          //
+          // Pai EFETIVO = ancestral HABILITADO mais próximo. Se o dono desligou a
+          // fase-pai estrutural, sobe na cadeia até achar uma habilitada; se nenhuma
+          // estiver habilitada, a fase abre para todas as seleções (parent = null).
+          // Sem isso, desligar uma fase do meio deixava as de baixo sem pool de
+          // candidatos — deadlock em "preencha primeiro X" apontando pra fase oculta.
+          let parent = PARENT_STAGE[type];
+          while (parent && enabledTypes && enabledTypes[parent] === false) {
+            parent = PARENT_STAGE[parent];
+          }
           const stageTeams = parent
             ? teams.filter((t) => {
                 const pool = new Set([...(myPicksByType[parent] || []), ...(myPicksByType[type] || [])]);

--- a/src/components/bolao/special-config.ts
+++ b/src/components/bolao/special-config.ts
@@ -1,0 +1,45 @@
+// ============================================================
+// Config canônico dos palpites especiais (funil de projeção).
+// ============================================================
+// Fonte única de verdade para o default de quais fases do funil estão
+// habilitadas. Existe porque `round_of_16` (Oitavas) foi adicionado depois
+// (migration 053) e nunca entrou no default do schema (migration 037), que só
+// tem {finalist, round_of_32, semifinalist, quarterfinalist}.
+//
+// Isso fazia admin e jogador divergirem ao resolver a chave faltante:
+//   - Admin   (`!!config[type]`)          → undefined vira OFF
+//   - Jogador (`config[type] !== false`)  → undefined vira ON  → card renderiza
+//
+// Resultado: a Oitavas aparecia pro jogador mesmo o admin mostrando desligada.
+// Normalizando o config em ambos os pontos de consumo, a chave faltante resolve
+// para o mesmo default canônico nos dois lados.
+
+export const SPECIAL_STAGE_KEYS = [
+  'round_of_32',
+  'round_of_16',
+  'quarterfinalist',
+  'semifinalist',
+  'finalist',
+] as const;
+
+export type SpecialStageKey = (typeof SPECIAL_STAGE_KEYS)[number];
+
+/** Default canônico: todas as fases do funil habilitadas. */
+export const DEFAULT_SPECIAL_CONFIG: Record<SpecialStageKey, boolean> = {
+  round_of_32: true,
+  round_of_16: true,
+  quarterfinalist: true,
+  semifinalist: true,
+  finalist: true,
+};
+
+/**
+ * Normaliza o config do bolão preenchendo chaves faltantes com o default
+ * canônico. Use sempre que for consumir `special_predictions_config` — assim
+ * admin e jogador enxergam exatamente o mesmo conjunto de fases habilitadas.
+ */
+export function normalizeSpecialConfig(
+  config: Record<string, boolean> | null | undefined,
+): Record<SpecialStageKey, boolean> {
+  return { ...DEFAULT_SPECIAL_CONFIG, ...(config ?? {}) };
+}

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -369,6 +369,7 @@ export function useUpdateBolaoSettings() {
         name?: string;
         description?: string | null;
         champion_enabled?: boolean;
+        knockout_real_predictions_enabled?: boolean;
         special_predictions_enabled?: boolean;
         special_predictions_config?: Record<string, boolean>;
         special_predictions_points?: Record<string, number>;

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -394,6 +394,7 @@ const BolaoDetail: React.FC = () => {
           championPoints={bolao.champion_points ?? 25}
           pointsConfig={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}
           specialDeadlines={bolao.special_deadlines ?? null}
+          knockoutRealMode={bolao.knockout_real_predictions_enabled ?? false}
         />
 
         {playerAwardsAnyEnabled && (
@@ -427,6 +428,7 @@ const BolaoDetail: React.FC = () => {
             specialDeadlines={bolao.special_deadlines ?? null}
             customBannerUrl={bolao.custom_banner_url ?? null}
             championEnabled={bolao.champion_enabled ?? true}
+            knockoutRealEnabled={bolao.knockout_real_predictions_enabled ?? false}
             specialPredictionsEnabled={bolao.special_predictions_enabled ?? true}
             specialPredictionsConfig={normalizeSpecialConfig(bolao.special_predictions_config)}
             specialPredictionsPoints={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}
@@ -465,13 +467,17 @@ const BolaoDetail: React.FC = () => {
                   {(() => {
                     const labels: string[] = [];
                     if (bolao.champion_enabled ?? true) labels.push('Campeão');
-                    const cfg = normalizeSpecialConfig(bolao.special_predictions_config);
-                    if (bolao.special_predictions_enabled ?? true) {
-                      if (cfg.finalist) labels.push('Finalistas');
-                      if (cfg.semifinalist) labels.push('Semis');
-                      if (cfg.quarterfinalist) labels.push('Quartas');
-                      if (cfg.round_of_16) labels.push('Oitavas');
-                      if (cfg.round_of_32) labels.push('16 avos');
+                    if (bolao.knockout_real_predictions_enabled) {
+                      labels.push('Mata-mata (jogo real)');
+                    } else {
+                      const cfg = normalizeSpecialConfig(bolao.special_predictions_config);
+                      if (bolao.special_predictions_enabled ?? true) {
+                        if (cfg.finalist) labels.push('Finalistas');
+                        if (cfg.semifinalist) labels.push('Semis');
+                        if (cfg.quarterfinalist) labels.push('Quartas');
+                        if (cfg.round_of_16) labels.push('Oitavas');
+                        if (cfg.round_of_32) labels.push('16 avos');
+                      }
                     }
                     return labels.join(', ') || 'Nenhum habilitado';
                   })()}
@@ -801,6 +807,7 @@ const BolaoDetail: React.FC = () => {
         championPoints={bolao.champion_points ?? 25}
         pointsConfig={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}
         specialDeadlines={bolao.special_deadlines ?? null}
+        knockoutRealMode={bolao.knockout_real_predictions_enabled ?? false}
       />
 
       {playerAwardsAnyEnabled && (
@@ -843,6 +850,7 @@ const BolaoDetail: React.FC = () => {
           specialDeadlines={bolao.special_deadlines ?? null}
           customBannerUrl={bolao.custom_banner_url ?? null}
           championEnabled={bolao.champion_enabled ?? true}
+          knockoutRealEnabled={bolao.knockout_real_predictions_enabled ?? false}
           specialPredictionsEnabled={bolao.special_predictions_enabled ?? true}
           specialPredictionsConfig={normalizeSpecialConfig(bolao.special_predictions_config)}
           specialPredictionsPoints={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -32,6 +32,7 @@ import { UserPredictionsModal } from '@/components/bolao/UserPredictionsModal';
 import { BolaoShareButton } from '@/components/bolao/BolaoShareButton';
 import { BolaoAdminPanel } from '@/components/bolao/BolaoAdminPanel';
 import { SpecialPredictionsModal } from '@/components/bolao/SpecialPredictionsModal';
+import { normalizeSpecialConfig } from '@/components/bolao/special-config';
 import { PlayerAwardsModal } from '@/components/bolao/PlayerAwardsModal';
 import { PredictionsModal } from '@/components/bolao/PredictionsModal';
 
@@ -389,7 +390,7 @@ const BolaoDetail: React.FC = () => {
           currentUserId={currentUserId}
           championEnabled={bolao.champion_enabled ?? true}
           specialPredictionsEnabled={bolao.special_predictions_enabled ?? true}
-          enabledTypes={bolao.special_predictions_config ?? undefined}
+          enabledTypes={normalizeSpecialConfig(bolao.special_predictions_config)}
           championPoints={bolao.champion_points ?? 25}
           pointsConfig={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}
           specialDeadlines={bolao.special_deadlines ?? null}
@@ -427,7 +428,7 @@ const BolaoDetail: React.FC = () => {
             customBannerUrl={bolao.custom_banner_url ?? null}
             championEnabled={bolao.champion_enabled ?? true}
             specialPredictionsEnabled={bolao.special_predictions_enabled ?? true}
-            specialPredictionsConfig={bolao.special_predictions_config ?? { finalist: true, semifinalist: true, quarterfinalist: true, round_of_16: true, round_of_32: true }}
+            specialPredictionsConfig={normalizeSpecialConfig(bolao.special_predictions_config)}
             specialPredictionsPoints={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}
             championPoints={bolao.champion_points ?? 10}
             playerAwardsEnabled={bolao.player_awards_enabled ?? undefined}
@@ -464,12 +465,13 @@ const BolaoDetail: React.FC = () => {
                   {(() => {
                     const labels: string[] = [];
                     if (bolao.champion_enabled ?? true) labels.push('Campeão');
-                    const cfg = bolao.special_predictions_config;
+                    const cfg = normalizeSpecialConfig(bolao.special_predictions_config);
                     if (bolao.special_predictions_enabled ?? true) {
-                      if (!cfg || cfg.finalist) labels.push('Finalistas');
-                      if (!cfg || cfg.semifinalist) labels.push('Semis');
-                      if (!cfg || cfg.quarterfinalist) labels.push('Quartas');
-                      if (!cfg || cfg.round_of_32) labels.push('Mata-mata');
+                      if (cfg.finalist) labels.push('Finalistas');
+                      if (cfg.semifinalist) labels.push('Semis');
+                      if (cfg.quarterfinalist) labels.push('Quartas');
+                      if (cfg.round_of_16) labels.push('Oitavas');
+                      if (cfg.round_of_32) labels.push('16 avos');
                     }
                     return labels.join(', ') || 'Nenhum habilitado';
                   })()}
@@ -795,7 +797,7 @@ const BolaoDetail: React.FC = () => {
         currentUserId={currentUserId}
         championEnabled={bolao.champion_enabled ?? true}
         specialPredictionsEnabled={bolao.special_predictions_enabled ?? true}
-        enabledTypes={bolao.special_predictions_config ?? undefined}
+        enabledTypes={normalizeSpecialConfig(bolao.special_predictions_config)}
         championPoints={bolao.champion_points ?? 25}
         pointsConfig={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}
         specialDeadlines={bolao.special_deadlines ?? null}
@@ -842,7 +844,7 @@ const BolaoDetail: React.FC = () => {
           customBannerUrl={bolao.custom_banner_url ?? null}
           championEnabled={bolao.champion_enabled ?? true}
           specialPredictionsEnabled={bolao.special_predictions_enabled ?? true}
-          specialPredictionsConfig={bolao.special_predictions_config ?? { finalist: true, semifinalist: true, quarterfinalist: true, round_of_16: true, round_of_32: true }}
+          specialPredictionsConfig={normalizeSpecialConfig(bolao.special_predictions_config)}
           specialPredictionsPoints={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}
           championPoints={bolao.champion_points ?? 10}
           playerAwardsEnabled={bolao.player_awards_enabled ?? undefined}

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -40,6 +40,7 @@ export interface Bolao {
   custom_color: string | null;
   custom_banner_url: string | null;
   champion_enabled: boolean;
+  knockout_real_predictions_enabled: boolean;
   special_predictions_enabled: boolean;
   special_predictions_config: {
     finalist: boolean;
@@ -782,6 +783,7 @@ export const bolaoService = {
       name?: string;
       description?: string | null;
       champion_enabled?: boolean;
+      knockout_real_predictions_enabled?: boolean;
       special_predictions_enabled?: boolean;
       special_predictions_config?: Record<string, boolean>;
       special_predictions_points?: Record<string, number>;

--- a/supabase/migrations/065_backfill_special_config_round_of_16.sql
+++ b/supabase/migrations/065_backfill_special_config_round_of_16.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- Backfill: round_of_16 (Oitavas) explícito no special_predictions_config
+-- ============================================================
+-- Contexto: o default do schema (037) só tinha
+--   {finalist, round_of_32, semifinalist, quarterfinalist}.
+-- A migration 053 adicionou a fase round_of_16 como tipo de palpite, mas NÃO
+-- a incluiu no default do config nem fez backfill. Com a chave ausente, admin
+-- e jogador divergiam ao resolver o default:
+--   - Admin   (`!!config[type]`)         → undefined = OFF  (toggle desligado)
+--   - Jogador (`config[type] !== false`) → undefined = ON   (card renderiza)
+-- Resultado: a Oitavas aparecia pro jogador mesmo o admin mostrando desligada.
+--
+-- O fix no front normaliza o config nos pontos de consumo (special-config.ts).
+-- Esta migration alinha os DADOS: preenche round_of_16=true onde a chave falta
+-- (preserva quem já desligou explicitamente) e atualiza o default da coluna
+-- para bolões novos nascerem com a chave.
+-- ============================================================
+
+-- 1) Bolões existentes: adiciona round_of_16=true só onde a chave está ausente.
+UPDATE public.boloes
+SET special_predictions_config =
+      jsonb_build_object('round_of_16', true) || special_predictions_config
+WHERE NOT (special_predictions_config ? 'round_of_16');
+
+-- 2) Default da coluna para bolões novos (inclui round_of_16).
+ALTER TABLE public.boloes
+  ALTER COLUMN special_predictions_config SET DEFAULT
+    '{"finalist": true, "round_of_16": true, "round_of_32": true, "semifinalist": true, "quarterfinalist": true}'::jsonb;

--- a/supabase/migrations/066_knockout_real_predictions_flag.sql
+++ b/supabase/migrations/066_knockout_real_predictions_flag.sql
@@ -1,0 +1,18 @@
+-- ============================================================
+-- Flag: palpite de placar nos confrontos REAIS do mata-mata
+-- ============================================================
+-- Modo opcional do dono (default OFF). Quando ligado, substitui o funil de
+-- projeção (escolher quais seleções avançam) por palpite de PLACAR nos jogos
+-- reais do mata-mata, liberados conforme os confrontos se definem ao fim da
+-- fase de grupos. O palpite de Campeão continua valendo nos dois modos.
+--
+-- O scoring já é stage-agnóstico (calculate_bolao_scores, migration 040), com
+-- multiplicador por fase via weighted_stages — então não exige mudança aqui.
+--
+-- Os times reais de cada jogo do mata-mata são preenchidos no wc_matches por um
+-- resolver server-side (próxima entrega, plugado na ingestão de scores), a
+-- partir dos resultados reais dos grupos e dos vencedores de cada jogo.
+-- ============================================================
+
+ALTER TABLE public.boloes
+  ADD COLUMN IF NOT EXISTS knockout_real_predictions_enabled boolean NOT NULL DEFAULT false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -123,15 +123,20 @@
   resolved "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz"
   integrity sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==
 
-"@esbuild/win32-x64@0.21.5":
+"@esbuild/darwin-arm64@0.21.5":
   version "0.21.5"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz"
-  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz"
+  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
 
-"@esbuild/win32-x64@0.25.0":
+"@esbuild/darwin-arm64@0.25.0":
   version "0.25.0"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz"
-  integrity sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz"
+  integrity sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==
+
+"@esbuild/darwin-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz"
+  integrity sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -1136,20 +1141,20 @@
   resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.20.0.tgz"
   integrity sha512-mUnk8rPJBI9loFDZ+YzPGdeniYK+FTmRD1TMCz7ev2SNIozyKKpnGgsxO34u6Z4z/t0ITuu7voi/AshfsGsgFg==
 
-"@rolldown/binding-win32-x64-msvc@1.0.0-rc.17":
+"@rolldown/binding-darwin-arm64@1.0.0-rc.17":
   version "1.0.0-rc.17"
-  resolved "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz"
-  integrity sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==
+  resolved "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz"
+  integrity sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==
 
 "@rolldown/pluginutils@1.0.0-rc.17":
   version "1.0.0-rc.17"
   resolved "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz"
   integrity sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==
 
-"@rollup/rollup-win32-x64-msvc@4.24.0":
+"@rollup/rollup-darwin-arm64@4.24.0":
   version "4.24.0"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz"
-  integrity sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==
+  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz"
+  integrity sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==
 
 "@standard-schema/spec@^1.1.0":
   version "1.1.0"
@@ -1219,10 +1224,10 @@
     "@supabase/realtime-js" "2.11.15"
     "@supabase/storage-js" "2.7.1"
 
-"@swc/core-win32-x64-msvc@1.7.39":
+"@swc/core-darwin-arm64@1.7.39":
   version "1.7.39"
-  resolved "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.39.tgz"
-  integrity sha512-o+5IMqgOtj9+BEOp16atTfBgCogVak9svhBpwsbcJQp67bQbxGYhAPPDW/hZ2rpSSF7UdzbY9wudoX9G4trcuQ==
+  resolved "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.39.tgz"
+  integrity sha512-o2nbEL6scMBMCTvY9OnbyVXtepLuNbdblV9oNJEFia5v5eGj9WMrnRQiylH3Wp/G2NYkW7V1/ZVW+kfvIeYe9A==
 
 "@swc/core@^1.7.26":
   version "1.7.39"
@@ -2272,7 +2277,7 @@ es-set-tostringtag@^2.1.0:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
-esbuild@^0.21.3, "esbuild@^0.27.0 || ^0.28.0":
+esbuild@^0.21.3:
   version "0.21.5"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz"
   integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
@@ -2331,6 +2336,38 @@ esbuild@^0.25.0:
     "@esbuild/win32-arm64" "0.25.0"
     "@esbuild/win32-ia32" "0.25.0"
     "@esbuild/win32-x64" "0.25.0"
+
+"esbuild@^0.27.0 || ^0.28.0":
+  version "0.28.0"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz"
+  integrity sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.0"
+    "@esbuild/android-arm" "0.28.0"
+    "@esbuild/android-arm64" "0.28.0"
+    "@esbuild/android-x64" "0.28.0"
+    "@esbuild/darwin-arm64" "0.28.0"
+    "@esbuild/darwin-x64" "0.28.0"
+    "@esbuild/freebsd-arm64" "0.28.0"
+    "@esbuild/freebsd-x64" "0.28.0"
+    "@esbuild/linux-arm" "0.28.0"
+    "@esbuild/linux-arm64" "0.28.0"
+    "@esbuild/linux-ia32" "0.28.0"
+    "@esbuild/linux-loong64" "0.28.0"
+    "@esbuild/linux-mips64el" "0.28.0"
+    "@esbuild/linux-ppc64" "0.28.0"
+    "@esbuild/linux-riscv64" "0.28.0"
+    "@esbuild/linux-s390x" "0.28.0"
+    "@esbuild/linux-x64" "0.28.0"
+    "@esbuild/netbsd-arm64" "0.28.0"
+    "@esbuild/netbsd-x64" "0.28.0"
+    "@esbuild/openbsd-arm64" "0.28.0"
+    "@esbuild/openbsd-x64" "0.28.0"
+    "@esbuild/openharmony-arm64" "0.28.0"
+    "@esbuild/sunos-x64" "0.28.0"
+    "@esbuild/win32-arm64" "0.28.0"
+    "@esbuild/win32-ia32" "0.28.0"
+    "@esbuild/win32-x64" "0.28.0"
 
 escalade@^3.2.0:
   version "3.2.0"
@@ -2610,6 +2647,11 @@ fraction.js@^4.3.7:
   version "4.3.7"
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
+
+fsevents@~2.3.2, fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -3034,10 +3076,10 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-lightningcss-win32-x64-msvc@1.32.0:
+lightningcss-darwin-arm64@1.32.0:
   version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz"
-  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
+  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz"
+  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
 
 lightningcss@^1.21.0, lightningcss@^1.32.0:
   version "1.32.0"
@@ -4189,7 +4231,7 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.1.0:
   version "2.8.0"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz"
   integrity sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==


### PR DESCRIPTION
Três ajustes nos palpites especiais do Bolão, reportados pelo Pedro (Bolão Kijani). Branch isolada a partir da `main` — independente da promoção do rebrand NBA (#172).

## A — Consistência admin × jogador (bug visível)
`round_of_16` (Oitavas) foi adicionado na migration 053 mas nunca entrou no default do config (037). Com a chave ausente, admin e jogador divergiam:
- Admin (`!!config[type]`) → undefined = **OFF** (toggle desligado)
- Jogador (`config[type] !== false`) → undefined = **ON** (card renderiza)

Resultado: a Oitavas aparecia pro jogador mesmo o admin mostrando desligada.

- `special-config.ts`: `DEFAULT_SPECIAL_CONFIG` + `normalizeSpecialConfig()`, usado nos pontos de consumo (jogador + admin)
- **Migration 065**: backfill `round_of_16=true` onde falta + ajusta o default da coluna

Validado em prod: 35/38 bolões sem a chave, **349 palpites de oitavas já existiam** → backfill pra `true` legitima esses palpites, nada vira órfão.

## B — Funil travava ao desligar fase do meio
Cada fase só listava os times da fase-pai **estrutural**. Desligar uma fase do meio (ex: 16 avos) deixava as de baixo sem pool de candidatos → deadlock em "preencha primeiro X" apontando pra fase oculta.

Agora o pai efetivo é o **ancestral habilitado mais próximo**; se nenhum, a fase abre pra todas as seleções. Assim "só semi + final" funciona.

## C1 — Modo "mata-mata por jogo real" (feature, opt-in)
Modo opcional do dono (**default OFF**). Quando ligado, substitui o funil de projeção por palpite de **placar** nos jogos reais do mata-mata. Campeão continua valendo.

- **Migration 066**: coluna `knockout_real_predictions_enabled` (default false)
- Toggle no admin; com a flag, o funil some (Section) e o card de Especiais fica desativado
- Scoring já é stage-agnóstico (`calculate_bolao_scores`) — sem mudança ali

**C2 (próxima entrega, antes do mata-mata, NÃO neste PR):** resolver server-side que grava os times reais no `wc_matches` (plugado na ingestão de scores) + os jogos do mata-mata aparecendo na aba de Jogos.

## Migrations a aplicar (já rodei 065 em prod via SQL editor)
- `065_backfill_special_config_round_of_16.sql` — **aplicada em prod**
- `066_knockout_real_predictions_flag.sql` — pendente

## Validação
- Build ✓, testes 59/59 ✓, zero erro novo de typecheck (baseline 60 = after 60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)