### PR TITLE
feat(bolao): passagem de bastão do dia da final — cartão no ranking (H1)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -41,5 +41,6 @@ jobs:
           supabase functions deploy notify-kickoff --no-verify-jwt
           supabase functions deploy notify-settlement --no-verify-jwt
           supabase functions deploy winback-backfill --no-verify-jwt
+          supabase functions deploy notify-handoff --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,5 +41,6 @@ jobs:
           supabase functions deploy notify-kickoff --no-verify-jwt
           supabase functions deploy notify-settlement --no-verify-jwt
           supabase functions deploy winback-backfill --no-verify-jwt
+          supabase functions deploy notify-handoff --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/HANDOFF_FINAL_SETUP.md
+++ b/HANDOFF_FINAL_SETUP.md
@@ -1,0 +1,29 @@
+# Passagem de bastão do dia da final (H1) — DM de encerramento
+
+No dia **19/jul**, depois da final encerrar, cada membro de bolão com Telegram recebe
+**uma DM** com sua posição definitiva + as duas portas: Betinho (casual) e análise de
+futebol (frequente). Par da peça web: `BolaoHandoffCard` (aba Ranking, aparece sozinho
+quando a final encerra).
+
+**Não tem cron.** Execução manual em 2 passos, no dia da final:
+
+```bash
+URL="https://<projeto>.supabase.co/functions/v1/notify-handoff"
+SECRET="<CRON_SECRET do painel>"
+
+# 1) RELATÓRIO — lista quem receberia e a posição em cada bolão. Não envia nada.
+curl -s -X POST "$URL?mode=report" -H "x-cron-secret: $SECRET"
+
+# 2) ENVIA — 1 DM por usuário (idempotente via bolao_handoff_notifications)
+curl -s -X POST "$URL?mode=send" -H "x-cron-secret: $SECRET"
+```
+
+**Guarda de segurança:** a função recusa (`412`) enquanto a final não estiver
+`is_finished` em `wc_matches` — impossível disparar antes da hora. Em staging,
+`&force=true` pula a guarda pra ensaio.
+
+O rank da DM vem de `get_bolao_ranking()` — a mesma função do site; nunca diverge.
+Respeita `settlement_reminders_muted`. Métricas: `bolao_handoff_dm_sent` {boloes_count,
+best_rank} + `bolao_handoff_view/click` (peça web) → taxa de reconquista H1.
+
+Dependência de rota: `/futebol/comecar` entra com o PR #188.

