### PR TITLE
fix(bolão): chaveamento real não resolvia os 16-avos (clique não funcionava)

### DIFF
--- a/src/components/bolao/bracket.test.ts
+++ b/src/components/bolao/bracket.test.ts
@@ -117,9 +117,11 @@ describe('resolveBracket', () => {
     // ko com códigos REAIS já gravados (preferRealCodes)
     const koReal = (n: number, stage: string, home: string, away: string, hc: string, ac: string): WcMatch =>
       ({ id: n, match_number: n, stage, group_name: null, home_team: home, away_team: away, home_team_code: hc, away_team_code: ac } as unknown as WcMatch);
+    // Em produção o backfill sobrescreve home_team/away_team com o NOME real
+    // ("Brasil"), que NÃO casa com o descritor — o código real é a fonte da verdade.
     const matches = [
-      koReal(1, 'round_of_32', '1º Grupo A', '2º Grupo B', 'BRA', 'ARG'),
-      koReal(2, 'round_of_32', '1º Grupo C', '3º Grupo ABC', 'GER', 'FRA'),
+      koReal(1, 'round_of_32', 'Brasil', 'Argentina', 'BRA', 'ARG'),
+      koReal(2, 'round_of_32', 'Alemanha', 'França', 'GER', 'FRA'),
       ko(3, 'round_of_16', 'Vencedor J1', 'Vencedor J2'),
     ];
     const picks: BracketPicks = { ...emptyPicks, round_of_16: ['BRA', 'GER'], quarterfinalist: ['BRA'] };

--- a/src/components/bolao/bracket.ts
+++ b/src/components/bolao/bracket.ts
@@ -193,20 +193,20 @@ export function resolveBracket(
     const homeRef = parseSlot(m.home_team);
     const awayRef = parseSlot(m.away_team);
 
-    // Slots de ENTRADA (16 avos): "1º Grupo X" / "3º Grupo XXXXX". No modo real,
-    // preferimos o código real já gravado no jogo. Fases seguintes ("Vencedor Jxx")
-    // continuam resolvendo pelo caminho previsto nos picks.
-    const homeIsEntry = homeRef.kind === 'group_pos' || homeRef.kind === 'third';
-    const awayIsEntry = awayRef.kind === 'group_pos' || awayRef.kind === 'third';
+    // Round de ENTRADA (16 avos). No modo real preferimos o código real já gravado
+    // no jogo — independente do texto do slot, que pode ter sido sobrescrito pelo
+    // nome real do time (ex: "Brasil") e não casar mais com o descritor. As fases
+    // seguintes ("Vencedor Jxx") continuam resolvendo pelo caminho previsto nos picks.
+    const isEntryRound = m.stage === 'round_of_32';
 
     const homeCode =
-      preferReal && homeIsEntry && realCode(m.home_team_code)
+      preferReal && isEntryRound && realCode(m.home_team_code)
         ? realCode(m.home_team_code)
         : homeRef.kind === 'third'
           ? thirdByMatch?.get(m.match_number) ?? null
           : resolveRef(homeRef);
     const awayCode =
-      preferReal && awayIsEntry && realCode(m.away_team_code)
+      preferReal && isEntryRound && realCode(m.away_team_code)
         ? realCode(m.away_team_code)
         : awayRef.kind === 'third'
           ? thirdByMatch?.get(m.match_number) ?? null


### PR DESCRIPTION
Hotfix em cima do #181 (já merdado na main).

## Problema
No modo "Chaveamento com times reais", o bracket renderizava os 16-avos mas **nenhum clique funcionava** — os times apareciam como nome em itálico (slot sem código), logo não clicáveis.

## Causa
O backfill (migration 071) sobrescreveu `home_team`/`away_team` dos 16-avos com o **nome real** do time ("Brasil"), que não casa com o descritor esperado ("1º Grupo A"). O `resolveBracket` fazia `parseSlot(home_team)` e, no modo real, só usava o código real quando o parse classificava o slot como `group_pos`/`third` — com nome real virava `unknown` → código `null` → card não clicável.

## Fix
No modo real, usar `home_team_code`/`away_team_code` real **direto para todo jogo de `round_of_32`** (gate por `stage`, não pelo parse do texto). Fases seguintes inalteradas (`Vencedor Jxx` → picks). Teste atualizado pra usar nomes reais nos descritores, reproduzindo produção.

Testes: bracket + special-deadlines (16/16). Typecheck limpo. Só código (sem migration nova).