### PR TITLE
feat(futebol): coletor de placares multi-liga (F1 do parecer do coletor)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,5 +44,6 @@ jobs:
           supabase functions deploy notify-handoff --no-verify-jwt
           supabase functions deploy notify-opportunities --no-verify-jwt
           supabase functions deploy go --no-verify-jwt
+          supabase functions deploy ingest-fixtures --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -44,5 +44,6 @@ jobs:
           supabase functions deploy notify-handoff --no-verify-jwt
           supabase functions deploy notify-opportunities --no-verify-jwt
           supabase functions deploy go --no-verify-jwt
+          supabase functions deploy ingest-fixtures --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/MULTI_LEAGUE_COLLECTOR_SETUP.md
+++ b/MULTI_LEAGUE_COLLECTOR_SETUP.md
@@ -37,6 +37,9 @@ Fora de janela de jogo: **zero** invocação — o gate é SQL no próprio cron.
 ```sql
 update leagues_config set enabled = true where league_id = 39; -- Premier volta 15/08
 ```
+⚠️ Ao habilitar liga no meio do dia, rode 1 curl de `?mode=calendar` na sequência —
+os jogos dela só entrariam sozinhos no calendário das 04h, e sem fixtures no banco
+o gate do live não abre pra ela.
 
 ## Plano de rollout (dual-run — decidido no parecer)
 