--- a/src/components/bolao/BolaoHandoffCard.tsx
+++ b/src/components/bolao/BolaoHandoffCard.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useRef } from 'react';
+import { usePostHog } from '@posthog/react';
+import { ClipboardList, ArrowRight, Trophy, LineChart } from 'lucide-react';
+
+interface BolaoHandoffCardProps {
+  bolaoId: string;
+  bolaoName: string;
+  /** Posição final do usuário no ranking (null = não pontuou / não está no ranking) */
+  myRank: number | null;
+  totalPlayers: number;
+}
+
+/**
+ * Cartão de encerramento — a "passagem de bastão" do dia da final (H1).
+ * Aparece na aba Ranking APENAS quando a final da Copa está encerrada
+ * (ou com ?handoff na URL, pra preview). O bolão morre por natureza no
+ * dia 19/jul; este cartão é a última conversa com essa audiência:
+ * casual → Betinho, apostador frequente → lista do futebol.
+ *
+ * Rotas de destino: /betinho/bolao (LP variante do bolão, já existe) e
+ * /futebol/comecar (LP de acesso antecipado — entra com o PR #188).
+ */
+export const BolaoHandoffCard: React.FC<BolaoHandoffCardProps> = ({
+  bolaoId,
+  bolaoName,
+  myRank,
+  totalPlayers,
+}) => {
+  const posthog = usePostHog();
+  const viewedRef = useRef(false);
+
+  useEffect(() => {
+    if (viewedRef.current) return;
+    viewedRef.current = true;
+    posthog?.capture('bolao_handoff_view', {
+      bolao_id: bolaoId,
+      rank: myRank,
+      total_players: totalPlayers,
+    });
+  }, [posthog, bolaoId, myRank, totalPlayers]);
+
+  const handleClick = (destination: 'betinho' | 'futebol') => {
+    posthog?.capture('bolao_handoff_click', {
+      bolao_id: bolaoId,
+      destination,
+      rank: myRank,
+    });
+  };
+
+  const isChampion = myRank === 1 && totalPlayers > 1;
+  const headline = isChampion
+    ? `Campeão do ${bolaoName}! 🏆`
+    : myRank != null
+      ? `Você fechou em ${myRank}º de ${totalPlayers}`
+      : 'O bolão chegou ao fim';
+
+  return (
+    <div
+      data-testid="bolao-handoff-card"
+      className="relative overflow-hidden rounded-rebrand-xl bg-forest text-white mb-5"
+    >
+      {/* brilho âmbar no canto — mesmo tratamento do hero das LPs */}
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_85%_10%,rgba(212,160,23,0.20),transparent_55%)] pointer-events-none" />
+      <div className="relative p-5 sm:p-7">
+        <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-amber mb-2.5 flex items-center gap-1.5">
+          <Trophy className="w-3.5 h-3.5" />
+          Bolão encerrado
+        </p>
+        <h3 className="font-display text-xl sm:text-2xl font-black leading-tight mb-2">
+          {headline}
+        </h3>
+        <p className="text-[13.5px] sm:text-[14px] text-white/75 leading-relaxed mb-5 max-w-xl">
+          A Copa acabou e o bolão termina aqui, valeu demais!
+          Mas se você aposta de verdade, o jogo continua:
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {/* trilho casual → Betinho */}
+          <div className="rounded-rebrand-lg border border-white/15 bg-white/[0.05] p-4 flex flex-col">
+            <p className="font-bold text-[14px] mb-1.5 flex items-center gap-2">
+              <ClipboardList className="w-4 h-4 text-amber shrink-0" />
+              Tá no lucro ou no prejuízo?
+            </p>
+            <p className="text-[12.5px] text-white/70 leading-relaxed mb-3.5 flex-1">
+              A maioria não sabe. Manda o print da aposta no Telegram e o Betinho
+              te responde: lucro, ROI e onde você acerta — sem planilha.
+            </p>
+            <a
+              href="/betinho/bolao"
+              onClick={() => handleClick('betinho')}
+              className="inline-flex items-center justify-center gap-2 h-10 px-4 rounded-rebrand-md bg-amber text-white hover:bg-amber-2 font-bold text-[13px] shadow-md transition-colors"
+            >
+              Conhecer o Betinho — grátis
+              <ArrowRight className="w-4 h-4 shrink-0" />
+            </a>
+          </div>
+          {/* trilho frequente → Futebol */}
+          <div className="rounded-rebrand-lg border border-white/15 bg-white/[0.05] p-4 flex flex-col">
+            <p className="font-bold text-[14px] mb-1.5 flex items-center gap-2">
+              <LineChart className="w-4 h-4 text-amber shrink-0" />
+              Onde vale apostar na próxima rodada?
+            </p>
+            <p className="text-[12.5px] text-white/70 leading-relaxed mb-3.5 flex-1">
+              A análise de futebol te mostra: as principais oportunidades de cada
+              jogo, com os prós e contras de cada aposta — sem achismo.
+            </p>
+            <a
+              href="/futebol/comecar"
+              onClick={() => handleClick('futebol')}
+              className="inline-flex items-center justify-center gap-2 h-10 px-4 rounded-rebrand-md border border-white/30 bg-white/[0.06] text-white hover:bg-white/15 font-bold text-[13px] transition-colors"
+            >
+              Conhecer a análise de futebol
+              <ArrowRight className="w-4 h-4 shrink-0" />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -28,6 +28,7 @@ import {
   computeMatchDeadline,
 } from '@/hooks/use-bolao';
 import { BolaoRankingTable } from '@/components/bolao/BolaoRankingTable';
+import { BolaoHandoffCard } from '@/components/bolao/BolaoHandoffCard';
 import { UserPredictionsModal } from '@/components/bolao/UserPredictionsModal';
 import { BolaoShareButton } from '@/components/bolao/BolaoShareButton';
 import { BolaoAdminPanel } from '@/components/bolao/BolaoAdminPanel';
