### PR TITLE
develop → main: chaveamento com times reais (bolão) + página de privacidade

### DIFF
--- a/src/components/bolao/BolaoAdminPanel.tsx
+++ b/src/components/bolao/BolaoAdminPanel.tsx
@@ -546,7 +546,7 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
     updateSettings.mutate(
       { bolaoId, settings: { knockout_real_predictions_enabled: newVal } },
       {
-        onSuccess: () => toast({ title: newVal ? 'Mata-mata por jogo real habilitado' : 'Mata-mata por jogo real desabilitado' }),
+        onSuccess: () => toast({ title: newVal ? 'Chaveamento com times reais habilitado' : 'Chaveamento com times reais desabilitado' }),
         onError: (err: any) => {
           setKnockoutReal(!newVal);
           toast({ title: 'Erro', description: err.message, variant: 'destructive' });
@@ -1390,22 +1390,22 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
       </Card>
 
       <Card
-        title="Mata-mata por jogo real"
-        sub="Substitui o funil de projeção: membros palpitam o PLACAR dos jogos reais do mata-mata, liberados conforme os confrontos se definem. O Campeão continua valendo."
+        title="Chaveamento com times reais"
+        sub="Os 16 avos já saem com os times reais classificados. Os membros montam o bracket — clicam em quem avança até a final + campeão — numa janela curta, que fecha no início do mata-mata."
         action={
           <Toggle
             on={knockoutReal}
             onClick={handleToggleKnockoutReal}
-            ariaLabel="Toggle mata-mata por jogo real"
+            ariaLabel="Toggle chaveamento com times reais"
             disabled={!isOwner}
           />
         }
       >
         {knockoutReal && (
           <p className="text-[12px] text-ink-2 leading-snug">
-            Ligado: o funil de projeção abaixo fica desativado e os palpites de
-            placar do mata-mata aparecem na aba de Jogos conforme os confrontos
-            se definem.
+            Ligado: o funil de projeção abaixo fica desativado e o chaveamento
+            aparece já com os times reais. Os palpites do bracket inteiro travam
+            no início do mata-mata (1º jogo dos 16 avos).
           </p>
         )}
       </Card>
@@ -1413,7 +1413,7 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
       <Card title="Palpites Especiais" sub="Cada modalidade pode ser ativada e ter pontos próprios">
         {knockoutReal && (
           <p className="text-[12px] text-ink-3 leading-snug pb-2">
-            Desativado enquanto o <span className="font-semibold">mata-mata por jogo real</span> estiver ligado.
+            Desativado enquanto o <span className="font-semibold">chaveamento com times reais</span> estiver ligado.
           </p>
         )}
         {Object.entries(SPECIAL_TYPES).map(([type, label]) => (

--- a/src/components/bolao/KnockoutBracket.tsx
+++ b/src/components/bolao/KnockoutBracket.tsx
@@ -15,17 +15,19 @@ const STAGE_COLS: { stage: string; label: string }[] = [
 
 interface Props {
   matches: WcMatch[];
-  projection: ProjectionResult;
+  projection: ProjectionResult | null;
   picks: BracketPicks;
   /** Avança (ou troca) o vencedor de um jogo. Sem isso, render é read-only. */
   onAdvance?: (match: ResolvedMatch, winnerCode: string) => void;
   busy?: boolean;
+  /** Modo "chaveamento real": 16 avos vêm dos times reais do wc_matches. */
+  realMode?: boolean;
 }
 
-export const KnockoutBracket: React.FC<Props> = ({ matches, projection, picks, onAdvance, busy }) => {
+export const KnockoutBracket: React.FC<Props> = ({ matches, projection, picks, onAdvance, busy, realMode }) => {
   const resolved = React.useMemo(
-    () => resolveBracket(matches, projection, picks),
-    [matches, projection, picks]
+    () => resolveBracket(matches, projection, picks, { preferRealCodes: realMode }),
+    [matches, projection, picks, realMode]
   );
   const byStage = React.useMemo(() => {
     const map = new Map<string, ResolvedMatch[]>();

--- a/src/components/bolao/PredictionsList.tsx
+++ b/src/components/bolao/PredictionsList.tsx
@@ -263,21 +263,28 @@ export const PredictionsList: React.FC<PredictionsListProps> = ({
     return { total, palpitated };
   }, [filterMode, dateFilter, matches, predictionsByMatch]);
 
-  // Auto-seleciona o primeiro dia com pendências quando entra no modo "date"
-  // pela primeira vez. User pode mudar pra "Todos" ou outro dia depois.
+  // Auto-seleciona o DIA DE HOJE quando entra no modo "date" pela primeira vez
+  // (ou o próximo dia com jogos, se hoje não tiver). User pode mudar depois.
+  // Antes caía no "primeiro dia pendente", o que obrigava o user a arrastar de
+  // volta pra achar o dia atual depois que os primeiros dias da Copa já tinham
+  // passado — ninguém quer rolar a Copa inteira pra ver o jogo de hoje.
   useEffect(() => {
     if (autoSelected) return;
     if (filterMode !== 'date') return;
     if (!matches || matches.length === 0) return;
     if (dates.length === 0) return;
 
-    // Primeiro dia que tem ao menos um jogo pendente
-    const firstPendingDate = dates.find((d) => (pendingByDate.get(d) ?? 0) > 0);
-    if (firstPendingDate) {
-      setDateFilter(firstPendingDate);
+    // Data local do dispositivo no mesmo formato do match_date ('YYYY-MM-DD').
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    // dates está ordenado asc: pega hoje se houver jogo, senão o próximo dia com
+    // jogos; se a Copa já acabou (tudo no passado), cai no último dia.
+    const target = dates.find((d) => d >= today) ?? dates[dates.length - 1];
+    if (target) {
+      setDateFilter(target);
     }
     setAutoSelected(true);
-  }, [autoSelected, filterMode, matches, dates, pendingByDate]);
+  }, [autoSelected, filterMode, matches, dates]);
 
   // Auto-focus no primeiro input "mandante" do primeiro card aberto pendente
   // ao trocar de dia. Skip quando todos do dia já foram palpitados.

--- a/src/components/bolao/SpecialPredictionsSection.tsx
+++ b/src/components/bolao/SpecialPredictionsSection.tsx
@@ -427,11 +427,11 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
     const locked: Record<string, boolean> = {};
     const label: Record<string, string | null> = {};
     for (const t of types) {
-      locked[t] = isSpecialLocked(t, matches, specialDeadlines);
-      label[t] = formatDeadlineLabel(t, matches, specialDeadlines);
+      locked[t] = isSpecialLocked(t, matches, specialDeadlines, Date.now(), knockoutRealMode);
+      label[t] = formatDeadlineLabel(t, matches, specialDeadlines, Date.now(), knockoutRealMode);
     }
     return { locked, label };
-  }, [matches, specialDeadlines]);
+  }, [matches, specialDeadlines, knockoutRealMode]);
 
   const myPicksByType = useMemo(() => {
     const map: Record<string, string[]> = {
@@ -524,7 +524,10 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
   const handleAdvance = (match: ResolvedMatch, winnerCode: string) => {
     const ns = nextStageOf(match.stage);
     if (!ns) return;
-    if (isSpecialLocked(ns, matches, specialDeadlines)) {
+    // No modo real, o campeão é mantido como o pessoal escolheu no início — o
+    // clique na final NÃO altera o campeão (ele segue no card lá em cima).
+    if (knockoutRealMode && ns === 'champion') return;
+    if (isSpecialLocked(ns, matches, specialDeadlines, Date.now(), knockoutRealMode)) {
       projToast({ title: 'Prazo encerrado', description: 'Os palpites desta fase já fecharam.' });
       return;
     }
@@ -539,18 +542,34 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
   };
   const canBracket = !!projection?.complete;
 
-  // Modo "mata-mata por jogo real": o funil de projeção dá lugar ao palpite de
-  // placar nos jogos reais (na aba de Jogos). O Campeão segue no Modal, acima.
+  // Modo "chaveamento com times reais": os 16 avos já saem com os times REAIS
+  // que se classificaram. O jogador clica em quem avança em cada confronto, dos
+  // 16 avos até a final + campeão. Janela curta — trava no início do mata-mata.
   if (knockoutRealMode) {
+    const koLabel = deadlineInfo.label.round_of_32;
+    const koLocked = deadlineInfo.locked.round_of_32;
     return (
-      <div className="rounded-rebrand-md border border-line bg-canvas-2 p-3">
-        <p className="text-[12px] text-ink leading-snug">
-          <span className="font-semibold">Mata-mata por jogo real.</span>{' '}
-          Os palpites de placar do mata-mata ficam na aba{' '}
-          <span className="font-semibold">Jogos</span>, liberados conforme os
-          confrontos se definem ao fim da fase de grupos. O palpite de{' '}
-          <span className="font-semibold">Campeão</span> continua aqui em cima.
-        </p>
+      <div className="space-y-3">
+        <div className="rounded-rebrand-md border border-line bg-canvas-2 p-3">
+          <p className="text-[12px] text-ink leading-snug">
+            <span className="font-semibold">Chaveamento com times reais.</span>{' '}
+            Clique no time que avança em cada confronto, dos 16 avos até a final.
+            O campeão segue o que você já escolheu lá em cima.{' '}
+            {koLocked ? (
+              <span className="font-semibold text-status-danger">Prazo encerrado.</span>
+            ) : koLabel ? (
+              <>Você palpita até o início do mata-mata (<span className="font-semibold">{koLabel.replace('fecha ', '')}</span>).</>
+            ) : null}
+          </p>
+        </div>
+        <KnockoutBracket
+          matches={matches}
+          projection={projection}
+          picks={bracketPicks}
+          onAdvance={koLocked ? undefined : handleAdvance}
+          busy={bracketBusy}
+          realMode
+        />
       </div>
     );
   }

--- a/src/components/bolao/bracket.test.ts
+++ b/src/components/bolao/bracket.test.ts
@@ -112,4 +112,30 @@ describe('resolveBracket', () => {
     expect(r[0].winner).toBeNull();
     expect(r[0].home.code).toBe('A1');
   });
+
+  it('modo real: 16 avos saem dos times reais (sem projeção); fases seguintes seguem os picks', () => {
+    // ko com códigos REAIS já gravados (preferRealCodes)
+    const koReal = (n: number, stage: string, home: string, away: string, hc: string, ac: string): WcMatch =>
+      ({ id: n, match_number: n, stage, group_name: null, home_team: home, away_team: away, home_team_code: hc, away_team_code: ac } as unknown as WcMatch);
+    const matches = [
+      koReal(1, 'round_of_32', '1º Grupo A', '2º Grupo B', 'BRA', 'ARG'),
+      koReal(2, 'round_of_32', '1º Grupo C', '3º Grupo ABC', 'GER', 'FRA'),
+      ko(3, 'round_of_16', 'Vencedor J1', 'Vencedor J2'),
+    ];
+    const picks: BracketPicks = { ...emptyPicks, round_of_16: ['BRA', 'GER'], quarterfinalist: ['BRA'] };
+    // projeção null — no modo real ela é irrelevante pros 16 avos
+    const r = resolveBracket(matches, null, picks, { preferRealCodes: true });
+    const byNum = new Map(r.map((m) => [m.match_number, m]));
+
+    expect(byNum.get(1)!.home.code).toBe('BRA');
+    expect(byNum.get(1)!.away.code).toBe('ARG');
+    expect(byNum.get(1)!.winner).toBe('BRA'); // está em round_of_16
+    expect(byNum.get(2)!.home.code).toBe('GER');
+    expect(byNum.get(2)!.away.code).toBe('FRA'); // terceiro vem do código real, não do emparelhamento
+    expect(byNum.get(2)!.winner).toBe('GER');
+    // oitavas: participantes = vencedores previstos dos 16 avos
+    expect(byNum.get(3)!.home.code).toBe('BRA');
+    expect(byNum.get(3)!.away.code).toBe('GER');
+    expect(byNum.get(3)!.winner).toBe('BRA'); // BRA em quarterfinalist
+  });
 });

--- a/src/components/bolao/bracket.ts
+++ b/src/components/bolao/bracket.ts
@@ -126,15 +126,23 @@ export function nextStageOf(stage: string): string | null {
  */
 export function resolveBracket(
   matches: WcMatch[],
-  projection: ProjectionResult,
-  picks: BracketPicks
+  projection: ProjectionResult | null,
+  picks: BracketPicks,
+  opts?: { preferRealCodes?: boolean }
 ): ResolvedMatch[] {
   const ko = matches
     .filter((m) => m.stage !== 'group')
     .sort((a, b) => a.match_number - b.match_number);
 
-  // projeção: grupo → standings ordenadas
-  const groupStandings = new Map(projection.groups.map((g) => [g.group, g.standings]));
+  // Modo "chaveamento real": os 16 avos vêm dos times REAIS já gravados no
+  // wc_matches (home_team_code/away_team_code != 'TBD'), não da projeção. As
+  // fases seguintes seguem o caminho que o usuário prevê (via picks).
+  const preferReal = opts?.preferRealCodes ?? false;
+  const realCode = (c: string | null | undefined): string | null =>
+    c && c !== 'TBD' ? c : null;
+
+  // projeção: grupo → standings ordenadas (pode ser null no modo real)
+  const groupStandings = new Map((projection?.groups ?? []).map((g) => [g.group, g.standings]));
 
   // emparelhamento dos terceiros
   const thirdSlots = ko
@@ -142,7 +150,7 @@ export function resolveBracket(
     .map((m) => ({ m, ref: parseSlot(m.away_team) }))
     .filter((x) => x.ref.kind === 'third')
     .map((x) => ({ matchNumber: x.m.match_number, groups: (x.ref as { groups: string[] }).groups }));
-  const qualifyingThirds = projection.thirdsRanked
+  const qualifyingThirds = (projection?.thirdsRanked ?? [])
     .filter((t) => t.in)
     .map((t) => ({ code: t.code, group: t.group }));
   const thirdByMatch =
@@ -185,10 +193,24 @@ export function resolveBracket(
     const homeRef = parseSlot(m.home_team);
     const awayRef = parseSlot(m.away_team);
 
+    // Slots de ENTRADA (16 avos): "1º Grupo X" / "3º Grupo XXXXX". No modo real,
+    // preferimos o código real já gravado no jogo. Fases seguintes ("Vencedor Jxx")
+    // continuam resolvendo pelo caminho previsto nos picks.
+    const homeIsEntry = homeRef.kind === 'group_pos' || homeRef.kind === 'third';
+    const awayIsEntry = awayRef.kind === 'group_pos' || awayRef.kind === 'third';
+
     const homeCode =
-      homeRef.kind === 'third' ? thirdByMatch?.get(m.match_number) ?? null : resolveRef(homeRef);
+      preferReal && homeIsEntry && realCode(m.home_team_code)
+        ? realCode(m.home_team_code)
+        : homeRef.kind === 'third'
+          ? thirdByMatch?.get(m.match_number) ?? null
+          : resolveRef(homeRef);
     const awayCode =
-      awayRef.kind === 'third' ? thirdByMatch?.get(m.match_number) ?? null : resolveRef(awayRef);
+      preferReal && awayIsEntry && realCode(m.away_team_code)
+        ? realCode(m.away_team_code)
+        : awayRef.kind === 'third'
+          ? thirdByMatch?.get(m.match_number) ?? null
+          : resolveRef(awayRef);
 
     // vencedor = participante presente na fase seguinte (ou campeão)
     let winner: string | null = null;

--- a/src/components/bolao/special-deadlines.test.ts
+++ b/src/components/bolao/special-deadlines.test.ts
@@ -60,6 +60,20 @@ describe('specialDeadline', () => {
     // tipos sem override seguem o preset normal
     expect(specialDeadline('round_of_32', MATCHES, cfg)?.toISOString()).toBe('2026-06-28T19:00:00.000Z');
   });
+
+  it('modo real: bracket de quem avança (16 avos → finalistas) trava no início do mata-mata', () => {
+    const KO = '2026-06-28T19:00:00.000Z'; // 1º round_of_32
+    expect(specialDeadline('round_of_32', MATCHES, null, true)?.toISOString()).toBe(KO);
+    expect(specialDeadline('quarterfinalist', MATCHES, null, true)?.toISOString()).toBe(KO);
+    expect(specialDeadline('finalist', MATCHES, null, true)?.toISOString()).toBe(KO);
+    // campeão fica de fora: mantém o prazo próprio (rolling → 1º jogo da final)
+    expect(specialDeadline('champion', MATCHES, null, true)?.toISOString()).toBe('2026-07-19T19:00:00.000Z');
+    // prêmios de jogador não são bracket → seguem abertura da Copa
+    expect(specialDeadline('top_scorer', MATCHES, null, true)?.toISOString()).toBe('2026-06-11T19:00:00.000Z');
+    // override ainda vence, mesmo no modo real
+    const cfg = { overrides: { finalist: '2026-07-15T20:00:00-03:00' } };
+    expect(specialDeadline('finalist', MATCHES, cfg, true)?.toISOString()).toBe('2026-07-15T23:00:00.000Z');
+  });
 });
 
 describe('isSpecialLocked', () => {

--- a/src/components/bolao/special-deadlines.ts
+++ b/src/components/bolao/special-deadlines.ts
@@ -40,6 +40,22 @@ function kickoffMs(m: WcMatch): number {
 }
 
 /**
+ * Tipos do chaveamento (palpite de quem avança). No modo "chaveamento real" todos
+ * travam de uma vez, no início do mata-mata (1º jogo dos 16 avos) — janela curta:
+ * o jogador preenche quem avança em cada fase até a final antes de começar.
+ *
+ * O CAMPEÃO fica de fora: o pessoal já escolheu lá no início (e ninguém aponta
+ * campeão que nem passou dos 16 avos), então mantém o prazo próprio dele.
+ */
+const BRACKET_TYPES = new Set<SpecialDeadlineType>([
+  'round_of_32',
+  'round_of_16',
+  'quarterfinalist',
+  'semifinalist',
+  'finalist',
+]);
+
+/**
  * Prazo (Date) do tipo, ou null se ainda não há jogos da fase decisiva.
  * Espelha o SQL: override por tipo vence; senão segue o preset do `config.mode`
  * ('opening' = abertura da Copa; 'rolling'/ausente = rodada que decide o tipo).
@@ -47,7 +63,8 @@ function kickoffMs(m: WcMatch): number {
 export function specialDeadline(
   type: SpecialDeadlineType,
   matches: WcMatch[],
-  config?: SpecialDeadlinesConfig | null
+  config?: SpecialDeadlinesConfig | null,
+  knockoutRealMode = false
 ): Date | null {
   // 1) Override explícito por tipo vence tudo.
   const override = config?.overrides?.[type];
@@ -56,6 +73,14 @@ export function specialDeadline(
     return Number.isNaN(d.getTime()) ? null : d;
   }
   if (!matches?.length) return null;
+  // 1.5) Modo "chaveamento real": todo o bracket trava no início do mata-mata.
+  if (knockoutRealMode && BRACKET_TYPES.has(type)) {
+    const times = matches
+      .filter((m) => m.stage === 'round_of_32')
+      .map(kickoffMs)
+      .filter((t) => Number.isFinite(t));
+    return times.length ? new Date(Math.min(...times)) : null;
+  }
   // 2) Preset: 'opening' usa todos os jogos; 'rolling' (default) usa a fase decisiva.
   const mode = config?.mode ?? 'rolling';
   const stage = mode === 'opening' ? null : DECIDING_STAGE[type];
@@ -70,9 +95,10 @@ export function isSpecialLocked(
   type: SpecialDeadlineType,
   matches: WcMatch[],
   config?: SpecialDeadlinesConfig | null,
-  now: number = Date.now()
+  now: number = Date.now(),
+  knockoutRealMode = false
 ): boolean {
-  const d = specialDeadline(type, matches, config);
+  const d = specialDeadline(type, matches, config, knockoutRealMode);
   return d != null && now >= d.getTime();
 }
 
@@ -81,9 +107,10 @@ export function formatDeadlineLabel(
   type: SpecialDeadlineType,
   matches: WcMatch[],
   config?: SpecialDeadlinesConfig | null,
-  now: number = Date.now()
+  now: number = Date.now(),
+  knockoutRealMode = false
 ): string | null {
-  const d = specialDeadline(type, matches, config);
+  const d = specialDeadline(type, matches, config, knockoutRealMode);
   if (!d) return null;
   if (now >= d.getTime()) return 'encerrado';
   const fmt = new Intl.DateTimeFormat('pt-BR', {

--- a/supabase/migrations/071_backfill_round_of_32_real_teams.sql
+++ b/supabase/migrations/071_backfill_round_of_32_real_teams.sql
@@ -1,0 +1,54 @@
+-- ============================================================
+-- 071_backfill_round_of_32_real_teams — preenche os 16-avos reais
+-- ============================================================
+-- Backfill one-off dos 16 jogos dos 16-avos (match_number 73..88) com os times
+-- REAIS, agora que a fase de grupos encerrou.
+--
+-- Fonte dos confrontos:
+--   - 1º/2º de cada grupo: classificação final (wc_matches, stage='group').
+--   - 8 melhores 3ºs: grupos B,D,E,F,I,J,K,L (7 com 4pts + SEN/I, melhor de 3pts
+--     por saldo +2). Alocação aos slots conforme a tabela oficial da FIFA
+--     (Anexo C, combinação {B,D,E,F,I,J,K,L}) — conferida com os descritores de
+--     elegibilidade de cada jogo (ex.: J80 "3º Grupo EHIJK" → K; J87 "DEIJL" → L).
+--
+-- Idempotente: só reescreve as linhas listadas em `assign`. Não toca no R16+
+-- (esses continuam "Vencedor Jxx" e resolvem conforme os jogos finalizam).
+-- ============================================================
+WITH assign(match_number, home_code, away_code) AS (
+  VALUES
+    (73, 'RSA', 'CAN'),  -- 2ºA × 2ºB
+    (74, 'GER', 'PAR'),  -- 1ºE × 3º(D)
+    (75, 'NED', 'MAR'),  -- 1ºF × 2ºC
+    (76, 'BRA', 'JPN'),  -- 1ºC × 2ºF
+    (77, 'FRA', 'SWE'),  -- 1ºI × 3º(F)
+    (78, 'CIV', 'NOR'),  -- 2ºE × 2ºI
+    (79, 'MEX', 'ECU'),  -- 1ºA × 3º(E)
+    (80, 'ENG', 'COD'),  -- 1ºL × 3º(K)
+    (81, 'USA', 'BIH'),  -- 1ºD × 3º(B)
+    (82, 'BEL', 'SEN'),  -- 1ºG × 3º(I)
+    (83, 'POR', 'CRO'),  -- 2ºK × 2ºL
+    (84, 'ESP', 'AUT'),  -- 1ºH × 2ºJ
+    (85, 'SUI', 'ALG'),  -- 1ºB × 3º(J)
+    (86, 'ARG', 'CPV'),  -- 1ºJ × 2ºH
+    (87, 'COL', 'GHA'),  -- 1ºK × 3º(L)
+    (88, 'AUS', 'EGY')   -- 2ºD × 2ºG
+),
+-- nome de exibição (pt-BR) a partir das linhas de grupo, por código
+names AS (
+  SELECT code, max(nm) AS nm FROM (
+    SELECT home_team_code AS code, home_team AS nm FROM wc_matches WHERE stage = 'group'
+    UNION ALL
+    SELECT away_team_code, away_team FROM wc_matches WHERE stage = 'group'
+  ) t
+  GROUP BY code
+)
+UPDATE wc_matches m
+SET home_team_code = a.home_code,
+    away_team_code = a.away_code,
+    home_team = COALESCE(hn.nm, m.home_team),
+    away_team = COALESCE(an.nm, m.away_team)
+FROM assign a
+LEFT JOIN names hn ON hn.code = a.home_code
+LEFT JOIN names an ON an.code = a.away_code
+WHERE m.match_number = a.match_number
+  AND m.stage = 'round_of_32';

--- a/supabase/migrations/072_special_deadline_knockout_real.sql
+++ b/supabase/migrations/072_special_deadline_knockout_real.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- 072_special_deadline_knockout_real — prazo do bracket no modo "times reais"
+-- ============================================================
+-- Quando o bolão liga `knockout_real_predictions_enabled` (chaveamento com times
+-- reais), o bracket de QUEM AVANÇA (16 avos → finalistas) trava de uma vez, no
+-- início do mata-mata (1º jogo dos 16 avos). É uma janela curta: o jogador
+-- preenche quem avança em cada fase até a final antes do mata-mata começar.
+-- O CAMPEÃO fica de fora — o pessoal já escolheu no início, então mantém o
+-- prazo próprio dele (preset/override normais).
+--
+-- Só altera o helper central `special_prediction_deadline`; os 5 RPCs que gating
+-- os especiais (toggle/bracket_advance/champion/…) já o consultam, então passam
+-- a respeitar a janela automaticamente. Sem o flag, comportamento é idêntico ao
+-- da migration 064 (override → preset rolling/opening). Mirror client em
+-- src/components/bolao/special-deadlines.ts (param knockoutRealMode).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.special_prediction_deadline(p_bolao_id uuid, p_type text)
+RETURNS timestamptz
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_cfg jsonb;
+  v_override text;
+  v_mode text;
+  v_stage text;
+  v_deadline timestamptz;
+  v_knockout_real boolean;
+BEGIN
+  SELECT special_deadlines, COALESCE(knockout_real_predictions_enabled, false)
+    INTO v_cfg, v_knockout_real
+    FROM boloes WHERE id = p_bolao_id;
+
+  -- 1) Override explícito por tipo vence tudo.
+  v_override := v_cfg -> 'overrides' ->> p_type;
+  IF v_override IS NOT NULL AND v_override <> '' THEN
+    RETURN v_override::timestamptz;
+  END IF;
+
+  -- 1.5) Modo "chaveamento com times reais": o bracket de quem avança (16 avos →
+  --      finalistas) trava no início do mata-mata (1º jogo dos 16 avos). O
+  --      campeão NÃO entra aqui — segue o prazo próprio (preset/override).
+  IF v_knockout_real AND p_type IN
+       ('round_of_32','round_of_16','quarterfinalist','semifinalist','finalist') THEN
+    SELECT min((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+      INTO v_deadline FROM wc_matches WHERE stage = 'round_of_32';
+    RETURN v_deadline;
+  END IF;
+
+  v_mode := COALESCE(v_cfg ->> 'mode', 'rolling');
+
+  -- 2) Preset "opening": tudo fecha na abertura da Copa.
+  IF v_mode = 'opening' THEN
+    SELECT min((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+      INTO v_deadline FROM wc_matches;
+    RETURN v_deadline;
+  END IF;
+
+  -- 3) Preset "rolling" (padrão): trava no início da rodada que decide o tipo.
+  v_stage := CASE p_type
+    WHEN 'round_of_32'     THEN 'round_of_32'
+    WHEN 'round_of_16'     THEN 'round_of_32'
+    WHEN 'quarterfinalist' THEN 'round_of_16'
+    WHEN 'semifinalist'    THEN 'quarter'
+    WHEN 'finalist'        THEN 'semi'
+    WHEN 'champion'        THEN 'final'
+    ELSE NULL  -- prêmios de jogador → abertura da Copa
+  END;
+
+  IF v_stage IS NULL THEN
+    SELECT min((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+      INTO v_deadline FROM wc_matches;
+  ELSE
+    SELECT min((match_date + match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo')
+      INTO v_deadline FROM wc_matches WHERE stage = v_stage;
+  END IF;
+  RETURN v_deadline;
+END;
+$function$;


### PR DESCRIPTION
Sobe pra produção o que está na `develop` além da `main` (2 commits).

## 1. Bolão — Chaveamento com times reais (Fase 1) + abrir palpites no dia

Feedback do Diody: no modo **"Chaveamento com times reais"** (`knockout_real_predictions_enabled`, repurposado), os 16-avos já saem com os times **reais** classificados e o jogador clica em quem avança em cada fase até a final. **Janela curta**: o bracket de quem avança (16-avos→finalistas) trava no **início do mata-mata** (1º jogo dos 16-avos). O **campeão fica de fora** — cada um já escolheu no início — e a final do bracket não o altera.

- `bracket.ts`: `resolveBracket` aceita `preferRealCodes` → 16-avos vêm dos `home/away_team_code` reais do `wc_matches`; fases seguintes seguem os picks. Projeção opcional no modo real.
- `KnockoutBracket.tsx`: prop `realMode`.
- `special-deadlines.ts`: no modo real, 16-avos→finalistas travam no início do mata-mata (campeão excluído).
- `SpecialPredictionsSection.tsx`: renderiza o chaveamento real (no lugar do aviso de placar); clique na final não mexe no campeão.
- `BolaoAdminPanel.tsx`: texto do toggle → "Chaveamento com times reais".
- `PredictionsList.tsx`: lista de palpites abre no **dia de hoje** (ou próximo dia com jogos).
- migration **071**: backfill dos 16-avos reais (classificação dos grupos + Anexo C FIFA).
- migration **072**: `special_prediction_deadline` respeita o modo real.

Testes: `bracket` + `special-deadlines` (16/16). Typecheck limpo.

## 2. Página de privacidade (#178)

Página pública `/privacidade` (Termos + Política de Privacidade) + link no footer.

## ⚠️ Pós-merge (banco / ação manual)
- **migration 071** já foi aplicada direto no banco; **072 ainda precisa ser aplicada** ao Supabase.
- Após deploy, ligar **"Chaveamento com times reais"** no admin do bolão.
- Prazo do bracket trava no kickoff do 1º jogo dos 16-avos — se subir após o jogo, usar `override` em `special_deadlines`.

## Fora desta entrega (próximas fases)
- Fase 2: propagar vencedores reais R16→final + ingestão de placar do mata-mata.
- Fase 3: pontuar os palpites especiais no ranking (hoje não pontuam pra ninguém).

🤖 Generated with [Claude Code](https://claude.com/claude-code)