--- a/MULTI_LEAGUE_COLLECTOR_SETUP.md
+++ b/MULTI_LEAGUE_COLLECTOR_SETUP.md
@@ -1,0 +1,65 @@
+# Coletor de placares multi-liga (F1) — Setup
+
+Implementa o desenho aprovado no parecer da task do coletor (Kasuya, 08/07):
+`fixtures?live={ids}` + confirmação de encerramento em lote + cadência adaptativa
+com **1 cron só** (gate SQL) + telemetria com alerta.
+
+## Peças
+
+| Peça | O que faz |
+| --- | --- |
+| Migration `082_multi_league_collector.sql` | Tabelas `fixtures` (com halftime/fulltime/extratime/penalty + trigger updated_at), `leagues_config` (seed Ondas 1+2, IDs API-Football), `team_aliases` (pro matching v2 — F2), `collector_runs` (telemetria) + 2 crons |
+| `ingest-fixtures` | `?mode=calendar` (diário 04:00 BRT, 1 chamada/liga habilitada) e `?mode=live` (2/2min SÓ quando o gate SQL detecta jogo em janela; live={ids} + `fixtures?ids=` em lote pra confirmar FT/AET/PEN e capturar o placar dos 90') |
+
+## Custo (contra o PRO: 7.500/dia, 300/min)
+
+Regime normal ~50–150 chamadas/dia; pico de fds cheio ~250–350 (números do parecer).
+Fora de janela de jogo: **zero** invocação — o gate é SQL no próprio cron.
+
+## Deploy
+
+1. Migration + function via CI (workflows já atualizados).
+2. **Vault** (uma vez por ambiente):
+   ```sql
+   select vault.create_secret('<mesmo CRON_SECRET>', 'ingest_fixtures_cron_secret');
+   select vault.create_secret('https://<projeto>.supabase.co/functions/v1/ingest-fixtures', 'ingest_fixtures_url');
+   ```
+3. Bootstrap: rodar 1x o calendário na mão (senão o gate do live nunca abre):
+   ```bash
+   curl -s -X POST "https://<projeto>.supabase.co/functions/v1/ingest-fixtures?mode=calendar" \
+     -H "x-cron-secret: <CRON_SECRET>"
+   ```
+4. (Opcional, recomendado) Alerta de falhas consecutivas: setar secrets
+   `ADMIN_TELEGRAM_CHAT_ID` (chat do admin) — `TELEGRAM_BOT_TOKEN` já existe.
+
+## Ligar/desligar ligas (dado, não deploy)
+
+```sql
+update leagues_config set enabled = true where league_id = 39; -- Premier volta 15/08
+```
+
+## Plano de rollout (dual-run — decidido no parecer)
+
+1. **F1 (isto):** coletor grava `public.fixtures` pra todas as ligas incl. Copa,
+   com `ingest-wc-scores` intocado → ~10 dias de paridade em staging.
+2. **F2 (próximo PR):** `notify-settlement` troca a leitura `wc_matches`→`fixtures`
+   (matching v2: `match_date ±30h`, hint de liga, `team_aliases`, veredito de
+   handicap asiático com half_won/half_lost) após paridade validada.
+3. **Pós-Copa:** aposentar `ingest-wc-scores` + cron da 048.
+4. `wc_matches` NÃO é migrada (é do bolão, morre 19/07).
+   `futebol.fact_fixtures` NÃO é fonte de settlement (latência de horas; dono é o DE).
+
+## Monitoramento
+
+```sql
+-- saúde do coletor (últimas execuções, chamadas, quota do plano)
+select ran_at, mode, live_fixtures, api_calls, quota_remaining, ok, error
+from collector_runs order by ran_at desc limit 20;
+```
+Alerta automático: DM pro admin após 5 falhas consecutivas.
+
+## Fora do escopo deste PR (fases seguintes do parecer)
+
+- F2: matching v2 + AH no computeVerdict
+- F3: marker de predictions vazias (lado data-engineering)
+- Rotação da API key (exposta no front via VITE_API_SPORTS_KEY) — fazer no cutover

--- a/supabase/functions/ingest-fixtures/index.ts
+++ b/supabase/functions/ingest-fixtures/index.ts
@@ -1,0 +1,194 @@
+// ============================================================
+// ingest-fixtures — coletor de placares multi-liga (F1 do parecer Kasuya)
+// ============================================================
+// Dois modos, dois crons (migration 082):
+//
+//   ?mode=calendar (diário 04:00 BRT) — 1 chamada por liga habilitada
+//     (fixtures?league&season): jogos novos, remarcações, TBD→NS. É o que
+//     alimenta o GATE do cron live (sem jogo em janela → live nem roda).
+//
+//   ?mode=live (a cada 2 min, SÓ quando o gate SQL detecta jogo em janela) —
+//     1 chamada fixtures?live={ids das ligas habilitadas} pra TODOS os jogos
+//     rolando + CONFIRMAÇÃO DE ENCERRAMENTO: jogo que estava em janela e
+//     sumiu do live (ou passou de 2H pra fim) é confirmado via
+//     fixtures?ids=a-b-c (lote de até 20) — devolve status terminal (FT/AET/
+//     PEN) e score.fulltime (90', a base de liquidação). Cobre o caso
+//     "último poll pegou o jogo aos 88'" e o AET/PEN de mata-mata.
+//
+// Telemetria (lacuna nº1 do parecer): toda execução grava collector_runs
+// (chamadas feitas, quota restante do header x-ratelimit) e, após 5 falhas
+// consecutivas, manda DM de alerta pro admin (env ADMIN_TELEGRAM_CHAT_ID).
+// "Degradar em silêncio" era o modo de falha — não é mais.
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, API_SPORTS_KEY,
+//                 CRON_SECRET (+ TELEGRAM_BOT_TOKEN e ADMIN_TELEGRAM_CHAT_ID
+//                 opcionais, pro alerta).
+// Runbook: MULTI_LEAGUE_COLLECTOR_SETUP.md
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const API_BASE = "https://v3.football.api-sports.io";
+const API_SPORTS_KEY = Deno.env.get("API_SPORTS_KEY") || "";
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const ADMIN_CHAT_ID = Deno.env.get("ADMIN_TELEGRAM_CHAT_ID") || "";
+
+const TERMINAL = new Set(["FT", "AET", "PEN", "CANC", "ABD", "AWD", "WO"]);
+const ALERT_AFTER_FAILURES = 5;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+// ── API-Football: fetch com captura do header de quota ───────
+let apiCalls = 0;
+let quotaRemaining: number | null = null;
+
+async function api(path: string): Promise<any> {
+  const res = await fetch(`${API_BASE}${path}`, { headers: { "x-apisports-key": API_SPORTS_KEY } });
+  apiCalls++;
+  const q = res.headers.get("x-ratelimit-requests-remaining");
+  if (q != null) quotaRemaining = Number(q);
+  if (!res.ok) throw new Error(`API-Sports ${res.status} em ${path}`);
+  const payload = await res.json();
+  if (payload?.errors && Object.keys(payload.errors).length > 0) {
+    throw new Error(`API-Sports errors em ${path}: ${JSON.stringify(payload.errors).slice(0, 200)}`);
+  }
+  return payload?.response ?? [];
+}
+
+// fixture da API → linha da nossa tabela
+function toRow(fx: any): Record<string, unknown> {
+  const winner = fx?.teams?.home?.winner === true ? "home" : fx?.teams?.away?.winner === true ? "away" : null;
+  return {
+    fixture_id: fx?.fixture?.id,
+    league_id: fx?.league?.id,
+    season: fx?.league?.season,
+    round: fx?.league?.round ?? null,
+    home_team_id: fx?.teams?.home?.id ?? null,
+    home_team: fx?.teams?.home?.name ?? "?",
+    away_team_id: fx?.teams?.away?.id ?? null,
+    away_team: fx?.teams?.away?.name ?? "?",
+    kickoff_utc: fx?.fixture?.date, // ISO com timezone
+    status_short: fx?.fixture?.status?.short ?? null,
+    elapsed: fx?.fixture?.status?.elapsed ?? null,
+    goals_home: fx?.goals?.home ?? null,
+    goals_away: fx?.goals?.away ?? null,
+    halftime_home: fx?.score?.halftime?.home ?? null,
+    halftime_away: fx?.score?.halftime?.away ?? null,
+    fulltime_home: fx?.score?.fulltime?.home ?? null,
+    fulltime_away: fx?.score?.fulltime?.away ?? null,
+    extratime_home: fx?.score?.extratime?.home ?? null,
+    extratime_away: fx?.score?.extratime?.away ?? null,
+    penalty_home: fx?.score?.penalty?.home ?? null,
+    penalty_away: fx?.score?.penalty?.away ?? null,
+    winner,
+  };
+}
+
+async function upsertRows(supabase: any, rows: Record<string, unknown>[]): Promise<void> {
+  if (rows.length === 0) return;
+  const { error } = await supabase.from("fixtures").upsert(rows, { onConflict: "fixture_id" });
+  if (error) throw new Error(`upsert fixtures: ${error.message}`);
+}
+
+// ── alerta de falhas consecutivas (telemetria acionável) ─────
+async function maybeAlertAdmin(supabase: any, mode: string, errMsg: string): Promise<void> {
+  if (!TELEGRAM_BOT_TOKEN || !ADMIN_CHAT_ID) return;
+  const { data } = await supabase
+    .from("collector_runs")
+    .select("ok")
+    .order("ran_at", { ascending: false })
+    .limit(ALERT_AFTER_FAILURES);
+  const runs = data ?? [];
+  if (runs.length < ALERT_AFTER_FAILURES || runs.some((r: any) => r.ok)) return;
+  await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: ADMIN_CHAT_ID,
+      text: `🚨 ingest-fixtures: ${ALERT_AFTER_FAILURES} falhas consecutivas (modo ${mode}).\nÚltimo erro: ${errMsg.slice(0, 300)}\nVer collector_runs.`,
+    }),
+  }).catch(() => {});
+}
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  if (!cronSecret || req.headers.get("x-cron-secret") !== cronSecret) return json({ error: "Unauthorized" }, 401);
+  if (!API_SPORTS_KEY) return json({ error: "API_SPORTS_KEY not set" }, 500);
+
+  const mode = new URL(req.url).searchParams.get("mode") || "live";
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  let liveCount = 0;
+  let confirmed = 0;
+
+  try {
+    const { data: leaguesData, error: lErr } = await supabase
+      .from("leagues_config")
+      .select("league_id, season")
+      .eq("enabled", true);
+    if (lErr) throw lErr;
+    const leagues: Array<{ league_id: number; season: number }> = leaguesData ?? [];
+    if (leagues.length === 0) return json({ ok: true, mode, motivo: "nenhuma liga habilitada" });
+
+    if (mode === "calendar") {
+      // 1 chamada por liga: temporada inteira (upsert idempotente)
+      for (const lg of leagues) {
+        const fixtures = await api(`/fixtures?league=${lg.league_id}&season=${lg.season}`);
+        await upsertRows(supabase, fixtures.map(toRow).filter((r: any) => r.fixture_id));
+      }
+    } else {
+      // ── LIVE ───────────────────────────────────────────────
+      const ids = [...new Set(leagues.map((l) => l.league_id))].join("-");
+      const live = await api(`/fixtures?live=${ids}`);
+      liveCount = live.length;
+      await upsertRows(supabase, live.map(toRow).filter((r: any) => r.fixture_id));
+
+      // CONFIRMAÇÃO: jogos em janela que começaram, não estão terminais no
+      // banco e NÃO apareceram no live → provavelmente acabaram → lote ids
+      const liveIds = new Set(live.map((fx: any) => fx?.fixture?.id));
+      const { data: pendData, error: pErr } = await supabase
+        .from("fixtures")
+        .select("fixture_id, status_short, kickoff_utc, league_id, season")
+        .lte("kickoff_utc", new Date().toISOString())
+        .gte("kickoff_utc", new Date(Date.now() - 6 * 3600_000).toISOString());
+      if (pErr) throw pErr;
+      const enabledKey = new Set(leagues.map((l) => `${l.league_id}:${l.season}`));
+      const toConfirm = (pendData ?? [])
+        .filter((f: any) =>
+          enabledKey.has(`${f.league_id}:${f.season}`) &&
+          !TERMINAL.has(f.status_short ?? "NS") &&
+          !liveIds.has(f.fixture_id)
+        )
+        .map((f: any) => f.fixture_id);
+
+      for (let i = 0; i < toConfirm.length; i += 20) {
+        const batch = toConfirm.slice(i, i + 20);
+        const fixtures = await api(`/fixtures?ids=${batch.join("-")}`);
+        await upsertRows(supabase, fixtures.map(toRow).filter((r: any) => r.fixture_id));
+        confirmed += fixtures.length;
+      }
+    }
+
+    await supabase.from("collector_runs").insert({
+      mode, window_active: mode === "live" ? true : null,
+      live_fixtures: liveCount, api_calls: apiCalls,
+      quota_remaining: quotaRemaining, ok: true,
+    });
+
+    return json({ ok: true, mode, ligas: leagues.length, live: liveCount, confirmados: confirmed, chamadas: apiCalls, quota_restante: quotaRemaining });
+  } catch (e) {
+    const msg = (e as Error)?.message ?? "erro desconhecido";
+    console.error("ingest-fixtures error:", msg);
+    await supabase.from("collector_runs").insert({
+      mode, window_active: null, live_fixtures: liveCount,
+      api_calls: apiCalls, quota_remaining: quotaRemaining, ok: false, error: msg.slice(0, 500),
+    }).then(() => maybeAlertAdmin(supabase, mode, msg)).catch(() => {});
+    return json({ error: msg }, 500);
+  }
+});

