### PR TITLE
fix(bolão): ranking quebrado (user_id ambíguo) + rótulos de fase trocados

### DIFF
--- a/src/components/bolao/BolaoStatsTopCards.tsx
+++ b/src/components/bolao/BolaoStatsTopCards.tsx
@@ -40,8 +40,8 @@ interface PredictionFront {
 
 const STAGE_LABELS: { key: WcMatch['stage']; label: string }[] = [
   { key: 'group', label: 'Fase de grupos' },
-  { key: 'round_of_32', label: 'Oitavas' },
-  { key: 'round_of_16', label: '16 Avos' },
+  { key: 'round_of_32', label: '16 avos' },
+  { key: 'round_of_16', label: 'Oitavas' },
   { key: 'quarter', label: 'Quartas' },
   { key: 'semi', label: 'Semis' },
   { key: 'final', label: 'Final' },

--- a/supabase/migrations/075_resolve_special_scores.sql
+++ b/supabase/migrations/075_resolve_special_scores.sql
@@ -139,11 +139,13 @@ BEGIN
   LEFT JOIN auth.users au ON au.id = bm.user_id
   LEFT JOIN bolao_predictions bp ON bp.bolao_id = bm.bolao_id AND bp.user_id = bm.user_id
   LEFT JOIN (
-    SELECT user_id, COALESCE(SUM(points_earned), 0) AS special_pts
-    FROM bolao_special_predictions
-    WHERE bolao_id = p_bolao_id
-    GROUP BY user_id
-  ) sp ON sp.user_id = bm.user_id
+    -- alias explícito: a função tem um OUT param `user_id`, então a coluna
+    -- precisa ser qualificada (bsp.) e renomeada (uid) pra não dar ambiguidade.
+    SELECT bsp.user_id AS uid, COALESCE(SUM(bsp.points_earned), 0) AS special_pts
+    FROM bolao_special_predictions bsp
+    WHERE bsp.bolao_id = p_bolao_id
+    GROUP BY bsp.user_id
+  ) sp ON sp.uid = bm.user_id
   WHERE bm.bolao_id = p_bolao_id
   GROUP BY bm.user_id, u.name, u.email, au.raw_user_meta_data, b.scoring_exact, b.scoring_result
   ORDER BY total_points DESC, exact_scores DESC, correct_results DESC;


### PR DESCRIPTION
Dois hotfixes em cima do #183 (já merdado).

## 1. `get_bolao_ranking` quebrado — `user_id` ambíguo (CRÍTICO)
A subquery nova de pontos especiais referenciava `user_id` sem qualificar; como a função tem um OUT param `user_id`, dava **"column reference user_id is ambiguous" em runtime** → ranking voltava vazio → **todo bolão caía na Tela A** ("Faça seus 16 palpites / não abre pra ver palpites e pontuações"). Fix: `bsp.user_id AS uid` + join por `sp.uid`.

## 2. Rótulos de fase trocados no card "Seus palpites"
`STAGE_LABELS` do `BolaoStatsTopCards` tinha `round_of_32`="Oitavas" e `round_of_16`="16 Avos" (invertido). Mostrava "Oitavas 13/13" pros 16-avos e "16 Avos 0/3" pras oitavas. Contagem certa, só o nome trocado. Corrige pra `round_of_32`="16 avos", `round_of_16`="Oitavas".

## Status em prod
- O fix nº 1 (função SQL) **já foi aplicado em prod** na mão (ranking voltou: 7 linhas / 170 pts confirmados).
- O fix nº 2 é **frontend** → reflete pro cliente após o **deploy** deste merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)