### PR TITLE
hotfix: restaura auth de /oportunidades (prod) + guard de branch

### DIFF
--- a/.github/BRANCH_PROTECTION_RUNBOOK.md
+++ b/.github/BRANCH_PROTECTION_RUNBOOK.md
@@ -1,0 +1,105 @@
+# Branch protection da `main` — runbook
+
+Objetivo: garantir o fluxo **feature → develop → main** e impedir que código vá
+para produção (push na `main` dispara `deploy-production.yml`) sem passar por
+staging (push na `develop` dispara `deploy-staging.yml`) e sem review/CI.
+
+Estado em 2026-06-30: `main` **sem nenhuma branch protection** (qualquer um pode
+dar push/merge direto). CI roda o job **`validate`** (`.github/workflows/ci.yml`)
+em PRs para `develop` e `main`.
+
+A regra "só `develop`/`hotfix/*`/`release/*` podem ir para main" **não existe** de
+forma nativa no GitHub (nem branch protection clássica nem rulesets restringem a
+branch de origem de um PR). Por isso ela é aplicada pelo workflow
+`guard-main-source.yml` (job `guard`), registrado como required status check.
+
+---
+
+## Fase 1 — Colocar o guard na `main`
+
+O workflow `guard-main-source.yml` precisa existir **na `main`** para rodar nos
+PRs que miram a `main`. Leve-o pela própria esteira (dogfood):
+
+```bash
+# a partir da develop, com o arquivo já commitado nela:
+#   feature/ci-guard -> develop -> main  (ou inclua na próxima promoção develop→main)
+```
+
+Confirme que o check `guard` aparece em um PR para `main` antes da Fase 2b.
+
+---
+
+## Fase 2 — Ativar a branch protection (precisa de admin)
+
+### 2a) Baseline seguro — pode rodar AGORA (sem depender do guard)
+
+Exige PR + 1 review + CI `validate` verde, bloqueia push direto e force-push:
+
+```bash
+gh api -X PUT repos/tech-lamjav/prop-play-predictor/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": { "strict": true, "contexts": ["validate"] },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+JSON
+```
+
+### 2b) Completo — rodar DEPOIS que o guard estiver na `main`
+
+Igual ao 2a, porém adicionando `guard` aos checks obrigatórios (esta é a linha que
+de fato bloqueia `feature → main`):
+
+```bash
+gh api -X PUT repos/tech-lamjav/prop-play-predictor/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": { "strict": true, "contexts": ["validate", "guard"] },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": false
+  },
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+JSON
+```
+
+> Opcional: proteger a `develop` também com `{"contexts":["validate"]}` + 1 review,
+> trocando `branches/main/protection` por `branches/develop/protection`.
+
+---
+
+## Decisões embutidas (ajuste se quiser)
+
+- `enforce_admins: false` → admins têm "break-glass" para emergências. Mude para
+  `true` para aplicar a regra inclusive a admins.
+- `strict: true` → a branch precisa estar atualizada com a `main` antes do merge.
+- `required_approving_review_count: 1` → suba para 2 se quiser dois revisores.
+- `guard` permite `develop`, `hotfix/*`, `release/*`. Edite o `case` em
+  `guard-main-source.yml` para mudar as exceções.
+
+## Conferir / reverter
+
+```bash
+# ver estado atual
+gh api repos/tech-lamjav/prop-play-predictor/branches/main/protection
+
+# remover toda a proteção (reverter)
+gh api -X DELETE repos/tech-lamjav/prop-play-predictor/branches/main/protection
+```

--- a/.github/workflows/guard-main-source.yml
+++ b/.github/workflows/guard-main-source.yml
@@ -1,0 +1,35 @@
+name: Guard main source
+
+# Bloqueia PRs para `main` cuja origem não seja `develop`, `hotfix/*` ou `release/*`.
+# Objetivo: forçar o fluxo  feature -> develop -> main.
+# `hotfix/*` e `release/*` são as exceções controladas do git-flow.
+#
+# Este job é registrado como required status check na branch protection da `main`
+# (contexto: "guard"). Enquanto este arquivo não estiver na `main`, NÃO marque
+# "guard" como obrigatório — senão todo PR para main fica travado aguardando um
+# check que nunca roda. Ver .github/BRANCH_PROTECTION_RUNBOOK.md.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validar branch de origem do PR
+        run: |
+          HEAD="${{ github.head_ref }}"
+          echo "PR: $HEAD -> main"
+          case "$HEAD" in
+            develop|hotfix/*|release/*)
+              echo "OK: '$HEAD' pode ser mergeado em main."
+              ;;
+            *)
+              echo "::error::Branch '$HEAD' nao pode ir direto para main. Use o fluxo feature -> develop -> main: reabra este PR contra 'develop'. Excecoes permitidas: hotfix/* e release/*."
+              exit 1
+              ;;
+          esac

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,8 +78,11 @@ const App = () => (
             <Route path="/" element={<LandingEcossistema />} />
             <Route path="/nba" element={<Landing />} />
             <Route path="/home-nba" element={<HomeNBA />} />
-            {/* TEMP: ProtectedRoute removido pra screenshot do rebrand. RESTAURAR antes do merge. */}
-            <Route path="/oportunidades" element={<Picks />} />
+            <Route path="/oportunidades" element={
+              <ProtectedRoute>
+                <Picks />
+              </ProtectedRoute>
+            } />
             <Route path="/betinho" element={<Betinho />} />
             {/* Variante da LP do Betinho pra usuários vindos do bolão da Copa.
                 Mesmo componente; useLocation detecta a rota e troca hero +


### PR DESCRIPTION
PR cirúrgico (hotfix a partir da `main`) com **só** o que é de governança/segurança — não arrasta nenhuma feature da develop.

## 1. 🔒 Fix de segurança (produção)
`/oportunidades` (página Picks) está **pública em produção desde 19/mai** (`ed7d7a2`): o `<ProtectedRoute>` foi removido "temporariamente pra screenshot" e nunca restaurado. Restaura o wrapper original.

## 2. 🛡️ Guard de branch
Adiciona `guard-main-source.yml` (job `guard`) que bloqueia PRs de feature direto pra `main` (só `develop`/`hotfix/*`/`release/*`). Após o merge, marcar `guard` como required check (passo 2b do runbook).

Diff = só estes 3 arquivos. Não toca em #180 (futebol) nem nos PRs de bolão — esses ficam com os devs/release manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)