--- a/supabase/functions/ingest-fixtures/index.ts
+++ b/supabase/functions/ingest-fixtures/index.ts
@@ -34,7 +34,10 @@ const API_SPORTS_KEY = Deno.env.get("API_SPORTS_KEY") || "";
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
 const ADMIN_CHAT_ID = Deno.env.get("ADMIN_TELEGRAM_CHAT_ID") || "";
 
-const TERMINAL = new Set(["FT", "AET", "PEN", "CANC", "ABD", "AWD", "WO"]);
+// PST (adiado) incluído: o portão do cron já o ignora, e sem ele aqui a
+// confirmação re-consultaria o jogo adiado a cada rodada enquanto outro
+// jogo mantivesse a janela aberta (achado da revisão do PR)
+const TERMINAL = new Set(["FT", "AET", "PEN", "CANC", "ABD", "AWD", "WO", "PST"]);
 const ALERT_AFTER_FAILURES = 5;
 
 function json(body: unknown, status = 200): Response {
@@ -160,11 +163,16 @@ serve(async (req) => {
       if (pErr) throw pErr;
       const enabledKey = new Set(leagues.map((l) => `${l.league_id}:${l.season}`));
       const toConfirm = (pendData ?? [])
-        .filter((f: any) =>
-          enabledKey.has(`${f.league_id}:${f.season}`) &&
-          !TERMINAL.has(f.status_short ?? "NS") &&
-          !liveIds.has(f.fixture_id)
-        )
+        .filter((f: any) => {
+          if (!enabledKey.has(`${f.league_id}:${f.season}`)) return false;
+          if (TERMINAL.has(f.status_short ?? "NS")) return false;
+          if (liveIds.has(f.fixture_id)) return false;
+          // jogo que nunca apareceu no live (NS/TBD): início atrasado é comum —
+          // espera 45min do kickoff antes de gastar chamada conferindo
+          const neverStarted = (f.status_short ?? "NS") === "NS" || f.status_short === "TBD";
+          if (neverStarted && new Date(f.kickoff_utc).getTime() > Date.now() - 45 * 60_000) return false;
+          return true;
+        })
         .map((f: any) => f.fixture_id);
 
       for (let i = 0; i < toConfirm.length; i += 20) {

--- a/supabase/migrations/082_multi_league_collector.sql
+++ b/supabase/migrations/082_multi_league_collector.sql
@@ -1,0 +1,176 @@
+-- ============================================================
+-- 082_multi_league_collector — coletor de placares multi-liga (F1)
+-- ============================================================
+-- Implementa o desenho aprovado pelo Kasuya na task wdx6zenqbv (parecer 08/07):
+--
+--   • fixtures genérica (multi-liga) com placar por período (halftime/fulltime/
+--     extratime/penalty), status/elapsed, trigger de updated_at e índices
+--   • leagues_config — quais ligas o coletor cobre (dado, não código)
+--   • team_aliases — apelidos por ID de time (substitui o dicionário hardcoded
+--     EN_ALIASES no futuro matching v2 do settlement — F2)
+--   • collector_runs — telemetria de cada execução (a lacuna nº1 do parecer:
+--     "o medo que gera é degradar em silêncio")
+--   • 1 ÚNICO cron a cada 2 min cujo SQL só chama a função SE existe jogo em
+--     janela (kickoff−10min < now < kickoff+3h) em liga habilitada — fora de
+--     janela: zero invocação, zero request, zero custo
+--   • 1 cron diário de calendário (04:00 BRT — 1 chamada por liga habilitada)
+--
+-- ESTRATÉGIA DE MIGRAÇÃO (dual-run, sem migrar histórico):
+--   wc_matches NÃO é migrada (é do bolão; morre com a Copa em 19/07).
+--   O coletor grava fixtures pra todas as ligas incl. Copa → ~10 dias de
+--   paridade em staging → notify-settlement troca a leitura (F2) → pós-Copa,
+--   aposentar ingest-wc-scores + cron 048.
+--   futebol.fact_fixtures (sync do BQ) NÃO serve pro settlement: latência de
+--   horas contra os ≤15min necessários — dono é o data-engineering.
+--
+-- PRÉ-REQUISITO POR AMBIENTE (rodar uma vez via SQL, igual 048/073/078):
+--   vault.create_secret('<x-cron-secret>', 'ingest_fixtures_cron_secret', ...);
+--   vault.create_secret('<url da função>', 'ingest_fixtures_url', ...);
+-- ============================================================
+
+-- ── Ligas cobertas: dado, não código ─────────────────────────
+CREATE TABLE IF NOT EXISTS public.leagues_config (
+  league_id integer NOT NULL,
+  season    integer NOT NULL,
+  name      text NOT NULL,
+  enabled   boolean NOT NULL DEFAULT false,
+  PRIMARY KEY (league_id, season)
+);
+COMMENT ON TABLE public.leagues_config IS
+  'Ligas que o coletor multi-liga cobre. enabled=true entra no live poll e no calendário diário. IDs da API-Football.';
+
+-- Seed: Copa (piloto/dual-run) + Ondas 1 e 2 da expansão. enabled=true só nas
+-- que têm jogo AGORA; as demais viram true na data de retorno (datas nas tasks
+-- das Ondas no ClickUp).
+INSERT INTO public.leagues_config (league_id, season, name, enabled) VALUES
+  (1,   2026, 'Copa do Mundo FIFA',        true),   -- até 19/07 (dual-run com ingest-wc-scores)
+  (71,  2026, 'Brasileirão Série A',       true),   -- volta 16/07
+  (72,  2026, 'Brasileirão Série B',       true),   -- não para
+  (73,  2026, 'Copa do Brasil',            true),   -- volta 30/07-01/08
+  (13,  2026, 'Copa Libertadores',         true),   -- volta 12/08 (odds antes)
+  (2,   2026, 'UEFA Champions League',     false),  -- volta 16/09
+  (39,  2026, 'Premier League (ENG)',      false),  -- volta 15/08
+  (140, 2026, 'La Liga (ESP)',             false),  -- volta 15/08
+  (11,  2026, 'Copa Sul-Americana',        false),  -- volta 15/07 → habilitar quando odds cobrirem
+  (135, 2026, 'Serie A (ITA)',             false),  -- volta 22/08
+  (78,  2026, 'Bundesliga (ALE)',          false),  -- volta 22/08
+  (61,  2026, 'Ligue 1 (FRA)',             false),  -- volta 23/08
+  (94,  2026, 'Primeira Liga (POR)',       false)   -- volta 08/08
+ON CONFLICT (league_id, season) DO NOTHING;
+
+-- ── Fixtures genérica (fonte do settlement multi-liga no F2) ─
+CREATE TABLE IF NOT EXISTS public.fixtures (
+  fixture_id     bigint PRIMARY KEY,          -- id da API-Football
+  league_id      integer NOT NULL,
+  season         integer NOT NULL,
+  round          text,
+  home_team_id   bigint,
+  home_team      text NOT NULL,
+  away_team_id   bigint,
+  away_team      text NOT NULL,
+  kickoff_utc    timestamptz NOT NULL,
+  status_short   text,                        -- NS/1H/HT/2H/ET/P/FT/AET/PEN/PST/CANC...
+  elapsed        integer,
+  goals_home     integer,                     -- placar corrente/final (inclui prorrogação)
+  goals_away     integer,
+  halftime_home  integer,                     -- mercados de 1º tempo (futuro)
+  halftime_away  integer,
+  fulltime_home  integer,                     -- 90' — BASE DE LIQUIDAÇÃO
+  fulltime_away  integer,
+  extratime_home integer,
+  extratime_away integer,
+  penalty_home   integer,
+  penalty_away   integer,
+  winner         text,                        -- 'home' | 'away' | null (empate/indefinido)
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE public.fixtures IS
+  'Placares multi-liga do coletor (edge function ingest-fixtures). Liquidação usa fulltime_* (90 min); goals_* inclui prorrogação.';
+CREATE INDEX IF NOT EXISTS idx_fixtures_kickoff ON public.fixtures (kickoff_utc);
+CREATE INDEX IF NOT EXISTS idx_fixtures_league  ON public.fixtures (league_id, season);
+-- trigger de updated_at (função já existe desde a 005; wc_matches não tinha — parecer 2c)
+DROP TRIGGER IF EXISTS update_fixtures_updated_at ON public.fixtures;
+CREATE TRIGGER update_fixtures_updated_at
+  BEFORE UPDATE ON public.fixtures
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+ALTER TABLE public.fixtures ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role (settlement/edge); o front lê pelo schema futebol (DE)
+
+-- ── Apelidos de time por ID (consumidor: matching v2 — F2) ───
+CREATE TABLE IF NOT EXISTS public.team_aliases (
+  api_team_id bigint NOT NULL,
+  alias       text   NOT NULL,   -- normalizado (sem acento, minúsculas)
+  PRIMARY KEY (api_team_id, alias)
+);
+COMMENT ON TABLE public.team_aliases IS
+  'Apelidos/aliases por ID de time da API-Football (ex.: 85→"psg"). Substitui dicionários hardcoded no matching aposta↔jogo.';
+ALTER TABLE public.team_aliases ENABLE ROW LEVEL SECURITY;
+
+-- ── Telemetria do coletor (lacuna nº1 do parecer) ────────────
+CREATE TABLE IF NOT EXISTS public.collector_runs (
+  id              bigserial PRIMARY KEY,
+  ran_at          timestamptz NOT NULL DEFAULT now(),
+  mode            text NOT NULL,              -- 'live' | 'calendar'
+  window_active   boolean,
+  live_fixtures   integer,
+  api_calls       integer,
+  quota_remaining integer,                    -- header x-ratelimit-requests-remaining
+  ok              boolean NOT NULL,
+  error           text
+);
+COMMENT ON TABLE public.collector_runs IS
+  'Cada execução do ingest-fixtures: chamadas feitas, quota restante do plano, sucesso/erro. Alerta admin após falhas consecutivas.';
+CREATE INDEX IF NOT EXISTS idx_collector_runs_ran_at ON public.collector_runs (ran_at DESC);
+ALTER TABLE public.collector_runs ENABLE ROW LEVEL SECURITY;
+
+-- ── Cron 1: live poll a cada 2 min, com GATE SQL ─────────────
+-- Fora de janela de jogo: o SELECT não chama net.http_post → zero invocação.
+-- O gate lê a própria fixtures (populada pelo calendário diário).
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'ingest-fixtures-live') THEN
+    PERFORM cron.unschedule('ingest-fixtures-live');
+  END IF;
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'ingest-fixtures-calendar') THEN
+    PERFORM cron.unschedule('ingest-fixtures-calendar');
+  END IF;
+END $$;
+
+SELECT cron.schedule('ingest-fixtures-live', '*/2 * * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_fixtures_url') || '?mode=live',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_fixtures_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  )
+  WHERE EXISTS (
+    SELECT 1
+    FROM public.fixtures f
+    JOIN public.leagues_config lc
+      ON lc.league_id = f.league_id AND lc.season = f.season AND lc.enabled
+    WHERE now() BETWEEN f.kickoff_utc - interval '10 minutes'
+                    AND f.kickoff_utc + interval '3 hours'
+      AND coalesce(f.status_short, 'NS') NOT IN ('FT','AET','PEN','CANC','ABD','AWD','WO','PST')
+  );
+$job$);
+
+-- ── Cron 2: calendário diário às 07:00 UTC (04:00 BRT) ───────
+-- 1 chamada por liga habilitada — pega jogos novos, remarcações e TBD→NS.
+SELECT cron.schedule('ingest-fixtures-calendar', '0 7 * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_fixtures_url') || '?mode=calendar',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_fixtures_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 120000
+  );
+$job$);