@@ -230,6 +231,23 @@ const BolaoDetail: React.FC = () => {
   const totalAvailableMatches = useMemo(
     () => matches?.filter(m => !m.is_finished && m.home_team_code !== 'TBD').length ?? 0,
     [matches]
+  );
+
+  // ── Passagem de bastão (H1): cartão de encerramento na aba Ranking ──
+  // Só quando a FINAL está encerrada (o bolão acabou de verdade); ?handoff
+  // na URL força a exibição pra preview/QA sem esperar o dia 19.
+  const finalOver = useMemo(
+    () => (matches ?? []).some(m => m.stage === 'final' && m.is_finished),
+    [matches]
+  );
+  const handoffForced = useMemo(
+    () => new URLSearchParams(window.location.search).has('handoff'),
+    []
+  );
+  const showHandoff = finalOver || handoffForced;
+  const myRankingEntry = useMemo(
+    () => ranking?.find(r => r.user_id === currentUserId) ?? null,
+    [ranking, currentUserId]
   );
 
   const predictionsByMatch = useMemo(
@@ -726,6 +744,14 @@ const BolaoDetail: React.FC = () => {
             {/* Tab: Ranking */}
             {activeTab === 'ranking' && (
               <div role="tabpanel" id="bolao-tab-panel-ranking" aria-labelledby="bolao-tab-ranking">
+                {showHandoff && bolao && (
+                  <BolaoHandoffCard
+                    bolaoId={bolao.id}
+                    bolaoName={bolao.name}
+                    myRank={myRankingEntry?.rank ?? null}
+                    totalPlayers={ranking?.length ?? 0}
+                  />
+                )}
                 {ranking && ranking.length > 1 && (
                   <div className="flex items-center justify-end gap-3 mb-3 flex-wrap text-[12px] text-ink-2">
                     <div className="inline-flex items-center rounded-rebrand-sm border border-line overflow-hidden mr-1" role="group" aria-label="Conteúdo da imagem">

--- a/supabase/functions/notify-handoff/index.ts
+++ b/supabase/functions/notify-handoff/index.ts
@@ -1,0 +1,187 @@
+// ============================================================
+// notify-handoff — DM de encerramento do bolão (H1, dia da final)
+// ============================================================
+// One-shot MANUAL (sem cron!). No dia 19/jul, depois da final encerrar,
+// o dev roda 2 vezes:
+//
+//   1. ?mode=report → NÃO envia nada. Lista quem receberia (chat, nome,
+//                     posição em cada bolão). Revisar antes de mandar.
+//   2. ?mode=send   → manda a DM única por usuário (idempotente via
+//                     bolao_handoff_notifications).
+//
+// A DM: posição definitiva no(s) bolão(ões) + as duas portas de
+// continuação — Betinho pro casual, análise de futebol pro frequente.
+// Mesma copy do cartão do ranking (BolaoHandoffCard), formato Telegram.
+//
+// GUARDA: só envia se a FINAL estiver encerrada em wc_matches (o bolão
+// precisa ter acabado de verdade). `&force=true` pula a guarda — só pra
+// ensaio em staging.
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN, CRON_SECRET.
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const BETINHO_URL = "https://www.smartbetting.app/betinho/bolao";
+const FUTEBOL_URL = "https://www.smartbetting.app/futebol/comecar";
+
+function esc(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface TargetRow {
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+  bolao_name: string;
+  user_rank: number;
+  total_players: number;
+}
+
+interface UserTarget {
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+  boloes: Array<{ name: string; rank: number; total: number }>;
+}
+
+// agrupa as linhas (usuário, bolão) → 1 alvo por usuário
+function groupTargets(rows: TargetRow[]): UserTarget[] {
+  const byUser = new Map<string, UserTarget>();
+  for (const r of rows) {
+    let t = byUser.get(r.user_id);
+    if (!t) {
+      t = { user_id: r.user_id, chat_id: r.chat_id, user_name: r.user_name, boloes: [] };
+      byUser.set(r.user_id, t);
+    }
+    t.boloes.push({ name: r.bolao_name, rank: Number(r.user_rank), total: Number(r.total_players) });
+  }
+  return [...byUser.values()];
+}
+
+function buildMessage(t: UserTarget): string {
+  const posicoes = t.boloes.slice(0, 2).map((b) => {
+    const medalha = b.rank === 1 && b.total > 1 ? " 🏆" : b.rank <= 3 && b.total >= 3 ? " 🏅" : "";
+    return `• <b>${esc(b.name)}</b>: ${b.rank}º de ${b.total}${medalha}`;
+  });
+  const extras = t.boloes.length > 2 ? `\n• e mais ${t.boloes.length - 2} ${t.boloes.length - 2 === 1 ? "bolão" : "bolões"}` : "";
+
+  return [
+    `🏆 <b>${esc(t.user_name || "E aí")}, a Copa acabou — e com ela o bolão!</b>`,
+    "",
+    `Seu resultado definitivo:`,
+    posicoes.join("\n") + extras,
+    "",
+    `Valeu demais por jogar com a gente. E se você aposta de verdade, o jogo continua:`,
+    "",
+    `<b>Tá no lucro ou no prejuízo?</b> A maioria não sabe. Manda o print da aposta no Telegram e o Betinho te responde: lucro, ROI e onde você acerta — sem planilha.`,
+    "",
+    `<b>Onde vale apostar na próxima rodada?</b> A análise de futebol te mostra: as principais oportunidades de cada jogo, com os prós e contras de cada aposta — sem achismo.`,
+  ].join("\n");
+}
+
+async function sendHandoffDm(t: UserTarget): Promise<void> {
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: t.chat_id,
+      text: buildMessage(t),
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      reply_markup: {
+        inline_keyboard: [
+          [{ text: "Conhecer o Betinho — grátis", url: BETINHO_URL }],
+          [{ text: "Conhecer a análise de futebol", url: FUTEBOL_URL }],
+        ],
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
+}
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  if (!cronSecret || req.headers.get("x-cron-secret") !== cronSecret) return json({ error: "Unauthorized" }, 401);
+  if (!TELEGRAM_BOT_TOKEN) return json({ error: "TELEGRAM_BOT_TOKEN not set" }, 500);
+
+  const url = new URL(req.url);
+  const mode = url.searchParams.get("mode") || "report";
+  const force = url.searchParams.get("force") === "true";
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+  const traceId = generateTraceId();
+
+  try {
+    // guarda: a final precisa ter acabado (o bolão só morre quando ela morre)
+    const { data: finalMatch, error: fErr } = await supabase
+      .from("wc_matches")
+      .select("id, is_finished")
+      .eq("stage", "final")
+      .maybeSingle();
+    if (fErr) throw fErr;
+    const finalOver = finalMatch?.is_finished === true;
+    if (!finalOver && !force) {
+      return json({ ok: false, error: "A final ainda não encerrou — use &force=true só em ensaio de staging." }, 412);
+    }
+
+    const { data: rows, error } = await supabase.rpc("get_handoff_targets");
+    if (error) throw error;
+    const targets = groupTargets((rows ?? []) as TargetRow[]);
+
+    if (mode === "report") {
+      return json({
+        ok: true, mode, final_encerrada: finalOver, alvos: targets.length,
+        preview: targets.map((t) => ({
+          user_name: t.user_name,
+          boloes: t.boloes.map((b) => `${b.name}: ${b.rank}º/${b.total}`),
+        })),
+      });
+    }
+
+    if (mode === "send") {
+      let sent = 0;
+      const errors: string[] = [];
+      for (const t of targets) {
+        try {
+          await sendHandoffDm(t);
+          const { error: insErr } = await supabase
+            .from("bolao_handoff_notifications")
+            .insert({ user_id: t.user_id, boloes_count: t.boloes.length });
+          if (insErr) throw insErr;
+          sent++;
+          await trackEvent(
+            "bolao_handoff_dm_sent",
+            {
+              boloes_count: t.boloes.length,
+              best_rank: Math.min(...t.boloes.map((b) => b.rank)),
+              channel: "telegram",
+            },
+            t.user_id, traceId
+          ).catch(() => {});
+        } catch (e) {
+          errors.push(`${t.user_id}: ${(e as Error)?.message}`);
+        }
+      }
+      return json({ ok: true, mode, alvos: targets.length, sent, errors });
+    }
+
+    return json({ error: `mode inválido: ${mode} (use report|send)` }, 400);
+  } catch (e) {
+    console.error("notify-handoff error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});

--- a/supabase/migrations/080_handoff_final_notifications.sql
+++ b/supabase/migrations/080_handoff_final_notifications.sql
@@ -1,0 +1,50 @@
+-- ============================================================
+-- 080_handoff_final_notifications — DM de encerramento do bolão (H1)
+-- ============================================================
+-- Suporte à edge function notify-handoff (one-shot MANUAL, sem cron):
+-- no dia da final (19/jul), cada membro de bolão com Telegram recebe UMA
+-- DM com sua posição definitiva + as duas portas de continuação
+-- (Betinho pro casual, análise de futebol pro frequente).
+--
+-- O rank vem de get_bolao_ranking() — a MESMA função que o site usa —
+-- então a DM nunca diverge do ranking exibido.
+-- ============================================================
+
+-- ── Idempotência: 1 DM por usuário, nunca 2 ──────────────────
+CREATE TABLE IF NOT EXISTS public.bolao_handoff_notifications (
+  user_id      uuid PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  sent_at      timestamptz NOT NULL DEFAULT now(),
+  boloes_count integer NOT NULL DEFAULT 0
+);
+COMMENT ON TABLE public.bolao_handoff_notifications IS
+  'Idempotência da DM de encerramento do bolão (notify-handoff): quem já recebeu não recebe de novo.';
+ALTER TABLE public.bolao_handoff_notifications ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role acessa
+
+-- ── RPC: alvos da DM — 1 linha por (usuário, bolão) ──────────
+-- A função agrupa por usuário; bolões ordenados do mais populoso pro menor.
+CREATE OR REPLACE FUNCTION public.get_handoff_targets()
+RETURNS TABLE(
+  user_id uuid, chat_id text, user_name text,
+  bolao_name text, user_rank bigint, total_players bigint
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  SELECT u.id, u.telegram_chat_id::text, u.name::text,
+         b.name::text, r.rank, cnt.total
+  FROM users u
+  JOIN bolao_members bm ON bm.user_id = u.id
+  JOIN boloes b ON b.id = bm.bolao_id
+  JOIN LATERAL (
+    SELECT g.rank FROM get_bolao_ranking(b.id) g WHERE g.user_id = u.id
+  ) r ON true
+  JOIN LATERAL (
+    SELECT count(*)::bigint AS total FROM bolao_members WHERE bolao_id = b.id
+  ) cnt ON true
+  WHERE u.telegram_chat_id IS NOT NULL
+    AND coalesce(u.settlement_reminders_muted, false) = false
+    AND NOT EXISTS (SELECT 1 FROM bolao_handoff_notifications n WHERE n.user_id = u.id)
+  ORDER BY u.id, cnt.total DESC, b.name;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_handoff_targets() TO service_role;


### PR DESCRIPTION
## O momento (H1 do roadmap de retenção)

**19/jul a final acaba e o bolão morre por natureza** — e com ele a audiência que a Copa juntou. Todo participante fará uma última visita pra ver o ranking definitivo. Hoje essa página é um beco sem saída. Este PR coloca a saída.

## O que muda

Cartão de encerramento no topo da aba **Ranking** do bolão, exibido **somente quando a final está encerrada** (`matches.some(stage === 'final' && is_finished)`). Preview/QA: `?handoff` na URL.

- Manchete personalizada: "Você fechou em 3º de 12" / "Campeão do {bolão}! 🏆"
- **Dois trilhos auto-segmentados pela dor** (tese casual × frequente do plano de retenção):

| Tá no lucro ou no prejuízo? | Onde vale apostar na próxima rodada? |
|---|---|
| "A maioria não sabe. Manda o print da aposta no Telegram e o Betinho te responde: lucro, ROI e onde você acerta — sem planilha." | "A análise de futebol te mostra: as principais oportunidades de cada jogo, com os prós e contras de cada aposta — sem achismo." |
| → `/betinho/bolao` (LP variante do bolão, já existe) | → `/futebol/comecar` (LP de early access) |

- Copy do Betinho espelha o hero da própria LP (consistência de mensagem dos dois lados do clique)
- PostHog: `bolao_handoff_view` {bolao_id, rank, total_players} e `bolao_handoff_click` {destination} — alimenta a métrica "taxa de reconquista (H1)" do plano

## ⚠️ Dependência

`/futebol/comecar` só existe com o **PR #188** (cross-sell futebol), que segue **aberto**. Merge do #188 antes deste chegar em produção — ou o botão do futebol 404a.

## Próxima peça (na sequência)

A DM de encerramento no Telegram (mesma mensagem, formato bot) — one-shot disparada quando a final encerrar, pros membros com Telegram linkado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)