### PR TITLE
feat(betinho): lembrete de liquidação no Telegram com resultado preenchido

### DIFF
--- a/SETTLEMENT_REMINDERS_SETUP.md
+++ b/SETTLEMENT_REMINDERS_SETUP.md
@@ -1,0 +1,71 @@
+# Lembretes de Liquidação — Setup (Telegram)
+
+O Betinho manda DM quando o jogo do usuário termina, com botões **[✅ Green] [❌ Red]** —
+1 toque liquida a aposta. Para jogos da Copa a mensagem chega **com o placar e o veredito
+sugerido** ("pelo placar, essa bateu ✅").
+
+## Peças
+
+| Peça | Onde | O que faz |
+| --- | --- | --- |
+| Migration `078_settlement_reminders.sql` | `supabase/migrations` | Colunas de cadência em `bets`, mute em `users`, placar 90' em `wc_matches`, RPC `get_settlement_reminder_candidates`, cron `notify-settlement` (15 min) |
+| `notify-settlement` | `supabase/functions` | Cron: acha pendentes com jogo encerrado, casa com `wc_matches`, computa veredito e manda a DM com botões |
+| `telegram-webhook` (alterado) | `supabase/functions` | Handler de `callback_query` (Green/Red/🔕) + comandos `/silenciar` e `/lembretes` |
+| `ingest-wc-scores` (alterado) | `supabase/functions` | Passa a gravar `fulltime_home/away` (placar dos 90' — base da liquidação; o placar cheio inclui prorrogação) |
+
+## Deploy (ordem)
+
+1. **Migration**: `supabase db push` (ou aplicar `078_settlement_reminders.sql` via SQL editor).
+2. **Functions**: deploy de `ingest-wc-scores`, `telegram-webhook` e `notify-settlement`
+   (`notify-settlement` com `--no-verify-jwt`, igual às outras de cron/webhook).
+3. **Vault** (uma vez por ambiente, igual 048/073):
+   ```sql
+   select vault.create_secret('<mesmo valor do env CRON_SECRET>', 'notify_settlement_cron_secret');
+   select vault.create_secret('https://<projeto>.supabase.co/functions/v1/notify-settlement', 'notify_settlement_url');
+   ```
+4. **Secrets da função** (painel → Edge Functions): já existem para as outras —
+   `TELEGRAM_BOT_TOKEN`, `CRON_SECRET`, `SUPABASE_SERVICE_ROLE_KEY` (automático).
+5. **⚠️ setWebhook do bot**: os botões chegam como `callback_query`. Se o `setWebhook`
+   foi feito com `allowed_updates` restrito a `["message"]`, os toques NÃO chegam.
+   Conferir/reconfigurar:
+   ```bash
+   curl "https://api.telegram.org/bot<TOKEN>/getWebhookInfo"
+   # se allowed_updates não incluir callback_query:
+   curl "https://api.telegram.org/bot<TOKEN>/setWebhook" \
+     -d "url=<url do telegram-webhook>" \
+     -d "secret_token=<TELEGRAM_WEBHOOK_SECRET>" \
+     -d 'allowed_updates=["message","edited_message","callback_query"]'
+   ```
+
+## Regras de produto (implementadas)
+
+- **Cadência**: máx. **2 lembretes por aposta**, gap de 20h; máx. **3 mensagens por usuário por run**.
+- **Copa** (casada com `wc_matches` encerrado): sai na hora do apito, com placar.
+  Veredito só em mercado direto — ML/1x2, over/under de **gols**, ambas marcam —
+  sempre pelo **placar dos 90'**. Múltipla, handicap, 1º tempo, classificação,
+  escanteios etc. → pergunta sem afirmar. Linha exata (push) → sem veredito.
+- **Genérica** (sem placar no banco): `match_date` passou há 3h+ (ou aposta com 24h+
+  quando sem data de jogo), só entre **09h–23h BRT**.
+- **Opt-out**: botão 🔕 na mensagem ou `/silenciar`; `/lembretes` reativa
+  (`users.settlement_reminders_muted`).
+
+## Teste manual (dev)
+
+```bash
+# disparar o cron na mão
+curl -X POST "https://<projeto>.supabase.co/functions/v1/notify-settlement" \
+  -H "x-cron-secret: <CRON_SECRET>"
+# resposta: { ok, candidates, wc_finished_recent, due, sent, ... }
+```
+Pré-condições para receber a DM: usuário com `telegram_chat_id` preenchido, aposta
+`pending` recente e (Copa) um `wc_matches` com `is_finished = true` cujos dois times
+apareçam na descrição da aposta.
+
+## Métricas (PostHog)
+
+- `settlement_reminder_sent` — {kind: wc|generic, verdict, betting_market, reminder_number}
+- `settlement_settled_via_bot` — {bet_id, outcome}
+- `settlement_reminders_muted` / `_unmuted` — {via: button|command}
+
+North star do Marco 0: taxa de liquidação ≥ 60% (hoje ~28%). Funil:
+`settlement_reminder_sent` → `settlement_settled_via_bot`.

--- a/supabase/functions/ingest-wc-scores/index.ts
+++ b/supabase/functions/ingest-wc-scores/index.ts
@@ -11,6 +11,8 @@
 //
 // Placar = goals.home/away (AET incluso; pênaltis à parte) → empate nos 120 quando
 // vai pra pênaltis, como manda a FIFA. O vencedor da disputa vai em winner_team_code.
+// Placar dos 90' = score.fulltime → fulltime_home/away. É a base de liquidação de
+// apostas (ML/over-under valem o tempo normal), usada pelo notify-settlement.
 //
 // Proteção: header `x-cron-secret` == env CRON_SECRET.
 // Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, API_SPORTS_KEY, CRON_SECRET.
@@ -65,7 +67,7 @@ serve(async (req) => {
     // 2) Nosso estado: todos os jogos + mapa de times (api_team_id → código)
     const { data: rows, error: selErr } = await supabase
       .from("wc_matches")
-      .select("id, match_number, stage, home_team, away_team, home_team_code, away_team_code, home_score, away_score, is_finished, api_fixture_id, winner_team_code");
+      .select("id, match_number, stage, home_team, away_team, home_team_code, away_team_code, home_score, away_score, fulltime_home, fulltime_away, is_finished, api_fixture_id, winner_team_code");
     if (selErr) throw selErr;
 
     const { data: teamMapRows, error: tmErr } = await supabase
@@ -133,13 +135,19 @@ serve(async (req) => {
       // Alinha o placar ao NOSSO mandante/visitante (a ordem da API pode diferir).
       const goalsHome = fx?.goals?.home ?? null;
       const goalsAway = fx?.goals?.away ?? null;
+      const ftHome = fx?.score?.fulltime?.home ?? null; // 90 minutos (sem prorrogação)
+      const ftAway = fx?.score?.fulltime?.away ?? null;
       let homeScore: number | null, awayScore: number | null;
+      let fulltimeHome: number | null, fulltimeAway: number | null;
       if (apiHome && apiHome === row.home_team_code) {
         homeScore = goalsHome; awayScore = goalsAway;
+        fulltimeHome = ftHome; fulltimeAway = ftAway;
       } else if (apiHome && apiHome === row.away_team_code) {
         homeScore = goalsAway; awayScore = goalsHome; // ordem invertida
+        fulltimeHome = ftAway; fulltimeAway = ftHome;
       } else {
         homeScore = goalsHome; awayScore = goalsAway; // fallback (grupo / linkado na mesma ordem)
+        fulltimeHome = ftHome; fulltimeAway = ftAway;
       }
 
       const status = fx?.fixture?.status?.short ?? "";
@@ -153,6 +161,8 @@ serve(async (req) => {
       if (justLinked) patch.api_fixture_id = fid;
       if (row.home_score !== homeScore) patch.home_score = homeScore;
       if (row.away_score !== awayScore) patch.away_score = awayScore;
+      if (row.fulltime_home !== fulltimeHome) patch.fulltime_home = fulltimeHome;
+      if (row.fulltime_away !== fulltimeAway) patch.fulltime_away = fulltimeAway;
       if (row.is_finished !== isFinished) patch.is_finished = isFinished;
       if (winnerCode && row.winner_team_code !== winnerCode) patch.winner_team_code = winnerCode;
 

--- a/supabase/functions/notify-settlement/index.ts
+++ b/supabase/functions/notify-settlement/index.ts
@@ -1,0 +1,446 @@
+// ============================================================
+// notify-settlement — lembrete de liquidação com resultado preenchido
+// ============================================================
+// Job de cron (roda a cada 15 min; migration 078). Ataca o buraco da retenção:
+// a maioria das apostas morre em 'pending' porque liquidar exige entrar no site.
+// Aqui o Betinho manda DM no Telegram quando o jogo termina, com botões inline
+// [✅ Green] [❌ Red] — 1 toque e a banca atualiza (handler no telegram-webhook).
+//
+// Duas classes de lembrete:
+//   • COPA — aposta casada com um wc_matches encerrado (por nome dos dois times
+//     na descrição): a mensagem chega COM o placar e, quando o mercado é
+//     computável (ML/1x2, over-under de gols, ambas marcam), com o veredito
+//     sugerido: "pelo placar, essa bateu ✅". Liquidação usa o placar dos 90'
+//     (fulltime_*); o placar final (com prorrogação) aparece só como contexto.
+//   • GENÉRICA — sem placar no banco: jogo já deve ter acabado (match_date
+//     passou, ou aposta com 24h+), pergunta com os mesmos botões, sem veredito.
+//     Respeita janela de silêncio (09h–23h BRT); a da Copa sai na hora do apito
+//     (quem apostou no jogo está acordado assistindo).
+//
+// Cadência: teto de 2 lembretes por aposta com gap de 20h (RPC), máx. 3
+// mensagens por usuário por run. Veredito NUNCA é dado em múltiplas/sistema,
+// nem em mercados de classificação/prorrogação (regras de casa divergem).
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN,
+//                 CRON_SECRET (+ POSTHOG_API_KEY opcional, via shared/posthog).
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const BETS_URL = "https://www.smartbetting.app/bets";
+const MAX_PER_USER_PER_RUN = 3;
+const QUIET_START = 9; // genéricas só entre 09:00–22:59 BRT
+const QUIET_END = 23;
+
+// ── Telegram ─────────────────────────────────────────────────
+function esc(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+async function sendReminder(chatId: string, text: string, betId: string): Promise<void> {
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text,
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      reply_markup: {
+        inline_keyboard: [
+          [
+            { text: "✅ Green", callback_data: `settle:${betId}:won` },
+            { text: "❌ Red", callback_data: `settle:${betId}:lost` },
+          ],
+          [
+            { text: "Outras opções ↗", url: BETS_URL },
+            { text: "🔕 Parar lembretes", callback_data: `mute:${betId}` },
+          ],
+        ],
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
+}
+
+// ── Normalização e casamento de times ────────────────────────
+function norm(s: unknown): string {
+  return String(s ?? "")
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "") // remove acentos (marcas combinantes)
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Nome em inglês (print de casa gringa) → nome PT usado em wc_matches.
+// Chaves e valores já normalizados (sem acento, minúsculas).
+const EN_ALIASES: Record<string, string> = {
+  "brazil": "brasil",
+  "france": "franca",
+  "germany": "alemanha",
+  "spain": "espanha",
+  "netherlands": "holanda",
+  "england": "inglaterra",
+  "portugal": "portugal",
+  "argentina": "argentina",
+  "uruguay": "uruguai",
+  "colombia": "colombia",
+  "ecuador": "equador",
+  "paraguay": "paraguai",
+  "mexico": "mexico",
+  "united states": "estados unidos",
+  "usa": "estados unidos",
+  "canada": "canada",
+  "belgium": "belgica",
+  "croatia": "croacia",
+  "switzerland": "suica",
+  "italy": "italia",
+  "poland": "polonia",
+  "austria": "austria",
+  "denmark": "dinamarca",
+  "norway": "noruega",
+  "sweden": "suecia",
+  "scotland": "escocia",
+  "turkey": "turquia",
+  "turkiye": "turquia",
+  "morocco": "marrocos",
+  "senegal": "senegal",
+  "ghana": "gana",
+  "egypt": "egito",
+  "algeria": "argelia",
+  "tunisia": "tunisia",
+  "nigeria": "nigeria",
+  "cameroon": "camaroes",
+  "ivory coast": "costa do marfim",
+  "cote d'ivoire": "costa do marfim",
+  "south africa": "africa do sul",
+  "japan": "japao",
+  "south korea": "coreia do sul",
+  "korea republic": "coreia do sul",
+  "saudi arabia": "arabia saudita",
+  "iran": "ira",
+  "qatar": "catar",
+  "jordan": "jordania",
+  "uzbekistan": "uzbequistao",
+  "australia": "australia",
+  "new zealand": "nova zelandia",
+  "panama": "panama",
+  "costa rica": "costa rica",
+  "haiti": "haiti",
+  "curacao": "curacao",
+  "cape verde": "cabo verde",
+};
+
+// true se ALGUM dos nomes aparece como palavra inteira no texto normalizado
+function hasTeam(textNorm: string, names: string[]): boolean {
+  return names.some((n) => {
+    if (!n || n.length < 3) return false;
+    return new RegExp(`(^|[^a-z])${escapeRegex(n)}([^a-z]|$)`).test(textNorm);
+  });
+}
+
+// Variações reconhecíveis de um time de wc_matches (nome PT + aliases EN + código)
+function teamNames(namePt: string, code: string): string[] {
+  const base = norm(namePt);
+  const names = [base, norm(code)];
+  for (const [en, pt] of Object.entries(EN_ALIASES)) if (pt === base) names.push(en);
+  return names;
+}
+
+interface WcMatch {
+  id: number;
+  stage: string;
+  home_team: string;
+  away_team: string;
+  home_team_code: string;
+  away_team_code: string;
+  match_date: string; // date
+  match_time_brasilia: string; // time
+  home_score: number | null;
+  away_score: number | null;
+  fulltime_home: number | null;
+  fulltime_away: number | null;
+  is_finished: boolean;
+}
+
+interface Candidate {
+  bet_id: string;
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+  bet_type: string | null;
+  sport: string | null;
+  league: string | null;
+  betting_market: string | null;
+  match_description: string | null;
+  bet_description: string | null;
+  odds: number;
+  stake_amount: number;
+  potential_return: number;
+  bet_date: string;
+  match_date: string | null;
+  reminder_count: number;
+}
+
+// ── Veredito pelo placar dos 90' ─────────────────────────────
+// Só para mercados diretos; qualquer ambiguidade → null (pergunta sem afirmar).
+type Verdict = "won" | "lost" | null;
+
+function computeVerdict(bet: Candidate, wc: WcMatch): Verdict {
+  // múltipla/sistema: pernas em jogos diversos, nunca decidível por 1 placar
+  const type = norm(bet.bet_type);
+  if (type === "multiple" || type === "system") return null;
+
+  const ftH = wc.fulltime_home;
+  const ftA = wc.fulltime_away;
+  if (ftH == null || ftA == null) return null; // sem placar de 90' → sem veredito
+
+  const desc = norm(bet.bet_description);
+  const market = norm(bet.betting_market);
+
+  // mercados fora do tempo normal / com regra própria → não arriscar
+  if (
+    /classific|avanc|qualif|prorrog|penalt|penalti|escanteio|cartao|cartoes|chute|finalizac|jogador|marca a qualquer|primeiro gol/.test(desc) ||
+    /1[oº°]?\s*tempo|2[oº°]?\s*tempo|primeiro tempo|segundo tempo|intervalo|halftime|1st half|2nd half/.test(desc)
+  ) {
+    return null;
+  }
+
+  const total = ftH + ftA;
+
+  // Over/Under de gols — "mais de 2,5", "over 2.5", "menos de 3"
+  const over = desc.match(/(?:mais de|over|acima de)\s*(\d+(?:[.,]\d+)?)/);
+  const under = desc.match(/(?:menos de|under|abaixo de)\s*(\d+(?:[.,]\d+)?)/);
+  if (over || under) {
+    // precisa ser de GOLS (explícito ou pelo mercado classificado)
+    const isGoals = /gol/.test(desc) || market === "over/under";
+    if (!isGoals) return null;
+    const line = parseFloat((over ?? under)![1].replace(",", "."));
+    if (Number.isNaN(line)) return null;
+    if (total === line) return null; // linha exata = push/void → usuário decide
+    if (over) return total > line ? "won" : "lost";
+    return total < line ? "won" : "lost";
+  }
+
+  // Ambas marcam (BTTS) — "não" explícito vira aposta no NÃO; cuidado com o
+  // "no" preposição do PT ("gols no jogo"): só conta como negativa em fim de
+  // frase ou depois de dois-pontos ("Ambas marcam: No")
+  if (market === "ambas marcam" || /ambas\s+(as\s+)?(equipes\s+)?marcam|btts|both teams to score/.test(desc)) {
+    const both = ftH > 0 && ftA > 0;
+    const betNo = /\bnao\b/.test(desc) || /:\s*no\b/.test(desc) || /\bno\s*$/.test(desc);
+    return (betNo ? !both : both) ? "won" : "lost";
+  }
+
+  // Money Line / 1x2 — em qual time a aposta foi?
+  if (market === "money line" || /\bml\b|money\s?line|vencedor|para vencer|vence\b|1x2/.test(desc)) {
+    const homeNames = teamNames(wc.home_team, wc.home_team_code);
+    const awayNames = teamNames(wc.away_team, wc.away_team_code);
+    const isDraw = /empate/.test(desc);
+    const pickedHome = hasTeam(desc, homeNames);
+    const pickedAway = hasTeam(desc, awayNames);
+
+    if (isDraw && !pickedHome && !pickedAway) return ftH === ftA ? "won" : "lost";
+    if (pickedHome && !pickedAway) return ftH > ftA ? "won" : "lost";
+    if (pickedAway && !pickedHome) return ftA > ftH ? "won" : "lost";
+    return null; // ambíguo (dois times citados / nenhum) → não afirmar
+  }
+
+  return null;
+}
+
+// ── Mensagens ────────────────────────────────────────────────
+const money = (v: number) => `R$ ${v.toFixed(2).replace(".", ",")}`;
+
+function betLine(bet: Candidate): string {
+  return (
+    `Sua aposta: <b>${esc(bet.bet_description)}</b>\n` +
+    `${money(bet.stake_amount)} · odd ${bet.odds} · retorno ${money(bet.potential_return)}`
+  );
+}
+
+function buildWcMessage(bet: Candidate, wc: WcMatch, verdict: Verdict): string {
+  // placar final (com prorrogação se houve) como contexto; 90' decide o veredito
+  const wentExtra =
+    wc.fulltime_home != null &&
+    (wc.home_score !== wc.fulltime_home || wc.away_score !== wc.fulltime_away);
+  const placar = `${esc(wc.home_team)} <b>${wc.home_score ?? "?"}×${wc.away_score ?? "?"}</b> ${esc(wc.away_team)}`;
+  const extra = wentExtra ? ` <i>(${wc.fulltime_home}×${wc.fulltime_away} no tempo normal)</i>` : "";
+
+  const ask =
+    verdict === "won"
+      ? "Pelo placar, essa <b>bateu</b> ✅ Confirma?"
+      : verdict === "lost"
+        ? "Pelo placar, essa <b>não bateu</b> ❌ Confirma?"
+        : "E aí, como foi?";
+
+  return `🏁 ${placar} — encerrado${extra}\n\n${betLine(bet)}\n\n${ask}`;
+}
+
+function buildGenericMessage(bet: Candidate): string {
+  const jogo = bet.match_description ? `<b>${esc(bet.match_description)}</b>\n` : "";
+  return `⏱️ Seu jogo já deve ter terminado:\n\n${jogo}${betLine(bet)}\n\nComo foi?`;
+}
+
+// ── Utilidades de tempo ──────────────────────────────────────
+// BRT é UTC-3 fixo (sem horário de verão desde 2019)
+const kickoffUtc = (wc: WcMatch) => new Date(`${wc.match_date}T${wc.match_time_brasilia}-03:00`);
+
+function brtHour(): number {
+  return Number(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: "America/Sao_Paulo",
+      hour: "numeric",
+      hour12: false,
+    }).format(new Date())
+  ) % 24;
+}
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  const provided = req.headers.get("x-cron-secret") || "";
+  if (!cronSecret || provided !== cronSecret) return json({ error: "Unauthorized" }, 401);
+  if (!TELEGRAM_BOT_TOKEN) return json({ error: "TELEGRAM_BOT_TOKEN not set" }, 500);
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  const traceId = generateTraceId();
+
+  try {
+    // 1) Apostas candidatas (pendentes, usuário linkado, cadência ok)
+    const { data: candData, error: candErr } = await supabase.rpc("get_settlement_reminder_candidates");
+    if (candErr) throw candErr;
+    const candidates: Candidate[] = candData ?? [];
+    if (candidates.length === 0) return json({ ok: true, candidates: 0, sent: 0 });
+
+    // 2) Jogos da Copa encerrados nas últimas 60h (janela do "acabou de acabar")
+    const { data: wcData, error: wcErr } = await supabase
+      .from("wc_matches")
+      .select(
+        "id, stage, home_team, away_team, home_team_code, away_team_code, match_date, match_time_brasilia, home_score, away_score, fulltime_home, fulltime_away, is_finished"
+      )
+      .eq("is_finished", true)
+      .gte("match_date", new Date(Date.now() - 60 * 3600_000).toISOString().slice(0, 10));
+    if (wcErr) throw wcErr;
+
+    const now = Date.now();
+    const wcRecent = (wcData ?? [])
+      .map((m: WcMatch) => ({
+        wc: m,
+        kickoff: kickoffUtc(m).getTime(),
+        homeNames: teamNames(m.home_team, m.home_team_code),
+        awayNames: teamNames(m.away_team, m.away_team_code),
+      }))
+      .filter((e) => e.kickoff <= now && e.kickoff > now - 60 * 3600_000);
+
+    // 3) Classifica cada candidata: casada com jogo da Copa (manda já) ou
+    //    genérica (jogo passou + janela de silêncio)
+    type Due = { bet: Candidate; kind: "wc" | "generic"; wc?: WcMatch; verdict: Verdict };
+    const due: Due[] = [];
+    const hour = brtHour();
+    const genericAllowed = hour >= QUIET_START && hour < QUIET_END;
+
+    for (const bet of candidates) {
+      // múltipla/sistema tem pernas em vários jogos — o placar de UM jogo não a
+      // representa; segue o caminho genérico (sem placar, sem veredito)
+      const type = norm(bet.bet_type);
+      const isMulti = type === "multiple" || type === "system";
+
+      const text = norm(`${bet.match_description ?? ""} ${bet.bet_description ?? ""}`);
+      const matched = isMulti
+        ? undefined
+        : wcRecent
+            .filter((e) => hasTeam(text, e.homeNames) && hasTeam(text, e.awayNames))
+            .sort((a, b) => b.kickoff - a.kickoff)[0];
+
+      if (matched) {
+        due.push({ bet, kind: "wc", wc: matched.wc, verdict: computeVerdict(bet, matched.wc) });
+        continue;
+      }
+
+      if (!genericAllowed) continue;
+      const matchOver = bet.match_date && new Date(bet.match_date).getTime() < now - 3 * 3600_000;
+      const betStale = !bet.match_date && new Date(bet.bet_date).getTime() < now - 24 * 3600_000;
+      if (matchOver || betStale) due.push({ bet, kind: "generic", verdict: null });
+    }
+
+    // 4) Teto por usuário por run (Copa primeiro — é o lembrete mais quente)
+    const byUser = new Map<string, Due[]>();
+    for (const d of due) {
+      const list = byUser.get(d.bet.user_id) ?? [];
+      list.push(d);
+      byUser.set(d.bet.user_id, list);
+    }
+
+    let sent = 0;
+    const errors: string[] = [];
+    for (const list of byUser.values()) {
+      list.sort((a, b) => (a.kind === b.kind ? 0 : a.kind === "wc" ? -1 : 1));
+      for (const d of list.slice(0, MAX_PER_USER_PER_RUN)) {
+        try {
+          const text = d.kind === "wc" ? buildWcMessage(d.bet, d.wc!, d.verdict) : buildGenericMessage(d.bet);
+          await sendReminder(d.bet.chat_id, text, d.bet.bet_id);
+
+          // marca cadência só depois de enviar (run que falha tenta de novo)
+          const { error: updErr } = await supabase
+            .from("bets")
+            .update({
+              settlement_reminder_count: d.bet.reminder_count + 1,
+              settlement_reminder_at: new Date().toISOString(),
+            })
+            .eq("id", d.bet.bet_id);
+          if (updErr) throw updErr;
+
+          sent++;
+          await trackEvent(
+            "settlement_reminder_sent",
+            {
+              bet_id: d.bet.bet_id,
+              kind: d.kind,
+              verdict: d.verdict,
+              betting_market: d.bet.betting_market,
+              sport: d.bet.sport,
+              league: d.bet.league,
+              reminder_number: d.bet.reminder_count + 1,
+              wc_match_id: d.wc?.id ?? null,
+              channel: "telegram",
+            },
+            d.bet.user_id,
+            traceId
+          ).catch(() => {});
+        } catch (e) {
+          console.error(`remind ${d.bet.bet_id}:`, (e as Error)?.message);
+          errors.push(`${d.bet.bet_id}: ${(e as Error)?.message}`);
+        }
+      }
+    }
+
+    return json({
+      ok: true,
+      candidates: candidates.length,
+      wc_finished_recent: wcRecent.length,
+      due: due.length,
+      sent,
+      generic_window_open: genericAllowed,
+      errors,
+    });
+  } catch (e) {
+    console.error("notify-settlement error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -14,6 +14,7 @@ const TELEGRAM_API_BASE = TELEGRAM_BOT_TOKEN
 
 const DAILY_BET_LIMIT = 3
 const TIMEZONE_GMT3 = "America/Cuiaba"
+const BETS_DASHBOARD_URL = "https://www.smartbetting.app/bets"
 
 // Simple in-memory guard to avoid reprocessing the same update_id on retries
 const processedUpdateIds = new Set<number>()
@@ -49,6 +50,14 @@ interface TelegramMessage {
   document?: TelegramFile
   // Telegram sends thumbnails as "thumbnail" in documents; not used directly
   thumbnail?: TelegramFile
+}
+
+// Toque num botão inline (lembrete de liquidação do notify-settlement)
+interface TelegramCallbackQuery {
+  id: string
+  from?: TelegramUser
+  message?: { message_id: number; chat: { id: number } }
+  data?: string
 }
 
 interface ProcessedBet {
@@ -291,6 +300,157 @@ async function sendConfirmationMessageTelegram(
   ].join("\n")
 
   await sendTelegramMessage(chatId, confirmationMessage)
+}
+
+// ============================================================
+// Liquidação por botão — [✅ Green] [❌ Red] do lembrete (notify-settlement)
+// ============================================================
+
+// Escapa HTML (os lembretes e suas edições usam parse_mode HTML)
+function escHtml(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
+const formatBRL = (v: number) => `R$ ${Number(v ?? 0).toFixed(2).replace(".", ",")}`
+
+async function answerCallbackQuery(callbackQueryId: string, text?: string): Promise<void> {
+  await telegramCall("answerCallbackQuery", { callback_query_id: callbackQueryId, text })
+}
+
+// Reescreve a mensagem do lembrete como recibo da liquidação (some o teclado)
+async function editSettledMessage(chatId: string | number, messageId: number, html: string): Promise<void> {
+  await telegramCall("editMessageText", {
+    chat_id: chatId,
+    message_id: messageId,
+    text: html,
+    parse_mode: "HTML",
+    disable_web_page_preview: true
+  })
+}
+
+function settledHtml(bet: any, status: string): string {
+  const jogo = bet.match_description ? `\n${escHtml(bet.match_description)}` : ""
+  const base = `<b>${escHtml(bet.bet_description)}</b>${jogo}`
+  if (status === "won") {
+    const lucro = (bet.potential_return ?? 0) - (bet.stake_amount ?? 0)
+    return `✅ <b>Green registrado!</b>\n\n${base}\nLucro: +${formatBRL(lucro)}\n\nBanca atualizada 📊 ${BETS_DASHBOARD_URL}`
+  }
+  if (status === "lost") {
+    return `❌ <b>Red registrado.</b>\n\n${base}\nPrejuízo: −${formatBRL(bet.stake_amount)}\n\nFaz parte. Banca atualizada 📊 ${BETS_DASHBOARD_URL}`
+  }
+  return `Registrada como <b>${escHtml(status)}</b>.\n\n${base}`
+}
+
+async function handleCallbackQuery(
+  supabase: any,
+  cq: TelegramCallbackQuery,
+  traceId: string
+): Promise<Response> {
+  const ok = (msg: string) =>
+    new Response(JSON.stringify({ success: true, message: msg }), {
+      headers: { "Content-Type": "application/json" },
+      status: 200
+    })
+
+  const data = cq.data || ""
+  const chatId = cq.message?.chat?.id
+  const messageId = cq.message?.message_id
+
+  if (!chatId || !messageId) {
+    await answerCallbackQuery(cq.id).catch(() => {})
+    return ok("callback without message")
+  }
+
+  const user = await findUserByTelegram(
+    supabase,
+    cq.from?.id ? String(cq.from.id) : undefined,
+    String(chatId),
+    traceId
+  )
+  if (!user) {
+    await answerCallbackQuery(cq.id, "Não achei sua conta. Manda /start pra sincronizar.")
+    return ok("callback user not found")
+  }
+
+  // 🔕 mute:<bet_id> — para os lembretes; mantém os botões de liquidar desta aposta
+  if (data.startsWith("mute:")) {
+    const betId = data.slice("mute:".length)
+    await supabase.from("users").update({ settlement_reminders_muted: true }).eq("id", user.id)
+    await telegramCall("editMessageReplyMarkup", {
+      chat_id: chatId,
+      message_id: messageId,
+      reply_markup: {
+        inline_keyboard: [
+          [
+            { text: "✅ Green", callback_data: `settle:${betId}:won` },
+            { text: "❌ Red", callback_data: `settle:${betId}:lost` }
+          ],
+          [{ text: "Outras opções ↗", url: BETS_DASHBOARD_URL }]
+        ]
+      }
+    })
+    await answerCallbackQuery(cq.id, "🔕 Ok, sem mais lembretes. Reative mandando /lembretes.")
+    await trackEvent(
+      "settlement_reminders_muted",
+      { via: "button", channel: "telegram" },
+      user.id,
+      traceId
+    ).catch(() => {})
+    return ok("reminders muted")
+  }
+
+  // ✅/❌ settle:<bet_id>:<won|lost>
+  if (data.startsWith("settle:")) {
+    const [, betId, outcome] = data.split(":")
+    if (!betId || (outcome !== "won" && outcome !== "lost")) {
+      await answerCallbackQuery(cq.id, "Não entendi esse toque 🤔")
+      return ok("bad callback data")
+    }
+
+    const { data: bet } = await supabase
+      .from("bets")
+      .select("id, user_id, status, bet_description, match_description, stake_amount, potential_return, odds")
+      .eq("id", betId)
+      .maybeSingle()
+
+    // dono confere? (callback vem do Telegram; a aposta TEM que ser deste usuário)
+    if (!bet || bet.user_id !== user.id) {
+      await answerCallbackQuery(cq.id, "Não achei essa aposta na sua conta.")
+      return ok("bet not found or not owner")
+    }
+
+    if (bet.status !== "pending") {
+      await answerCallbackQuery(cq.id, "Essa já estava registrada 👍")
+      await editSettledMessage(chatId, messageId, settledHtml(bet, bet.status)).catch(() => {})
+      return ok("already settled")
+    }
+
+    const { data: updated, error: updErr } = await supabase
+      .from("bets")
+      .update({ status: outcome })
+      .eq("id", betId)
+      .eq("status", "pending") // guarda otimista: dois toques ≠ duas liquidações
+      .select()
+      .maybeSingle()
+
+    if (updErr || !updated) {
+      await answerCallbackQuery(cq.id, "Deu ruim ao registrar — tenta de novo.")
+      return ok("settle update failed")
+    }
+
+    await editSettledMessage(chatId, messageId, settledHtml(updated, outcome)).catch(() => {})
+    await answerCallbackQuery(cq.id, outcome === "won" ? "✅ Green registrado!" : "❌ Red registrado.")
+    await trackEvent(
+      "settlement_settled_via_bot",
+      { bet_id: betId, outcome, channel: "telegram" },
+      user.id,
+      traceId
+    ).catch(() => {})
+    return ok("bet settled")
+  }
+
+  await answerCallbackQuery(cq.id).catch(() => {})
+  return ok("unknown callback")
 }
 
 async function getDailyBetCount(supabase: any, userId: string, traceId?: string): Promise<number> {
@@ -1484,6 +1644,25 @@ serve(async (req) => {
       processedUpdateIds.add(updateId)
     }
 
+    // Toque em botão inline (lembrete de liquidação) — trata e sai antes do fluxo
+    // de mensagem. Requer setWebhook com allowed_updates incluindo callback_query.
+    if (payload.callback_query) {
+      const cbSupabaseUrl = Deno.env.get("SUPABASE_URL")
+      const cbServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")
+      if (!cbSupabaseUrl || !cbServiceKey) {
+        console.error("Missing Supabase configuration (callback_query)")
+        return new Response(
+          JSON.stringify({ success: false, error: "Server configuration error" }),
+          { headers: { "Content-Type": "application/json" }, status: 500 }
+        )
+      }
+      return await handleCallbackQuery(
+        createClient(cbSupabaseUrl, cbServiceKey),
+        payload.callback_query as TelegramCallbackQuery,
+        generateTraceId()
+      )
+    }
+
     const updateMessage: TelegramMessage | undefined = payload.message || payload.edited_message || payload.channel_post
 
     // Log raw payload (truncate to avoid huge logs)
@@ -1668,6 +1847,29 @@ serve(async (req) => {
       user.id,
       traceId
     ).catch(() => {})
+
+    // Preferência dos lembretes de liquidação (par do botão 🔕 do notify-settlement)
+    const command = text.trim().toLowerCase()
+    if (command === "/silenciar" || command === "/lembretes") {
+      const mute = command === "/silenciar"
+      await supabase.from("users").update({ settlement_reminders_muted: mute }).eq("id", user.id)
+      await sendTelegramMessage(
+        chatId,
+        mute
+          ? "🔕 Beleza — parei com os lembretes de liquidação. Pra voltar, é só mandar /lembretes."
+          : "🔔 Lembretes reativados! Quando um jogo seu terminar, eu te chamo aqui pra fechar a aposta."
+      )
+      await trackEvent(
+        mute ? "settlement_reminders_muted" : "settlement_reminders_unmuted",
+        { via: "command", channel: "telegram" },
+        user.id,
+        traceId
+      ).catch(() => {})
+      return new Response(
+        JSON.stringify({ success: true, message: "Reminder preference updated" }),
+        { headers: { "Content-Type": "application/json" }, status: 200 }
+      )
+    }
 
     let actualContent = text
     let mediaUrl: string | null = null

--- a/supabase/migrations/078_settlement_reminders.sql
+++ b/supabase/migrations/078_settlement_reminders.sql
@@ -1,0 +1,114 @@
+-- ============================================================
+-- 078_settlement_reminders — lembrete de liquidação no Telegram
+-- ============================================================
+-- Ataca o buraco da retenção: ~72% das apostas morrem em 'pending' porque
+-- liquidar exige entrar no site. Agora o Betinho manda DM quando o jogo acaba,
+-- com botões inline [✅ Green] [❌ Red] — 1 toque e a banca atualiza.
+--
+-- Duas classes de lembrete (decididas na edge function notify-settlement):
+--   • Copa (casada com wc_matches encerrado): chega COM o placar e, quando o
+--     mercado é computável (ML/over-under/ambas marcam), com o veredito
+--     sugerido — "pelo placar, essa bateu ✅".
+--   • Genérica (qualquer esporte/liga sem placar no banco): jogo já passou →
+--     pergunta com os mesmos botões, sem veredito.
+--
+-- Também adiciona o placar dos 90' em wc_matches (fulltime_*): mercados de
+-- aposta liquidam no tempo normal; home/away_score inclui prorrogação e
+-- liquidaria errado jogo de mata-mata que foi pro tempo extra.
+--
+-- PRÉ-REQUISITO POR AMBIENTE (rodar uma vez via SQL, igual ao 048/073):
+--   vault.create_secret('<x-cron-secret>', 'notify_settlement_cron_secret', ...);
+--   vault.create_secret('<url da função>', 'notify_settlement_url', ...);
+--   E os secrets da função (TELEGRAM_BOT_TOKEN, CRON_SECRET) no painel.
+-- Além disso: o setWebhook do bot precisa entregar callback_query (se
+-- allowed_updates foi restringido a ["message"], reconfigurar — ver runbook).
+-- ============================================================
+
+-- ── wc_matches: placar dos 90 minutos (base de liquidação) ──
+ALTER TABLE public.wc_matches
+  ADD COLUMN IF NOT EXISTS fulltime_home integer,
+  ADD COLUMN IF NOT EXISTS fulltime_away integer;
+COMMENT ON COLUMN public.wc_matches.fulltime_home IS
+  'Gols do mandante nos 90 min (score.fulltime da API). Base de liquidação de apostas; home_score inclui prorrogação.';
+COMMENT ON COLUMN public.wc_matches.fulltime_away IS
+  'Gols do visitante nos 90 min (score.fulltime da API). Base de liquidação de apostas; away_score inclui prorrogação.';
+
+-- ── bets: cadência/idempotência do lembrete ──────────────────
+ALTER TABLE public.bets
+  ADD COLUMN IF NOT EXISTS settlement_reminder_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS settlement_reminder_at timestamptz;
+COMMENT ON COLUMN public.bets.settlement_reminder_count IS
+  'Quantos lembretes de liquidação já enviamos (teto 2 — não vira spam).';
+COMMENT ON COLUMN public.bets.settlement_reminder_at IS
+  'Último lembrete enviado (gap mínimo de 20h entre lembretes da mesma aposta).';
+
+-- Consulta do cron: pendentes recentes com lembrete disponível.
+CREATE INDEX IF NOT EXISTS idx_bets_settlement_pending
+  ON public.bets (bet_date)
+  WHERE status = 'pending' AND settlement_reminder_count < 2;
+
+-- ── users: opt-out (botão 🔕 na própria mensagem) ────────────
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS settlement_reminders_muted boolean NOT NULL DEFAULT false;
+COMMENT ON COLUMN public.users.settlement_reminders_muted IS
+  'true = usuário pediu pra parar os lembretes de liquidação (🔕 no bot). /lembretes reativa.';
+
+-- ── RPC: candidatas a lembrete AGORA ─────────────────────────
+-- Filtro grosso no banco (pendente, usuário linkado e não mutado, lembretes
+-- restantes, gap respeitado, aposta recente). O refinamento — casar com
+-- wc_matches encerrado, janela de silêncio, teto por usuário — fica na função,
+-- que loga e instrumenta cada decisão.
+CREATE OR REPLACE FUNCTION public.get_settlement_reminder_candidates()
+RETURNS TABLE(
+  bet_id uuid, user_id uuid, chat_id text, user_name text,
+  bet_type text, sport text, league text, betting_market text,
+  match_description text, bet_description text,
+  odds numeric, stake_amount numeric, potential_return numeric,
+  bet_date timestamptz, match_date timestamptz,
+  reminder_count integer
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  -- casts: colunas varchar(n) da tabela ≠ text do RETURNS TABLE sem cast explícito
+  SELECT b.id, b.user_id, u.telegram_chat_id::text, u.name::text,
+         b.bet_type::text, b.sport::text, b.league::text, b.betting_market::text,
+         b.match_description::text, b.bet_description::text,
+         b.odds::numeric, b.stake_amount::numeric, b.potential_return::numeric,
+         b.bet_date, b.match_date,
+         b.settlement_reminder_count
+  FROM bets b
+  JOIN users u ON u.id = b.user_id
+    AND u.telegram_chat_id IS NOT NULL
+    AND u.settlement_reminders_muted = false
+  WHERE b.status = 'pending'
+    AND b.settlement_reminder_count < 2
+    AND (b.settlement_reminder_at IS NULL OR b.settlement_reminder_at < now() - interval '20 hours')
+    AND b.bet_date > now() - interval '14 days'
+  ORDER BY b.bet_date DESC
+  LIMIT 500;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_settlement_reminder_candidates() TO service_role;
+
+-- ── Cron: a cada 15 min (o "logo após o apito" é o momento mágico) ──
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notify-settlement') THEN
+    PERFORM cron.unschedule('notify-settlement');
+  END IF;
+END $$;
+
+SELECT cron.schedule('notify-settlement', '*/15 * * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_settlement_url'),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_settlement_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+$job$);


### PR DESCRIPTION
## O problema

**~72% das apostas registradas nunca são liquidadas.** A pessoa registra pelo Telegram em 10 segundos, mas pra marcar green/red precisa lembrar de entrar no site — e não entra. Sem liquidação não há recompensa variável, e o loop de retenção quebra (Marco 0 do roadmap de retenção).

## A solução

Quando o jogo do usuário termina, **o Betinho manda DM com botões inline** — 1 toque liquida a aposta, sem abrir nada:

> 🏁 Brasil **2×1** França — encerrado
>
> Sua aposta: **Mais de 2,5 gols**
> R$ 50,00 · odd 1.85 · retorno R$ 92,50
>
> Pelo placar, essa **bateu** ✅ Confirma?
>
> `[✅ Green] [❌ Red]`
> `[Outras opções ↗] [🔕 Parar lembretes]`

### Duas classes de lembrete

| | Copa (casada com `wc_matches`) | Genérica (qualquer liga) |
|---|---|---|
| Quando | Na hora do apito (`is_finished`) | `match_date` passou há 3h+ (ou aposta 24h+), 09h–23h BRT |
| Conteúdo | Placar + **veredito sugerido** quando o mercado é direto | Pergunta com os mesmos botões |

### Onde o veredito é (e não é) dado

- ✅ ML/1x2, over/under de **gols**, ambas marcam — sempre pelo **placar dos 90'** (`fulltime_*`, novo no `wc_matches`; o placar cheio inclui prorrogação e liquidaria errado — ex.: ML com empate nos 90' e classificação nos pênaltis é **red**, e o código acerta isso)
- ❌ Múltipla/sistema, handicap, 1º tempo, escanteios/cartões, classificação, linha exata (push) → mensagem pergunta **sem afirmar**

### Anti-spam

Teto de **2 lembretes por aposta** (gap 20h) · máx **3 msgs/usuário por run** · opt-out por botão 🔕 ou `/silenciar` (reativa com `/lembretes`)

## Mudanças

- **`notify-settlement`** (nova, cron 15min): RPC de candidatas → casamento com `wc_matches` (nomes PT + aliases EN + códigos, palavra inteira) → veredito → DM com teclado
- **`telegram-webhook`**: handler de `callback_query` (settle com guarda otimista `status='pending'`, recibo editado na própria mensagem, validação de dono) + comandos `/silenciar` `/lembretes`
- **`ingest-wc-scores`**: grava `fulltime_home/away` (auto-backfill dos jogos já encerrados no próximo run)
- **Migration 078**: colunas de cadência em `bets` (+índice parcial), mute em `users`, fulltime em `wc_matches`, RPC `get_settlement_reminder_candidates` (SECURITY DEFINER, service_role), cron via Vault (padrão 048/073)
- **PostHog**: `settlement_reminder_sent` → `settlement_settled_via_bot` (funil de liquidação), `settlement_reminders_muted/unmuted`

## Validação

- Lógica pura (normalização, casamento por palavra, veredito): **29 casos, 29 ✅** — incluindo "brasileirão" ≠ "brasil", "no" preposição ≠ BTTS-Não, push, prints em inglês
- `tsc --noEmit`: sem erros novos (2 `mime_type` pré-existentes no webhook)

## Deploy (atenção)

Ver `SETTLEMENT_REMINDERS_SETUP.md`:
1. Migration + deploy das 3 functions
2. Vault: `notify_settlement_url` + `notify_settlement_cron_secret`
3. ⚠️ **`setWebhook` do bot precisa entregar `callback_query`** (se `allowed_updates` estiver restrito a `["message"]`, os botões não chegam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)