### PR DESCRIPTION
## O que é (F1 do parecer do coletor — task wdx6zenqbv)

Implementa o coletor de placares multi-liga **exatamente no desenho aprovado pelo Kasuya** (parecer de 08/07 na task), incluindo todos os ajustes dele:

### Coleta
- **`live={ids}`** em vez de `live=all` — ids vêm de `leagues_config` (dado, não código)
- **Confirmação de encerramento** via `fixtures?ids=a-b-c` (lote de 20): jogo que estava em janela e sumiu do live é confirmado com status terminal (FT/AET/PEN) e **`score.fulltime` (90' — a base de liquidação)**. Cobre o "último poll pegou o jogo aos 88'" e o AET/PEN de mata-mata
- **1 cron só** (`*/2min`) com **gate SQL**: fora de janela de jogo (kickoff−10min → +3h em liga habilitada), zero invocação/request/custo — o TODO da migration 048 finalmente atendido
- Calendário diário 04:00 BRT: 1 chamada/liga (remarcações, TBD→NS) — é o que alimenta o gate

### Schema (migration 082)
- **`fixtures`** genérica: halftime/fulltime/extratime/penalty (DM pode mostrar "X×Y no tempo normal"; mercados de 1ºT no futuro), status/elapsed, **trigger de `updated_at`** (o que faltava na wc_matches), índices em kickoff e liga
- **`leagues_config`**: seed com Copa + Ondas 1 e 2 (IDs API-Football; BR habilitadas, europeias `enabled=false` até a data de retorno — ligar liga = UPDATE, não deploy)
- **`team_aliases`** (api_team_id → alias): pronta pro matching v2 do settlement (F2) substituir o dicionário hardcoded EN_ALIASES
- **`collector_runs`**: telemetria de cada execução

### Telemetria (lacuna nº1 do parecer)
Cada run grava chamadas feitas + **quota restante do header `x-ratelimit`**; após **5 falhas consecutivas**, DM de alerta pro admin (`ADMIN_TELEGRAM_CHAT_ID`). Fim do "degradar em silêncio".

## Custo (validado no parecer)
Regime normal ~50–150 chamadas/dia · pico fds cheio ~250–350 — contra 7.500/dia do PRO.

## Rollout (dual-run, decidido no parecer)
1. **F1 (este PR)**: coletor grava `public.fixtures` pra todas as ligas incl. Copa, `ingest-wc-scores` **intocado** → ~10 dias de paridade em staging
2. **F2 (PR próprio)**: settlement troca leitura `wc_matches`→`fixtures` + matching v2 (`match_date ±30h`, hint de liga, `team_aliases`) + veredito de **handicap asiático** (half_won/half_lost)
3. Pós-Copa: aposentar `ingest-wc-scores`. `wc_matches` não é migrada (bolão). `futebol.fact_fixtures` não é fonte de settlement (latência)

## Bootstrap pós-merge (runbook `MULTI_LEAGUE_COLLECTOR_SETUP.md`)
1. Vault: `ingest_fixtures_url` + `ingest_fixtures_cron_secret`
2. 1 curl `?mode=calendar` na mão (povoar fixtures → abrir o gate do live)
3. Opcional: `ADMIN_TELEGRAM_CHAT_ID` pro alerta

## Fora do escopo (fases seguintes do parecer)
F2 (matching v2 + AH) · F3 (marker de predictions vazias — lado DE) · rotação da API key (no cutover)

⚠️ Lembrete F0 do parecer: o **#195 → main** continua sendo o desbloqueio mais urgente (liquidação em produção antes das semis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
