### PR TITLE
develop → main: notificação de kickoff (Telegram) + pontuação do mata-mata (Fases 2 e 3)

### DIFF
--- a/src/components/bolao/BolaoAdminPanel.tsx
+++ b/src/components/bolao/BolaoAdminPanel.tsx
@@ -15,6 +15,7 @@ import {
   Target,
   Pencil,
   Trash2,
+  Send,
 } from 'lucide-react';
 import {
   Dialog,
@@ -38,6 +39,8 @@ import { ToastAction } from '@/components/ui/toast';
 import { ConfirmDialog } from '@/components/bolao/ConfirmDialog';
 import type { BolaoRankingEntry, WcMatch, SpecialDeadlinesConfig } from '@/services/bolao.service';
 import { specialDeadline } from '@/components/bolao/special-deadlines';
+import { useTelegramLink } from '@/hooks/use-telegram-link';
+import { telegramBotUrl } from '@/config/environment';
 
 interface BolaoAdminPanelProps {
   open: boolean;
@@ -54,6 +57,7 @@ interface BolaoAdminPanelProps {
   customBannerUrl: string | null;
   championEnabled: boolean;
   knockoutRealEnabled: boolean;
+  kickoffNotifyTelegram: boolean;
   specialPredictionsEnabled: boolean;
   specialPredictionsConfig: Record<string, boolean>;
   specialPredictionsPoints: Record<string, number>;
@@ -319,6 +323,7 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   customBannerUrl,
   championEnabled,
   knockoutRealEnabled,
+  kickoffNotifyTelegram,
   specialPredictionsEnabled,
   specialPredictionsConfig,
   specialPredictionsPoints,
@@ -371,6 +376,7 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   // Modalidades state
   const [champEnabled, setChampEnabled] = useState(championEnabled);
   const [knockoutReal, setKnockoutReal] = useState(knockoutRealEnabled);
+  const [kickoffNotify, setKickoffNotify] = useState(kickoffNotifyTelegram);
   const [specialConfig, setSpecialConfig] = useState<Record<string, boolean>>(specialPredictionsConfig);
   const [specialPoints, setSpecialPoints] = useState<Record<string, number>>(specialPredictionsPoints);
   const [champPoints, setChampPoints] = useState(championPoints);
@@ -400,6 +406,8 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
   const updateDeadlineMode = useUpdateBolaoDeadlineMode();
   const deleteBolao = useDeleteBolao();
   const { data: bolaoStats } = useBolaoStats(bolaoId, open && currentUserId === ownerUserId);
+  // Status do link de Telegram do dono — decide entre o switch e o "Conectar".
+  const { data: tgLink, refetch: refetchTg } = useTelegramLink(open ? currentUserId : undefined);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Modo read-only pra membros (nao-dono): mostra config mas tudo disabled,
@@ -549,6 +557,21 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
         onSuccess: () => toast({ title: newVal ? 'Chaveamento com times reais habilitado' : 'Chaveamento com times reais desabilitado' }),
         onError: (err: any) => {
           setKnockoutReal(!newVal);
+          toast({ title: 'Erro', description: err.message, variant: 'destructive' });
+        },
+      }
+    );
+  };
+
+  const handleToggleKickoffNotify = () => {
+    const newVal = !kickoffNotify;
+    setKickoffNotify(newVal);
+    updateSettings.mutate(
+      { bolaoId, settings: { kickoff_notify_telegram: newVal } },
+      {
+        onSuccess: () => toast({ title: newVal ? 'Aviso no Telegram ligado' : 'Aviso no Telegram desligado' }),
+        onError: (err: any) => {
+          setKickoffNotify(!newVal);
           toast({ title: 'Erro', description: err.message, variant: 'destructive' });
         },
       }
@@ -1408,6 +1431,49 @@ export const BolaoAdminPanel: React.FC<BolaoAdminPanelProps> = ({
             no início do mata-mata (1º jogo dos 16 avos).
           </p>
         )}
+      </Card>
+
+      <Card
+        title="Avisar no meu Telegram quando o jogo começar"
+        sub="No início de cada jogo, você (dono) recebe no seu Telegram os palpites de todos os membros — placar, quem cada um acha que avança e o campeão. Só você recebe."
+        action={
+          tgLink?.linked ? (
+            <Toggle
+              on={kickoffNotify}
+              onClick={handleToggleKickoffNotify}
+              ariaLabel="Toggle aviso de kickoff no Telegram"
+              disabled={!isOwner}
+            />
+          ) : undefined
+        }
+      >
+        {!tgLink?.linked ? (
+          <div className="space-y-2">
+            <p className="text-[12px] text-ink-2 leading-snug">
+              Conecte seu Telegram pra ativar o aviso.
+            </p>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => window.open(`${telegramBotUrl}?start=force_contact`, '_blank')}
+                className="inline-flex items-center gap-1.5 h-9 px-3.5 rounded-rebrand-md bg-forest text-white text-[12px] font-semibold hover:bg-forest-2 transition-colors"
+              >
+                <Send className="w-3.5 h-3.5" /> Conectar Telegram
+              </button>
+              <button
+                type="button"
+                onClick={() => refetchTg()}
+                className="h-9 px-3 rounded-rebrand-md border border-line text-[12px] font-semibold text-ink-2 hover:bg-canvas-2 transition-colors"
+              >
+                Já conectei
+              </button>
+            </div>
+          </div>
+        ) : kickoffNotify ? (
+          <p className="text-[12px] text-ink-2 leading-snug">
+            Ligado: você recebe no Telegram{tgLink?.username ? ` (@${tgLink.username})` : ''} no início de cada jogo.
+          </p>
+        ) : null}
       </Card>
 
       <Card title="Palpites Especiais" sub="Cada modalidade pode ser ativada e ter pontos próprios">

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -370,6 +370,7 @@ export function useUpdateBolaoSettings() {
         description?: string | null;
         champion_enabled?: boolean;
         knockout_real_predictions_enabled?: boolean;
+        kickoff_notify_telegram?: boolean;
         special_predictions_enabled?: boolean;
         special_predictions_config?: Record<string, boolean>;
         special_predictions_points?: Record<string, number>;

--- a/src/hooks/use-telegram-link.ts
+++ b/src/hooks/use-telegram-link.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { createClient } from '@/integrations/supabase/client';
+
+/**
+ * Status do link de Telegram do usuário (dono do bolão). Usado pra decidir, no
+ * admin, se mostramos o switch de aviso de kickoff ou o botão "Conectar Telegram".
+ * O linking em si acontece no bot (fluxo já existente em Settings) — aqui só lemos.
+ */
+export function useTelegramLink(userId: string | undefined) {
+  return useQuery({
+    queryKey: ['telegram-link', userId],
+    enabled: !!userId,
+    queryFn: async () => {
+      const supabase = createClient();
+      const { data, error } = await supabase
+        .from('users')
+        .select('telegram_chat_id, telegram_username')
+        .eq('id', userId!)
+        .single();
+      if (error) throw error;
+      return {
+        linked: !!data?.telegram_chat_id,
+        username: data?.telegram_username ?? null,
+      };
+    },
+  });
+}

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -432,6 +432,7 @@ const BolaoDetail: React.FC = () => {
             customBannerUrl={bolao.custom_banner_url ?? null}
             championEnabled={bolao.champion_enabled ?? true}
             knockoutRealEnabled={bolao.knockout_real_predictions_enabled ?? false}
+            kickoffNotifyTelegram={bolao.kickoff_notify_telegram ?? false}
             specialPredictionsEnabled={bolao.special_predictions_enabled ?? true}
             specialPredictionsConfig={normalizeSpecialConfig(bolao.special_predictions_config)}
             specialPredictionsPoints={bolao.special_predictions_points ?? { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1 }}

--- a/src/services/bolao.service.ts
+++ b/src/services/bolao.service.ts
@@ -41,6 +41,8 @@ export interface Bolao {
   custom_banner_url: string | null;
   champion_enabled: boolean;
   knockout_real_predictions_enabled: boolean;
+  /** Opt-in do dono: avisar no Telegram dele quando cada jogo começa. */
+  kickoff_notify_telegram: boolean;
   special_predictions_enabled: boolean;
   special_predictions_config: {
     finalist: boolean;
@@ -784,6 +786,7 @@ export const bolaoService = {
       description?: string | null;
       champion_enabled?: boolean;
       knockout_real_predictions_enabled?: boolean;
+      kickoff_notify_telegram?: boolean;
       special_predictions_enabled?: boolean;
       special_predictions_config?: Record<string, boolean>;
       special_predictions_points?: Record<string, number>;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -23,6 +23,10 @@ verify_jwt = false
 # Job de cron — sem JWT de usuário. Protegida pelo header x-cron-secret (CRON_SECRET).
 verify_jwt = false
 
+[functions.notify-kickoff]
+# Job de cron (aviso de kickoff no Telegram do dono) — header x-cron-secret (CRON_SECRET).
+verify_jwt = false
+
 [functions.ingest-wc-squads]
 # Ingestão de elencos sob demanda — protegida pelo header x-cron-secret (CRON_SECRET).
 verify_jwt = false

--- a/supabase/functions/ingest-wc-scores/index.ts
+++ b/supabase/functions/ingest-wc-scores/index.ts
@@ -1,19 +1,20 @@
 // ============================================================
 // ingest-wc-scores — ingestão de placar da Copa (API-Sports → wc_matches)
 // ============================================================
-// Job de cron (não user-facing). Puxa os fixtures da Copa 2026 na API-Sports,
-// atualiza placar + is_finished em wc_matches (casando por api_fixture_id) e
-// dispara calculate_bolao_scores nos jogos que mudaram pra finalizado.
+// Job de cron. Puxa os fixtures da Copa 2026 na API-Sports e:
+//   1. atualiza placar + is_finished (casando por api_fixture_id);
+//   2. captura o VENCEDOR real (incl. pênaltis) em winner_team_code;
+//   3. AUTO-LINKA jogos do mata-mata: quando a API define os times de uma rodada,
+//      casa por (rodada + par de times via wc_team_map) e grava api_fixture_id;
+//   4. PROPAGA o vencedor/perdedor pros próximos jogos ("Vencedor/Perdedor Jxx");
+//   5. dispara calculate_bolao_scores nos jogos que (re)finalizaram.
 //
-// Proteção: header `x-cron-secret` == env CRON_SECRET (evita chamada pública).
+// Placar = goals.home/away (AET incluso; pênaltis à parte) → empate nos 120 quando
+// vai pra pênaltis, como manda a FIFA. O vencedor da disputa vai em winner_team_code.
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
 // Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, API_SPORTS_KEY, CRON_SECRET.
-//
-// Idempotente: só escreve quando o valor muda; só recalcula pontos quando o jogo
-// vira finalizado ou o placar muda.
-//
-// Escopo atual: fase de grupos (api_fixture_id já semeado na migration 047). O
-// mata-mata (32 jogos) ainda não carregou na API e tem times TBD no nosso seed —
-// o auto-link dele entra numa iteração futura (ver TODO no fim).
+// Idempotente: só escreve quando muda; só recalcula quando (re)finaliza.
 // ============================================================
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
@@ -23,13 +24,26 @@ const WC_LEAGUE_ID = 1;
 const WC_SEASON = 2026;
 const FINISHED = new Set(["FT", "AET", "PEN"]); // status.short que contam como encerrado
 
+// league.round (API-Sports) → nosso stage. Casamento case-insensitive.
+const ROUND_TO_STAGE: Record<string, string> = {
+  "round of 32": "round_of_32",
+  "round of 16": "round_of_16",
+  "quarter-finals": "quarter",
+  "semi-finals": "semi",
+  "3rd place final": "third_place",
+  "final": "final",
+};
+function roundToStage(round: string | undefined): string | null {
+  if (!round) return null;
+  return ROUND_TO_STAGE[round.trim().toLowerCase()] ?? null;
+}
+
+const pairKey = (a: string, b: string) => [a, b].sort().join("|");
+
 serve(async (req) => {
-  // Auth de cron: header secreto
   const cronSecret = Deno.env.get("CRON_SECRET") || "";
   const provided = req.headers.get("x-cron-secret") || "";
-  if (!cronSecret || provided !== cronSecret) {
-    return json({ error: "Unauthorized" }, 401);
-  }
+  if (!cronSecret || provided !== cronSecret) return json({ error: "Unauthorized" }, 401);
 
   const apiKey = Deno.env.get("API_SPORTS_KEY") || "";
   if (!apiKey) return json({ error: "API_SPORTS_KEY not set" }, 500);
@@ -40,82 +54,142 @@ serve(async (req) => {
   );
 
   try {
-    // 1) Puxa todos os fixtures da Copa (1 request — escala trivial p/ 1 liga)
-    const res = await fetch(
-      `${API_BASE}/fixtures?league=${WC_LEAGUE_ID}&season=${WC_SEASON}`,
-      { headers: { "x-apisports-key": apiKey } }
-    );
+    // 1) Fixtures da Copa
+    const res = await fetch(`${API_BASE}/fixtures?league=${WC_LEAGUE_ID}&season=${WC_SEASON}`, {
+      headers: { "x-apisports-key": apiKey },
+    });
     if (!res.ok) return json({ error: `API ${res.status}` }, 502);
     const payload = await res.json();
     const fixtures: any[] = payload?.response ?? [];
 
-    // 2) Carrega o estado atual dos jogos já linkados (api_fixture_id NOT NULL)
+    // 2) Nosso estado: todos os jogos + mapa de times (api_team_id → código)
     const { data: rows, error: selErr } = await supabase
       .from("wc_matches")
-      .select("id, api_fixture_id, home_score, away_score, is_finished")
-      .not("api_fixture_id", "is", null);
+      .select("id, match_number, stage, home_team, away_team, home_team_code, away_team_code, home_score, away_score, is_finished, api_fixture_id, winner_team_code");
     if (selErr) throw selErr;
 
+    const { data: teamMapRows, error: tmErr } = await supabase
+      .from("wc_team_map")
+      .select("api_team_id, team_code");
+    if (tmErr) throw tmErr;
+    const codeByApiTeam = new Map<number, string>();
+    for (const t of teamMapRows ?? []) codeByApiTeam.set(Number(t.api_team_id), t.team_code);
+
     const byFixture = new Map<number, any>();
-    for (const r of rows ?? []) byFixture.set(Number(r.api_fixture_id), r);
+    // index de jogos do mata-mata NÃO linkados, por (stage + par de times)
+    const unlinkedKo = new Map<string, any>();
+    for (const r of rows ?? []) {
+      if (r.api_fixture_id != null) byFixture.set(Number(r.api_fixture_id), r);
+      else if (
+        r.stage !== "group" &&
+        r.home_team_code && r.home_team_code !== "TBD" &&
+        r.away_team_code && r.away_team_code !== "TBD"
+      ) {
+        unlinkedKo.set(`${r.stage}::${pairKey(r.home_team_code, r.away_team_code)}`, r);
+      }
+    }
 
     const changedMatchIds: number[] = [];
     let updated = 0;
+    let linked = 0;
     let skippedUnlinked = 0;
+    let koFinished = false; // algum jogo de mata-mata (re)finalizou neste ciclo?
 
-    // 3) Para cada fixture, atualiza o jogo correspondente se algo mudou
     for (const fx of fixtures) {
       const fid = Number(fx?.fixture?.id);
-      const row = byFixture.get(fid);
+      const apiHome = codeByApiTeam.get(Number(fx?.teams?.home?.id)) ?? null;
+      const apiAway = codeByApiTeam.get(Number(fx?.teams?.away?.id)) ?? null;
+
+      // Acha nossa linha: por fixture já linkado, ou auto-link por (stage + par).
+      let row = byFixture.get(fid);
+      let justLinked = false;
       if (!row) {
-        skippedUnlinked++; // mata-mata ainda não linkado, etc.
-        continue;
+        const stage = roundToStage(fx?.league?.round);
+        if (stage && apiHome && apiAway) {
+          const key = `${stage}::${pairKey(apiHome, apiAway)}`;
+          const cand = unlinkedKo.get(key);
+          if (cand) {
+            row = cand;
+            justLinked = true;
+            unlinkedKo.delete(key);
+          }
+        }
+      }
+      if (!row) { skippedUnlinked++; continue; }
+
+      // Alinha o placar ao NOSSO mandante/visitante (a ordem da API pode diferir).
+      const goalsHome = fx?.goals?.home ?? null;
+      const goalsAway = fx?.goals?.away ?? null;
+      let homeScore: number | null, awayScore: number | null;
+      if (apiHome && apiHome === row.home_team_code) {
+        homeScore = goalsHome; awayScore = goalsAway;
+      } else if (apiHome && apiHome === row.away_team_code) {
+        homeScore = goalsAway; awayScore = goalsHome; // ordem invertida
+      } else {
+        homeScore = goalsHome; awayScore = goalsAway; // fallback (grupo / linkado na mesma ordem)
       }
 
       const status = fx?.fixture?.status?.short ?? "";
       const isFinished = FINISHED.has(status);
-      const homeScore = fx?.goals?.home ?? null; // resultado (AET incluso; pênaltis à parte)
-      const awayScore = fx?.goals?.away ?? null;
+      // Vencedor real (incl. pênaltis): quem tem winner=true na API.
+      const winnerCode = fx?.teams?.home?.winner === true ? apiHome
+        : fx?.teams?.away?.winner === true ? apiAway
+        : null;
 
-      const scoreChanged =
-        row.home_score !== homeScore || row.away_score !== awayScore;
-      const finishedChanged = row.is_finished !== isFinished;
-      if (!scoreChanged && !finishedChanged) continue;
+      const patch: Record<string, unknown> = {};
+      if (justLinked) patch.api_fixture_id = fid;
+      if (row.home_score !== homeScore) patch.home_score = homeScore;
+      if (row.away_score !== awayScore) patch.away_score = awayScore;
+      if (row.is_finished !== isFinished) patch.is_finished = isFinished;
+      if (winnerCode && row.winner_team_code !== winnerCode) patch.winner_team_code = winnerCode;
 
-      const { error: updErr } = await supabase
-        .from("wc_matches")
-        .update({
-          home_score: homeScore,
-          away_score: awayScore,
-          is_finished: isFinished,
-        })
-        .eq("id", row.id);
+      if (Object.keys(patch).length === 0) continue;
+
+      const { error: updErr } = await supabase.from("wc_matches").update(patch).eq("id", row.id);
       if (updErr) throw updErr;
       updated++;
+      if (justLinked) linked++;
 
-      // Recalcula pontos só quando o jogo (passa a) estar finalizado
-      if (isFinished) changedMatchIds.push(row.id);
+      // Refinalizou (passou a estar encerrado, ou placar mudou já encerrado)?
+      const becameFinished = isFinished && (row.is_finished !== true || row.home_score !== homeScore || row.away_score !== awayScore);
+      if (becameFinished) {
+        changedMatchIds.push(row.id);
+        if (row.stage !== "group") koFinished = true;
+      }
+
+      // 4) PROPAGAÇÃO — joga o vencedor/perdedor pros próximos jogos.
+      if (isFinished && winnerCode && row.stage !== "group") {
+        const loserCode = winnerCode === row.home_team_code ? row.away_team_code
+          : winnerCode === row.away_team_code ? row.home_team_code : null;
+        await propagate(supabase, rows ?? [], row.match_number, winnerCode, loserCode);
+      }
     }
 
-    // 4) Dispara o cálculo de pontos dos bolões pros jogos que mudaram
+    // 5) Recalcula pontos de placar dos jogos que (re)finalizaram.
     const scored: number[] = [];
     for (const matchId of changedMatchIds) {
-      const { error: rpcErr } = await supabase.rpc("calculate_bolao_scores", {
-        p_match_id: matchId,
-      });
-      if (rpcErr) {
-        console.error(`calculate_bolao_scores(${matchId}) falhou:`, rpcErr.message);
-        continue;
-      }
+      const { error: rpcErr } = await supabase.rpc("calculate_bolao_scores", { p_match_id: matchId });
+      if (rpcErr) { console.error(`calculate_bolao_scores(${matchId}):`, rpcErr.message); continue; }
       scored.push(matchId);
+    }
+
+    // Mata-mata (re)finalizou → recomputa os palpites especiais "quem avança"
+    // (só pontua as fases que fecharam; idempotente).
+    let specialResolved = false;
+    if (koFinished) {
+      const { error: spErr } = await supabase.rpc("resolve_all_special_scores");
+      if (spErr) console.error("resolve_all_special_scores:", spErr.message);
+      else specialResolved = true;
     }
 
     return json({
       ok: true,
       fixtures_recebidos: fixtures.length,
       jogos_atualizados: updated,
+      jogos_linkados: linked,
       jogos_recalculados: scored.length,
-      fixtures_sem_link: skippedUnlinked, // esperado p/ mata-mata por enquanto
+      especiais_recalculados: specialResolved,
+      fixtures_sem_link: skippedUnlinked,
     });
   } catch (e) {
     console.error("ingest-wc-scores error:", e);
@@ -123,13 +197,36 @@ serve(async (req) => {
   }
 });
 
+// Preenche o time real nas linhas que dependem deste jogo:
+//   "Vencedor J{n}" → vencedor;  "Perdedor J{n}" → perdedor (disputa de 3º).
+// Só escreve onde ainda está TBD (não clobbera correção manual). Idempotente.
+async function propagate(
+  supabase: any,
+  rows: any[],
+  matchNumber: number,
+  winnerCode: string,
+  loserCode: string | null
+) {
+  const winLabel = `Vencedor J${matchNumber}`;
+  const loseLabel = `Perdedor J${matchNumber}`;
+  for (const r of rows) {
+    if (r.stage === "group") continue;
+    const patch: Record<string, unknown> = {};
+    if (r.home_team === winLabel && r.home_team_code === "TBD") patch.home_team_code = winnerCode;
+    if (r.away_team === winLabel && r.away_team_code === "TBD") patch.away_team_code = winnerCode;
+    if (loserCode && r.home_team === loseLabel && r.home_team_code === "TBD") patch.home_team_code = loserCode;
+    if (loserCode && r.away_team === loseLabel && r.away_team_code === "TBD") patch.away_team_code = loserCode;
+    if (Object.keys(patch).length === 0) continue;
+    // reflete no objeto em memória (caso outra propagação no mesmo run o use)
+    Object.assign(r, patch);
+    const { error } = await supabase.from("wc_matches").update(patch).eq("id", r.id);
+    if (error) throw error;
+  }
+}
+
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "Content-Type": "application/json" },
   });
 }
-
-// TODO (iteração futura): auto-link do mata-mata. Quando a API carregar os 32
-// jogos do knockout (com times reais) e o nosso bracket resolver os TBD, casar
-// por par de times via wc_team_map e gravar api_fixture_id nas linhas knockout.

--- a/supabase/functions/notify-kickoff/index.ts
+++ b/supabase/functions/notify-kickoff/index.ts
@@ -1,0 +1,144 @@
+// ============================================================
+// notify-kickoff — aviso de kickoff no Telegram do dono do bolão
+// ============================================================
+// Job de cron (não user-facing). Roda nos minutos :00 e :30. Para cada jogo que
+// começou na última janela, em cada bolão com opt-in (kickoff_notify_telegram) e
+// dono com Telegram linkado, envia uma DM ao dono com os palpites de todos os
+// membros (placar + quem avança no mata-mata + campeão). Idempotente via tabela
+// bolao_kickoff_notifications.
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN, CRON_SECRET.
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+
+const STAGE_LABEL: Record<string, string> = {
+  group: "Fase de grupos",
+  round_of_32: "16 avos",
+  round_of_16: "Oitavas",
+  quarter: "Quartas",
+  semi: "Semifinais",
+  third_place: "3º lugar",
+  final: "Final",
+};
+
+// Escapa o que vai no HTML do Telegram (nomes de usuário/seleção podem ter < & >).
+function esc(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+async function sendTelegramMessage(chatId: string, text: string): Promise<void> {
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text,
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+    }),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
+}
+
+interface DueRow {
+  bolao_id: string;
+  bolao_name: string;
+  match_id: number;
+  owner_chat_id: string;
+  stage: string;
+  home_team: string;
+  away_team: string;
+  home_team_code: string;
+  away_team_code: string;
+}
+interface PickRow {
+  user_name: string;
+  predicted_home: number | null;
+  predicted_away: number | null;
+  champion_code: string | null;
+  advance_code: string | null;
+}
+
+function buildMessage(row: DueRow, picks: PickRow[]): string {
+  const stageLabel = STAGE_LABEL[row.stage] ?? row.stage;
+  const isKnockout = row.stage !== "group";
+
+  const lines = picks.map((p) => {
+    const placar =
+      p.predicted_home != null && p.predicted_away != null
+        ? `${p.predicted_home} x ${p.predicted_away}`
+        : "não palpitou";
+    const parts = [`• ${esc(p.user_name)} — ${esc(placar)}`];
+    if (isKnockout && p.advance_code) parts.push(`avança: ${esc(p.advance_code)}`);
+    if (p.champion_code) parts.push(`🏆 ${esc(p.champion_code)}`);
+    return parts.join("  ·  ");
+  });
+
+  const body = lines.length ? lines.join("\n") : "Ninguém no bolão ainda.";
+  return (
+    `🏁 <b>Vai começar!</b> · ${esc(stageLabel)}\n` +
+    `${esc(row.home_team)} x ${esc(row.away_team)}\n` +
+    `<i>${esc(row.bolao_name)}</i>\n\n` +
+    `<b>Palpites (já travados):</b>\n${body}\n\n` +
+    `Boa sorte! 🍀`
+  );
+}
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  const provided = req.headers.get("x-cron-secret") || "";
+  if (!cronSecret || provided !== cronSecret) return json({ error: "Unauthorized" }, 401);
+  if (!TELEGRAM_BOT_TOKEN) return json({ error: "TELEGRAM_BOT_TOKEN not set" }, 500);
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  try {
+    const { data: due, error: dueErr } = await supabase.rpc("get_due_kickoff_notifications");
+    if (dueErr) throw dueErr;
+
+    const rows: DueRow[] = due ?? [];
+    let sent = 0;
+    const errors: string[] = [];
+
+    for (const row of rows) {
+      try {
+        const { data: picks, error: pErr } = await supabase.rpc("get_bolao_match_picks", {
+          p_bolao_id: row.bolao_id,
+          p_match_id: row.match_id,
+        });
+        if (pErr) throw pErr;
+
+        await sendTelegramMessage(row.owner_chat_id, buildMessage(row, (picks ?? []) as PickRow[]));
+
+        // Marca como notificado só após enviar (evita reenvio em runs futuros).
+        const { error: insErr } = await supabase
+          .from("bolao_kickoff_notifications")
+          .insert({ bolao_id: row.bolao_id, match_id: row.match_id });
+        if (insErr) throw insErr;
+        sent++;
+      } catch (e) {
+        console.error(`notify ${row.bolao_id}/${row.match_id}:`, (e as Error)?.message);
+        errors.push(`${row.bolao_id}/${row.match_id}: ${(e as Error)?.message}`);
+      }
+    }
+
+    return json({ ok: true, due: rows.length, sent, errors });
+  } catch (e) {
+    console.error("notify-kickoff error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/073_kickoff_telegram_notifications.sql
+++ b/supabase/migrations/073_kickoff_telegram_notifications.sql
@@ -1,0 +1,120 @@
+-- ============================================================
+-- 073_kickoff_telegram_notifications — aviso de kickoff no Telegram do dono
+-- ============================================================
+-- Opt-in do dono do bolão: no início de cada jogo, ele recebe no SEU Telegram os
+-- palpites de todos os membros (placar + quem cada um acha que avança no mata-mata
+-- + campeão). Ninguém além do dono recebe. Reusa o linking de Telegram que já
+-- existe (users.telegram_chat_id).
+--
+-- Econômico: o cron roda só nos minutos :00 e :30 (os kickoffs da Copa são
+-- "redondos"), e a função sai na hora quando não há jogo começando.
+--
+-- PRÉ-REQUISITO POR AMBIENTE (rodar uma vez via SQL, igual ao 048):
+--   vault.create_secret('<x-cron-secret>', 'notify_kickoff_cron_secret', ...);
+--   vault.create_secret('<url da função>', 'notify_kickoff_url', ...);
+--   E os secrets da função (TELEGRAM_BOT_TOKEN, CRON_SECRET) no painel.
+-- ============================================================
+
+ALTER TABLE public.boloes
+  ADD COLUMN IF NOT EXISTS kickoff_notify_telegram boolean NOT NULL DEFAULT false;
+COMMENT ON COLUMN public.boloes.kickoff_notify_telegram IS
+  'Opt-in do dono: avisar no Telegram dele quando cada jogo começa (palpites do bolão).';
+
+-- Idempotência: (bolão, jogo) já notificado → não repete.
+CREATE TABLE IF NOT EXISTS public.bolao_kickoff_notifications (
+  bolao_id uuid    NOT NULL REFERENCES public.boloes(id)     ON DELETE CASCADE,
+  match_id integer NOT NULL REFERENCES public.wc_matches(id) ON DELETE CASCADE,
+  sent_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (bolao_id, match_id)
+);
+COMMENT ON TABLE public.bolao_kickoff_notifications IS
+  'Idempotência do aviso de kickoff: registra (bolão, jogo) já notificado.';
+
+-- ── RPC: pares (bolão, jogo) a notificar AGORA ──────────────
+-- Jogo começou na última janela (~40 min), bolão com opt-in, dono com Telegram,
+-- e ainda não notificado. A janela > intervalo do cron (30 min) garante que um
+-- run perdido seja coberto no próximo, sem duplicar (idempotência cuida disso).
+CREATE OR REPLACE FUNCTION public.get_due_kickoff_notifications()
+RETURNS TABLE(
+  bolao_id uuid, bolao_name text, match_id integer, owner_chat_id text,
+  stage text, home_team text, away_team text,
+  home_team_code text, away_team_code text
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  SELECT b.id, b.name, m.id, u.telegram_chat_id,
+         m.stage, m.home_team, m.away_team, m.home_team_code, m.away_team_code
+  FROM wc_matches m
+  JOIN boloes b ON b.kickoff_notify_telegram = true
+  JOIN users  u ON u.id = b.owner_id AND u.telegram_chat_id IS NOT NULL
+  WHERE (m.match_date + m.match_time_brasilia) AT TIME ZONE 'America/Sao_Paulo'
+          BETWEEN now() - interval '40 minutes' AND now() + interval '2 minutes'
+    AND NOT EXISTS (
+      SELECT 1 FROM bolao_kickoff_notifications n
+      WHERE n.bolao_id = b.id AND n.match_id = m.id
+    );
+$function$;
+
+-- ── RPC: palpites de cada membro do bolão pra um jogo ───────
+-- Placar + campeão de cada um + (mata-mata) quem ele acha que avança neste jogo.
+CREATE OR REPLACE FUNCTION public.get_bolao_match_picks(p_bolao_id uuid, p_match_id integer)
+RETURNS TABLE(
+  user_name text,
+  predicted_home integer, predicted_away integer,
+  champion_code text, advance_code text
+)
+LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE v_home text; v_away text;
+BEGIN
+  SELECT home_team_code, away_team_code INTO v_home, v_away FROM wc_matches WHERE id = p_match_id;
+  RETURN QUERY
+  SELECT u.name,
+         bp.predicted_home_score, bp.predicted_away_score,
+         champ.predicted_team_code,
+         adv.predicted_team_code
+  FROM bolao_members bm
+  JOIN users u ON u.id = bm.user_id
+  LEFT JOIN bolao_predictions bp
+    ON bp.bolao_id = bm.bolao_id AND bp.user_id = bm.user_id AND bp.match_id = p_match_id
+  LEFT JOIN bolao_special_predictions champ
+    ON champ.bolao_id = bm.bolao_id AND champ.user_id = bm.user_id
+   AND champ.prediction_type = 'champion'
+  LEFT JOIN LATERAL (
+    SELECT sp.predicted_team_code
+    FROM bolao_special_predictions sp
+    WHERE sp.bolao_id = bm.bolao_id AND sp.user_id = bm.user_id
+      AND sp.prediction_type IN ('round_of_16','quarterfinalist','semifinalist','finalist')
+      AND sp.predicted_team_code IN (v_home, v_away)
+    LIMIT 1
+  ) adv ON true
+  WHERE bm.bolao_id = p_bolao_id
+  ORDER BY u.name;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_due_kickoff_notifications()            TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_bolao_match_picks(uuid, integer)        TO service_role;
+
+-- ── Cron: roda nos minutos :00 e :30 (kickoffs são redondos) ─
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notify-kickoff') THEN
+    PERFORM cron.unschedule('notify-kickoff');
+  END IF;
+END $$;
+
+SELECT cron.schedule('notify-kickoff', '0,30 * * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_kickoff_url'),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_kickoff_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+$job$);

--- a/supabase/migrations/074_wc_matches_winner.sql
+++ b/supabase/migrations/074_wc_matches_winner.sql
@@ -1,0 +1,14 @@
+-- ============================================================
+-- 074_wc_matches_winner — vencedor real do jogo (inclui pênaltis)
+-- ============================================================
+-- O placar (home_score/away_score) guarda o resultado FIFA (empate nos 120 quando
+-- vai pra pênaltis). Mas pra "andar" o chaveamento e pontuar o "quem avança" a
+-- gente precisa saber QUEM passou — incl. quando foi decidido nos pênaltis.
+-- Esta coluna guarda o código do vencedor real; é preenchida pela ingestão
+-- (ingest-wc-scores), que lê teams.home/away.winner da API-Sports.
+-- ============================================================
+ALTER TABLE public.wc_matches
+  ADD COLUMN IF NOT EXISTS winner_team_code text;
+
+COMMENT ON COLUMN public.wc_matches.winner_team_code IS
+  'Vencedor real do jogo (inclui pênaltis). Alimenta a propagação do chaveamento e a pontuação do "quem avança".';

--- a/supabase/migrations/075_resolve_special_scores.sql
+++ b/supabase/migrations/075_resolve_special_scores.sql
@@ -1,0 +1,151 @@
+-- ============================================================
+-- 075_resolve_special_scores — pontua o "quem avança" + soma no ranking
+-- ============================================================
+-- Credita os pontos dos palpites especiais de QUEM AVANÇA, com o modelo
+-- "fecha a fase, então pontua":
+--   - Uma fase só é pontuada quando está 100% decidida (nenhum TBD na rodada).
+--   - Mapa fase→stage: round_of_16=oitavas, quarterfinalist=quartas,
+--     semifinalist=semis, finalist=final, round_of_32=16 avos. Um time "alcançou
+--     a fase X" se aparece como mandante/visitante em algum jogo do stage X.
+--   - Campeão: decidido quando a final encerra (wc_matches.winner_team_code).
+--   - Por MODO do bolão: real → oitavas..campeão (round_of_32 é vestigial, não
+--     pontua); projeção → inclui round_of_32 ("acertou os classificados").
+--   - Lê a config de pontos NA HORA (special_predictions_points / champion_points)
+--     → dono pode ajustar os pontos de uma fase até ela fechar. Recalculável.
+-- Prêmios de jogador continuam no resolve_player_awards (migration 052).
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.resolve_special_scores(p_bolao_id uuid)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_real boolean; v_cfg jsonb; v_pts jsonb; v_champ_pts int;
+  v_special_enabled boolean; v_champ_enabled boolean;
+  v_types text[]; v_t text; v_stage text; v_determined boolean; v_pt int;
+  v_champion text;
+BEGIN
+  SELECT COALESCE(knockout_real_predictions_enabled, false),
+         COALESCE(special_predictions_config, '{}'::jsonb),
+         COALESCE(special_predictions_points, '{}'::jsonb),
+         COALESCE(champion_points, 0),
+         COALESCE(special_predictions_enabled, true),
+         COALESCE(champion_enabled, true)
+    INTO v_real, v_cfg, v_pts, v_champ_pts, v_special_enabled, v_champ_enabled
+    FROM boloes WHERE id = p_bolao_id;
+  IF NOT FOUND THEN RETURN json_build_object('success', false, 'error', 'Bolão não encontrado'); END IF;
+
+  -- Tipos a pontuar conforme o modo
+  IF v_real THEN
+    v_types := ARRAY['round_of_16','quarterfinalist','semifinalist','finalist'];
+  ELSE
+    v_types := ARRAY['round_of_32','round_of_16','quarterfinalist','semifinalist','finalist'];
+  END IF;
+
+  IF v_special_enabled THEN
+    FOREACH v_t IN ARRAY v_types LOOP
+      -- respeita a config de habilitado da fase (default true)
+      CONTINUE WHEN COALESCE((v_cfg ->> v_t)::boolean, true) = false;
+
+      v_stage := CASE v_t
+        WHEN 'round_of_32' THEN 'round_of_32' WHEN 'round_of_16' THEN 'round_of_16'
+        WHEN 'quarterfinalist' THEN 'quarter' WHEN 'semifinalist' THEN 'semi'
+        WHEN 'finalist' THEN 'final' END;
+
+      -- fase 100% decidida? (existe e nenhum TBD)
+      SELECT EXISTS (SELECT 1 FROM wc_matches WHERE stage = v_stage)
+         AND NOT EXISTS (SELECT 1 FROM wc_matches WHERE stage = v_stage
+                           AND (home_team_code = 'TBD' OR away_team_code = 'TBD'))
+        INTO v_determined;
+      CONTINUE WHEN NOT v_determined;
+
+      v_pt := COALESCE((v_pts ->> v_t)::int, 0);
+
+      UPDATE bolao_special_predictions sp
+      SET points_earned = CASE WHEN sp.predicted_team_code IN (
+            SELECT home_team_code FROM wc_matches WHERE stage = v_stage AND home_team_code <> 'TBD'
+            UNION
+            SELECT away_team_code FROM wc_matches WHERE stage = v_stage AND away_team_code <> 'TBD'
+          ) THEN v_pt ELSE 0 END
+      WHERE sp.bolao_id = p_bolao_id AND sp.prediction_type = v_t;
+    END LOOP;
+  END IF;
+
+  -- Campeão: decidido quando a final encerra (vencedor real setado)
+  IF v_champ_enabled THEN
+    SELECT winner_team_code INTO v_champion
+      FROM wc_matches WHERE stage = 'final' AND is_finished = true AND winner_team_code IS NOT NULL
+      LIMIT 1;
+    IF v_champion IS NOT NULL THEN
+      UPDATE bolao_special_predictions sp
+      SET points_earned = CASE WHEN sp.predicted_team_code = v_champion THEN v_champ_pts ELSE 0 END
+      WHERE sp.bolao_id = p_bolao_id AND sp.prediction_type = 'champion';
+    END IF;
+  END IF;
+
+  RETURN json_build_object('success', true);
+END;
+$function$;
+
+-- Recomputa todos os bolões (gancho do cron + recompute manual após ajustar pontos)
+CREATE OR REPLACE FUNCTION public.resolve_all_special_scores()
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE r record; n int := 0;
+BEGIN
+  FOR r IN SELECT id FROM boloes
+           WHERE COALESCE(special_predictions_enabled, true) OR COALESCE(champion_enabled, true) LOOP
+    PERFORM resolve_special_scores(r.id);
+    n := n + 1;
+  END LOOP;
+  RETURN json_build_object('success', true, 'boloes', n);
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.resolve_special_scores(uuid) TO service_role, authenticated;
+GRANT EXECUTE ON FUNCTION public.resolve_all_special_scores()  TO service_role;
+
+-- ── Ranking passa a somar placar + especiais ────────────────
+CREATE OR REPLACE FUNCTION public.get_bolao_ranking(p_bolao_id uuid)
+RETURNS TABLE(user_id uuid, user_name text, user_email text, total_points integer, exact_scores integer, correct_results integer, total_predictions integer, rank bigint)
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT
+    bm.user_id,
+    COALESCE(
+      NULLIF(TRIM(u.name), ''),
+      au.raw_user_meta_data->>'full_name',
+      au.raw_user_meta_data->>'name',
+      INITCAP(REPLACE(REPLACE(split_part(u.email, '@', 1), '.', ' '), '_', ' '))
+    )::text AS user_name,
+    u.email::text AS user_email,
+    (COALESCE(SUM(bp.points_earned), 0) + COALESCE(MAX(sp.special_pts), 0))::int AS total_points,
+    COUNT(CASE WHEN bp.points_earned IS NOT NULL AND bp.points_earned >= b.scoring_exact THEN 1 END)::int AS exact_scores,
+    COUNT(CASE WHEN bp.points_earned IS NOT NULL AND bp.points_earned = b.scoring_result THEN 1 END)::int AS correct_results,
+    COUNT(bp.id)::int AS total_predictions,
+    RANK() OVER (ORDER BY (COALESCE(SUM(bp.points_earned), 0) + COALESCE(MAX(sp.special_pts), 0)) DESC) AS rank
+  FROM bolao_members bm
+  JOIN users u ON u.id = bm.user_id
+  JOIN boloes b ON b.id = bm.bolao_id
+  LEFT JOIN auth.users au ON au.id = bm.user_id
+  LEFT JOIN bolao_predictions bp ON bp.bolao_id = bm.bolao_id AND bp.user_id = bm.user_id
+  LEFT JOIN (
+    SELECT user_id, COALESCE(SUM(points_earned), 0) AS special_pts
+    FROM bolao_special_predictions
+    WHERE bolao_id = p_bolao_id
+    GROUP BY user_id
+  ) sp ON sp.user_id = bm.user_id
+  WHERE bm.bolao_id = p_bolao_id
+  GROUP BY bm.user_id, u.name, u.email, au.raw_user_meta_data, b.scoring_exact, b.scoring_result
+  ORDER BY total_points DESC, exact_scores DESC, correct_results DESC;
+END;
+$function$;


### PR DESCRIPTION
Sobe pra produção 2 entregas (2 commits).

## 1. Aviso de kickoff no Telegram do dono (opt-in)
No início de cada jogo, o **dono** do bolão (se ativar) recebe no **seu** Telegram os palpites de todos os membros — placar + quem cada um acha que avança + campeão. Só o dono recebe.

- migration **073**: `boloes.kickoff_notify_telegram` + tabela de idempotência `bolao_kickoff_notifications` + RPCs (`get_due_kickoff_notifications`, `get_bolao_match_picks`) + cron `0,30 * * * *` (econômico).
- edge function **notify-kickoff** (auth `x-cron-secret`, mensagem HTML).
- admin: card com toggle; se o dono não tem Telegram linkado, mostra **Conectar Telegram** e só libera o switch depois.

## 2. Mata-mata: vencedor, propagação e pontuação do "quem avança" (Fases 2 e 3)
- **Fase 2** (`ingest-wc-scores`): captura o **vencedor real** (incl. pênaltis) em `wc_matches.winner_team_code` (migration **074**); **auto-link** dos jogos do mata-mata por (rodada + par de times) → acaba com o link manual; **propagação** (`Vencedor/Perdedor Jxx` → time real) → o chaveamento anda sozinho. Placar segue FIFA (empate nos 120, pênaltis à parte).
- **Fase 3** (migration **075**): `resolve_special_scores` credita o "quem avança" **por modo** (real: oitavas→campeão; projeção: inclui 16-avos), **só quando a fase fecha**, lendo os pontos por fase **na hora** (ajustáveis até fechar) e **recalculável**; `get_bolao_ranking` passa a somar **placar + especiais** (e prêmios de jogador).

## Pós-merge (ordem importa)
1. Aplicar migrations **073, 074, 075** (074 antes da 075).
2. **Deploy** das edge functions `ingest-wc-scores` e `notify-kickoff`.
3. Criar os secrets do cron do `notify-kickoff` no Vault (`notify_kickoff_url`, `notify_kickoff_cron_secret`) + `CRON_SECRET` na função.
4. Recompute inicial: `select resolve_all_special_scores();`

Notas: modelo "fecha a fase, então pontua" — oitavas+ só pontuam quando a rodada inteira termina; em bolões de projeção o round_of_32 já pontua. Ajustou pontos de uma fase? rode `resolve_all_special_scores()` de novo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)