### PR TITLE
fix(auth): restaura ProtectedRoute em /oportunidades

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,8 +78,11 @@ const App = () => (
             <Route path="/" element={<LandingEcossistema />} />
             <Route path="/nba" element={<Landing />} />
             <Route path="/home-nba" element={<HomeNBA />} />
-            {/* TEMP: ProtectedRoute removido pra screenshot do rebrand. RESTAURAR antes do merge. */}
-            <Route path="/oportunidades" element={<Picks />} />
+            <Route path="/oportunidades" element={
+              <ProtectedRoute>
+                <Picks />
+              </ProtectedRoute>
+            } />
             <Route path="/betinho" element={<Betinho />} />
             {/* Variante da LP do Betinho pra usuários vindos do bolão da Copa.
                 Mesmo componente; useLocation detecta a rota e troca hero +


### PR DESCRIPTION
## Problema
A rota `/oportunidades` (página Picks) está **pública em produção** desde `ed7d7a2` (19/mai): o `<ProtectedRoute>` foi removido "temporariamente pra screenshot do rebrand" e nunca restaurado (o TODO do próprio commit pedia restaurar). Usuários não logados acessam conteúdo que exige login.

## Fix
Restaura o wrapper `<ProtectedRoute>` original em volta de `<Picks />` e remove o comentário TEMP.

Verificado local: `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)