### PR TITLE
develop → main: futebol multi-liga + auto-liquidação do Betinho + fixes do bolão (077)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -42,5 +42,7 @@ jobs:
           supabase functions deploy notify-settlement --no-verify-jwt
           supabase functions deploy winback-backfill --no-verify-jwt
           supabase functions deploy notify-handoff --no-verify-jwt
+          supabase functions deploy notify-opportunities --no-verify-jwt
+          supabase functions deploy go --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -40,5 +40,6 @@ jobs:
           supabase functions deploy ingest-wc-scores --no-verify-jwt
           supabase functions deploy notify-kickoff --no-verify-jwt
           supabase functions deploy notify-settlement --no-verify-jwt
+          supabase functions deploy winback-backfill --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -37,5 +37,8 @@ jobs:
           supabase functions deploy whatsapp-webhook --no-verify-jwt
           supabase functions deploy share-create --no-verify-jwt
           supabase functions deploy share-resolve --no-verify-jwt
+          supabase functions deploy ingest-wc-scores --no-verify-jwt
+          supabase functions deploy notify-kickoff --no-verify-jwt
+          supabase functions deploy notify-settlement --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,5 +44,6 @@ jobs:
           supabase functions deploy notify-handoff --no-verify-jwt
           supabase functions deploy notify-opportunities --no-verify-jwt
           supabase functions deploy go --no-verify-jwt
+          supabase functions deploy ingest-fixtures --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -41,5 +41,6 @@ jobs:
           supabase functions deploy notify-kickoff --no-verify-jwt
           supabase functions deploy notify-settlement --no-verify-jwt
           supabase functions deploy winback-backfill --no-verify-jwt
+          supabase functions deploy notify-handoff --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -42,5 +42,7 @@ jobs:
           supabase functions deploy notify-settlement --no-verify-jwt
           supabase functions deploy winback-backfill --no-verify-jwt
           supabase functions deploy notify-handoff --no-verify-jwt
+          supabase functions deploy notify-opportunities --no-verify-jwt
+          supabase functions deploy go --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -40,5 +40,6 @@ jobs:
           supabase functions deploy ingest-wc-scores --no-verify-jwt
           supabase functions deploy notify-kickoff --no-verify-jwt
           supabase functions deploy notify-settlement --no-verify-jwt
+          supabase functions deploy winback-backfill --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -37,5 +37,8 @@ jobs:
           supabase functions deploy whatsapp-webhook --no-verify-jwt
           supabase functions deploy share-create --no-verify-jwt
           supabase functions deploy share-resolve --no-verify-jwt
+          supabase functions deploy ingest-wc-scores --no-verify-jwt
+          supabase functions deploy notify-kickoff --no-verify-jwt
+          supabase functions deploy notify-settlement --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -44,5 +44,6 @@ jobs:
           supabase functions deploy notify-handoff --no-verify-jwt
           supabase functions deploy notify-opportunities --no-verify-jwt
           supabase functions deploy go --no-verify-jwt
+          supabase functions deploy ingest-fixtures --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,5 +41,6 @@ jobs:
           supabase functions deploy notify-kickoff --no-verify-jwt
           supabase functions deploy notify-settlement --no-verify-jwt
           supabase functions deploy winback-backfill --no-verify-jwt
+          supabase functions deploy notify-handoff --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/HANDOFF_FINAL_SETUP.md
+++ b/HANDOFF_FINAL_SETUP.md
@@ -1,0 +1,29 @@
+# Passagem de bastão do dia da final (H1) — DM de encerramento
+
+No dia **19/jul**, depois da final encerrar, cada membro de bolão com Telegram recebe
+**uma DM** com sua posição definitiva + as duas portas: Betinho (casual) e análise de
+futebol (frequente). Par da peça web: `BolaoHandoffCard` (aba Ranking, aparece sozinho
+quando a final encerra).
+
+**Não tem cron.** Execução manual em 2 passos, no dia da final:
+
+```bash
+URL="https://<projeto>.supabase.co/functions/v1/notify-handoff"
+SECRET="<CRON_SECRET do painel>"
+
+# 1) RELATÓRIO — lista quem receberia e a posição em cada bolão. Não envia nada.
+curl -s -X POST "$URL?mode=report" -H "x-cron-secret: $SECRET"
+
+# 2) ENVIA — 1 DM por usuário (idempotente via bolao_handoff_notifications)
+curl -s -X POST "$URL?mode=send" -H "x-cron-secret: $SECRET"
+```
+
+**Guarda de segurança:** a função recusa (`412`) enquanto a final não estiver
+`is_finished` em `wc_matches` — impossível disparar antes da hora. Em staging,
+`&force=true` pula a guarda pra ensaio.
+
+O rank da DM vem de `get_bolao_ranking()` — a mesma função do site; nunca diverge.
+Respeita `settlement_reminders_muted`. Métricas: `bolao_handoff_dm_sent` {boloes_count,
+best_rank} + `bolao_handoff_view/click` (peça web) → taxa de reconquista H1.
+
+Dependência de rota: `/futebol/comecar` entra com o PR #188.

--- a/MAPA_MENSAGENS_BOT.md
+++ b/MAPA_MENSAGENS_BOT.md
@@ -1,0 +1,49 @@
+# Mapa de mensagens do bot — quando cada uma dispara
+
+Toda mensagem que o Betinho pode mandar no Telegram, com gatilho, momento, teto e
+opt-out. **Regra de ouro do produto: mensagem só existe se merecer existir** — dia
+fraco = silêncio; usuário que ignora = para de receber.
+
+## Recorrentes (automáticas)
+
+| # | Mensagem | Gatilho | Quando chega | Teto anti-spam | Opt-out |
+|---|---|---|---|---|---|
+| 1 | **"✅ Fechei sua aposta: green/red"** (auto-liquidação) | Jogo da aposta terminou + match perfeito (mercado direto, placar no banco) | **~5–20 min após o apito** (placar entra ~5 min; carteiro roda a cada 15 min). Qualquer hora — quem apostou no jogo está acordado vendo o jogo | Compartilha o teto de **3 msgs de liquidação por usuário por rodada de 15 min** | 🔕 botão / `/silenciar` |
+| 2 | **"🏁 Placar X×Y — como foi?"** (jogo casado, mercado não-computável: múltipla, prop...) | Mesmo gatilho da #1, quando o bot não pode cravar | Mesmo momento da #1 | Mesmo teto da #1 + máx **2 lembretes por aposta** (gap 20h) | 🔕 |
+| 3 | **"⏱️ Seu jogo já deve ter terminado — como foi?"** (genérico, sem placar no banco) | `match_date` passou há 3h+, ou aposta com 24h+ sem data de jogo | Só entre **09h–23h BRT** | Mesmo teto da #1 + máx 2 por aposta (gap 20h) | 🔕 |
+| 4 | **"⚽ As oportunidades de hoje"** (daily) | Cron diário | **10h BRT em ponto**, 1x/dia — e SÓ se houver pick acima do corte (Score ≥ 40). Sem pick = sem mensagem | Reativação (segmento B): **2 envios sem clique → para pra sempre** | 🔕 |
+| 5 | **Confirmação de aposta registrada** | Usuário mandou print/texto | Imediato (resposta ao registro) | Reativa — só responde ao que o usuário fez | n/a |
+| 6 | **Aviso de kickoff do bolão** (só pro DONO do bolão) | Jogo da Copa começando | No minuto do kickoff (:00/:30) | 1 por jogo por bolão | opt-in explícito do dono |
+
+## One-shot (disparo manual, 1x por usuário PRA SEMPRE)
+
+| # | Mensagem | Quando dispara | Quem controla |
+|---|---|---|---|
+| 7 | **"📋 Atualizamos seu histórico — seu ROI real"** (winback R1) | Uma única vez, após o backfill do histórico (3 curls do runbook) | Dev, manualmente |
+| 8 | **"🏆 A Copa acabou — e com ela o bolão!"** (handoff da final) | Dia 19/07, após a final encerrar (guarda técnica impede antes) | Dev, manualmente (2 curls) |
+
+## Interno (não vai pra usuário)
+
+| # | Mensagem | Gatilho |
+|---|---|---|
+| 9 | Alerta de coletor quebrado | 5 falhas consecutivas do ingest-fixtures → DM só pro admin |
+
+## O pior dia possível (teste de metralhadora)
+
+Cenário extremo — dia da final, usuário com 3 apostas no jogo, no bolão e na lista do daily:
+
+- 10h00 → oportunidades do dia (1 msg, se houver pick)
+- ~19h20 (pós-apito) → até 3 liquidações/perguntas na primeira rodada do carteiro
+- ~20h → handoff da final (1 msg, manual — o dev escolhe a hora)
+
+**Total no pior caso: ~5 mensagens num dia de final de Copa** — todas com conteúdo
+que o usuário quer receber (resultado das apostas dele + posição final dele). Em dia
+normal: 0 a 2. O silêncio é parte do produto.
+
+## Regras transversais
+
+- `users.settlement_reminders_muted` (🔕/`/silenciar`) cala **tudo** que é recorrente
+  de liquidação e o winback/handoff também respeitam. `/lembretes` reativa.
+- Toda mensagem tem evento no PostHog (enviada + clicada/corrigida) — a "taxa de
+  incômodo" (mute + correções) é métrica acompanhável.
+- Novas mensagens DEVEM entrar neste mapa antes de ir pra develop.

--- a/MULTI_LEAGUE_COLLECTOR_SETUP.md
+++ b/MULTI_LEAGUE_COLLECTOR_SETUP.md
@@ -37,6 +37,9 @@ Fora de janela de jogo: **zero** invocação — o gate é SQL no próprio cron.
 ```sql
 update leagues_config set enabled = true where league_id = 39; -- Premier volta 15/08
 ```
+⚠️ Ao habilitar liga no meio do dia, rode 1 curl de `?mode=calendar` na sequência —
+os jogos dela só entrariam sozinhos no calendário das 04h, e sem fixtures no banco
+o gate do live não abre pra ela.
 
 ## Plano de rollout (dual-run — decidido no parecer)
 

--- a/MULTI_LEAGUE_COLLECTOR_SETUP.md
+++ b/MULTI_LEAGUE_COLLECTOR_SETUP.md
@@ -1,0 +1,65 @@
+# Coletor de placares multi-liga (F1) — Setup
+
+Implementa o desenho aprovado no parecer da task do coletor (Kasuya, 08/07):
+`fixtures?live={ids}` + confirmação de encerramento em lote + cadência adaptativa
+com **1 cron só** (gate SQL) + telemetria com alerta.
+
+## Peças
+
+| Peça | O que faz |
+| --- | --- |
+| Migration `082_multi_league_collector.sql` | Tabelas `fixtures` (com halftime/fulltime/extratime/penalty + trigger updated_at), `leagues_config` (seed Ondas 1+2, IDs API-Football), `team_aliases` (pro matching v2 — F2), `collector_runs` (telemetria) + 2 crons |
+| `ingest-fixtures` | `?mode=calendar` (diário 04:00 BRT, 1 chamada/liga habilitada) e `?mode=live` (2/2min SÓ quando o gate SQL detecta jogo em janela; live={ids} + `fixtures?ids=` em lote pra confirmar FT/AET/PEN e capturar o placar dos 90') |
+
+## Custo (contra o PRO: 7.500/dia, 300/min)
+
+Regime normal ~50–150 chamadas/dia; pico de fds cheio ~250–350 (números do parecer).
+Fora de janela de jogo: **zero** invocação — o gate é SQL no próprio cron.
+
+## Deploy
+
+1. Migration + function via CI (workflows já atualizados).
+2. **Vault** (uma vez por ambiente):
+   ```sql
+   select vault.create_secret('<mesmo CRON_SECRET>', 'ingest_fixtures_cron_secret');
+   select vault.create_secret('https://<projeto>.supabase.co/functions/v1/ingest-fixtures', 'ingest_fixtures_url');
+   ```
+3. Bootstrap: rodar 1x o calendário na mão (senão o gate do live nunca abre):
+   ```bash
+   curl -s -X POST "https://<projeto>.supabase.co/functions/v1/ingest-fixtures?mode=calendar" \
+     -H "x-cron-secret: <CRON_SECRET>"
+   ```
+4. (Opcional, recomendado) Alerta de falhas consecutivas: setar secrets
+   `ADMIN_TELEGRAM_CHAT_ID` (chat do admin) — `TELEGRAM_BOT_TOKEN` já existe.
+
+## Ligar/desligar ligas (dado, não deploy)
+
+```sql
+update leagues_config set enabled = true where league_id = 39; -- Premier volta 15/08
+```
+
+## Plano de rollout (dual-run — decidido no parecer)
+
+1. **F1 (isto):** coletor grava `public.fixtures` pra todas as ligas incl. Copa,
+   com `ingest-wc-scores` intocado → ~10 dias de paridade em staging.
+2. **F2 (próximo PR):** `notify-settlement` troca a leitura `wc_matches`→`fixtures`
+   (matching v2: `match_date ±30h`, hint de liga, `team_aliases`, veredito de
+   handicap asiático com half_won/half_lost) após paridade validada.
+3. **Pós-Copa:** aposentar `ingest-wc-scores` + cron da 048.
+4. `wc_matches` NÃO é migrada (é do bolão, morre 19/07).
+   `futebol.fact_fixtures` NÃO é fonte de settlement (latência de horas; dono é o DE).
+
+## Monitoramento
+
+```sql
+-- saúde do coletor (últimas execuções, chamadas, quota do plano)
+select ran_at, mode, live_fixtures, api_calls, quota_remaining, ok, error
+from collector_runs order by ran_at desc limit 20;
+```
+Alerta automático: DM pro admin após 5 falhas consecutivas.
+
+## Fora do escopo deste PR (fases seguintes do parecer)
+
+- F2: matching v2 + AH no computeVerdict
+- F3: marker de predictions vazias (lado data-engineering)
+- Rotação da API key (exposta no front via VITE_API_SPORTS_KEY) — fazer no cutover

--- a/NOTIFY_OPPORTUNITIES_SETUP.md
+++ b/NOTIFY_OPPORTUNITIES_SETUP.md
@@ -1,0 +1,52 @@
+# Oportunidades do dia no Telegram (08′) — Setup
+
+Daily automático (cron **10h BRT**, após a carga do dbt): os melhores picks do dia do
+`get_futebol_value_board` — a mesma fonte do site — direto no Telegram, com Score,
+faixa e evidência. **Sem nome de casa de aposta** na mensagem.
+
+## Peças
+
+| Peça | O que faz |
+| --- | --- |
+| Migration `081_notify_opportunities.sql` | Tabelas `opportunity_dispatch_state` (cadência) e `notification_clicks` (funil) + RPC `get_opportunity_recipients` + cron 13:00 UTC |
+| `notify-opportunities` | O daily: board → jogos de hoje → melhor pick por jogo → top 3 (Score ≥ 40) → DM. **Dia fraco = não manda nada.** |
+| `go` | Redirecionador público dos links (registra clique, zera a régua da reativação, 302 pro site) |
+
+## Regras de público
+
+- **A · Futebol ativo** (assinante `users.futebol_subscription_status='premium'` OU trial de 7d vigente) + Telegram → recebe sempre.
+- **B · Reativação** (Telegram linkado, sem aposta há 14+ dias) → recebe **até 2 envios; sem
+  nenhum clique, para**. Clique (via `go`) zera o contador. Régua ajustável na RPC.
+- Respeita `settlement_reminders_muted` (o 🔕 geral do bot).
+
+## Deploy
+
+1. Migration + functions via CI (já listadas nos workflows).
+2. **Vault** (uma vez por ambiente):
+   ```sql
+   select vault.create_secret('<mesmo CRON_SECRET>', 'notify_opportunities_cron_secret');
+   select vault.create_secret('https://<projeto>.supabase.co/functions/v1/notify-opportunities', 'notify_opportunities_url');
+   ```
+3. Dependências de produto: rotas `/futebol` e `/futebol/jogo/:id` (PR #180) no ar;
+   suprimento de odds (Copa hoje; Brasileirão = ondas de expansão).
+
+## Ensaio / teste manual
+
+```bash
+# relatório: picks do dia + quem receberia (não envia nada)
+curl -s -X POST "https://<projeto>.supabase.co/functions/v1/notify-opportunities?mode=report" \
+  -H "x-cron-secret: <CRON_SECRET>"
+
+# envio real (mesmo que o cron faz)
+curl -s -X POST "https://<projeto>.supabase.co/functions/v1/notify-opportunities" \
+  -H "x-cron-secret: <CRON_SECRET>"
+```
+Obs.: se o board não tiver jogo FUTURO acima do corte, a resposta é `picks: 0` e nada é
+enviado — comportamento correto, não bug.
+
+## Métricas (PostHog + banco)
+
+- `daily_opportunities_sent` {segment, picks_count, top_score}
+- `daily_opportunities_click` {destination} (disparado pelo `go`)
+- Funil completo no banco: `opportunity_dispatch_state` (enviado) → `notification_clicks`
+  (clicou) → `bets.channel` (registrou)

--- a/SETTLEMENT_REMINDERS_SETUP.md
+++ b/SETTLEMENT_REMINDERS_SETUP.md
@@ -40,10 +40,15 @@ sugerido** ("pelo placar, essa bateu ✅").
 ## Regras de produto (implementadas)
 
 - **Cadência**: máx. **2 lembretes por aposta**, gap de 20h; máx. **3 mensagens por usuário por run**.
-- **Copa** (casada com `wc_matches` encerrado): sai na hora do apito, com placar.
-  Veredito só em mercado direto — ML/1x2, over/under de **gols**, ambas marcam —
-  sempre pelo **placar dos 90'**. Múltipla, handicap, 1º tempo, classificação,
-  escanteios etc. → pergunta sem afirmar. Linha exata (push) → sem veredito.
+- **AUTO-LIQUIDAÇÃO** (decisão de produto 09/07): **match perfeito** — jogo casado
+  com `wc_matches` encerrado + mercado direto (ML/1x2, over/under de **gols**,
+  ambas marcam), sempre pelo **placar dos 90'** — a aposta é **liquidada sozinha**
+  (won/lost + evidência em `processed_data.auto_settle`) e o usuário recebe
+  "✅ Fechei sua aposta: green! ... [↩️ Corrigir]". O **Corrigir** desfaz (volta
+  pra pendente) e devolve os botões clássicos.
+- **Sem match perfeito** — múltipla, handicap, 1º tempo, classificação, escanteios,
+  props, linha exata (push), jogo ambíguo → **pergunta sem afirmar** (botões
+  Green/Red), como sempre.
 - **Genérica** (sem placar no banco): `match_date` passou há 3h+ (ou aposta com 24h+
   quando sem data de jogo), só entre **09h–23h BRT**.
 - **Opt-out**: botão 🔕 na mensagem ou `/silenciar`; `/lembretes` reativa
@@ -63,6 +68,8 @@ apareçam na descrição da aposta.
 
 ## Métricas (PostHog)
 
+- `bet_auto_settled` — {bet_id, verdict, betting_market} (match perfeito, fechada sozinha)
+- `auto_settle_corrected` — {bet_id, previous_status} (usuário tocou em Corrigir — **taxa de erro do motor**)
 - `settlement_reminder_sent` — {kind: wc|generic, verdict, betting_market, reminder_number}
 - `settlement_settled_via_bot` — {bet_id, outcome}
 - `settlement_reminders_muted` / `_unmuted` — {via: button|command}

--- a/SETTLEMENT_REMINDERS_SETUP.md
+++ b/SETTLEMENT_REMINDERS_SETUP.md
@@ -42,13 +42,15 @@ sugerido** ("pelo placar, essa bateu ✅").
 - **Cadência**: máx. **2 lembretes por aposta**, gap de 20h; máx. **3 mensagens por usuário por run**.
 - **AUTO-LIQUIDAÇÃO** (decisão de produto 09/07): **match perfeito** — jogo casado
   com `wc_matches` encerrado + mercado direto (ML/1x2, over/under de **gols**,
-  ambas marcam), sempre pelo **placar dos 90'** — a aposta é **liquidada sozinha**
-  (won/lost + evidência em `processed_data.auto_settle`) e o usuário recebe
-  "✅ Fechei sua aposta: green! ... [↩️ Corrigir]". O **Corrigir** desfaz (volta
-  pra pendente) e devolve os botões clássicos.
-- **Sem match perfeito** — múltipla, handicap, 1º tempo, classificação, escanteios,
-  props, linha exata (push), jogo ambíguo → **pergunta sem afirmar** (botões
-  Green/Red), como sempre.
+  ambas marcam e **handicap asiático**), sempre pelo **placar dos 90'** — a aposta
+  é **liquidada sozinha** (won/lost/void/half_won/half_lost + evidência em
+  `processed_data.auto_settle`) e o usuário recebe "✅ Fechei sua aposta: green!
+  ... [↩️ Corrigir]". O **Corrigir** desfaz (volta pra pendente) e devolve os
+  botões clássicos. Handicap: linha inteira pode dar push → **void** (anulada,
+  stake devolvido); linha quarter (±0.25/±0.75) → **meio green/meio red**.
+- **Sem match perfeito** — múltipla, 1º tempo, classificação, escanteios, props,
+  handicap europeu ("empate −1"), O/U em linha exata, jogo ambíguo → **pergunta
+  sem afirmar** (botões Green/Red), como sempre.
 - **Genérica** (sem placar no banco): `match_date` passou há 3h+ (ou aposta com 24h+
   quando sem data de jogo), só entre **09h–23h BRT**.
 - **Opt-out**: botão 🔕 na mensagem ou `/silenciar`; `/lembretes` reativa

--- a/SETTLEMENT_REMINDERS_SETUP.md
+++ b/SETTLEMENT_REMINDERS_SETUP.md
@@ -1,0 +1,71 @@
+# Lembretes de Liquidação — Setup (Telegram)
+
+O Betinho manda DM quando o jogo do usuário termina, com botões **[✅ Green] [❌ Red]** —
+1 toque liquida a aposta. Para jogos da Copa a mensagem chega **com o placar e o veredito
+sugerido** ("pelo placar, essa bateu ✅").
+
+## Peças
+
+| Peça | Onde | O que faz |
+| --- | --- | --- |
+| Migration `078_settlement_reminders.sql` | `supabase/migrations` | Colunas de cadência em `bets`, mute em `users`, placar 90' em `wc_matches`, RPC `get_settlement_reminder_candidates`, cron `notify-settlement` (15 min) |
+| `notify-settlement` | `supabase/functions` | Cron: acha pendentes com jogo encerrado, casa com `wc_matches`, computa veredito e manda a DM com botões |
+| `telegram-webhook` (alterado) | `supabase/functions` | Handler de `callback_query` (Green/Red/🔕) + comandos `/silenciar` e `/lembretes` |
+| `ingest-wc-scores` (alterado) | `supabase/functions` | Passa a gravar `fulltime_home/away` (placar dos 90' — base da liquidação; o placar cheio inclui prorrogação) |
+
+## Deploy (ordem)
+
+1. **Migration**: `supabase db push` (ou aplicar `078_settlement_reminders.sql` via SQL editor).
+2. **Functions**: deploy de `ingest-wc-scores`, `telegram-webhook` e `notify-settlement`
+   (`notify-settlement` com `--no-verify-jwt`, igual às outras de cron/webhook).
+3. **Vault** (uma vez por ambiente, igual 048/073):
+   ```sql
+   select vault.create_secret('<mesmo valor do env CRON_SECRET>', 'notify_settlement_cron_secret');
+   select vault.create_secret('https://<projeto>.supabase.co/functions/v1/notify-settlement', 'notify_settlement_url');
+   ```
+4. **Secrets da função** (painel → Edge Functions): já existem para as outras —
+   `TELEGRAM_BOT_TOKEN`, `CRON_SECRET`, `SUPABASE_SERVICE_ROLE_KEY` (automático).
+5. **⚠️ setWebhook do bot**: os botões chegam como `callback_query`. Se o `setWebhook`
+   foi feito com `allowed_updates` restrito a `["message"]`, os toques NÃO chegam.
+   Conferir/reconfigurar:
+   ```bash
+   curl "https://api.telegram.org/bot<TOKEN>/getWebhookInfo"
+   # se allowed_updates não incluir callback_query:
+   curl "https://api.telegram.org/bot<TOKEN>/setWebhook" \
+     -d "url=<url do telegram-webhook>" \
+     -d "secret_token=<TELEGRAM_WEBHOOK_SECRET>" \
+     -d 'allowed_updates=["message","edited_message","callback_query"]'
+   ```
+
+## Regras de produto (implementadas)
+
+- **Cadência**: máx. **2 lembretes por aposta**, gap de 20h; máx. **3 mensagens por usuário por run**.
+- **Copa** (casada com `wc_matches` encerrado): sai na hora do apito, com placar.
+  Veredito só em mercado direto — ML/1x2, over/under de **gols**, ambas marcam —
+  sempre pelo **placar dos 90'**. Múltipla, handicap, 1º tempo, classificação,
+  escanteios etc. → pergunta sem afirmar. Linha exata (push) → sem veredito.
+- **Genérica** (sem placar no banco): `match_date` passou há 3h+ (ou aposta com 24h+
+  quando sem data de jogo), só entre **09h–23h BRT**.
+- **Opt-out**: botão 🔕 na mensagem ou `/silenciar`; `/lembretes` reativa
+  (`users.settlement_reminders_muted`).
+
+## Teste manual (dev)
+
+```bash
+# disparar o cron na mão
+curl -X POST "https://<projeto>.supabase.co/functions/v1/notify-settlement" \
+  -H "x-cron-secret: <CRON_SECRET>"
+# resposta: { ok, candidates, wc_finished_recent, due, sent, ... }
+```
+Pré-condições para receber a DM: usuário com `telegram_chat_id` preenchido, aposta
+`pending` recente e (Copa) um `wc_matches` com `is_finished = true` cujos dois times
+apareçam na descrição da aposta.
+
+## Métricas (PostHog)
+
+- `settlement_reminder_sent` — {kind: wc|generic, verdict, betting_market, reminder_number}
+- `settlement_settled_via_bot` — {bet_id, outcome}
+- `settlement_reminders_muted` / `_unmuted` — {via: button|command}
+
+North star do Marco 0: taxa de liquidação ≥ 60% (hoje ~28%). Funil:
+`settlement_reminder_sent` → `settlement_settled_via_bot`.

--- a/WINBACK_BACKFILL_SETUP.md
+++ b/WINBACK_BACKFILL_SETUP.md
@@ -1,0 +1,60 @@
+# Winback — fechar o histórico antigo e avisar quem sumiu (R1)
+
+Fecha em lote as apostas **pendentes antigas** (7 dias a 1 ano) com dado verificável e
+manda **uma única DM** de reconquista: *"atualizamos seu histórico — seu ROI real está pronto"*.
+
+**Não tem cron.** A execução é manual e em 3 passos, com revisão humana entre eles.
+
+## Pré-requisitos
+
+- PR do lembrete de liquidação (#190/#191) **já em produção** — a DM aponta pro rail de
+  botões e o público-alvo volta a receber lembretes normais dali em diante
+- Function `winback-backfill` deployada (CI faz) e migration 079 aplicada (CI faz)
+- Secrets da função (já existem no projeto): `CRON_SECRET`, `OPENAI_API_KEY`,
+  `API_SPORTS_KEY`, `TELEGRAM_BOT_TOKEN`
+
+## Os 3 comandos (rodar em ordem, revisando entre cada um)
+
+```bash
+URL="https://<projeto>.supabase.co/functions/v1/winback-backfill"
+SECRET="<CRON_SECRET do painel>"
+
+# 1) RELATÓRIO — não escreve nada. Salve e revise.
+curl -s -X POST "$URL?mode=report" -H "x-cron-secret: $SECRET" > winback-report.json
+# revisar: totals (liquidaveis/greens/reds/pulados), amostrar "liquidaveis" e
+# conferir a evidência de cada veredito; olhar os skip_reason dos "pulados"
+
+# 2) EXECUTA — liquida as aprovadas, gravando evidência em processed_data.winback
+curl -s -X POST "$URL?mode=execute" -H "x-cron-secret: $SECRET"
+# idempotente: só toca aposta ainda 'pending'; rodar 2x não duplica
+
+# 3) AVISA — 1 DM por usuário afetado com Telegram (idempotente via winback_notifications)
+curl -s -X POST "$URL?mode=notify" -H "x-cron-secret: $SECRET"
+```
+
+## O que o motor fecha (e o que ele se recusa a fechar)
+
+| Fatia | Como decide |
+| --- | --- |
+| NBA singles (props) | GPT-4o estrutura a descrição (apelidos/typos → jogador canônico + stat + linha); código cruza com `nba_mart.ft_game_player_stats` (via RPCs da 079) e compara. |
+| Futebol singles (ML, over/under gols, ambas marcam) | GPT-4o estrutura times+mercado; código busca o jogo histórico na API-Sports (`fixtures?date=` — 1 chamada por DATA, cacheada) e liquida pelo **placar dos 90'**. |
+| Múltiplas, combos, handicap, escanteios, 1º tempo, props de quarto, "fg", push na linha exata, jogador que não jogou (DNP), jogo ambíguo/não achado | **skip** com motivo no relatório — ficam pendentes pro usuário resolver por botão/site. |
+
+Custo: 1 chamada GPT-4o (lote inteiro, centavos) + ~40–80 chamadas API-Sports one-shot.
+
+## Verificação pós-execução
+
+```sql
+-- o que o winback fechou (com evidência)
+select id, bet_description, status, processed_data->'winback'->>'evidence' as evidencia
+from bets where processed_data ? 'winback' order by updated_at desc;
+
+-- quem foi avisado
+select * from winback_notifications order by sent_at desc;
+```
+
+## Métricas (PostHog)
+
+- `winback_backfill_executed` — totais do lote
+- `winback_dm_sent` — por usuário {bets_settled, greens, roi, leftovers}
+- Retorno = usuários com evento no site/bot nos 7 dias após `winback_dm_sent`

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -1,0 +1,15 @@
+# analytics/
+
+Queries SQL versionadas do plano de métricas de retenção (ver `docs/plano-metricas-retencao.md`).
+
+**Banco:** projeto Supabase **"Smart Betting"** (prod, ref `lavclmlvvfzkblrstojd`). Todas são `SELECT` read-only.
+
+Métricas que vivem no banco (não no PostHog) porque dependem de estado limpo da tabela `bets`:
+liquidação, North Star (aposta liquidada/semana), ativação, tamanho da base ativa.
+Comportamento (funis, retenção de telas, views) fica no PostHog via os eventos instrumentados.
+
+| Arquivo | Métrica |
+|---|---|
+| `retencao.sql` | Bloco único com todas as queries, rotuladas por métrica (E1, E2/B1 coorte, viés de sobrevivência, base ativa) |
+
+> ⚠️ `days_to_settle` histórico está contaminado pelo backfill de 31/jan/2026 (`updated_at` reescrito em lote). A janela "≤7d" só é confiável para apostas criadas após essa data. Daqui pra frente o evento `bet_settled` (com `settled_by`) dá a medição limpa no PostHog.

--- a/analytics/retencao.sql
+++ b/analytics/retencao.sql
@@ -1,0 +1,65 @@
+-- Métricas de retenção — Smart Betting (projeto prod "Smart Betting", ref lavclmlvvfzkblrstojd)
+-- Todas read-only. Ver docs/plano-metricas-retencao.md. Colunas validadas contra o schema em 2026-07-08.
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- E2 / B1 — Liquidação POR COORTE DE NOVOS (1ª aposta liquidada em <=7 dias),
+-- por semana de entrada do usuário. NÃO usar taxa agregada (viés de sobrevivência).
+-- ─────────────────────────────────────────────────────────────────────────────
+with primeira_aposta as (
+  select user_id,
+         min(created_at)                                   as entrada,
+         (array_agg(status     order by created_at))[1]    as status_1a,
+         (array_agg(updated_at order by created_at))[1]    as updated_1a,
+         (array_agg(created_at order by created_at))[1]    as created_1a
+  from public.bets
+  group by user_id
+)
+select date_trunc('week', entrada)::date as semana_entrada,
+       count(*)                          as novos,
+       count(*) filter (where status_1a <> 'pending'
+         and updated_1a <= created_1a + interval '7 days') as liquidaram_1a_7d,
+       round(100.0 * count(*) filter (where status_1a <> 'pending'
+         and updated_1a <= created_1a + interval '7 days') / count(*), 1) as pct
+from primeira_aposta
+group by 1 order by 1 desc;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Retrato de viés de sobrevivência — liquidação por intensidade de uso.
+-- Explica por que a taxa agregada engana (poucos power users liquidam ~tudo).
+-- ─────────────────────────────────────────────────────────────────────────────
+with u as (
+  select user_id,
+         count(*)                                   as total,
+         count(*) filter (where status <> 'pending') as settled
+  from public.bets
+  group by user_id
+)
+select case when total >= 50 then 'd) 50+'
+            when total >= 10 then 'c) 10-49'
+            when total >= 2  then 'b) 2-9'
+            else 'a) 1' end            as perfil,
+       count(*)                        as usuarios,
+       sum(total)                      as apostas,
+       round(100.0 * sum(settled) / sum(total), 1) as pct_liquidada
+from u
+group by 1 order by 1;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- E1 — North Star: usuários com >=1 aposta liquidada na semana, por canal.
+-- ─────────────────────────────────────────────────────────────────────────────
+select date_trunc('week', updated_at)::date        as semana,
+       coalesce(channel, '(legado)')               as canal,
+       count(distinct user_id)                     as usuarios_ns
+from public.bets
+where status in ('won', 'lost', 'void', 'half_won', 'half_lost', 'cashout')
+group by 1, 2 order by 1 desc;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Base ativa — o gargalo real. Tamanho e concentração.
+-- ─────────────────────────────────────────────────────────────────────────────
+select count(distinct user_id)                                                            as usuarios_total,
+       count(distinct user_id) filter (where created_at > now() - interval '30 days')     as ativos_30d,
+       count(distinct user_id) filter (where created_at > now() - interval '90 days')     as ativos_90d,
+       count(*)                                                                           as apostas_total,
+       round(count(*)::numeric / nullif(count(distinct user_id), 0), 1)                   as apostas_por_usuario
+from public.bets;

--- a/src/components/bolao/BolaoHandoffCard.tsx
+++ b/src/components/bolao/BolaoHandoffCard.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useRef } from 'react';
+import { usePostHog } from '@posthog/react';
+import { ClipboardList, ArrowRight, Trophy, LineChart } from 'lucide-react';
+
+interface BolaoHandoffCardProps {
+  bolaoId: string;
+  bolaoName: string;
+  /** Posição final do usuário no ranking (null = não pontuou / não está no ranking) */
+  myRank: number | null;
+  totalPlayers: number;
+}
+
+/**
+ * Cartão de encerramento — a "passagem de bastão" do dia da final (H1).
+ * Aparece na aba Ranking APENAS quando a final da Copa está encerrada
+ * (ou com ?handoff na URL, pra preview). O bolão morre por natureza no
+ * dia 19/jul; este cartão é a última conversa com essa audiência:
+ * casual → Betinho, apostador frequente → lista do futebol.
+ *
+ * Rotas de destino: /betinho/bolao (LP variante do bolão, já existe) e
+ * /futebol/comecar (LP de acesso antecipado — entra com o PR #188).
+ */
+export const BolaoHandoffCard: React.FC<BolaoHandoffCardProps> = ({
+  bolaoId,
+  bolaoName,
+  myRank,
+  totalPlayers,
+}) => {
+  const posthog = usePostHog();
+  const viewedRef = useRef(false);
+
+  useEffect(() => {
+    if (viewedRef.current) return;
+    viewedRef.current = true;
+    posthog?.capture('bolao_handoff_view', {
+      bolao_id: bolaoId,
+      rank: myRank,
+      total_players: totalPlayers,
+    });
+  }, [posthog, bolaoId, myRank, totalPlayers]);
+
+  const handleClick = (destination: 'betinho' | 'futebol') => {
+    posthog?.capture('bolao_handoff_click', {
+      bolao_id: bolaoId,
+      destination,
+      rank: myRank,
+    });
+  };
+
+  const isChampion = myRank === 1 && totalPlayers > 1;
+  const headline = isChampion
+    ? `Campeão do ${bolaoName}! 🏆`
+    : myRank != null
+      ? `Você fechou em ${myRank}º de ${totalPlayers}`
+      : 'O bolão chegou ao fim';
+
+  return (
+    <div
+      data-testid="bolao-handoff-card"
+      className="relative overflow-hidden rounded-rebrand-xl bg-forest text-white mb-5"
+    >
+      {/* brilho âmbar no canto — mesmo tratamento do hero das LPs */}
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_85%_10%,rgba(212,160,23,0.20),transparent_55%)] pointer-events-none" />
+      <div className="relative p-5 sm:p-7">
+        <p className="font-mono text-[10px] font-bold uppercase tracking-[0.2em] text-amber mb-2.5 flex items-center gap-1.5">
+          <Trophy className="w-3.5 h-3.5" />
+          Bolão encerrado
+        </p>
+        <h3 className="font-display text-xl sm:text-2xl font-black leading-tight mb-2">
+          {headline}
+        </h3>
+        <p className="text-[13.5px] sm:text-[14px] text-white/75 leading-relaxed mb-5 max-w-xl">
+          A Copa acabou e o bolão termina aqui, valeu demais!
+          Mas se você aposta de verdade, o jogo continua:
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {/* trilho casual → Betinho */}
+          <div className="rounded-rebrand-lg border border-white/15 bg-white/[0.05] p-4 flex flex-col">
+            <p className="font-bold text-[14px] mb-1.5 flex items-center gap-2">
+              <ClipboardList className="w-4 h-4 text-amber shrink-0" />
+              Tá no lucro ou no prejuízo?
+            </p>
+            <p className="text-[12.5px] text-white/70 leading-relaxed mb-3.5 flex-1">
+              A maioria não sabe. Manda o print da aposta no Telegram e o Betinho
+              te responde: lucro, ROI e onde você acerta — sem planilha.
+            </p>
+            <a
+              href="/betinho/bolao"
+              onClick={() => handleClick('betinho')}
+              className="inline-flex items-center justify-center gap-2 h-10 px-4 rounded-rebrand-md bg-amber text-white hover:bg-amber-2 font-bold text-[13px] shadow-md transition-colors"
+            >
+              Conhecer o Betinho — grátis
+              <ArrowRight className="w-4 h-4 shrink-0" />
+            </a>
+          </div>
+          {/* trilho frequente → Futebol */}
+          <div className="rounded-rebrand-lg border border-white/15 bg-white/[0.05] p-4 flex flex-col">
+            <p className="font-bold text-[14px] mb-1.5 flex items-center gap-2">
+              <LineChart className="w-4 h-4 text-amber shrink-0" />
+              Onde vale apostar na próxima rodada?
+            </p>
+            <p className="text-[12.5px] text-white/70 leading-relaxed mb-3.5 flex-1">
+              A análise de futebol te mostra: as principais oportunidades de cada
+              jogo, com os prós e contras de cada aposta — sem achismo.
+            </p>
+            <a
+              href="/futebol/comecar"
+              onClick={() => handleClick('futebol')}
+              className="inline-flex items-center justify-center gap-2 h-10 px-4 rounded-rebrand-md border border-white/30 bg-white/[0.06] text-white hover:bg-white/15 font-bold text-[13px] transition-colors"
+            >
+              Conhecer a análise de futebol
+              <ArrowRight className="w-4 h-4 shrink-0" />
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/bolao/SpecialPredictionsModal.tsx
+++ b/src/components/bolao/SpecialPredictionsModal.tsx
@@ -223,7 +223,7 @@ export const SpecialPredictionsModal: React.FC<SpecialPredictionsModalProps> = (
       if (enabled.finalist !== false) items.push({ label: 'Finalistas (2)', pts: pointsConfig.finalist * 2 });
       if (enabled.semifinalist !== false) items.push({ label: 'Semis (4)', pts: pointsConfig.semifinalist * 4 });
       if (enabled.quarterfinalist !== false) items.push({ label: 'Quartas (8)', pts: pointsConfig.quarterfinalist * 8 });
-      if (enabled.round_of_16 !== false) items.push({ label: 'Oitavas (16)', pts: (pointsConfig.round_of_16 ?? 2) * 16 });
+      if (enabled.round_of_16 !== false) items.push({ label: 'Oitavas (16)', pts: (pointsConfig.round_of_16 ?? 1) * 16 });
       if (enabled.round_of_32 !== false) items.push({ label: '16 avos (32)', pts: (pointsConfig.round_of_32 ?? 1) * 32 });
     }
     const total = items.reduce((acc, i) => acc + i.pts, 0);

--- a/src/components/bolao/SpecialPredictionsSection.tsx
+++ b/src/components/bolao/SpecialPredictionsSection.tsx
@@ -503,7 +503,8 @@ export const SpecialPredictionsSection: React.FC<Props> = ({
   }, [summary]);
 
   // Merge com defaults — bolões criados antes das Oitavas não têm round_of_16 no points.
-  const pts: PointsConfig = { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 2, round_of_32: 1, ...(pointsConfig ?? {}) };
+  // round_of_16: 1 = mesmo fallback do BolaoAdminPanel e do backfill (migration 077).
+  const pts: PointsConfig = { finalist: 10, semifinalist: 5, quarterfinalist: 3, round_of_16: 1, round_of_32: 1, ...(pointsConfig ?? {}) };
   const POINTS_LABEL: Record<SpecialType, string> = {
     finalist: `+${pts.finalist} pts cada`,
     semifinalist: `+${pts.semifinalist} pts cada`,

--- a/src/hooks/use-bolao.ts
+++ b/src/hooks/use-bolao.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { usePostHog } from '@posthog/react';
 import { bolaoService } from '@/services/bolao.service';
 import type { WcMatch } from '@/services/bolao.service';
 
@@ -122,6 +123,7 @@ export function useBolaoPredictions(bolaoId: string | undefined, userId?: string
 
 export function useUpsertPrediction() {
   const queryClient = useQueryClient();
+  const posthog = usePostHog();
 
   return useMutation({
     mutationFn: (params: {
@@ -131,6 +133,7 @@ export function useUpsertPrediction() {
       predicted_away_score: number;
     }) => bolaoService.upsertPrediction(params),
     onSuccess: (_data, variables) => {
+      posthog?.capture('bolao_palpite_saved', { mode: 'single', count: 1, bolao_id: variables.bolao_id });
       queryClient.invalidateQueries({ queryKey: ['bolao-predictions', variables.bolao_id] });
       // user_predictions/pending_predictions na home dependem disso
       queryClient.invalidateQueries({ queryKey: ['user-boloes'] });
@@ -153,6 +156,7 @@ export function useDeletePrediction() {
 
 export function useUpsertPredictionsBatch() {
   const queryClient = useQueryClient();
+  const posthog = usePostHog();
 
   return useMutation({
     mutationFn: (params: {
@@ -160,6 +164,7 @@ export function useUpsertPredictionsBatch() {
       predictions: { match_id: number; predicted_home_score: number; predicted_away_score: number }[];
     }) => bolaoService.upsertPredictionsBatch(params.bolaoId, params.predictions),
     onSuccess: (_data, variables) => {
+      posthog?.capture('bolao_palpite_saved', { mode: 'batch', count: variables.predictions.length, bolao_id: variables.bolaoId });
       queryClient.invalidateQueries({ queryKey: ['bolao-predictions', variables.bolaoId] });
       queryClient.invalidateQueries({ queryKey: ['bolao-ranking', variables.bolaoId] });
       queryClient.invalidateQueries({ queryKey: ['user-boloes'] });

--- a/src/pages/Analise360Detail.tsx
+++ b/src/pages/Analise360Detail.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { usePostHog } from '@posthog/react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
@@ -650,12 +651,18 @@ export default function Analise360Detail() {
   const { triggerPlayerId } = useParams<{ triggerPlayerId: string }>();
   const navigate = useNavigate();
   const isMobile = useIsMobile();
+  const posthog = usePostHog();
   const { data, isLoading, error } = useAnalise360Data();
   const opportunities = data?.opportunities ?? [];
   const playerStarsMap = data?.playerStarsMap ?? new Map<number, number>();
 
   const [selectedStat, setSelectedStat] = useState<string>('all');
   const [hoverBackup, setHoverBackup] = useState<number | null>(null);
+
+  // Analytics: visualização da Análise 360 (Marco 3 — retenção por superfície, N3).
+  useEffect(() => {
+    posthog?.capture('nba_analise360_viewed', { player_id: triggerPlayerId });
+  }, [triggerPlayerId, posthog]);
 
   const triggerIdNum = Number(triggerPlayerId);
   const triggerOpps = useMemo(() => opportunities.filter(o => o.trigger_player_id === triggerIdNum), [opportunities, triggerIdNum]);

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -28,6 +28,7 @@ import {
   computeMatchDeadline,
 } from '@/hooks/use-bolao';
 import { BolaoRankingTable } from '@/components/bolao/BolaoRankingTable';
+import { BolaoHandoffCard } from '@/components/bolao/BolaoHandoffCard';
 import { UserPredictionsModal } from '@/components/bolao/UserPredictionsModal';
 import { BolaoShareButton } from '@/components/bolao/BolaoShareButton';
 import { BolaoAdminPanel } from '@/components/bolao/BolaoAdminPanel';
@@ -230,6 +231,23 @@ const BolaoDetail: React.FC = () => {
   const totalAvailableMatches = useMemo(
     () => matches?.filter(m => !m.is_finished && m.home_team_code !== 'TBD').length ?? 0,
     [matches]
+  );
+
+  // ── Passagem de bastão (H1): cartão de encerramento na aba Ranking ──
+  // Só quando a FINAL está encerrada (o bolão acabou de verdade); ?handoff
+  // na URL força a exibição pra preview/QA sem esperar o dia 19.
+  const finalOver = useMemo(
+    () => (matches ?? []).some(m => m.stage === 'final' && m.is_finished),
+    [matches]
+  );
+  const handoffForced = useMemo(
+    () => new URLSearchParams(window.location.search).has('handoff'),
+    []
+  );
+  const showHandoff = finalOver || handoffForced;
+  const myRankingEntry = useMemo(
+    () => ranking?.find(r => r.user_id === currentUserId) ?? null,
+    [ranking, currentUserId]
   );
 
   const predictionsByMatch = useMemo(
@@ -726,6 +744,14 @@ const BolaoDetail: React.FC = () => {
             {/* Tab: Ranking */}
             {activeTab === 'ranking' && (
               <div role="tabpanel" id="bolao-tab-panel-ranking" aria-labelledby="bolao-tab-ranking">
+                {showHandoff && bolao && (
+                  <BolaoHandoffCard
+                    bolaoId={bolao.id}
+                    bolaoName={bolao.name}
+                    myRank={myRankingEntry?.rank ?? null}
+                    totalPlayers={ranking?.length ?? 0}
+                  />
+                )}
                 {ranking && ranking.length > 1 && (
                   <div className="flex items-center justify-end gap-3 mb-3 flex-wrap text-[12px] text-ink-2">
                     <div className="inline-flex items-center rounded-rebrand-sm border border-line overflow-hidden mr-1" role="group" aria-label="Conteúdo da imagem">

--- a/src/pages/BolaoDetail.tsx
+++ b/src/pages/BolaoDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
+import { usePostHog } from '@posthog/react';
 import { useParams, useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import AnalyticsNav from '@/components/AnalyticsNav';
@@ -94,6 +95,7 @@ const BolaoDetail: React.FC = () => {
     });
   };
   const [activeTab, setActiveTab] = useState<Tab>('ranking');
+  const posthog = usePostHog();
   const [currentUserId, setCurrentUserId] = useState<string | undefined>();
   const [showAdmin, setShowAdmin] = useState(false);
   const [showPremiumWelcome, setShowPremiumWelcome] = useState(false);
@@ -107,6 +109,14 @@ const BolaoDetail: React.FC = () => {
       setCurrentUserId(data.user?.id);
     });
   }, []);
+
+  // Analytics: visualização do ranking do bolão. Marca "usuário ativo no bolão" — base da
+  // coorte de migração para Betinho/Futebol no handoff de 19/jul (métrica E4 do plano).
+  useEffect(() => {
+    if (id && activeTab === 'ranking') {
+      posthog?.capture('bolao_ranking_viewed', { bolao_id: id });
+    }
+  }, [id, activeTab, posthog]);
 
   const [predictionsModalOpen, setPredictionsModalOpen] = useState(false);
   const [specialPredictionsOpen, setSpecialPredictionsOpen] = useState(false);

--- a/src/pages/GameDetail.tsx
+++ b/src/pages/GameDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { usePostHog } from '@posthog/react';
 import { Helmet } from 'react-helmet-async';
 import { Link, Navigate, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
@@ -1048,6 +1049,7 @@ export default function GameDetail() {
   const location = useLocation();
   const { user, isLoading: authLoading } = useAuth();
   const { toast } = useToast();
+  const posthog = usePostHog();
 
   const initCache = gameId ? gameDetailCache.get(gameId) : undefined;
   const [game, setGame] = useState<Game | null>(initCache?.game ?? null);
@@ -1071,6 +1073,11 @@ export default function GameDetail() {
   useEffect(() => {
     if (game) setActiveTab(finished ? 'boxscore' : 'lineups');
   }, [game?.game_id, finished]);
+
+  // Analytics: visualização do detalhe de jogo NBA (Marco 3 — retenção por superfície, N3).
+  useEffect(() => {
+    posthog?.capture('nba_game_viewed', { game_id: gameId });
+  }, [gameId, posthog]);
 
   useEffect(() => {
     if (!authLoading && user && !hasLoaded.current) {

--- a/src/pages/HomeNBA.tsx
+++ b/src/pages/HomeNBA.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { usePostHog } from '@posthog/react';
 import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';
 import { Search, ChevronRight, Star, FileText, LayoutGrid, ArrowRight } from 'lucide-react';
@@ -98,6 +99,7 @@ function SectionHeader({ eyebrow, title, count, actionLabel, onAction, actionHre
 
 export default function HomeNBA() {
   const navigate = useNavigate();
+  const posthog = usePostHog();
   const { data, isLoading } = useHomeNBAData();
   const games = data?.games ?? [];
   const players = data?.players ?? [];
@@ -106,6 +108,11 @@ export default function HomeNBA() {
 
   const [searchTerm, setSearchTerm] = useState('');
   const [injuryModalOpen, setInjuryModalOpen] = useState(false);
+
+  // Analytics: visualização da home NBA. Baseline de offseason; régua pronta para a temporada (Marco 3).
+  useEffect(() => {
+    posthog?.capture('nba_home_viewed');
+  }, [posthog]);
 
   // --- Derived data ---
 

--- a/src/pages/Picks.tsx
+++ b/src/pages/Picks.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { usePostHog } from '@posthog/react';
 import { useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
 import {
@@ -402,6 +403,7 @@ type ViewMode = 'score' | 'trigger';
 
 export default function Picks() {
   const navigate = useNavigate();
+  const posthog = usePostHog();
   const { isPremium } = useSubscription();
 
   const [opportunities, setOpportunities] = useState<DailyOpportunity[]>([]);
@@ -422,6 +424,11 @@ export default function Picks() {
   const FREE_VISIBLE_COUNT = 2;
   const isRowFree = (idx: number) => isPremium || idx < FREE_VISIBLE_COUNT;
   const getBlur = (idx: number) => isRowFree(idx) ? '' : 'blur-sm select-none pointer-events-none';
+
+  // Analytics: visualização da tela de Picks NBA (Marco 3 — retenção por superfície, N3).
+  useEffect(() => {
+    posthog?.capture('nba_picks_viewed');
+  }, [posthog]);
 
   useEffect(() => {
     const load = async () => {

--- a/supabase/functions/go/index.ts
+++ b/supabase/functions/go/index.ts
@@ -1,0 +1,72 @@
+// ============================================================
+// go — redirecionador rastreado das DMs (clique → registro → destino)
+// ============================================================
+// Os links das mensagens do bot passam por aqui: registramos QUEM clicou
+// em QUÊ (notification_clicks) — o que alimenta o funil enviado → clicou
+// e ZERA o contador da regra de reativação (2 envios sem clique = para,
+// do notify-opportunities) — e mandamos a pessoa pro destino num 302.
+//
+// URL: /go?u=<user_id>&d=<dest>&s=<hmac>
+//   dest permitidos: "board" → /futebol · "jogo-<id>" → /futebol/jogo/<id>
+//   s = HMAC-SHA256(CRON_SECRET, "<u>:<d>") — impede forjar clique de outro
+//       usuário. Assinatura inválida → redireciona mesmo assim (usuário
+//       nunca vê erro), só não registra.
+//
+// PÚBLICA (--no-verify-jwt): quem chama é o navegador do usuário.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, CRON_SECRET.
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+
+const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
+const SITE = "https://www.smartbetting.app";
+const CAMPAIGN = "daily_opportunities";
+
+function destUrl(dest: string): string {
+  if (dest === "board") return `${SITE}/futebol?utm_source=telegram&utm_campaign=${CAMPAIGN}`;
+  const jogo = dest.match(/^jogo-(\d+)$/);
+  if (jogo) return `${SITE}/futebol/jogo/${jogo[1]}?utm_source=telegram&utm_campaign=${CAMPAIGN}`;
+  return SITE; // destino desconhecido → home (nunca mostrar erro pro usuário)
+}
+
+async function hmacHex(msg: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw", new TextEncoder().encode(CRON_SECRET), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(msg));
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("").slice(0, 16);
+}
+
+serve(async (req) => {
+  const url = new URL(req.url);
+  const u = url.searchParams.get("u") || "";
+  const d = url.searchParams.get("d") || "";
+  const s = url.searchParams.get("s") || "";
+  const target = destUrl(d);
+
+  // registra o clique só com assinatura válida — mas SEMPRE redireciona
+  try {
+    if (u && d && s && CRON_SECRET && s === (await hmacHex(`${u}:${d}`))) {
+      const supabase = createClient(
+        Deno.env.get("SUPABASE_URL") || "",
+        Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+      );
+      await supabase.from("notification_clicks").insert({ user_id: u, campaign: CAMPAIGN, destination: d });
+      // clique = engajou → zera a régua da reativação
+      await supabase
+        .from("opportunity_dispatch_state")
+        .update({ sends_without_click: 0, last_click_at: new Date().toISOString() })
+        .eq("user_id", u);
+      await trackEvent(
+        "daily_opportunities_click",
+        { destination: d, channel: "telegram" },
+        u, generateTraceId()
+      ).catch(() => {});
+    }
+  } catch (e) {
+    console.error("go tracking error:", (e as Error)?.message); // rastreio nunca bloqueia o redirect
+  }
+
+  return new Response(null, { status: 302, headers: { Location: target } });
+});

--- a/supabase/functions/ingest-fixtures/index.ts
+++ b/supabase/functions/ingest-fixtures/index.ts
@@ -1,0 +1,194 @@
+// ============================================================
+// ingest-fixtures — coletor de placares multi-liga (F1 do parecer Kasuya)
+// ============================================================
+// Dois modos, dois crons (migration 082):
+//
+//   ?mode=calendar (diário 04:00 BRT) — 1 chamada por liga habilitada
+//     (fixtures?league&season): jogos novos, remarcações, TBD→NS. É o que
+//     alimenta o GATE do cron live (sem jogo em janela → live nem roda).
+//
+//   ?mode=live (a cada 2 min, SÓ quando o gate SQL detecta jogo em janela) —
+//     1 chamada fixtures?live={ids das ligas habilitadas} pra TODOS os jogos
+//     rolando + CONFIRMAÇÃO DE ENCERRAMENTO: jogo que estava em janela e
+//     sumiu do live (ou passou de 2H pra fim) é confirmado via
+//     fixtures?ids=a-b-c (lote de até 20) — devolve status terminal (FT/AET/
+//     PEN) e score.fulltime (90', a base de liquidação). Cobre o caso
+//     "último poll pegou o jogo aos 88'" e o AET/PEN de mata-mata.
+//
+// Telemetria (lacuna nº1 do parecer): toda execução grava collector_runs
+// (chamadas feitas, quota restante do header x-ratelimit) e, após 5 falhas
+// consecutivas, manda DM de alerta pro admin (env ADMIN_TELEGRAM_CHAT_ID).
+// "Degradar em silêncio" era o modo de falha — não é mais.
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, API_SPORTS_KEY,
+//                 CRON_SECRET (+ TELEGRAM_BOT_TOKEN e ADMIN_TELEGRAM_CHAT_ID
+//                 opcionais, pro alerta).
+// Runbook: MULTI_LEAGUE_COLLECTOR_SETUP.md
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const API_BASE = "https://v3.football.api-sports.io";
+const API_SPORTS_KEY = Deno.env.get("API_SPORTS_KEY") || "";
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const ADMIN_CHAT_ID = Deno.env.get("ADMIN_TELEGRAM_CHAT_ID") || "";
+
+const TERMINAL = new Set(["FT", "AET", "PEN", "CANC", "ABD", "AWD", "WO"]);
+const ALERT_AFTER_FAILURES = 5;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+// ── API-Football: fetch com captura do header de quota ───────
+let apiCalls = 0;
+let quotaRemaining: number | null = null;
+
+async function api(path: string): Promise<any> {
+  const res = await fetch(`${API_BASE}${path}`, { headers: { "x-apisports-key": API_SPORTS_KEY } });
+  apiCalls++;
+  const q = res.headers.get("x-ratelimit-requests-remaining");
+  if (q != null) quotaRemaining = Number(q);
+  if (!res.ok) throw new Error(`API-Sports ${res.status} em ${path}`);
+  const payload = await res.json();
+  if (payload?.errors && Object.keys(payload.errors).length > 0) {
+    throw new Error(`API-Sports errors em ${path}: ${JSON.stringify(payload.errors).slice(0, 200)}`);
+  }
+  return payload?.response ?? [];
+}
+
+// fixture da API → linha da nossa tabela
+function toRow(fx: any): Record<string, unknown> {
+  const winner = fx?.teams?.home?.winner === true ? "home" : fx?.teams?.away?.winner === true ? "away" : null;
+  return {
+    fixture_id: fx?.fixture?.id,
+    league_id: fx?.league?.id,
+    season: fx?.league?.season,
+    round: fx?.league?.round ?? null,
+    home_team_id: fx?.teams?.home?.id ?? null,
+    home_team: fx?.teams?.home?.name ?? "?",
+    away_team_id: fx?.teams?.away?.id ?? null,
+    away_team: fx?.teams?.away?.name ?? "?",
+    kickoff_utc: fx?.fixture?.date, // ISO com timezone
+    status_short: fx?.fixture?.status?.short ?? null,
+    elapsed: fx?.fixture?.status?.elapsed ?? null,
+    goals_home: fx?.goals?.home ?? null,
+    goals_away: fx?.goals?.away ?? null,
+    halftime_home: fx?.score?.halftime?.home ?? null,
+    halftime_away: fx?.score?.halftime?.away ?? null,
+    fulltime_home: fx?.score?.fulltime?.home ?? null,
+    fulltime_away: fx?.score?.fulltime?.away ?? null,
+    extratime_home: fx?.score?.extratime?.home ?? null,
+    extratime_away: fx?.score?.extratime?.away ?? null,
+    penalty_home: fx?.score?.penalty?.home ?? null,
+    penalty_away: fx?.score?.penalty?.away ?? null,
+    winner,
+  };
+}
+
+async function upsertRows(supabase: any, rows: Record<string, unknown>[]): Promise<void> {
+  if (rows.length === 0) return;
+  const { error } = await supabase.from("fixtures").upsert(rows, { onConflict: "fixture_id" });
+  if (error) throw new Error(`upsert fixtures: ${error.message}`);
+}
+
+// ── alerta de falhas consecutivas (telemetria acionável) ─────
+async function maybeAlertAdmin(supabase: any, mode: string, errMsg: string): Promise<void> {
+  if (!TELEGRAM_BOT_TOKEN || !ADMIN_CHAT_ID) return;
+  const { data } = await supabase
+    .from("collector_runs")
+    .select("ok")
+    .order("ran_at", { ascending: false })
+    .limit(ALERT_AFTER_FAILURES);
+  const runs = data ?? [];
+  if (runs.length < ALERT_AFTER_FAILURES || runs.some((r: any) => r.ok)) return;
+  await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: ADMIN_CHAT_ID,
+      text: `🚨 ingest-fixtures: ${ALERT_AFTER_FAILURES} falhas consecutivas (modo ${mode}).\nÚltimo erro: ${errMsg.slice(0, 300)}\nVer collector_runs.`,
+    }),
+  }).catch(() => {});
+}
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  if (!cronSecret || req.headers.get("x-cron-secret") !== cronSecret) return json({ error: "Unauthorized" }, 401);
+  if (!API_SPORTS_KEY) return json({ error: "API_SPORTS_KEY not set" }, 500);
+
+  const mode = new URL(req.url).searchParams.get("mode") || "live";
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  let liveCount = 0;
+  let confirmed = 0;
+
+  try {
+    const { data: leaguesData, error: lErr } = await supabase
+      .from("leagues_config")
+      .select("league_id, season")
+      .eq("enabled", true);
+    if (lErr) throw lErr;
+    const leagues: Array<{ league_id: number; season: number }> = leaguesData ?? [];
+    if (leagues.length === 0) return json({ ok: true, mode, motivo: "nenhuma liga habilitada" });
+
+    if (mode === "calendar") {
+      // 1 chamada por liga: temporada inteira (upsert idempotente)
+      for (const lg of leagues) {
+        const fixtures = await api(`/fixtures?league=${lg.league_id}&season=${lg.season}`);
+        await upsertRows(supabase, fixtures.map(toRow).filter((r: any) => r.fixture_id));
+      }
+    } else {
+      // ── LIVE ───────────────────────────────────────────────
+      const ids = [...new Set(leagues.map((l) => l.league_id))].join("-");
+      const live = await api(`/fixtures?live=${ids}`);
+      liveCount = live.length;
+      await upsertRows(supabase, live.map(toRow).filter((r: any) => r.fixture_id));
+
+      // CONFIRMAÇÃO: jogos em janela que começaram, não estão terminais no
+      // banco e NÃO apareceram no live → provavelmente acabaram → lote ids
+      const liveIds = new Set(live.map((fx: any) => fx?.fixture?.id));
+      const { data: pendData, error: pErr } = await supabase
+        .from("fixtures")
+        .select("fixture_id, status_short, kickoff_utc, league_id, season")
+        .lte("kickoff_utc", new Date().toISOString())
+        .gte("kickoff_utc", new Date(Date.now() - 6 * 3600_000).toISOString());
+      if (pErr) throw pErr;
+      const enabledKey = new Set(leagues.map((l) => `${l.league_id}:${l.season}`));
+      const toConfirm = (pendData ?? [])
+        .filter((f: any) =>
+          enabledKey.has(`${f.league_id}:${f.season}`) &&
+          !TERMINAL.has(f.status_short ?? "NS") &&
+          !liveIds.has(f.fixture_id)
+        )
+        .map((f: any) => f.fixture_id);
+
+      for (let i = 0; i < toConfirm.length; i += 20) {
+        const batch = toConfirm.slice(i, i + 20);
+        const fixtures = await api(`/fixtures?ids=${batch.join("-")}`);
+        await upsertRows(supabase, fixtures.map(toRow).filter((r: any) => r.fixture_id));
+        confirmed += fixtures.length;
+      }
+    }
+
+    await supabase.from("collector_runs").insert({
+      mode, window_active: mode === "live" ? true : null,
+      live_fixtures: liveCount, api_calls: apiCalls,
+      quota_remaining: quotaRemaining, ok: true,
+    });
+
+    return json({ ok: true, mode, ligas: leagues.length, live: liveCount, confirmados: confirmed, chamadas: apiCalls, quota_restante: quotaRemaining });
+  } catch (e) {
+    const msg = (e as Error)?.message ?? "erro desconhecido";
+    console.error("ingest-fixtures error:", msg);
+    await supabase.from("collector_runs").insert({
+      mode, window_active: null, live_fixtures: liveCount,
+      api_calls: apiCalls, quota_remaining: quotaRemaining, ok: false, error: msg.slice(0, 500),
+    }).then(() => maybeAlertAdmin(supabase, mode, msg)).catch(() => {});
+    return json({ error: msg }, 500);
+  }
+});

--- a/supabase/functions/ingest-fixtures/index.ts
+++ b/supabase/functions/ingest-fixtures/index.ts
@@ -34,7 +34,10 @@ const API_SPORTS_KEY = Deno.env.get("API_SPORTS_KEY") || "";
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
 const ADMIN_CHAT_ID = Deno.env.get("ADMIN_TELEGRAM_CHAT_ID") || "";
 
-const TERMINAL = new Set(["FT", "AET", "PEN", "CANC", "ABD", "AWD", "WO"]);
+// PST (adiado) incluído: o portão do cron já o ignora, e sem ele aqui a
+// confirmação re-consultaria o jogo adiado a cada rodada enquanto outro
+// jogo mantivesse a janela aberta (achado da revisão do PR)
+const TERMINAL = new Set(["FT", "AET", "PEN", "CANC", "ABD", "AWD", "WO", "PST"]);
 const ALERT_AFTER_FAILURES = 5;
 
 function json(body: unknown, status = 200): Response {
@@ -160,11 +163,16 @@ serve(async (req) => {
       if (pErr) throw pErr;
       const enabledKey = new Set(leagues.map((l) => `${l.league_id}:${l.season}`));
       const toConfirm = (pendData ?? [])
-        .filter((f: any) =>
-          enabledKey.has(`${f.league_id}:${f.season}`) &&
-          !TERMINAL.has(f.status_short ?? "NS") &&
-          !liveIds.has(f.fixture_id)
-        )
+        .filter((f: any) => {
+          if (!enabledKey.has(`${f.league_id}:${f.season}`)) return false;
+          if (TERMINAL.has(f.status_short ?? "NS")) return false;
+          if (liveIds.has(f.fixture_id)) return false;
+          // jogo que nunca apareceu no live (NS/TBD): início atrasado é comum —
+          // espera 45min do kickoff antes de gastar chamada conferindo
+          const neverStarted = (f.status_short ?? "NS") === "NS" || f.status_short === "TBD";
+          if (neverStarted && new Date(f.kickoff_utc).getTime() > Date.now() - 45 * 60_000) return false;
+          return true;
+        })
         .map((f: any) => f.fixture_id);
 
       for (let i = 0; i < toConfirm.length; i += 20) {

--- a/supabase/functions/ingest-wc-scores/index.ts
+++ b/supabase/functions/ingest-wc-scores/index.ts
@@ -11,6 +11,8 @@
 //
 // Placar = goals.home/away (AET incluso; pênaltis à parte) → empate nos 120 quando
 // vai pra pênaltis, como manda a FIFA. O vencedor da disputa vai em winner_team_code.
+// Placar dos 90' = score.fulltime → fulltime_home/away. É a base de liquidação de
+// apostas (ML/over-under valem o tempo normal), usada pelo notify-settlement.
 //
 // Proteção: header `x-cron-secret` == env CRON_SECRET.
 // Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, API_SPORTS_KEY, CRON_SECRET.
@@ -65,7 +67,7 @@ serve(async (req) => {
     // 2) Nosso estado: todos os jogos + mapa de times (api_team_id → código)
     const { data: rows, error: selErr } = await supabase
       .from("wc_matches")
-      .select("id, match_number, stage, home_team, away_team, home_team_code, away_team_code, home_score, away_score, is_finished, api_fixture_id, winner_team_code");
+      .select("id, match_number, stage, home_team, away_team, home_team_code, away_team_code, home_score, away_score, fulltime_home, fulltime_away, is_finished, api_fixture_id, winner_team_code");
     if (selErr) throw selErr;
 
     const { data: teamMapRows, error: tmErr } = await supabase
@@ -133,13 +135,19 @@ serve(async (req) => {
       // Alinha o placar ao NOSSO mandante/visitante (a ordem da API pode diferir).
       const goalsHome = fx?.goals?.home ?? null;
       const goalsAway = fx?.goals?.away ?? null;
+      const ftHome = fx?.score?.fulltime?.home ?? null; // 90 minutos (sem prorrogação)
+      const ftAway = fx?.score?.fulltime?.away ?? null;
       let homeScore: number | null, awayScore: number | null;
+      let fulltimeHome: number | null, fulltimeAway: number | null;
       if (apiHome && apiHome === row.home_team_code) {
         homeScore = goalsHome; awayScore = goalsAway;
+        fulltimeHome = ftHome; fulltimeAway = ftAway;
       } else if (apiHome && apiHome === row.away_team_code) {
         homeScore = goalsAway; awayScore = goalsHome; // ordem invertida
+        fulltimeHome = ftAway; fulltimeAway = ftHome;
       } else {
         homeScore = goalsHome; awayScore = goalsAway; // fallback (grupo / linkado na mesma ordem)
+        fulltimeHome = ftHome; fulltimeAway = ftAway;
       }
 
       const status = fx?.fixture?.status?.short ?? "";
@@ -153,6 +161,8 @@ serve(async (req) => {
       if (justLinked) patch.api_fixture_id = fid;
       if (row.home_score !== homeScore) patch.home_score = homeScore;
       if (row.away_score !== awayScore) patch.away_score = awayScore;
+      if (row.fulltime_home !== fulltimeHome) patch.fulltime_home = fulltimeHome;
+      if (row.fulltime_away !== fulltimeAway) patch.fulltime_away = fulltimeAway;
       if (row.is_finished !== isFinished) patch.is_finished = isFinished;
       if (winnerCode && row.winner_team_code !== winnerCode) patch.winner_team_code = winnerCode;
 

--- a/supabase/functions/notify-handoff/index.ts
+++ b/supabase/functions/notify-handoff/index.ts
@@ -1,0 +1,187 @@
+// ============================================================
+// notify-handoff — DM de encerramento do bolão (H1, dia da final)
+// ============================================================
+// One-shot MANUAL (sem cron!). No dia 19/jul, depois da final encerrar,
+// o dev roda 2 vezes:
+//
+//   1. ?mode=report → NÃO envia nada. Lista quem receberia (chat, nome,
+//                     posição em cada bolão). Revisar antes de mandar.
+//   2. ?mode=send   → manda a DM única por usuário (idempotente via
+//                     bolao_handoff_notifications).
+//
+// A DM: posição definitiva no(s) bolão(ões) + as duas portas de
+// continuação — Betinho pro casual, análise de futebol pro frequente.
+// Mesma copy do cartão do ranking (BolaoHandoffCard), formato Telegram.
+//
+// GUARDA: só envia se a FINAL estiver encerrada em wc_matches (o bolão
+// precisa ter acabado de verdade). `&force=true` pula a guarda — só pra
+// ensaio em staging.
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN, CRON_SECRET.
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const BETINHO_URL = "https://www.smartbetting.app/betinho/bolao";
+const FUTEBOL_URL = "https://www.smartbetting.app/futebol/comecar";
+
+function esc(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface TargetRow {
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+  bolao_name: string;
+  user_rank: number;
+  total_players: number;
+}
+
+interface UserTarget {
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+  boloes: Array<{ name: string; rank: number; total: number }>;
+}
+
+// agrupa as linhas (usuário, bolão) → 1 alvo por usuário
+function groupTargets(rows: TargetRow[]): UserTarget[] {
+  const byUser = new Map<string, UserTarget>();
+  for (const r of rows) {
+    let t = byUser.get(r.user_id);
+    if (!t) {
+      t = { user_id: r.user_id, chat_id: r.chat_id, user_name: r.user_name, boloes: [] };
+      byUser.set(r.user_id, t);
+    }
+    t.boloes.push({ name: r.bolao_name, rank: Number(r.user_rank), total: Number(r.total_players) });
+  }
+  return [...byUser.values()];
+}
+
+function buildMessage(t: UserTarget): string {
+  const posicoes = t.boloes.slice(0, 2).map((b) => {
+    const medalha = b.rank === 1 && b.total > 1 ? " 🏆" : b.rank <= 3 && b.total >= 3 ? " 🏅" : "";
+    return `• <b>${esc(b.name)}</b>: ${b.rank}º de ${b.total}${medalha}`;
+  });
+  const extras = t.boloes.length > 2 ? `\n• e mais ${t.boloes.length - 2} ${t.boloes.length - 2 === 1 ? "bolão" : "bolões"}` : "";
+
+  return [
+    `🏆 <b>${esc(t.user_name || "E aí")}, a Copa acabou — e com ela o bolão!</b>`,
+    "",
+    `Seu resultado definitivo:`,
+    posicoes.join("\n") + extras,
+    "",
+    `Valeu demais por jogar com a gente. E se você aposta de verdade, o jogo continua:`,
+    "",
+    `<b>Tá no lucro ou no prejuízo?</b> A maioria não sabe. Manda o print da aposta no Telegram e o Betinho te responde: lucro, ROI e onde você acerta — sem planilha.`,
+    "",
+    `<b>Onde vale apostar na próxima rodada?</b> A análise de futebol te mostra: as principais oportunidades de cada jogo, com os prós e contras de cada aposta — sem achismo.`,
+  ].join("\n");
+}
+
+async function sendHandoffDm(t: UserTarget): Promise<void> {
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: t.chat_id,
+      text: buildMessage(t),
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      reply_markup: {
+        inline_keyboard: [
+          [{ text: "Conhecer o Betinho — grátis", url: BETINHO_URL }],
+          [{ text: "Conhecer a análise de futebol", url: FUTEBOL_URL }],
+        ],
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
+}
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  if (!cronSecret || req.headers.get("x-cron-secret") !== cronSecret) return json({ error: "Unauthorized" }, 401);
+  if (!TELEGRAM_BOT_TOKEN) return json({ error: "TELEGRAM_BOT_TOKEN not set" }, 500);
+
+  const url = new URL(req.url);
+  const mode = url.searchParams.get("mode") || "report";
+  const force = url.searchParams.get("force") === "true";
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+  const traceId = generateTraceId();
+
+  try {
+    // guarda: a final precisa ter acabado (o bolão só morre quando ela morre)
+    const { data: finalMatch, error: fErr } = await supabase
+      .from("wc_matches")
+      .select("id, is_finished")
+      .eq("stage", "final")
+      .maybeSingle();
+    if (fErr) throw fErr;
+    const finalOver = finalMatch?.is_finished === true;
+    if (!finalOver && !force) {
+      return json({ ok: false, error: "A final ainda não encerrou — use &force=true só em ensaio de staging." }, 412);
+    }
+
+    const { data: rows, error } = await supabase.rpc("get_handoff_targets");
+    if (error) throw error;
+    const targets = groupTargets((rows ?? []) as TargetRow[]);
+
+    if (mode === "report") {
+      return json({
+        ok: true, mode, final_encerrada: finalOver, alvos: targets.length,
+        preview: targets.map((t) => ({
+          user_name: t.user_name,
+          boloes: t.boloes.map((b) => `${b.name}: ${b.rank}º/${b.total}`),
+        })),
+      });
+    }
+
+    if (mode === "send") {
+      let sent = 0;
+      const errors: string[] = [];
+      for (const t of targets) {
+        try {
+          await sendHandoffDm(t);
+          const { error: insErr } = await supabase
+            .from("bolao_handoff_notifications")
+            .insert({ user_id: t.user_id, boloes_count: t.boloes.length });
+          if (insErr) throw insErr;
+          sent++;
+          await trackEvent(
+            "bolao_handoff_dm_sent",
+            {
+              boloes_count: t.boloes.length,
+              best_rank: Math.min(...t.boloes.map((b) => b.rank)),
+              channel: "telegram",
+            },
+            t.user_id, traceId
+          ).catch(() => {});
+        } catch (e) {
+          errors.push(`${t.user_id}: ${(e as Error)?.message}`);
+        }
+      }
+      return json({ ok: true, mode, alvos: targets.length, sent, errors });
+    }
+
+    return json({ error: `mode inválido: ${mode} (use report|send)` }, 400);
+  } catch (e) {
+    console.error("notify-handoff error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -1,0 +1,242 @@
+// ============================================================
+// notify-opportunities — as oportunidades do dia no Telegram (08′)
+// ============================================================
+// Cron diário (10h BRT, logo após a carga do dbt). O motor de valor já
+// existe (dbt → fact_value_opportunities → get_futebol_value_board); esta
+// função é SÓ o formato de entrega:
+//
+//   1. Lê o board (mesma fonte do site — zero lógica duplicada)
+//   2. Jogos de HOJE ainda não iniciados → melhor pick por jogo → top 3
+//      por Score, com corte mínimo (>= 40 / faixa Média)
+//   3. SEM oportunidade boa → NÃO manda nada (o silêncio no dia fraco é o
+//      que torna a mensagem crível no dia forte)
+//   4. Envia pros dois segmentos (RPC get_opportunity_recipients):
+//        A · futebol ativo (trial/assinante) — recebe sempre
+//        B · reativação — até 2 envios sem clique, depois para
+//   5. Links passam pelo redirecionador `go` (clique rastreado → zera o
+//      contador do B e alimenta o funil enviado → clicou → registrou)
+//
+// A DM fala a língua do site: pickLabel/Score/faixa/evidências portados de
+// src/utils/futebol-score.ts. Sem nome de casa de aposta (decisão 08/07).
+//
+// ?mode=report → não envia; devolve picks do dia + destinatários (ensaio).
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN, CRON_SECRET.
+// Runbook: NOTIFY_OPPORTUNITIES_SETUP.md
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
+const SITE = "https://www.smartbetting.app";
+
+const MIN_SCORE = 40;   // corte: faixa Média pra cima
+const MAX_PICKS = 3;    // top N do dia
+const CAMPAIGN = "daily_opportunities";
+
+// ── rótulos (portados de src/utils/futebol-score.ts — mesma língua do site) ──
+function fmtHandicapLine(line: number): string {
+  const sign = line > 0 ? "+" : line < 0 ? "−" : "";
+  return `${sign}${String(Math.abs(line)).replace(".", ",")}`;
+}
+function outcomePt(outcome: string, homeName: string, awayName: string): string {
+  switch (outcome) {
+    case "Home": return homeName;
+    case "Away": return awayName;
+    case "Draw": return "Empate";
+    default: return outcome;
+  }
+}
+function pickLabel(market: string, outcome: string, line: number | null, homeName: string, awayName: string): string {
+  if (market === "goals_over_under") {
+    const n = line != null ? String(line).replace(".", ",") : "";
+    return outcome === "Over" ? `Mais de ${n} gols` : `Menos de ${n} gols`;
+  }
+  if (market === "asian_handicap") {
+    const team = outcome === "Home" ? homeName : awayName;
+    const sideLine = line != null ? (outcome === "Away" ? -line : line) : null;
+    return sideLine != null ? `${team} ${fmtHandicapLine(sideLine)}` : team;
+  }
+  if (market === "btts") return outcome === "Yes" ? "Ambos marcam: Sim" : "Ambos marcam: Não";
+  if (market === "double_chance") return outcome === "1X" ? `${homeName} ou empate` : `Empate ou ${awayName}`;
+  if (market === "match_winner") return `Vitória: ${outcomePt(outcome, homeName, awayName)}`;
+  return outcomePt(outcome, homeName, awayName);
+}
+
+// ── util ─────────────────────────────────────────────────────
+function esc(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+// kickoff_utc vem "YYYY-MM-DD HH:MM:SS" (UTC, sem timezone)
+const kickoffDate = (s: string) => new Date(s.replace(" ", "T") + "Z");
+
+function brtDay(d: Date): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "America/Sao_Paulo" }).format(d); // YYYY-MM-DD
+}
+function brtHourMin(d: Date): string {
+  return new Intl.DateTimeFormat("pt-BR", { timeZone: "America/Sao_Paulo", hour: "2-digit", minute: "2-digit" }).format(d);
+}
+
+// link rastreado: /functions/v1/go?u=<user>&d=<dest>&s=<hmac>
+async function hmacHex(msg: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw", new TextEncoder().encode(CRON_SECRET), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(msg));
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("").slice(0, 16);
+}
+async function trackedUrl(userId: string, dest: string): Promise<string> {
+  const s = await hmacHex(`${userId}:${dest}`);
+  return `${SUPABASE_URL}/functions/v1/go?u=${userId}&d=${encodeURIComponent(dest)}&s=${s}`;
+}
+
+interface BoardRow {
+  fixture_id: number;
+  home_team_name: string;
+  away_team_name: string;
+  competition: string;
+  kickoff_utc: string;
+  status_short: string;
+  market: string;
+  outcome: string;
+  line_value: number | null;
+  best_odd: number;
+  score: number;
+  faixa: string;
+  evidencias: string[] | null;
+}
+
+interface Recipient {
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+  segment: "A" | "B";
+  sends_without_click: number;
+}
+
+async function buildMessage(picks: BoardRow[], userId: string): Promise<string> {
+  const lines: string[] = [
+    `⚽ <b>As oportunidades de hoje</b> · ${picks.length} ${picks.length === 1 ? "jogo" : "jogos"} com valor`,
+    "",
+  ];
+  for (const p of picks) {
+    const jogoUrl = await trackedUrl(userId, `jogo-${p.fixture_id}`);
+    const hora = brtHourMin(kickoffDate(p.kickoff_utc));
+    const pick = pickLabel(p.market, p.outcome, p.line_value, p.home_team_name, p.away_team_name);
+    const evidencia = p.evidencias?.length ? `\n✓ ${esc(p.evidencias[0])}` : "";
+    lines.push(
+      `<a href="${jogoUrl}"><b>${esc(p.home_team_name)} × ${esc(p.away_team_name)}</b></a> · ${hora}`,
+      `${esc(pick)} · odd ${p.best_odd} · Score <b>${p.score} · ${esc(p.faixa)}</b>${evidencia}`,
+      ""
+    );
+  }
+  lines.push(`<i>Score = confiabilidade da oportunidade (0–100), calculado contra a linha sharp do mercado.</i>`);
+  return lines.join("\n");
+}
+
+async function sendDaily(chatId: string, text: string, boardUrl: string): Promise<void> {
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text,
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      reply_markup: { inline_keyboard: [[{ text: "Ver a análise completa", url: boardUrl }]] },
+    }),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
+}
+
+serve(async (req) => {
+  if (!CRON_SECRET || req.headers.get("x-cron-secret") !== CRON_SECRET) return json({ error: "Unauthorized" }, 401);
+  if (!TELEGRAM_BOT_TOKEN) return json({ error: "TELEGRAM_BOT_TOKEN not set" }, 500);
+
+  const mode = new URL(req.url).searchParams.get("mode") || "send";
+  const supabase = createClient(SUPABASE_URL, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "");
+  const traceId = generateTraceId();
+
+  try {
+    // 1) board do dia — mesma fonte do site
+    const { data: board, error: bErr } = await supabase.rpc("get_futebol_value_board");
+    if (bErr) throw bErr;
+
+    const now = new Date();
+    const today = brtDay(now);
+    const todayRows = ((board ?? []) as BoardRow[]).filter((r) => {
+      const k = kickoffDate(r.kickoff_utc);
+      return k.getTime() > now.getTime() && brtDay(k) === today && r.score >= MIN_SCORE;
+    });
+
+    // melhor pick por jogo → top N por Score
+    const bestByFixture = new Map<number, BoardRow>();
+    for (const r of todayRows) {
+      const cur = bestByFixture.get(r.fixture_id);
+      if (!cur || r.score > cur.score) bestByFixture.set(r.fixture_id, r);
+    }
+    const picks = [...bestByFixture.values()].sort((a, b) => b.score - a.score).slice(0, MAX_PICKS);
+
+    // 3) dia fraco → silêncio (nada de mensagem "hoje não tem nada")
+    if (picks.length === 0) {
+      return json({ ok: true, mode, picks: 0, sent: 0, motivo: "sem oportunidade acima do corte hoje" });
+    }
+
+    // 4) destinatários
+    const { data: recData, error: rErr } = await supabase.rpc("get_opportunity_recipients");
+    if (rErr) throw rErr;
+    const recipients = (recData ?? []) as Recipient[];
+
+    if (mode === "report") {
+      return json({
+        ok: true, mode,
+        picks: picks.map((p) => ({
+          jogo: `${p.home_team_name} × ${p.away_team_name}`,
+          pick: pickLabel(p.market, p.outcome, p.line_value, p.home_team_name, p.away_team_name),
+          odd: p.best_odd, score: p.score, faixa: p.faixa,
+        })),
+        destinatarios: recipients.map((r) => ({ segment: r.segment, user_name: r.user_name, sends_without_click: r.sends_without_click })),
+      });
+    }
+
+    // 5) envio + estado de cadência
+    let sent = 0;
+    const errors: string[] = [];
+    for (const r of recipients) {
+      try {
+        const text = await buildMessage(picks, r.user_id);
+        const boardUrl = await trackedUrl(r.user_id, "board");
+        await sendDaily(r.chat_id, text, boardUrl);
+
+        const { error: upErr } = await supabase.from("opportunity_dispatch_state").upsert({
+          user_id: r.user_id,
+          segment: r.segment,
+          sends_without_click: r.sends_without_click + 1, // clique zera via `go`
+          last_sent_at: new Date().toISOString(),
+        });
+        if (upErr) throw upErr;
+
+        sent++;
+        await trackEvent(
+          "daily_opportunities_sent",
+          { segment: r.segment, picks_count: picks.length, top_score: picks[0].score, channel: "telegram" },
+          r.user_id, traceId
+        ).catch(() => {});
+      } catch (e) {
+        errors.push(`${r.user_id}: ${(e as Error)?.message}`);
+      }
+    }
+
+    return json({ ok: true, mode, picks: picks.length, destinatarios: recipients.length, sent, errors });
+  } catch (e) {
+    console.error("notify-opportunities error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});

--- a/supabase/functions/notify-settlement/index.ts
+++ b/supabase/functions/notify-settlement/index.ts
@@ -192,7 +192,30 @@ interface Candidate {
 
 // ── Veredito pelo placar dos 90' ─────────────────────────────
 // Só para mercados diretos; qualquer ambiguidade → null (pergunta sem afirmar).
-type Verdict = "won" | "lost" | null;
+// Handicap asiático (quick win do parecer do coletor) pode devolver void
+// (push em linha inteira) e meio-resultados (linha quarter ±0.25/±0.75) —
+// os status half_won/half_lost/void já existem no banco e no dashboard.
+type Verdict = "won" | "lost" | "void" | "half_won" | "half_lost" | null;
+
+// meia-aposta do handicap: ajustado >0 ganha, <0 perde, =0 devolve (push)
+function settleAhHalf(adjusted: number): "won" | "lost" | "void" {
+  if (adjusted > 0.001) return "won";
+  if (adjusted < -0.001) return "lost";
+  return "void";
+}
+
+// Handicap asiático pelos 90': margin = gols do time apostado − adversário;
+// line = handicap NA ÓTICA do time apostado (como escrito na aposta).
+// Linha quarter (x.25/x.75) decompõe em duas metades — padrão do mercado.
+function settleAsianHandicap(margin: number, line: number): Verdict {
+  const isQuarter = Math.abs((line * 4) % 2) === 1;
+  if (!isQuarter) return settleAhHalf(margin + line);
+  const a = settleAhHalf(margin + (line - 0.25));
+  const b = settleAhHalf(margin + (line + 0.25));
+  if (a === b) return a;                              // won+won / lost+lost
+  if (a === "won" || b === "won") return "half_won";  // won + push
+  return "half_lost";                                 // push + lost
+}
 
 function computeVerdict(bet: Candidate, wc: WcMatch): Verdict {
   // múltipla/sistema: pernas em jogos diversos, nunca decidível por 1 placar
@@ -239,8 +262,12 @@ function computeVerdict(bet: Candidate, wc: WcMatch): Verdict {
     return (betNo ? !both : both) ? "won" : "lost";
   }
 
+  // linha com sinal ("−1,5", "-0.5", "+0,25") — presença dela indica handicap;
+  // também desarma o ML (um "Vencedor: Belgium -1.5" não é money line puro)
+  const lineMatch = desc.replace(/−/g, "-").match(/([+-])\s*(\d+(?:[.,]\d+)?)/);
+
   // Money Line / 1x2 — em qual time a aposta foi?
-  if (market === "money line" || /\bml\b|money\s?line|vencedor|para vencer|vence\b|1x2/.test(desc)) {
+  if (!lineMatch && (market === "money line" || /\bml\b|money\s?line|vencedor|para vencer|vence\b|1x2/.test(desc))) {
     const homeNames = teamNames(wc.home_team, wc.home_team_code);
     const awayNames = teamNames(wc.away_team, wc.away_team_code);
     const isDraw = /empate/.test(desc);
@@ -251,6 +278,24 @@ function computeVerdict(bet: Candidate, wc: WcMatch): Verdict {
     if (pickedHome && !pickedAway) return ftH > ftA ? "won" : "lost";
     if (pickedAway && !pickedHome) return ftA > ftH ? "won" : "lost";
     return null; // ambíguo (dois times citados / nenhum) → não afirmar
+  }
+
+  // Handicap asiático — "Belgium −1,5", "Handicap -0.5 Atletico" (aritmética
+  // dos 90' como os demais). Europeu ("empate (-1)") fica fora: regra diverge.
+  if (lineMatch && !/empate/.test(desc)) {
+    const raw = parseFloat(lineMatch[2].replace(",", "."));
+    const line = (lineMatch[1] === "-" ? -1 : 1) * raw;
+    // sanidade: linha múltipla de 0.25 e dentro do plausível
+    if (!Number.isInteger(line * 4) || Math.abs(line) > 6) return null;
+
+    const homeNames = teamNames(wc.home_team, wc.home_team_code);
+    const awayNames = teamNames(wc.away_team, wc.away_team_code);
+    const pickedHome = hasTeam(desc, homeNames);
+    const pickedAway = hasTeam(desc, awayNames);
+    if (pickedHome === pickedAway) return null; // nenhum ou os dois → ambíguo
+
+    const margin = pickedHome ? ftH - ftA : ftA - ftH;
+    return settleAsianHandicap(margin, line);
   }
 
   return null;
@@ -298,12 +343,34 @@ function placarLine(wc: WcMatch): string {
   return `🏁 ${esc(wc.home_team)} <b>${wc.home_score ?? "?"}×${wc.away_score ?? "?"}</b> ${esc(wc.away_team)} — encerrado${extra}`;
 }
 
-async function sendAutoSettleDm(bet: Candidate, wc: WcMatch, verdict: "won" | "lost"): Promise<void> {
+type SettleStatus = Exclude<Verdict, null>;
+
+async function sendAutoSettleDm(bet: Candidate, wc: WcMatch, verdict: SettleStatus): Promise<void> {
   const profit = bet.potential_return - bet.stake_amount;
-  const header = verdict === "won" ? "✅ <b>Fechei sua aposta: green!</b>" : "❌ <b>Fechei sua aposta: red.</b>";
-  const resultado = verdict === "won"
-    ? `Lucro: <b>+${money(profit)}</b> · banca atualizada 📊`
-    : `Prejuízo: <b>−${money(bet.stake_amount)}</b> · faz parte. Banca atualizada 📊`;
+  const COPY: Record<SettleStatus, { header: string; resultado: string }> = {
+    won: {
+      header: "✅ <b>Fechei sua aposta: green!</b>",
+      resultado: `Lucro: <b>+${money(profit)}</b> · banca atualizada 📊`,
+    },
+    lost: {
+      header: "❌ <b>Fechei sua aposta: red.</b>",
+      resultado: `Prejuízo: <b>−${money(bet.stake_amount)}</b> · faz parte. Banca atualizada 📊`,
+    },
+    void: {
+      header: "↔️ <b>Fechei sua aposta: anulada (push).</b>",
+      resultado: `A linha bateu em cheio — valor devolvido: <b>${money(bet.stake_amount)}</b>`,
+    },
+    half_won: {
+      header: "✅ <b>Fechei sua aposta: meio green!</b>",
+      resultado: `Metade ganhou, metade voltou. Lucro: <b>+${money(profit / 2)}</b> · banca atualizada 📊`,
+    },
+    half_lost: {
+      header: "❌ <b>Fechei sua aposta: meio red.</b>",
+      resultado: `Metade voltou, metade perdeu. Prejuízo: <b>−${money(bet.stake_amount / 2)}</b> · banca atualizada 📊`,
+    },
+  };
+  const header = COPY[verdict].header;
+  const resultado = COPY[verdict].resultado;
   const text = [
     header,
     placarLine(wc),
@@ -336,7 +403,7 @@ async function sendAutoSettleDm(bet: Candidate, wc: WcMatch, verdict: "won" | "l
 // Liquida com guarda otimista (status='pending'); false = não liquidou (cai no
 // fluxo de pergunta). Ordem deliberada: grava ANTES de avisar — o valor está
 // na banca certa; a DM falhar não desfaz a liquidação.
-async function autoSettle(supabase: any, bet: Candidate, wc: WcMatch, verdict: "won" | "lost"): Promise<boolean> {
+async function autoSettle(supabase: any, bet: Candidate, wc: WcMatch, verdict: SettleStatus): Promise<boolean> {
   const evidence = `${wc.home_team} ${wc.fulltime_home}×${wc.fulltime_away} ${wc.away_team} (90') · wc_matches ${wc.id}`;
   const { data: cur } = await supabase.from("bets").select("processed_data").eq("id", bet.bet_id).maybeSingle();
   const pd = cur?.processed_data && typeof cur.processed_data === "object" && !Array.isArray(cur.processed_data)

--- a/supabase/functions/notify-settlement/index.ts
+++ b/supabase/functions/notify-settlement/index.ts
@@ -8,10 +8,12 @@
 //
 // Duas classes de lembrete:
 //   • COPA — aposta casada com um wc_matches encerrado (por nome dos dois times
-//     na descrição): a mensagem chega COM o placar e, quando o mercado é
-//     computável (ML/1x2, over-under de gols, ambas marcam), com o veredito
-//     sugerido: "pelo placar, essa bateu ✅". Liquidação usa o placar dos 90'
-//     (fulltime_*); o placar final (com prorrogação) aparece só como contexto.
+//     na descrição). Quando o mercado é computável (ML/1x2, over-under de gols,
+//     ambas marcam), o veredito sai pelo placar dos 90' (fulltime_*) e a aposta
+//     é AUTO-LIQUIDADA (decisão de produto 09/07): grava won/lost + evidência
+//     em processed_data.auto_settle e avisa com botão [↩️ Corrigir] (handler
+//     fix:<bet_id> no telegram-webhook, que desfaz pra pendente). Sem veredito
+//     computável, a mensagem chega com o placar e PERGUNTA com os botões.
 //   • GENÉRICA — sem placar no banco: jogo já deve ter acabado (match_date
 //     passou, ou aposta com 24h+), pergunta com os mesmos botões, sem veredito.
 //     Respeita janela de silêncio (09h–23h BRT); a da Copa sai na hora do apito
@@ -287,6 +289,73 @@ function buildGenericMessage(bet: Candidate): string {
   return `⏱️ Seu jogo já deve ter terminado:\n\n${jogo}${betLine(bet)}\n\nComo foi?`;
 }
 
+// ── Auto-liquidação (match perfeito → fecha sozinho + Corrigir) ──
+function placarLine(wc: WcMatch): string {
+  const wentExtra =
+    wc.fulltime_home != null &&
+    (wc.home_score !== wc.fulltime_home || wc.away_score !== wc.fulltime_away);
+  const extra = wentExtra ? ` <i>(${wc.fulltime_home}×${wc.fulltime_away} no tempo normal)</i>` : "";
+  return `🏁 ${esc(wc.home_team)} <b>${wc.home_score ?? "?"}×${wc.away_score ?? "?"}</b> ${esc(wc.away_team)} — encerrado${extra}`;
+}
+
+async function sendAutoSettleDm(bet: Candidate, wc: WcMatch, verdict: "won" | "lost"): Promise<void> {
+  const profit = bet.potential_return - bet.stake_amount;
+  const header = verdict === "won" ? "✅ <b>Fechei sua aposta: green!</b>" : "❌ <b>Fechei sua aposta: red.</b>";
+  const resultado = verdict === "won"
+    ? `Lucro: <b>+${money(profit)}</b> · banca atualizada 📊`
+    : `Prejuízo: <b>−${money(bet.stake_amount)}</b> · faz parte. Banca atualizada 📊`;
+  const text = [
+    header,
+    placarLine(wc),
+    "",
+    `<b>${esc(bet.bet_description)}</b> · ${money(bet.stake_amount)} · odd ${bet.odds}`,
+    resultado,
+    "",
+    `<i>Liquidei pelo placar dos 90 minutos. Errei? Toca em Corrigir.</i>`,
+  ].join("\n");
+
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: bet.chat_id,
+      text,
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      reply_markup: {
+        inline_keyboard: [[
+          { text: "↩️ Corrigir", callback_data: `fix:${bet.bet_id}` },
+          { text: "Ver minha banca", url: BETS_URL },
+        ]],
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
+}
+
+// Liquida com guarda otimista (status='pending'); false = não liquidou (cai no
+// fluxo de pergunta). Ordem deliberada: grava ANTES de avisar — o valor está
+// na banca certa; a DM falhar não desfaz a liquidação.
+async function autoSettle(supabase: any, bet: Candidate, wc: WcMatch, verdict: "won" | "lost"): Promise<boolean> {
+  const evidence = `${wc.home_team} ${wc.fulltime_home}×${wc.fulltime_away} ${wc.away_team} (90') · wc_matches ${wc.id}`;
+  const { data: cur } = await supabase.from("bets").select("processed_data").eq("id", bet.bet_id).maybeSingle();
+  const pd = cur?.processed_data && typeof cur.processed_data === "object" && !Array.isArray(cur.processed_data)
+    ? cur.processed_data : {};
+  const { data: upd, error } = await supabase
+    .from("bets")
+    .update({
+      status: verdict,
+      processed_data: { ...pd, auto_settle: { evidence, settled_at: new Date().toISOString(), source: "auto_settlement_v1" } },
+    })
+    .eq("id", bet.bet_id)
+    .eq("status", "pending")
+    .select("id")
+    .maybeSingle();
+  if (error || !upd) return false;
+  await sendAutoSettleDm(bet, wc, verdict);
+  return true;
+}
+
 // ── Utilidades de tempo ──────────────────────────────────────
 // BRT é UTC-3 fixo (sem horário de verão desde 2019)
 const kickoffUtc = (wc: WcMatch) => new Date(`${wc.match_date}T${wc.match_time_brasilia}-03:00`);
@@ -386,6 +455,31 @@ serve(async (req) => {
       list.sort((a, b) => (a.kind === b.kind ? 0 : a.kind === "wc" ? -1 : 1));
       for (const d of list.slice(0, MAX_PER_USER_PER_RUN)) {
         try {
+          // Match perfeito (jogo casado + mercado direto) → liquida sozinho e
+          // avisa com [↩️ Corrigir]. Qualquer outra situação → pergunta.
+          if (d.kind === "wc" && d.verdict) {
+            const settled = await autoSettle(supabase, d.bet, d.wc!, d.verdict);
+            if (settled) {
+              sent++;
+              await trackEvent(
+                "bet_auto_settled",
+                {
+                  bet_id: d.bet.bet_id,
+                  verdict: d.verdict,
+                  betting_market: d.bet.betting_market,
+                  sport: d.bet.sport,
+                  league: d.bet.league,
+                  wc_match_id: d.wc?.id ?? null,
+                  channel: "telegram",
+                },
+                d.bet.user_id,
+                traceId
+              ).catch(() => {});
+              continue;
+            }
+            // não liquidou (estado mudou no meio) → segue pro fluxo de pergunta
+          }
+
           const text = d.kind === "wc" ? buildWcMessage(d.bet, d.wc!, d.verdict) : buildGenericMessage(d.bet);
           await sendReminder(d.bet.chat_id, text, d.bet.bet_id);
 

--- a/supabase/functions/notify-settlement/index.ts
+++ b/supabase/functions/notify-settlement/index.ts
@@ -1,0 +1,446 @@
+// ============================================================
+// notify-settlement — lembrete de liquidação com resultado preenchido
+// ============================================================
+// Job de cron (roda a cada 15 min; migration 078). Ataca o buraco da retenção:
+// a maioria das apostas morre em 'pending' porque liquidar exige entrar no site.
+// Aqui o Betinho manda DM no Telegram quando o jogo termina, com botões inline
+// [✅ Green] [❌ Red] — 1 toque e a banca atualiza (handler no telegram-webhook).
+//
+// Duas classes de lembrete:
+//   • COPA — aposta casada com um wc_matches encerrado (por nome dos dois times
+//     na descrição): a mensagem chega COM o placar e, quando o mercado é
+//     computável (ML/1x2, over-under de gols, ambas marcam), com o veredito
+//     sugerido: "pelo placar, essa bateu ✅". Liquidação usa o placar dos 90'
+//     (fulltime_*); o placar final (com prorrogação) aparece só como contexto.
+//   • GENÉRICA — sem placar no banco: jogo já deve ter acabado (match_date
+//     passou, ou aposta com 24h+), pergunta com os mesmos botões, sem veredito.
+//     Respeita janela de silêncio (09h–23h BRT); a da Copa sai na hora do apito
+//     (quem apostou no jogo está acordado assistindo).
+//
+// Cadência: teto de 2 lembretes por aposta com gap de 20h (RPC), máx. 3
+// mensagens por usuário por run. Veredito NUNCA é dado em múltiplas/sistema,
+// nem em mercados de classificação/prorrogação (regras de casa divergem).
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN,
+//                 CRON_SECRET (+ POSTHOG_API_KEY opcional, via shared/posthog).
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const BETS_URL = "https://www.smartbetting.app/bets";
+const MAX_PER_USER_PER_RUN = 3;
+const QUIET_START = 9; // genéricas só entre 09:00–22:59 BRT
+const QUIET_END = 23;
+
+// ── Telegram ─────────────────────────────────────────────────
+function esc(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+async function sendReminder(chatId: string, text: string, betId: string): Promise<void> {
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text,
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      reply_markup: {
+        inline_keyboard: [
+          [
+            { text: "✅ Green", callback_data: `settle:${betId}:won` },
+            { text: "❌ Red", callback_data: `settle:${betId}:lost` },
+          ],
+          [
+            { text: "Outras opções ↗", url: BETS_URL },
+            { text: "🔕 Parar lembretes", callback_data: `mute:${betId}` },
+          ],
+        ],
+      },
+    }),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
+}
+
+// ── Normalização e casamento de times ────────────────────────
+function norm(s: unknown): string {
+  return String(s ?? "")
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "") // remove acentos (marcas combinantes)
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Nome em inglês (print de casa gringa) → nome PT usado em wc_matches.
+// Chaves e valores já normalizados (sem acento, minúsculas).
+const EN_ALIASES: Record<string, string> = {
+  "brazil": "brasil",
+  "france": "franca",
+  "germany": "alemanha",
+  "spain": "espanha",
+  "netherlands": "holanda",
+  "england": "inglaterra",
+  "portugal": "portugal",
+  "argentina": "argentina",
+  "uruguay": "uruguai",
+  "colombia": "colombia",
+  "ecuador": "equador",
+  "paraguay": "paraguai",
+  "mexico": "mexico",
+  "united states": "estados unidos",
+  "usa": "estados unidos",
+  "canada": "canada",
+  "belgium": "belgica",
+  "croatia": "croacia",
+  "switzerland": "suica",
+  "italy": "italia",
+  "poland": "polonia",
+  "austria": "austria",
+  "denmark": "dinamarca",
+  "norway": "noruega",
+  "sweden": "suecia",
+  "scotland": "escocia",
+  "turkey": "turquia",
+  "turkiye": "turquia",
+  "morocco": "marrocos",
+  "senegal": "senegal",
+  "ghana": "gana",
+  "egypt": "egito",
+  "algeria": "argelia",
+  "tunisia": "tunisia",
+  "nigeria": "nigeria",
+  "cameroon": "camaroes",
+  "ivory coast": "costa do marfim",
+  "cote d'ivoire": "costa do marfim",
+  "south africa": "africa do sul",
+  "japan": "japao",
+  "south korea": "coreia do sul",
+  "korea republic": "coreia do sul",
+  "saudi arabia": "arabia saudita",
+  "iran": "ira",
+  "qatar": "catar",
+  "jordan": "jordania",
+  "uzbekistan": "uzbequistao",
+  "australia": "australia",
+  "new zealand": "nova zelandia",
+  "panama": "panama",
+  "costa rica": "costa rica",
+  "haiti": "haiti",
+  "curacao": "curacao",
+  "cape verde": "cabo verde",
+};
+
+// true se ALGUM dos nomes aparece como palavra inteira no texto normalizado
+function hasTeam(textNorm: string, names: string[]): boolean {
+  return names.some((n) => {
+    if (!n || n.length < 3) return false;
+    return new RegExp(`(^|[^a-z])${escapeRegex(n)}([^a-z]|$)`).test(textNorm);
+  });
+}
+
+// Variações reconhecíveis de um time de wc_matches (nome PT + aliases EN + código)
+function teamNames(namePt: string, code: string): string[] {
+  const base = norm(namePt);
+  const names = [base, norm(code)];
+  for (const [en, pt] of Object.entries(EN_ALIASES)) if (pt === base) names.push(en);
+  return names;
+}
+
+interface WcMatch {
+  id: number;
+  stage: string;
+  home_team: string;
+  away_team: string;
+  home_team_code: string;
+  away_team_code: string;
+  match_date: string; // date
+  match_time_brasilia: string; // time
+  home_score: number | null;
+  away_score: number | null;
+  fulltime_home: number | null;
+  fulltime_away: number | null;
+  is_finished: boolean;
+}
+
+interface Candidate {
+  bet_id: string;
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+  bet_type: string | null;
+  sport: string | null;
+  league: string | null;
+  betting_market: string | null;
+  match_description: string | null;
+  bet_description: string | null;
+  odds: number;
+  stake_amount: number;
+  potential_return: number;
+  bet_date: string;
+  match_date: string | null;
+  reminder_count: number;
+}
+
+// ── Veredito pelo placar dos 90' ─────────────────────────────
+// Só para mercados diretos; qualquer ambiguidade → null (pergunta sem afirmar).
+type Verdict = "won" | "lost" | null;
+
+function computeVerdict(bet: Candidate, wc: WcMatch): Verdict {
+  // múltipla/sistema: pernas em jogos diversos, nunca decidível por 1 placar
+  const type = norm(bet.bet_type);
+  if (type === "multiple" || type === "system") return null;
+
+  const ftH = wc.fulltime_home;
+  const ftA = wc.fulltime_away;
+  if (ftH == null || ftA == null) return null; // sem placar de 90' → sem veredito
+
+  const desc = norm(bet.bet_description);
+  const market = norm(bet.betting_market);
+
+  // mercados fora do tempo normal / com regra própria → não arriscar
+  if (
+    /classific|avanc|qualif|prorrog|penalt|penalti|escanteio|cartao|cartoes|chute|finalizac|jogador|marca a qualquer|primeiro gol/.test(desc) ||
+    /1[oº°]?\s*tempo|2[oº°]?\s*tempo|primeiro tempo|segundo tempo|intervalo|halftime|1st half|2nd half/.test(desc)
+  ) {
+    return null;
+  }
+
+  const total = ftH + ftA;
+
+  // Over/Under de gols — "mais de 2,5", "over 2.5", "menos de 3"
+  const over = desc.match(/(?:mais de|over|acima de)\s*(\d+(?:[.,]\d+)?)/);
+  const under = desc.match(/(?:menos de|under|abaixo de)\s*(\d+(?:[.,]\d+)?)/);
+  if (over || under) {
+    // precisa ser de GOLS (explícito ou pelo mercado classificado)
+    const isGoals = /gol/.test(desc) || market === "over/under";
+    if (!isGoals) return null;
+    const line = parseFloat((over ?? under)![1].replace(",", "."));
+    if (Number.isNaN(line)) return null;
+    if (total === line) return null; // linha exata = push/void → usuário decide
+    if (over) return total > line ? "won" : "lost";
+    return total < line ? "won" : "lost";
+  }
+
+  // Ambas marcam (BTTS) — "não" explícito vira aposta no NÃO; cuidado com o
+  // "no" preposição do PT ("gols no jogo"): só conta como negativa em fim de
+  // frase ou depois de dois-pontos ("Ambas marcam: No")
+  if (market === "ambas marcam" || /ambas\s+(as\s+)?(equipes\s+)?marcam|btts|both teams to score/.test(desc)) {
+    const both = ftH > 0 && ftA > 0;
+    const betNo = /\bnao\b/.test(desc) || /:\s*no\b/.test(desc) || /\bno\s*$/.test(desc);
+    return (betNo ? !both : both) ? "won" : "lost";
+  }
+
+  // Money Line / 1x2 — em qual time a aposta foi?
+  if (market === "money line" || /\bml\b|money\s?line|vencedor|para vencer|vence\b|1x2/.test(desc)) {
+    const homeNames = teamNames(wc.home_team, wc.home_team_code);
+    const awayNames = teamNames(wc.away_team, wc.away_team_code);
+    const isDraw = /empate/.test(desc);
+    const pickedHome = hasTeam(desc, homeNames);
+    const pickedAway = hasTeam(desc, awayNames);
+
+    if (isDraw && !pickedHome && !pickedAway) return ftH === ftA ? "won" : "lost";
+    if (pickedHome && !pickedAway) return ftH > ftA ? "won" : "lost";
+    if (pickedAway && !pickedHome) return ftA > ftH ? "won" : "lost";
+    return null; // ambíguo (dois times citados / nenhum) → não afirmar
+  }
+
+  return null;
+}
+
+// ── Mensagens ────────────────────────────────────────────────
+const money = (v: number) => `R$ ${v.toFixed(2).replace(".", ",")}`;
+
+function betLine(bet: Candidate): string {
+  return (
+    `Sua aposta: <b>${esc(bet.bet_description)}</b>\n` +
+    `${money(bet.stake_amount)} · odd ${bet.odds} · retorno ${money(bet.potential_return)}`
+  );
+}
+
+function buildWcMessage(bet: Candidate, wc: WcMatch, verdict: Verdict): string {
+  // placar final (com prorrogação se houve) como contexto; 90' decide o veredito
+  const wentExtra =
+    wc.fulltime_home != null &&
+    (wc.home_score !== wc.fulltime_home || wc.away_score !== wc.fulltime_away);
+  const placar = `${esc(wc.home_team)} <b>${wc.home_score ?? "?"}×${wc.away_score ?? "?"}</b> ${esc(wc.away_team)}`;
+  const extra = wentExtra ? ` <i>(${wc.fulltime_home}×${wc.fulltime_away} no tempo normal)</i>` : "";
+
+  const ask =
+    verdict === "won"
+      ? "Pelo placar, essa <b>bateu</b> ✅ Confirma?"
+      : verdict === "lost"
+        ? "Pelo placar, essa <b>não bateu</b> ❌ Confirma?"
+        : "E aí, como foi?";
+
+  return `🏁 ${placar} — encerrado${extra}\n\n${betLine(bet)}\n\n${ask}`;
+}
+
+function buildGenericMessage(bet: Candidate): string {
+  const jogo = bet.match_description ? `<b>${esc(bet.match_description)}</b>\n` : "";
+  return `⏱️ Seu jogo já deve ter terminado:\n\n${jogo}${betLine(bet)}\n\nComo foi?`;
+}
+
+// ── Utilidades de tempo ──────────────────────────────────────
+// BRT é UTC-3 fixo (sem horário de verão desde 2019)
+const kickoffUtc = (wc: WcMatch) => new Date(`${wc.match_date}T${wc.match_time_brasilia}-03:00`);
+
+function brtHour(): number {
+  return Number(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone: "America/Sao_Paulo",
+      hour: "numeric",
+      hour12: false,
+    }).format(new Date())
+  ) % 24;
+}
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  const provided = req.headers.get("x-cron-secret") || "";
+  if (!cronSecret || provided !== cronSecret) return json({ error: "Unauthorized" }, 401);
+  if (!TELEGRAM_BOT_TOKEN) return json({ error: "TELEGRAM_BOT_TOKEN not set" }, 500);
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  const traceId = generateTraceId();
+
+  try {
+    // 1) Apostas candidatas (pendentes, usuário linkado, cadência ok)
+    const { data: candData, error: candErr } = await supabase.rpc("get_settlement_reminder_candidates");
+    if (candErr) throw candErr;
+    const candidates: Candidate[] = candData ?? [];
+    if (candidates.length === 0) return json({ ok: true, candidates: 0, sent: 0 });
+
+    // 2) Jogos da Copa encerrados nas últimas 60h (janela do "acabou de acabar")
+    const { data: wcData, error: wcErr } = await supabase
+      .from("wc_matches")
+      .select(
+        "id, stage, home_team, away_team, home_team_code, away_team_code, match_date, match_time_brasilia, home_score, away_score, fulltime_home, fulltime_away, is_finished"
+      )
+      .eq("is_finished", true)
+      .gte("match_date", new Date(Date.now() - 60 * 3600_000).toISOString().slice(0, 10));
+    if (wcErr) throw wcErr;
+
+    const now = Date.now();
+    const wcRecent = (wcData ?? [])
+      .map((m: WcMatch) => ({
+        wc: m,
+        kickoff: kickoffUtc(m).getTime(),
+        homeNames: teamNames(m.home_team, m.home_team_code),
+        awayNames: teamNames(m.away_team, m.away_team_code),
+      }))
+      .filter((e) => e.kickoff <= now && e.kickoff > now - 60 * 3600_000);
+
+    // 3) Classifica cada candidata: casada com jogo da Copa (manda já) ou
+    //    genérica (jogo passou + janela de silêncio)
+    type Due = { bet: Candidate; kind: "wc" | "generic"; wc?: WcMatch; verdict: Verdict };
+    const due: Due[] = [];
+    const hour = brtHour();
+    const genericAllowed = hour >= QUIET_START && hour < QUIET_END;
+
+    for (const bet of candidates) {
+      // múltipla/sistema tem pernas em vários jogos — o placar de UM jogo não a
+      // representa; segue o caminho genérico (sem placar, sem veredito)
+      const type = norm(bet.bet_type);
+      const isMulti = type === "multiple" || type === "system";
+
+      const text = norm(`${bet.match_description ?? ""} ${bet.bet_description ?? ""}`);
+      const matched = isMulti
+        ? undefined
+        : wcRecent
+            .filter((e) => hasTeam(text, e.homeNames) && hasTeam(text, e.awayNames))
+            .sort((a, b) => b.kickoff - a.kickoff)[0];
+
+      if (matched) {
+        due.push({ bet, kind: "wc", wc: matched.wc, verdict: computeVerdict(bet, matched.wc) });
+        continue;
+      }
+
+      if (!genericAllowed) continue;
+      const matchOver = bet.match_date && new Date(bet.match_date).getTime() < now - 3 * 3600_000;
+      const betStale = !bet.match_date && new Date(bet.bet_date).getTime() < now - 24 * 3600_000;
+      if (matchOver || betStale) due.push({ bet, kind: "generic", verdict: null });
+    }
+
+    // 4) Teto por usuário por run (Copa primeiro — é o lembrete mais quente)
+    const byUser = new Map<string, Due[]>();
+    for (const d of due) {
+      const list = byUser.get(d.bet.user_id) ?? [];
+      list.push(d);
+      byUser.set(d.bet.user_id, list);
+    }
+
+    let sent = 0;
+    const errors: string[] = [];
+    for (const list of byUser.values()) {
+      list.sort((a, b) => (a.kind === b.kind ? 0 : a.kind === "wc" ? -1 : 1));
+      for (const d of list.slice(0, MAX_PER_USER_PER_RUN)) {
+        try {
+          const text = d.kind === "wc" ? buildWcMessage(d.bet, d.wc!, d.verdict) : buildGenericMessage(d.bet);
+          await sendReminder(d.bet.chat_id, text, d.bet.bet_id);
+
+          // marca cadência só depois de enviar (run que falha tenta de novo)
+          const { error: updErr } = await supabase
+            .from("bets")
+            .update({
+              settlement_reminder_count: d.bet.reminder_count + 1,
+              settlement_reminder_at: new Date().toISOString(),
+            })
+            .eq("id", d.bet.bet_id);
+          if (updErr) throw updErr;
+
+          sent++;
+          await trackEvent(
+            "settlement_reminder_sent",
+            {
+              bet_id: d.bet.bet_id,
+              kind: d.kind,
+              verdict: d.verdict,
+              betting_market: d.bet.betting_market,
+              sport: d.bet.sport,
+              league: d.bet.league,
+              reminder_number: d.bet.reminder_count + 1,
+              wc_match_id: d.wc?.id ?? null,
+              channel: "telegram",
+            },
+            d.bet.user_id,
+            traceId
+          ).catch(() => {});
+        } catch (e) {
+          console.error(`remind ${d.bet.bet_id}:`, (e as Error)?.message);
+          errors.push(`${d.bet.bet_id}: ${(e as Error)?.message}`);
+        }
+      }
+    }
+
+    return json({
+      ok: true,
+      candidates: candidates.length,
+      wc_finished_recent: wcRecent.length,
+      due: due.length,
+      sent,
+      generic_window_open: genericAllowed,
+      errors,
+    });
+  } catch (e) {
+    console.error("notify-settlement error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -414,7 +414,8 @@ async function handleCallbackQuery(
       await answerCallbackQuery(cq.id, "Não achei essa aposta na sua conta.")
       return ok("fix: bet not found or not owner")
     }
-    if (bet.status !== "won" && bet.status !== "lost") {
+    const REVERTIBLE = ["won", "lost", "void", "half_won", "half_lost"] // nunca cashout
+    if (!REVERTIBLE.includes(bet.status)) {
       await answerCallbackQuery(cq.id, "Essa aposta não está mais liquidada 👍")
       return ok("fix: invalid status")
     }
@@ -432,7 +433,7 @@ async function handleCallbackQuery(
         },
       })
       .eq("id", betId)
-      .in("status", ["won", "lost"]) // nunca reverte cashout/void
+      .in("status", ["won", "lost", "void", "half_won", "half_lost"]) // nunca reverte cashout
 
     if (fixErr) {
       await answerCallbackQuery(cq.id, "Deu ruim ao desfazer — tenta de novo.")

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -399,6 +399,72 @@ async function handleCallbackQuery(
     return ok("reminders muted")
   }
 
+  // ↩️ fix:<bet_id> — desfaz a AUTO-liquidação (notify-settlement): volta pra
+  // pendente e devolve os botões clássicos pro usuário dizer o resultado certo
+  if (data.startsWith("fix:")) {
+    const betId = data.slice("fix:".length)
+
+    const { data: bet } = await supabase
+      .from("bets")
+      .select("id, user_id, status, bet_description, match_description, stake_amount, potential_return, processed_data")
+      .eq("id", betId)
+      .maybeSingle()
+
+    if (!bet || bet.user_id !== user.id) {
+      await answerCallbackQuery(cq.id, "Não achei essa aposta na sua conta.")
+      return ok("fix: bet not found or not owner")
+    }
+    if (bet.status !== "won" && bet.status !== "lost") {
+      await answerCallbackQuery(cq.id, "Essa aposta não está mais liquidada 👍")
+      return ok("fix: invalid status")
+    }
+
+    const pd = bet.processed_data && typeof bet.processed_data === "object" && !Array.isArray(bet.processed_data)
+      ? bet.processed_data
+      : {}
+    const { error: fixErr } = await supabase
+      .from("bets")
+      .update({
+        status: "pending",
+        processed_data: {
+          ...pd,
+          auto_settle: { ...((pd as any).auto_settle ?? {}), corrected_at: new Date().toISOString() },
+        },
+      })
+      .eq("id", betId)
+      .in("status", ["won", "lost"]) // nunca reverte cashout/void
+
+    if (fixErr) {
+      await answerCallbackQuery(cq.id, "Deu ruim ao desfazer — tenta de novo.")
+      return ok("fix: update failed")
+    }
+
+    await telegramCall("editMessageText", {
+      chat_id: chatId,
+      message_id: messageId,
+      text: `↩️ Desfeito — voltou pra pendente.\n\n<b>${escHtml(bet.bet_description)}</b>${bet.match_description ? `\n${escHtml(bet.match_description)}` : ""}\n\nComo foi essa?`,
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      reply_markup: {
+        inline_keyboard: [
+          [
+            { text: "✅ Green", callback_data: `settle:${betId}:won` },
+            { text: "❌ Red", callback_data: `settle:${betId}:lost` }
+          ],
+          [{ text: "Outras opções ↗", url: BETS_DASHBOARD_URL }]
+        ]
+      }
+    })
+    await answerCallbackQuery(cq.id, "↩️ Desfeito.")
+    await trackEvent(
+      "auto_settle_corrected",
+      { bet_id: betId, previous_status: bet.status, channel: "telegram" },
+      user.id,
+      traceId
+    ).catch(() => {})
+    return ok("auto settle corrected")
+  }
+
   // ✅/❌ settle:<bet_id>:<won|lost>
   if (data.startsWith("settle:")) {
     const [, betId, outcome] = data.split(":")

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -14,6 +14,7 @@ const TELEGRAM_API_BASE = TELEGRAM_BOT_TOKEN
 
 const DAILY_BET_LIMIT = 3
 const TIMEZONE_GMT3 = "America/Cuiaba"
+const BETS_DASHBOARD_URL = "https://www.smartbetting.app/bets"
 
 // Simple in-memory guard to avoid reprocessing the same update_id on retries
 const processedUpdateIds = new Set<number>()
@@ -49,6 +50,14 @@ interface TelegramMessage {
   document?: TelegramFile
   // Telegram sends thumbnails as "thumbnail" in documents; not used directly
   thumbnail?: TelegramFile
+}
+
+// Toque num botão inline (lembrete de liquidação do notify-settlement)
+interface TelegramCallbackQuery {
+  id: string
+  from?: TelegramUser
+  message?: { message_id: number; chat: { id: number } }
+  data?: string
 }
 
 interface ProcessedBet {
@@ -291,6 +300,157 @@ async function sendConfirmationMessageTelegram(
   ].join("\n")
 
   await sendTelegramMessage(chatId, confirmationMessage)
+}
+
+// ============================================================
+// Liquidação por botão — [✅ Green] [❌ Red] do lembrete (notify-settlement)
+// ============================================================
+
+// Escapa HTML (os lembretes e suas edições usam parse_mode HTML)
+function escHtml(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+}
+
+const formatBRL = (v: number) => `R$ ${Number(v ?? 0).toFixed(2).replace(".", ",")}`
+
+async function answerCallbackQuery(callbackQueryId: string, text?: string): Promise<void> {
+  await telegramCall("answerCallbackQuery", { callback_query_id: callbackQueryId, text })
+}
+
+// Reescreve a mensagem do lembrete como recibo da liquidação (some o teclado)
+async function editSettledMessage(chatId: string | number, messageId: number, html: string): Promise<void> {
+  await telegramCall("editMessageText", {
+    chat_id: chatId,
+    message_id: messageId,
+    text: html,
+    parse_mode: "HTML",
+    disable_web_page_preview: true
+  })
+}
+
+function settledHtml(bet: any, status: string): string {
+  const jogo = bet.match_description ? `\n${escHtml(bet.match_description)}` : ""
+  const base = `<b>${escHtml(bet.bet_description)}</b>${jogo}`
+  if (status === "won") {
+    const lucro = (bet.potential_return ?? 0) - (bet.stake_amount ?? 0)
+    return `✅ <b>Green registrado!</b>\n\n${base}\nLucro: +${formatBRL(lucro)}\n\nBanca atualizada 📊 ${BETS_DASHBOARD_URL}`
+  }
+  if (status === "lost") {
+    return `❌ <b>Red registrado.</b>\n\n${base}\nPrejuízo: −${formatBRL(bet.stake_amount)}\n\nFaz parte. Banca atualizada 📊 ${BETS_DASHBOARD_URL}`
+  }
+  return `Registrada como <b>${escHtml(status)}</b>.\n\n${base}`
+}
+
+async function handleCallbackQuery(
+  supabase: any,
+  cq: TelegramCallbackQuery,
+  traceId: string
+): Promise<Response> {
+  const ok = (msg: string) =>
+    new Response(JSON.stringify({ success: true, message: msg }), {
+      headers: { "Content-Type": "application/json" },
+      status: 200
+    })
+
+  const data = cq.data || ""
+  const chatId = cq.message?.chat?.id
+  const messageId = cq.message?.message_id
+
+  if (!chatId || !messageId) {
+    await answerCallbackQuery(cq.id).catch(() => {})
+    return ok("callback without message")
+  }
+
+  const user = await findUserByTelegram(
+    supabase,
+    cq.from?.id ? String(cq.from.id) : undefined,
+    String(chatId),
+    traceId
+  )
+  if (!user) {
+    await answerCallbackQuery(cq.id, "Não achei sua conta. Manda /start pra sincronizar.")
+    return ok("callback user not found")
+  }
+
+  // 🔕 mute:<bet_id> — para os lembretes; mantém os botões de liquidar desta aposta
+  if (data.startsWith("mute:")) {
+    const betId = data.slice("mute:".length)
+    await supabase.from("users").update({ settlement_reminders_muted: true }).eq("id", user.id)
+    await telegramCall("editMessageReplyMarkup", {
+      chat_id: chatId,
+      message_id: messageId,
+      reply_markup: {
+        inline_keyboard: [
+          [
+            { text: "✅ Green", callback_data: `settle:${betId}:won` },
+            { text: "❌ Red", callback_data: `settle:${betId}:lost` }
+          ],
+          [{ text: "Outras opções ↗", url: BETS_DASHBOARD_URL }]
+        ]
+      }
+    })
+    await answerCallbackQuery(cq.id, "🔕 Ok, sem mais lembretes. Reative mandando /lembretes.")
+    await trackEvent(
+      "settlement_reminders_muted",
+      { via: "button", channel: "telegram" },
+      user.id,
+      traceId
+    ).catch(() => {})
+    return ok("reminders muted")
+  }
+
+  // ✅/❌ settle:<bet_id>:<won|lost>
+  if (data.startsWith("settle:")) {
+    const [, betId, outcome] = data.split(":")
+    if (!betId || (outcome !== "won" && outcome !== "lost")) {
+      await answerCallbackQuery(cq.id, "Não entendi esse toque 🤔")
+      return ok("bad callback data")
+    }
+
+    const { data: bet } = await supabase
+      .from("bets")
+      .select("id, user_id, status, bet_description, match_description, stake_amount, potential_return, odds")
+      .eq("id", betId)
+      .maybeSingle()
+
+    // dono confere? (callback vem do Telegram; a aposta TEM que ser deste usuário)
+    if (!bet || bet.user_id !== user.id) {
+      await answerCallbackQuery(cq.id, "Não achei essa aposta na sua conta.")
+      return ok("bet not found or not owner")
+    }
+
+    if (bet.status !== "pending") {
+      await answerCallbackQuery(cq.id, "Essa já estava registrada 👍")
+      await editSettledMessage(chatId, messageId, settledHtml(bet, bet.status)).catch(() => {})
+      return ok("already settled")
+    }
+
+    const { data: updated, error: updErr } = await supabase
+      .from("bets")
+      .update({ status: outcome })
+      .eq("id", betId)
+      .eq("status", "pending") // guarda otimista: dois toques ≠ duas liquidações
+      .select()
+      .maybeSingle()
+
+    if (updErr || !updated) {
+      await answerCallbackQuery(cq.id, "Deu ruim ao registrar — tenta de novo.")
+      return ok("settle update failed")
+    }
+
+    await editSettledMessage(chatId, messageId, settledHtml(updated, outcome)).catch(() => {})
+    await answerCallbackQuery(cq.id, outcome === "won" ? "✅ Green registrado!" : "❌ Red registrado.")
+    await trackEvent(
+      "settlement_settled_via_bot",
+      { bet_id: betId, outcome, channel: "telegram" },
+      user.id,
+      traceId
+    ).catch(() => {})
+    return ok("bet settled")
+  }
+
+  await answerCallbackQuery(cq.id).catch(() => {})
+  return ok("unknown callback")
 }
 
 async function getDailyBetCount(supabase: any, userId: string, traceId?: string): Promise<number> {
@@ -1484,6 +1644,25 @@ serve(async (req) => {
       processedUpdateIds.add(updateId)
     }
 
+    // Toque em botão inline (lembrete de liquidação) — trata e sai antes do fluxo
+    // de mensagem. Requer setWebhook com allowed_updates incluindo callback_query.
+    if (payload.callback_query) {
+      const cbSupabaseUrl = Deno.env.get("SUPABASE_URL")
+      const cbServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")
+      if (!cbSupabaseUrl || !cbServiceKey) {
+        console.error("Missing Supabase configuration (callback_query)")
+        return new Response(
+          JSON.stringify({ success: false, error: "Server configuration error" }),
+          { headers: { "Content-Type": "application/json" }, status: 500 }
+        )
+      }
+      return await handleCallbackQuery(
+        createClient(cbSupabaseUrl, cbServiceKey),
+        payload.callback_query as TelegramCallbackQuery,
+        generateTraceId()
+      )
+    }
+
     const updateMessage: TelegramMessage | undefined = payload.message || payload.edited_message || payload.channel_post
 
     // Log raw payload (truncate to avoid huge logs)
@@ -1668,6 +1847,29 @@ serve(async (req) => {
       user.id,
       traceId
     ).catch(() => {})
+
+    // Preferência dos lembretes de liquidação (par do botão 🔕 do notify-settlement)
+    const command = text.trim().toLowerCase()
+    if (command === "/silenciar" || command === "/lembretes") {
+      const mute = command === "/silenciar"
+      await supabase.from("users").update({ settlement_reminders_muted: mute }).eq("id", user.id)
+      await sendTelegramMessage(
+        chatId,
+        mute
+          ? "🔕 Beleza — parei com os lembretes de liquidação. Pra voltar, é só mandar /lembretes."
+          : "🔔 Lembretes reativados! Quando um jogo seu terminar, eu te chamo aqui pra fechar a aposta."
+      )
+      await trackEvent(
+        mute ? "settlement_reminders_muted" : "settlement_reminders_unmuted",
+        { via: "command", channel: "telegram" },
+        user.id,
+        traceId
+      ).catch(() => {})
+      return new Response(
+        JSON.stringify({ success: true, message: "Reminder preference updated" }),
+        { headers: { "Content-Type": "application/json" }, status: 200 }
+      )
+    }
 
     let actualContent = text
     let mediaUrl: string | null = null

--- a/supabase/functions/winback-backfill/index.ts
+++ b/supabase/functions/winback-backfill/index.ts
@@ -163,7 +163,7 @@ async function parseBetsWithLLM(bets: OldBet[]): Promise<Map<string, ParsedBet>>
 
 Para cada item, classifique kind:
 - "nba_prop": UMA prop de UM jogador da NBA (ex: "wemby over 27,5 pts" → Victor Wembanyama, player_points, 27.5, over). Resolva apelidos para o NOME COMPLETO oficial do jogador ("jb"→"Jaylen Brown", "wemby"→"Victor Wembanyama", "fox"→"De'Aaron Fox", "maxey"→"Tyrese Maxey", "tatum"→"Jayson Tatum"). "N+ pontos" = over com line N-0.5. Props de quarto/tempo parcial ("q1", "1st half"): period="partial". Stats SEM chave disponível (field goals, minutos, %): kind="unparseable".
-- "football_single": UMA aposta simples de futebol com os DOIS times identificáveis. market: ml_home/ml_away/ml_draw (vencedor no tempo normal), over_goals/under_goals (com goals_line), btts_yes/btts_no. Handicap, escanteios, cartões, gols de jogador, 1º tempo, "para se classificar": market="other".
+- "football_single": UMA aposta simples de futebol com os DOIS times identificáveis. Expanda abreviações e apelidos de clube para o nome oficial internacional ("PSG"→"Paris Saint Germain", "City"→"Manchester City", "Atleti"→"Atletico Madrid", "Barça"→"Barcelona", "Fla"→"Flamengo"). market: ml_home/ml_away/ml_draw (vencedor no tempo normal), over_goals/under_goals (com goals_line), btts_yes/btts_no. Handicap, escanteios, cartões, gols de jogador, 1º tempo, "para se classificar": market="other".
 - "combo_or_multi": mais de uma seleção na mesma descrição (ex: "20 pts tatum e 20 pts brown").
 - "unparseable": não dá pra estruturar com confiança.
 
@@ -335,7 +335,11 @@ async function buildDecisions(supabase: any): Promise<{ decisions: Decision[]; t
   const all: OldBet[] = betsData ?? [];
 
   const decisions: Decision[] = [];
-  const singles = all.filter((b) => b.bet_type === "single" && (b.sport === "Basquete" || b.sport === "Futebol"));
+  // esporte por nome normalizado: registros antigos têm "NBA" (em vez de
+  // "Basquete") e até vazio — o kind final quem decide é o LLM, então o filtro
+  // só corta o que certamente não é NBA/futebol
+  const PARSE_SPORTS = new Set(["basquete", "futebol", "nba", ""]);
+  const singles = all.filter((b) => b.bet_type === "single" && PARSE_SPORTS.has(norm(b.sport ?? "")));
   for (const b of all) {
     if (!singles.includes(b)) {
       decisions.push({

--- a/supabase/functions/winback-backfill/index.ts
+++ b/supabase/functions/winback-backfill/index.ts
@@ -1,0 +1,502 @@
+// ============================================================
+// winback-backfill — fecha o histórico antigo e reconquista quem sumiu (R1)
+// ============================================================
+// One-shot MANUAL (sem cron!). O dev roda 3 vezes, verificando entre cada uma:
+//
+//   1. ?mode=report   → NÃO escreve nada. Devolve o relatório: o que seria
+//                       liquidado, com veredito + evidência, e o que foi pulado
+//                       (e por quê). Revisar antes de seguir.
+//   2. ?mode=execute  → liquida as apostas aprovadas no report (won/lost),
+//                       gravando a evidência em processed_data.winback.
+//                       Idempotente: só toca aposta ainda 'pending'.
+//   3. ?mode=notify   → manda a DM única ("atualizamos seu histórico — seu ROI
+//                       real está pronto") pra cada usuário afetado com Telegram.
+//                       Idempotente via tabela winback_notifications.
+//
+// Filosofia: o LLM ESTRUTURA a aposta (jogador/stat/linha ou times/mercado —
+// as descrições reais têm apelido, typo e abreviação: "wemby over 27,5 pts"),
+// mas quem DECIDE o veredito é código puro contra dado verificável:
+//   • NBA (singles): nba_mart.ft_game_player_stats (stat realizada vs linha)
+//   • Futebol (singles): placar dos 90' via API-Sports histórico (fixtures?date=)
+// Qualquer ambiguidade (múltipla, combo, "fg geral" sem stat no mart, jogador
+// não encontrado, jogo não casado, push) → skip com motivo. Sem chute.
+//
+// Proteção: header `x-cron-secret` == env CRON_SECRET (mesmo padrão dos crons).
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN,
+//                 OPENAI_API_KEY, API_SPORTS_KEY, CRON_SECRET.
+// Runbook: WINBACK_BACKFILL_SETUP.md
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+
+const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY") || "";
+const API_SPORTS_KEY = Deno.env.get("API_SPORTS_KEY") || "";
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const BETS_URL = "https://www.smartbetting.app/bets";
+
+// Backlog alvo: pendentes com 7+ dias, até 1 ano (mais velho que isso não fecha)
+const MIN_AGE_DAYS = 7;
+const MAX_AGE_DAYS = 365;
+
+// ── util ─────────────────────────────────────────────────────
+function esc(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function norm(s: unknown): string {
+  return String(s ?? "")
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+const money = (v: number) => `R$ ${Number(v ?? 0).toFixed(2).replace(".", ",")}`;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// ── tipos ────────────────────────────────────────────────────
+interface OldBet {
+  id: string;
+  user_id: string;
+  sport: string | null;
+  league: string | null;
+  bet_type: string;
+  betting_market: string | null;
+  match_description: string | null;
+  bet_description: string;
+  odds: number;
+  stake_amount: number;
+  potential_return: number;
+  bet_date: string;
+  match_date: string | null;
+  processed_data: Record<string, unknown> | null;
+}
+
+// O que o LLM devolve por aposta (estrutura, nunca veredito)
+interface ParsedBet {
+  bet_id: string;
+  kind: "nba_prop" | "football_single" | "combo_or_multi" | "unparseable";
+  // nba_prop:
+  player_full_name: string | null;
+  stat_key: string | null; // chave do nba_mart (player_points, player_rebounds...)
+  line: number | null;
+  direction: "over" | "under" | null;
+  period: "full_game" | "partial" | null;
+  // football_single:
+  home_team: string | null;
+  away_team: string | null;
+  market: "ml_home" | "ml_away" | "ml_draw" | "over_goals" | "under_goals" | "btts_yes" | "btts_no" | "other" | null;
+  goals_line: number | null;
+}
+
+interface Decision {
+  bet_id: string;
+  bet_description: string;
+  user_id: string;
+  action: "settle" | "skip";
+  verdict?: "won" | "lost";
+  evidence?: string;      // humano-legível: "Jokic fez 31 pts em 12/04 (linha 25.5 over)"
+  skip_reason?: string;
+}
+
+// ── 1. LLM: estrutura o lote de descrições (uma chamada) ─────
+const PARSE_SCHEMA = {
+  type: "object",
+  properties: {
+    bets: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          bet_id: { type: "string" },
+          kind: { type: "string", enum: ["nba_prop", "football_single", "combo_or_multi", "unparseable"] },
+          player_full_name: { type: ["string", "null"] },
+          stat_key: {
+            type: ["string", "null"],
+            enum: [
+              "player_points", "player_rebounds", "player_assists", "player_threes",
+              "player_blocks", "player_steals", "player_turnovers",
+              "player_points_rebounds_assists", "player_points_assists",
+              "player_points_rebounds", "player_rebounds_assists",
+              "player_blocks_steals", "player_double_double", "player_triple_double",
+              null,
+            ],
+          },
+          line: { type: ["number", "null"] },
+          direction: { type: ["string", "null"], enum: ["over", "under", null] },
+          period: { type: ["string", "null"], enum: ["full_game", "partial", null] },
+          home_team: { type: ["string", "null"] },
+          away_team: { type: ["string", "null"] },
+          market: {
+            type: ["string", "null"],
+            enum: ["ml_home", "ml_away", "ml_draw", "over_goals", "under_goals", "btts_yes", "btts_no", "other", null],
+          },
+          goals_line: { type: ["number", "null"] },
+        },
+        required: [
+          "bet_id", "kind", "player_full_name", "stat_key", "line", "direction",
+          "period", "home_team", "away_team", "market", "goals_line",
+        ],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["bets"],
+  additionalProperties: false,
+};
+
+async function parseBetsWithLLM(bets: OldBet[]): Promise<Map<string, ParsedBet>> {
+  const items = bets.map((b) => ({
+    bet_id: b.id,
+    sport: b.sport,
+    description: b.bet_description,
+    match: b.match_description,
+  }));
+
+  const prompt = `Você estrutura descrições de apostas esportivas registradas por usuários (podem ter apelidos, typos e abreviações). NÃO decida se a aposta ganhou — apenas estruture.
+
+Para cada item, classifique kind:
+- "nba_prop": UMA prop de UM jogador da NBA (ex: "wemby over 27,5 pts" → Victor Wembanyama, player_points, 27.5, over). Resolva apelidos para o NOME COMPLETO oficial do jogador ("jb"→"Jaylen Brown", "wemby"→"Victor Wembanyama", "fox"→"De'Aaron Fox", "maxey"→"Tyrese Maxey", "tatum"→"Jayson Tatum"). "N+ pontos" = over com line N-0.5. Props de quarto/tempo parcial ("q1", "1st half"): period="partial". Stats SEM chave disponível (field goals, minutos, %): kind="unparseable".
+- "football_single": UMA aposta simples de futebol com os DOIS times identificáveis. market: ml_home/ml_away/ml_draw (vencedor no tempo normal), over_goals/under_goals (com goals_line), btts_yes/btts_no. Handicap, escanteios, cartões, gols de jogador, 1º tempo, "para se classificar": market="other".
+- "combo_or_multi": mais de uma seleção na mesma descrição (ex: "20 pts tatum e 20 pts brown").
+- "unparseable": não dá pra estruturar com confiança.
+
+Campos que não se aplicam: null. Linhas com vírgula decimal ("27,5") → number 27.5.
+
+ITENS:
+${JSON.stringify(items)}`;
+
+  const res = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${OPENAI_API_KEY}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: prompt }],
+      response_format: {
+        type: "json_schema",
+        json_schema: { name: "parsed_bets", strict: true, schema: PARSE_SCHEMA },
+      },
+      temperature: 0,
+      max_tokens: 8000,
+    }),
+  });
+  if (!res.ok) throw new Error(`OpenAI ${res.status}: ${(await res.text()).slice(0, 300)}`);
+  const out = await res.json();
+  const parsed = JSON.parse(out.choices[0].message.content) as { bets: ParsedBet[] };
+  return new Map(parsed.bets.map((p) => [p.bet_id, p]));
+}
+
+// ── 2. NBA: veredito contra o nba_mart ───────────────────────
+async function decideNba(supabase: any, bet: OldBet, p: ParsedBet): Promise<Decision> {
+  const base = { bet_id: bet.id, bet_description: bet.bet_description, user_id: bet.user_id };
+  if (p.period === "partial") return { ...base, action: "skip", skip_reason: "prop de tempo parcial (q1/half) — sem dado no mart v1" };
+  if (!p.player_full_name || !p.stat_key || p.line == null || !p.direction) {
+    return { ...base, action: "skip", skip_reason: "estrutura incompleta (jogador/stat/linha)" };
+  }
+
+  // jogador: match por nome via RPC (nba_mart é trancado pra acesso direto — 056)
+  const lastName = p.player_full_name.split(" ").pop()!;
+  const { data: players, error: pErr } = await supabase.rpc("winback_find_nba_player", { p_name_part: lastName });
+  if (pErr) return { ...base, action: "skip", skip_reason: `winback_find_nba_player: ${pErr.message}` };
+  const target = norm(p.player_full_name);
+  let player = (players ?? []).find((x: any) => norm(x.player_name) === target) ?? null;
+  if (!player) {
+    const cands = (players ?? []).filter((x: any) => norm(x.player_name).includes(norm(lastName)));
+    if (cands.length === 1) player = cands[0]; // sobrenome único no mart → seguro
+  }
+  if (!player) return { ...base, action: "skip", skip_reason: `jogador não encontrado no mart: ${p.player_full_name}` };
+
+  // jogo: a stat realizada mais próxima da data da aposta (janela -1..+2 dias)
+  const betDate = bet.bet_date.slice(0, 10);
+  const { data: stats, error: sErr } = await supabase.rpc("winback_nba_stat_window", {
+    p_player_id: player.player_id,
+    p_stat_type: p.stat_key,
+    p_from: new Date(new Date(betDate).getTime() - 86400_000).toISOString().slice(0, 10),
+    p_to: new Date(new Date(betDate).getTime() + 2 * 86400_000).toISOString().slice(0, 10),
+  });
+  if (sErr) return { ...base, action: "skip", skip_reason: `winback_nba_stat_window: ${sErr.message}` };
+  if (!stats?.length) return { ...base, action: "skip", skip_reason: "nenhum jogo do jogador na janela da aposta" };
+  if (stats.length > 1) return { ...base, action: "skip", skip_reason: `ambíguo: ${stats.length} jogos na janela` };
+
+  const s = stats[0];
+  if (s.is_played === "false" || s.stat_value == null) {
+    return { ...base, action: "skip", skip_reason: "jogador não jogou (provável void — resolver manual)" };
+  }
+  if (s.stat_value === p.line) return { ...base, action: "skip", skip_reason: `push: stat ${s.stat_value} == linha ${p.line}` };
+
+  const won = p.direction === "over" ? s.stat_value > p.line : s.stat_value < p.line;
+  return {
+    ...base,
+    action: "settle",
+    verdict: won ? "won" : "lost",
+    evidence: `${player.player_name}: ${s.stat_value} (${p.stat_key.replace("player_", "")}) em ${s.game_date} · linha ${p.direction} ${p.line} · fonte nba_mart`,
+  };
+}
+
+// ── 3. Futebol: veredito via placar histórico da API-Sports ──
+// Cache por data: 1 chamada fixtures?date=D cobre TODOS os jogos do dia.
+const fixturesByDate = new Map<string, any[]>();
+let apiCalls = 0;
+
+async function fixturesOn(date: string): Promise<any[]> {
+  if (fixturesByDate.has(date)) return fixturesByDate.get(date)!;
+  const res = await fetch(`https://v3.football.api-sports.io/fixtures?date=${date}&status=FT-AET-PEN`, {
+    headers: { "x-apisports-key": API_SPORTS_KEY },
+  });
+  apiCalls++;
+  if (!res.ok) throw new Error(`API-Sports ${res.status}`);
+  const payload = await res.json();
+  const list = payload?.response ?? [];
+  fixturesByDate.set(date, list);
+  return list;
+}
+
+// os dois nomes casam? (contém/contido, normalizado — "Atletico de Madrid" ~ "Atletico Madrid")
+function teamMatches(ours: string, api: string): boolean {
+  const a = norm(ours), b = norm(api);
+  if (!a || !b) return false;
+  return a === b || a.includes(b) || b.includes(a);
+}
+
+async function decideFootball(bet: OldBet, p: ParsedBet): Promise<Decision> {
+  const base = { bet_id: bet.id, bet_description: bet.bet_description, user_id: bet.user_id };
+  if (!p.home_team || !p.away_team) return { ...base, action: "skip", skip_reason: "times não identificados" };
+  if (!p.market || p.market === "other") return { ...base, action: "skip", skip_reason: "mercado fora do v1 (handicap/escanteio/1ºT/etc)" };
+
+  // procura o jogo: dia da aposta e os 2 seguintes (aposta pré-jogo)
+  const betDate = new Date(bet.bet_date);
+  let fx: any = null;
+  let when = "";
+  for (const offset of [0, 1, 2]) {
+    const d = new Date(betDate.getTime() + offset * 86400_000).toISOString().slice(0, 10);
+    const candidates = (await fixturesOn(d)).filter((f: any) => {
+      const h = f?.teams?.home?.name ?? "", a = f?.teams?.away?.name ?? "";
+      return (teamMatches(p.home_team!, h) && teamMatches(p.away_team!, a)) ||
+             (teamMatches(p.home_team!, a) && teamMatches(p.away_team!, h));
+    });
+    if (candidates.length === 1) { fx = candidates[0]; when = d; break; }
+    if (candidates.length > 1) return { ...base, action: "skip", skip_reason: `ambíguo: ${candidates.length} jogos ${p.home_team} x ${p.away_team} em ${d}` };
+  }
+  if (!fx) return { ...base, action: "skip", skip_reason: `jogo não encontrado (${p.home_team} x ${p.away_team}, ~${bet.bet_date.slice(0, 10)})` };
+
+  // placar dos 90' (mercados liquidam no tempo normal)
+  const ftH = fx?.score?.fulltime?.home;
+  const ftA = fx?.score?.fulltime?.away;
+  if (ftH == null || ftA == null) return { ...base, action: "skip", skip_reason: "sem placar de 90' no fixture" };
+
+  // orienta o placar pros NOSSOS home/away (a ordem da API pode diferir)
+  const apiHomeIsOurs = teamMatches(p.home_team, fx.teams.home.name);
+  const ourH = apiHomeIsOurs ? ftH : ftA;
+  const ourA = apiHomeIsOurs ? ftA : ftH;
+  const total = ftH + ftA;
+
+  let won: boolean | null = null;
+  switch (p.market) {
+    case "ml_home": won = ourH > ourA; break;
+    case "ml_away": won = ourA > ourH; break;
+    case "ml_draw": won = ourH === ourA; break;
+    case "btts_yes": won = ftH > 0 && ftA > 0; break;
+    case "btts_no": won = !(ftH > 0 && ftA > 0); break;
+    case "over_goals":
+      if (p.goals_line == null) return { ...base, action: "skip", skip_reason: "linha de gols ausente" };
+      if (total === p.goals_line) return { ...base, action: "skip", skip_reason: "push na linha exata" };
+      won = total > p.goals_line; break;
+    case "under_goals":
+      if (p.goals_line == null) return { ...base, action: "skip", skip_reason: "linha de gols ausente" };
+      if (total === p.goals_line) return { ...base, action: "skip", skip_reason: "push na linha exata" };
+      won = total < p.goals_line; break;
+  }
+  if (won == null) return { ...base, action: "skip", skip_reason: "mercado não decidível" };
+
+  return {
+    ...base,
+    action: "settle",
+    verdict: won ? "won" : "lost",
+    evidence: `${fx.teams.home.name} ${ftH}×${ftA} ${fx.teams.away.name} (90') em ${when} · ${p.market}${p.goals_line != null ? ` ${p.goals_line}` : ""} · fonte API-Sports fixture ${fx.fixture?.id}`,
+  };
+}
+
+// ── pipeline: report/execute compartilham a mesma decisão ────
+async function buildDecisions(supabase: any): Promise<{ decisions: Decision[]; totals: Record<string, number> }> {
+  const { data: betsData, error } = await supabase
+    .from("bets")
+    .select("id, user_id, sport, league, bet_type, betting_market, match_description, bet_description, odds, stake_amount, potential_return, bet_date, match_date, processed_data")
+    .eq("status", "pending")
+    .lt("bet_date", new Date(Date.now() - MIN_AGE_DAYS * 86400_000).toISOString())
+    .gt("bet_date", new Date(Date.now() - MAX_AGE_DAYS * 86400_000).toISOString())
+    .order("bet_date", { ascending: false });
+  if (error) throw error;
+  const all: OldBet[] = betsData ?? [];
+
+  const decisions: Decision[] = [];
+  const singles = all.filter((b) => b.bet_type === "single" && (b.sport === "Basquete" || b.sport === "Futebol"));
+  for (const b of all) {
+    if (!singles.includes(b)) {
+      decisions.push({
+        bet_id: b.id, bet_description: b.bet_description, user_id: b.user_id,
+        action: "skip",
+        skip_reason: b.bet_type !== "single" ? "múltipla/sistema — não fechável por 1 placar" : `esporte fora do v1 (${b.sport || "?"})`,
+      });
+    }
+  }
+
+  if (singles.length > 0) {
+    const parsed = await parseBetsWithLLM(singles);
+    for (const b of singles) {
+      const p = parsed.get(b.id);
+      if (!p) {
+        decisions.push({ bet_id: b.id, bet_description: b.bet_description, user_id: b.user_id, action: "skip", skip_reason: "LLM não retornou estrutura" });
+        continue;
+      }
+      if (p.kind === "combo_or_multi") {
+        decisions.push({ bet_id: b.id, bet_description: b.bet_description, user_id: b.user_id, action: "skip", skip_reason: "combo de várias seleções na descrição" });
+      } else if (p.kind === "unparseable") {
+        decisions.push({ bet_id: b.id, bet_description: b.bet_description, user_id: b.user_id, action: "skip", skip_reason: "descrição não estruturável com confiança" });
+      } else if (p.kind === "nba_prop") {
+        decisions.push(await decideNba(supabase, b, p));
+      } else {
+        decisions.push(await decideFootball(b, p));
+      }
+    }
+  }
+
+  const totals = {
+    backlog: all.length,
+    liquidaveis: decisions.filter((d) => d.action === "settle").length,
+    greens: decisions.filter((d) => d.verdict === "won").length,
+    reds: decisions.filter((d) => d.verdict === "lost").length,
+    pulados: decisions.filter((d) => d.action === "skip").length,
+    chamadas_api_sports: apiCalls,
+  };
+  return { decisions, totals };
+}
+
+// ── notify: a DM única de reconquista ────────────────────────
+async function sendWinbackDm(chatId: string, name: string | null, settled: number, greens: number, profit: number, roi: number, leftovers: number): Promise<void> {
+  const roiTxt = `${roi >= 0 ? "+" : ""}${roi.toFixed(1)}%`;
+  const profitTxt = `${profit >= 0 ? "+" : "−"}${money(Math.abs(profit))}`;
+  const lines = [
+    `📋 <b>${esc(name || "E aí")}, a gente atualizou seu histórico.</b>`,
+    "",
+    `Fechamos <b>${settled} aposta${settled === 1 ? "" : "s"}</b> antiga${settled === 1 ? "" : "s"} que estava${settled === 1 ? "" : "m"} pendente${settled === 1 ? "" : "s"} (${greens} green${greens === 1 ? "" : "s"}) — com o placar/estatística real de cada jogo.`,
+    "",
+    `Seu resultado real no período: <b>${profitTxt}</b> · ROI <b>${roiTxt}</b>`,
+  ];
+  if (leftovers > 0) {
+    lines.push("", `Ficaram ${leftovers} que não conseguimos confirmar — dá pra resolver em segundos no painel.`);
+  }
+  lines.push("", `Qualquer aposta que a gente tenha fechado errado, é só corrigir por lá.`);
+
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text: lines.join("\n"),
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      reply_markup: { inline_keyboard: [[{ text: "📊 Ver meu histórico completo", url: BETS_URL }]] },
+    }),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
+}
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  if (!cronSecret || req.headers.get("x-cron-secret") !== cronSecret) return json({ error: "Unauthorized" }, 401);
+
+  const mode = new URL(req.url).searchParams.get("mode") || "report";
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+  const traceId = generateTraceId();
+
+  try {
+    // ── REPORT / EXECUTE ─────────────────────────────────────
+    if (mode === "report" || mode === "execute") {
+      if (!OPENAI_API_KEY) return json({ error: "OPENAI_API_KEY not set" }, 500);
+      if (!API_SPORTS_KEY) return json({ error: "API_SPORTS_KEY not set" }, 500);
+
+      const { decisions, totals } = await buildDecisions(supabase);
+
+      if (mode === "report") {
+        return json({
+          ok: true, mode, totals,
+          liquidaveis: decisions.filter((d) => d.action === "settle"),
+          pulados: decisions.filter((d) => d.action === "skip"),
+        });
+      }
+
+      // execute: aplica os settles (guarda otimista em status=pending)
+      let settled = 0;
+      const errors: string[] = [];
+      for (const d of decisions) {
+        if (d.action !== "settle") continue;
+        const { data: bet } = await supabase.from("bets").select("processed_data").eq("id", d.bet_id).maybeSingle();
+        // processed_data pode não ser objeto em registros antigos — não espalhar string
+        const pd = bet?.processed_data && typeof bet.processed_data === "object" && !Array.isArray(bet.processed_data)
+          ? bet.processed_data : {};
+        const { error: updErr, data: upd } = await supabase
+          .from("bets")
+          .update({
+            status: d.verdict,
+            processed_data: {
+              ...pd,
+              winback: { evidence: d.evidence, settled_at: new Date().toISOString(), source: "winback_backfill_v1" },
+            },
+          })
+          .eq("id", d.bet_id)
+          .eq("status", "pending")
+          .select("id")
+          .maybeSingle();
+        if (updErr) { errors.push(`${d.bet_id}: ${updErr.message}`); continue; }
+        if (upd) settled++;
+      }
+
+      await trackEvent("winback_backfill_executed", { ...totals, settled }, "system", traceId).catch(() => {});
+      return json({ ok: true, mode, totals, settled, errors });
+    }
+
+    // ── NOTIFY ───────────────────────────────────────────────
+    if (mode === "notify") {
+      if (!TELEGRAM_BOT_TOKEN) return json({ error: "TELEGRAM_BOT_TOKEN not set" }, 500);
+
+      // usuários com apostas fechadas pelo winback e ainda não avisados
+      const { data: rows, error } = await supabase.rpc("get_winback_notify_targets");
+      if (error) throw error;
+
+      let sent = 0;
+      const errors: string[] = [];
+      for (const r of rows ?? []) {
+        try {
+          await sendWinbackDm(r.chat_id, r.user_name, Number(r.settled), Number(r.greens), Number(r.profit), Number(r.roi), Number(r.leftovers));
+          const { error: insErr } = await supabase
+            .from("winback_notifications")
+            .insert({ user_id: r.user_id, bets_settled: r.settled, roi: r.roi });
+          if (insErr) throw insErr;
+          sent++;
+          await trackEvent(
+            "winback_dm_sent",
+            { bets_settled: r.settled, greens: r.greens, roi: r.roi, leftovers: r.leftovers, channel: "telegram" },
+            r.user_id, traceId
+          ).catch(() => {});
+        } catch (e) {
+          errors.push(`${r.user_id}: ${(e as Error)?.message}`);
+        }
+      }
+      return json({ ok: true, mode, alvo: (rows ?? []).length, sent, errors });
+    }
+
+    return json({ error: `mode inválido: ${mode} (use report|execute|notify)` }, 400);
+  } catch (e) {
+    console.error("winback-backfill error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});

--- a/supabase/migrations/077_backfill_special_points_round_of_16.sql
+++ b/supabase/migrations/077_backfill_special_points_round_of_16.sql
@@ -1,0 +1,31 @@
+-- ============================================================
+-- 077_backfill_special_points_round_of_16 — pontos das Oitavas
+-- ============================================================
+-- Mesmo esquecimento da 065, só que nos PONTOS: o default de
+-- special_predictions_points (037) não tem a chave round_of_16
+-- ({finalist:10, round_of_32:1, semifinalist:5, quarterfinalist:3}).
+-- A 065 backfillou a CONFIG (fase habilitada) mas não os pontos.
+--
+-- Efeito do bug: o resolve_special_scores lê COALESCE(pts->>'round_of_16', 0)
+-- → quem acertou classificado pras oitavas ganhou 0 ponto nos bolões cujo
+-- dono nunca ajustou os pontos. O front sempre PROMETEU 2 pts por acerto
+-- (fallback `pointsConfig.round_of_16 ?? 2` no SpecialPredictionsModal /
+-- SpecialPredictionsSection) — o backfill usa o mesmo 2.
+--
+-- Preserva quem configurou explicitamente (só adiciona onde a chave falta).
+-- Após aplicar, rodar: SELECT resolve_all_special_scores();  (recalculável)
+-- ============================================================
+
+-- 1) Bolões existentes: adiciona round_of_16=2 só onde a chave está ausente.
+UPDATE public.boloes
+SET special_predictions_points =
+      jsonb_build_object('round_of_16', 2) || special_predictions_points
+WHERE NOT (special_predictions_points ? 'round_of_16');
+
+-- 2) Default da coluna para bolões novos (inclui round_of_16).
+ALTER TABLE public.boloes
+  ALTER COLUMN special_predictions_points SET DEFAULT
+    '{"finalist": 10, "round_of_16": 2, "round_of_32": 1, "semifinalist": 5, "quarterfinalist": 3}'::jsonb;
+
+-- 3) Recredita o "quem avança" com os pontos corretos (idempotente).
+SELECT public.resolve_all_special_scores();

--- a/supabase/migrations/077_backfill_special_points_round_of_16.sql
+++ b/supabase/migrations/077_backfill_special_points_round_of_16.sql
@@ -8,24 +8,25 @@
 --
 -- Efeito do bug: o resolve_special_scores lê COALESCE(pts->>'round_of_16', 0)
 -- → quem acertou classificado pras oitavas ganhou 0 ponto nos bolões cujo
--- dono nunca ajustou os pontos. O front sempre PROMETEU 2 pts por acerto
--- (fallback `pointsConfig.round_of_16 ?? 2` no SpecialPredictionsModal /
--- SpecialPredictionsSection) — o backfill usa o mesmo 2.
+-- dono nunca ajustou os pontos. O painel de configurações sempre EXIBIU
+-- "Vale 1 pt(s) cada" pra esses bolões (fallback `?? 1` do BolaoAdminPanel,
+-- visível a dono e membros) — o backfill honra esse 1. Auditoria em prod
+-- (05/07): 35 bolões sem a chave; só 2 salvaram valor explícito (preservados).
 --
 -- Preserva quem configurou explicitamente (só adiciona onde a chave falta).
 -- Após aplicar, rodar: SELECT resolve_all_special_scores();  (recalculável)
 -- ============================================================
 
--- 1) Bolões existentes: adiciona round_of_16=2 só onde a chave está ausente.
+-- 1) Bolões existentes: adiciona round_of_16=1 só onde a chave está ausente.
 UPDATE public.boloes
 SET special_predictions_points =
-      jsonb_build_object('round_of_16', 2) || special_predictions_points
+      jsonb_build_object('round_of_16', 1) || special_predictions_points
 WHERE NOT (special_predictions_points ? 'round_of_16');
 
 -- 2) Default da coluna para bolões novos (inclui round_of_16).
 ALTER TABLE public.boloes
   ALTER COLUMN special_predictions_points SET DEFAULT
-    '{"finalist": 10, "round_of_16": 2, "round_of_32": 1, "semifinalist": 5, "quarterfinalist": 3}'::jsonb;
+    '{"finalist": 10, "round_of_16": 1, "round_of_32": 1, "semifinalist": 5, "quarterfinalist": 3}'::jsonb;
 
 -- 3) Recredita o "quem avança" com os pontos corretos (idempotente).
 SELECT public.resolve_all_special_scores();

--- a/supabase/migrations/078_settlement_reminders.sql
+++ b/supabase/migrations/078_settlement_reminders.sql
@@ -1,0 +1,114 @@
+-- ============================================================
+-- 078_settlement_reminders — lembrete de liquidação no Telegram
+-- ============================================================
+-- Ataca o buraco da retenção: ~72% das apostas morrem em 'pending' porque
+-- liquidar exige entrar no site. Agora o Betinho manda DM quando o jogo acaba,
+-- com botões inline [✅ Green] [❌ Red] — 1 toque e a banca atualiza.
+--
+-- Duas classes de lembrete (decididas na edge function notify-settlement):
+--   • Copa (casada com wc_matches encerrado): chega COM o placar e, quando o
+--     mercado é computável (ML/over-under/ambas marcam), com o veredito
+--     sugerido — "pelo placar, essa bateu ✅".
+--   • Genérica (qualquer esporte/liga sem placar no banco): jogo já passou →
+--     pergunta com os mesmos botões, sem veredito.
+--
+-- Também adiciona o placar dos 90' em wc_matches (fulltime_*): mercados de
+-- aposta liquidam no tempo normal; home/away_score inclui prorrogação e
+-- liquidaria errado jogo de mata-mata que foi pro tempo extra.
+--
+-- PRÉ-REQUISITO POR AMBIENTE (rodar uma vez via SQL, igual ao 048/073):
+--   vault.create_secret('<x-cron-secret>', 'notify_settlement_cron_secret', ...);
+--   vault.create_secret('<url da função>', 'notify_settlement_url', ...);
+--   E os secrets da função (TELEGRAM_BOT_TOKEN, CRON_SECRET) no painel.
+-- Além disso: o setWebhook do bot precisa entregar callback_query (se
+-- allowed_updates foi restringido a ["message"], reconfigurar — ver runbook).
+-- ============================================================
+
+-- ── wc_matches: placar dos 90 minutos (base de liquidação) ──
+ALTER TABLE public.wc_matches
+  ADD COLUMN IF NOT EXISTS fulltime_home integer,
+  ADD COLUMN IF NOT EXISTS fulltime_away integer;
+COMMENT ON COLUMN public.wc_matches.fulltime_home IS
+  'Gols do mandante nos 90 min (score.fulltime da API). Base de liquidação de apostas; home_score inclui prorrogação.';
+COMMENT ON COLUMN public.wc_matches.fulltime_away IS
+  'Gols do visitante nos 90 min (score.fulltime da API). Base de liquidação de apostas; away_score inclui prorrogação.';
+
+-- ── bets: cadência/idempotência do lembrete ──────────────────
+ALTER TABLE public.bets
+  ADD COLUMN IF NOT EXISTS settlement_reminder_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS settlement_reminder_at timestamptz;
+COMMENT ON COLUMN public.bets.settlement_reminder_count IS
+  'Quantos lembretes de liquidação já enviamos (teto 2 — não vira spam).';
+COMMENT ON COLUMN public.bets.settlement_reminder_at IS
+  'Último lembrete enviado (gap mínimo de 20h entre lembretes da mesma aposta).';
+
+-- Consulta do cron: pendentes recentes com lembrete disponível.
+CREATE INDEX IF NOT EXISTS idx_bets_settlement_pending
+  ON public.bets (bet_date)
+  WHERE status = 'pending' AND settlement_reminder_count < 2;
+
+-- ── users: opt-out (botão 🔕 na própria mensagem) ────────────
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS settlement_reminders_muted boolean NOT NULL DEFAULT false;
+COMMENT ON COLUMN public.users.settlement_reminders_muted IS
+  'true = usuário pediu pra parar os lembretes de liquidação (🔕 no bot). /lembretes reativa.';
+
+-- ── RPC: candidatas a lembrete AGORA ─────────────────────────
+-- Filtro grosso no banco (pendente, usuário linkado e não mutado, lembretes
+-- restantes, gap respeitado, aposta recente). O refinamento — casar com
+-- wc_matches encerrado, janela de silêncio, teto por usuário — fica na função,
+-- que loga e instrumenta cada decisão.
+CREATE OR REPLACE FUNCTION public.get_settlement_reminder_candidates()
+RETURNS TABLE(
+  bet_id uuid, user_id uuid, chat_id text, user_name text,
+  bet_type text, sport text, league text, betting_market text,
+  match_description text, bet_description text,
+  odds numeric, stake_amount numeric, potential_return numeric,
+  bet_date timestamptz, match_date timestamptz,
+  reminder_count integer
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  -- casts: colunas varchar(n) da tabela ≠ text do RETURNS TABLE sem cast explícito
+  SELECT b.id, b.user_id, u.telegram_chat_id::text, u.name::text,
+         b.bet_type::text, b.sport::text, b.league::text, b.betting_market::text,
+         b.match_description::text, b.bet_description::text,
+         b.odds::numeric, b.stake_amount::numeric, b.potential_return::numeric,
+         b.bet_date, b.match_date,
+         b.settlement_reminder_count
+  FROM bets b
+  JOIN users u ON u.id = b.user_id
+    AND u.telegram_chat_id IS NOT NULL
+    AND u.settlement_reminders_muted = false
+  WHERE b.status = 'pending'
+    AND b.settlement_reminder_count < 2
+    AND (b.settlement_reminder_at IS NULL OR b.settlement_reminder_at < now() - interval '20 hours')
+    AND b.bet_date > now() - interval '14 days'
+  ORDER BY b.bet_date DESC
+  LIMIT 500;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_settlement_reminder_candidates() TO service_role;
+
+-- ── Cron: a cada 15 min (o "logo após o apito" é o momento mágico) ──
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notify-settlement') THEN
+    PERFORM cron.unschedule('notify-settlement');
+  END IF;
+END $$;
+
+SELECT cron.schedule('notify-settlement', '*/15 * * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_settlement_url'),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_settlement_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+$job$);

--- a/supabase/migrations/079_winback_backfill.sql
+++ b/supabase/migrations/079_winback_backfill.sql
@@ -1,0 +1,113 @@
+-- ============================================================
+-- 079_winback_backfill — reconquista de quem sumiu (R1 do roadmap)
+-- ============================================================
+-- Suporte à edge function winback-backfill (one-shot MANUAL, sem cron):
+-- fecha o histórico antigo de apostas pendentes com dado verificável
+-- (nba_mart pra props NBA, API-Sports histórico pra futebol) e manda UMA
+-- DM de reconquista: "atualizamos seu histórico — seu ROI real está pronto".
+--
+-- Aqui: tabela de idempotência do aviso + RPCs de leitura do nba_mart
+-- (o schema é trancado pra acesso direto desde a 056 — padrão é RPC) +
+-- RPC que monta os alvos do notify com ROI real calculado.
+--
+-- SEM cron de propósito: a execução é decisão humana (report → execute →
+-- notify), ver runbook WINBACK_BACKFILL_SETUP.md.
+-- ============================================================
+
+-- ── Idempotência do aviso: 1 DM por usuário, nunca 2 ─────────
+CREATE TABLE IF NOT EXISTS public.winback_notifications (
+  user_id      uuid PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  sent_at      timestamptz NOT NULL DEFAULT now(),
+  bets_settled integer NOT NULL DEFAULT 0,
+  roi          numeric
+);
+COMMENT ON TABLE public.winback_notifications IS
+  'Idempotência do aviso de reconquista (winback-backfill mode=notify): quem já recebeu não recebe de novo.';
+ALTER TABLE public.winback_notifications ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role acessa (RLS bloqueia anon/authenticated)
+
+-- ── RPC: busca jogador no mart por pedaço do nome ────────────
+CREATE OR REPLACE FUNCTION public.winback_find_nba_player(p_name_part text)
+RETURNS TABLE(player_id bigint, player_name text)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  SELECT DISTINCT p.player_id, p.player_name
+  FROM nba_mart.dim_players p
+  WHERE p.player_name ILIKE '%' || p_name_part || '%'
+  LIMIT 25;
+$function$;
+
+-- ── RPC: stat realizada do jogador numa janela de datas ──────
+CREATE OR REPLACE FUNCTION public.winback_nba_stat_window(
+  p_player_id bigint, p_stat_type text, p_from date, p_to date
+)
+RETURNS TABLE(game_date date, stat_value double precision, is_played text)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  SELECT s.game_date, s.stat_value, s.is_played
+  FROM nba_mart.ft_game_player_stats s
+  WHERE s.player_id = p_player_id
+    AND s.stat_type = p_stat_type
+    AND s.game_date BETWEEN p_from AND p_to
+  ORDER BY s.game_date;
+$function$;
+
+-- ── RPC: alvos do notify, com ROI real calculado ─────────────
+-- Usuário entra se: tem aposta fechada pelo winback (evidência em
+-- processed_data.winback), tem Telegram, não silenciou lembretes e ainda
+-- não recebeu o aviso. Devolve tudo que a DM precisa.
+CREATE OR REPLACE FUNCTION public.get_winback_notify_targets()
+RETURNS TABLE(
+  user_id uuid, chat_id text, user_name text,
+  settled bigint, greens bigint,
+  profit numeric, roi numeric, leftovers bigint
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  WITH winback_settled AS (
+    SELECT b.user_id,
+           count(*) AS settled,
+           count(*) FILTER (WHERE b.status = 'won') AS greens
+    FROM bets b
+    WHERE b.processed_data ? 'winback'
+      AND b.status IN ('won','lost')
+    GROUP BY b.user_id
+  ),
+  historico AS (  -- ROI real: TODAS as apostas resolvidas do usuário
+    SELECT b.user_id,
+           sum(b.stake_amount) AS staked,
+           sum(CASE
+             WHEN b.status = 'won'       THEN b.potential_return
+             WHEN b.status = 'cashout'   THEN coalesce(b.cashout_amount, 0)
+             WHEN b.status = 'half_won'  THEN (b.stake_amount + b.potential_return) / 2
+             WHEN b.status = 'half_lost' THEN b.stake_amount / 2
+             ELSE 0
+           END) AS returns
+    FROM bets b
+    WHERE b.status IN ('won','lost','cashout','half_won','half_lost')
+    GROUP BY b.user_id
+  ),
+  sobras AS (  -- pendências antigas que o motor não conseguiu fechar
+    SELECT b.user_id, count(*) AS leftovers
+    FROM bets b
+    WHERE b.status = 'pending' AND b.bet_date < now() - interval '7 days'
+    GROUP BY b.user_id
+  )
+  SELECT u.id, u.telegram_chat_id::text, u.name::text,
+         w.settled, w.greens,
+         round(coalesce(h.returns, 0) - coalesce(h.staked, 0), 2) AS profit,
+         round(CASE WHEN coalesce(h.staked, 0) > 0
+           THEN (coalesce(h.returns, 0) - h.staked) / h.staked * 100 ELSE 0 END, 1) AS roi,
+         coalesce(s.leftovers, 0) AS leftovers
+  FROM winback_settled w
+  JOIN users u ON u.id = w.user_id
+    AND u.telegram_chat_id IS NOT NULL
+    AND coalesce(u.settlement_reminders_muted, false) = false
+  LEFT JOIN historico h ON h.user_id = w.user_id
+  LEFT JOIN sobras s ON s.user_id = w.user_id
+  WHERE NOT EXISTS (SELECT 1 FROM winback_notifications n WHERE n.user_id = w.user_id);
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.winback_find_nba_player(text)                        TO service_role;
+GRANT EXECUTE ON FUNCTION public.winback_nba_stat_window(bigint, text, date, date)    TO service_role;
+GRANT EXECUTE ON FUNCTION public.get_winback_notify_targets()                         TO service_role;

--- a/supabase/migrations/080_handoff_final_notifications.sql
+++ b/supabase/migrations/080_handoff_final_notifications.sql
@@ -1,0 +1,50 @@
+-- ============================================================
+-- 080_handoff_final_notifications — DM de encerramento do bolão (H1)
+-- ============================================================
+-- Suporte à edge function notify-handoff (one-shot MANUAL, sem cron):
+-- no dia da final (19/jul), cada membro de bolão com Telegram recebe UMA
+-- DM com sua posição definitiva + as duas portas de continuação
+-- (Betinho pro casual, análise de futebol pro frequente).
+--
+-- O rank vem de get_bolao_ranking() — a MESMA função que o site usa —
+-- então a DM nunca diverge do ranking exibido.
+-- ============================================================
+
+-- ── Idempotência: 1 DM por usuário, nunca 2 ──────────────────
+CREATE TABLE IF NOT EXISTS public.bolao_handoff_notifications (
+  user_id      uuid PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  sent_at      timestamptz NOT NULL DEFAULT now(),
+  boloes_count integer NOT NULL DEFAULT 0
+);
+COMMENT ON TABLE public.bolao_handoff_notifications IS
+  'Idempotência da DM de encerramento do bolão (notify-handoff): quem já recebeu não recebe de novo.';
+ALTER TABLE public.bolao_handoff_notifications ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role acessa
+
+-- ── RPC: alvos da DM — 1 linha por (usuário, bolão) ──────────
+-- A função agrupa por usuário; bolões ordenados do mais populoso pro menor.
+CREATE OR REPLACE FUNCTION public.get_handoff_targets()
+RETURNS TABLE(
+  user_id uuid, chat_id text, user_name text,
+  bolao_name text, user_rank bigint, total_players bigint
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  SELECT u.id, u.telegram_chat_id::text, u.name::text,
+         b.name::text, r.rank, cnt.total
+  FROM users u
+  JOIN bolao_members bm ON bm.user_id = u.id
+  JOIN boloes b ON b.id = bm.bolao_id
+  JOIN LATERAL (
+    SELECT g.rank FROM get_bolao_ranking(b.id) g WHERE g.user_id = u.id
+  ) r ON true
+  JOIN LATERAL (
+    SELECT count(*)::bigint AS total FROM bolao_members WHERE bolao_id = b.id
+  ) cnt ON true
+  WHERE u.telegram_chat_id IS NOT NULL
+    AND coalesce(u.settlement_reminders_muted, false) = false
+    AND NOT EXISTS (SELECT 1 FROM bolao_handoff_notifications n WHERE n.user_id = u.id)
+  ORDER BY u.id, cnt.total DESC, b.name;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_handoff_targets() TO service_role;

--- a/supabase/migrations/081_notify_opportunities.sql
+++ b/supabase/migrations/081_notify_opportunities.sql
@@ -1,0 +1,101 @@
+-- ============================================================
+-- 081_notify_opportunities — oportunidades do dia no Telegram (08′)
+-- ============================================================
+-- O motor já existe (dbt → fact_value_opportunities → get_futebol_value_board);
+-- aqui entra SÓ o formato de entrega: um daily no Telegram com os melhores
+-- picks do dia (Score + evidências, mesma língua do site).
+--
+-- Dois segmentos de público (decisão de produto 2026-07-08):
+--   A · futebol ativo  — trial vigente ou assinante + Telegram. Recebe sempre.
+--   B · reativação     — conectou o Telegram mas está inativo. Recebe até
+--       2 envios; se não CLICAR em nenhum, para de receber (a mensagem tem
+--       que merecer continuar existindo). Clique zera o contador.
+--
+-- O clique é medido pelo redirecionador `go` (edge function): registra em
+-- notification_clicks + zera o contador, e manda a pessoa pro destino.
+--
+-- PRÉ-REQUISITO POR AMBIENTE (rodar uma vez via SQL, igual 048/073/078):
+--   vault.create_secret('<x-cron-secret>', 'notify_opportunities_cron_secret', ...);
+--   vault.create_secret('<url da função>', 'notify_opportunities_url', ...);
+-- ============================================================
+
+-- ── Estado de cadência por usuário ───────────────────────────
+CREATE TABLE IF NOT EXISTS public.opportunity_dispatch_state (
+  user_id             uuid PRIMARY KEY REFERENCES public.users(id) ON DELETE CASCADE,
+  segment             text NOT NULL,               -- 'A' (futebol ativo) | 'B' (reativação)
+  sends_without_click integer NOT NULL DEFAULT 0,  -- regra do B: >= 2 → para
+  last_sent_at        timestamptz,
+  last_click_at       timestamptz
+);
+COMMENT ON TABLE public.opportunity_dispatch_state IS
+  'Cadência do daily de oportunidades: no segmento B (reativação), 2 envios sem clique = para de receber.';
+ALTER TABLE public.opportunity_dispatch_state ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role
+
+-- ── Cliques rastreados (funil enviado → clicou) ──────────────
+CREATE TABLE IF NOT EXISTS public.notification_clicks (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     uuid REFERENCES public.users(id) ON DELETE CASCADE,
+  campaign    text NOT NULL,
+  destination text NOT NULL,
+  clicked_at  timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_notification_clicks_user ON public.notification_clicks(user_id, clicked_at);
+ALTER TABLE public.notification_clicks ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role
+
+-- ── RPC: quem recebe o daily HOJE ────────────────────────────
+-- A: acesso ao futebol vigente (assinante OU trial de 7d ainda rodando).
+-- B: Telegram linkado + inativo no Betinho (sem aposta há 14+ dias) + ainda
+--    dentro da regra dos 2 envios sem clique. A e B são disjuntos (B exclui A).
+CREATE OR REPLACE FUNCTION public.get_opportunity_recipients()
+RETURNS TABLE(user_id uuid, chat_id text, user_name text, segment text, sends_without_click integer)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  WITH base AS (
+    SELECT u.id, u.telegram_chat_id, u.name,
+           (coalesce(u.futebol_subscription_status,'free') = 'premium'
+             OR (u.futebol_trial_started_at IS NOT NULL
+                 AND u.futebol_trial_started_at + interval '7 days' > now())) AS futebol_ativo,
+           (SELECT max(b.bet_date) FROM bets b WHERE b.user_id = u.id) AS ultima_aposta
+    FROM users u
+    WHERE u.telegram_chat_id IS NOT NULL
+      AND coalesce(u.settlement_reminders_muted, false) = false
+  )
+  SELECT b.id, b.telegram_chat_id::text, b.name::text,
+         CASE WHEN b.futebol_ativo THEN 'A' ELSE 'B' END AS segment,
+         coalesce(s.sends_without_click, 0)
+  FROM base b
+  LEFT JOIN opportunity_dispatch_state s ON s.user_id = b.id
+  WHERE b.futebol_ativo
+     OR (
+       -- reativação: inativo há 14+ dias (ou nunca apostou) e regra dos 2 envios
+       (b.ultima_aposta IS NULL OR b.ultima_aposta < now() - interval '14 days')
+       AND coalesce(s.sends_without_click, 0) < 2
+     );
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_opportunity_recipients() TO service_role;
+
+-- ── Cron: diário às 13:00 UTC (10h BRT — logo após o dbt da madrugada) ──
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notify-opportunities') THEN
+    PERFORM cron.unschedule('notify-opportunities');
+  END IF;
+END $$;
+
+SELECT cron.schedule('notify-opportunities', '0 13 * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_opportunities_url'),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_opportunities_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 60000
+  );
+$job$);

--- a/supabase/migrations/082_multi_league_collector.sql
+++ b/supabase/migrations/082_multi_league_collector.sql
@@ -1,0 +1,176 @@
+-- ============================================================
+-- 082_multi_league_collector — coletor de placares multi-liga (F1)
+-- ============================================================
+-- Implementa o desenho aprovado pelo Kasuya na task wdx6zenqbv (parecer 08/07):
+--
+--   • fixtures genérica (multi-liga) com placar por período (halftime/fulltime/
+--     extratime/penalty), status/elapsed, trigger de updated_at e índices
+--   • leagues_config — quais ligas o coletor cobre (dado, não código)
+--   • team_aliases — apelidos por ID de time (substitui o dicionário hardcoded
+--     EN_ALIASES no futuro matching v2 do settlement — F2)
+--   • collector_runs — telemetria de cada execução (a lacuna nº1 do parecer:
+--     "o medo que gera é degradar em silêncio")
+--   • 1 ÚNICO cron a cada 2 min cujo SQL só chama a função SE existe jogo em
+--     janela (kickoff−10min < now < kickoff+3h) em liga habilitada — fora de
+--     janela: zero invocação, zero request, zero custo
+--   • 1 cron diário de calendário (04:00 BRT — 1 chamada por liga habilitada)
+--
+-- ESTRATÉGIA DE MIGRAÇÃO (dual-run, sem migrar histórico):
+--   wc_matches NÃO é migrada (é do bolão; morre com a Copa em 19/07).
+--   O coletor grava fixtures pra todas as ligas incl. Copa → ~10 dias de
+--   paridade em staging → notify-settlement troca a leitura (F2) → pós-Copa,
+--   aposentar ingest-wc-scores + cron 048.
+--   futebol.fact_fixtures (sync do BQ) NÃO serve pro settlement: latência de
+--   horas contra os ≤15min necessários — dono é o data-engineering.
+--
+-- PRÉ-REQUISITO POR AMBIENTE (rodar uma vez via SQL, igual 048/073/078):
+--   vault.create_secret('<x-cron-secret>', 'ingest_fixtures_cron_secret', ...);
+--   vault.create_secret('<url da função>', 'ingest_fixtures_url', ...);
+-- ============================================================
+
+-- ── Ligas cobertas: dado, não código ─────────────────────────
+CREATE TABLE IF NOT EXISTS public.leagues_config (
+  league_id integer NOT NULL,
+  season    integer NOT NULL,
+  name      text NOT NULL,
+  enabled   boolean NOT NULL DEFAULT false,
+  PRIMARY KEY (league_id, season)
+);
+COMMENT ON TABLE public.leagues_config IS
+  'Ligas que o coletor multi-liga cobre. enabled=true entra no live poll e no calendário diário. IDs da API-Football.';
+
+-- Seed: Copa (piloto/dual-run) + Ondas 1 e 2 da expansão. enabled=true só nas
+-- que têm jogo AGORA; as demais viram true na data de retorno (datas nas tasks
+-- das Ondas no ClickUp).
+INSERT INTO public.leagues_config (league_id, season, name, enabled) VALUES
+  (1,   2026, 'Copa do Mundo FIFA',        true),   -- até 19/07 (dual-run com ingest-wc-scores)
+  (71,  2026, 'Brasileirão Série A',       true),   -- volta 16/07
+  (72,  2026, 'Brasileirão Série B',       true),   -- não para
+  (73,  2026, 'Copa do Brasil',            true),   -- volta 30/07-01/08
+  (13,  2026, 'Copa Libertadores',         true),   -- volta 12/08 (odds antes)
+  (2,   2026, 'UEFA Champions League',     false),  -- volta 16/09
+  (39,  2026, 'Premier League (ENG)',      false),  -- volta 15/08
+  (140, 2026, 'La Liga (ESP)',             false),  -- volta 15/08
+  (11,  2026, 'Copa Sul-Americana',        false),  -- volta 15/07 → habilitar quando odds cobrirem
+  (135, 2026, 'Serie A (ITA)',             false),  -- volta 22/08
+  (78,  2026, 'Bundesliga (ALE)',          false),  -- volta 22/08
+  (61,  2026, 'Ligue 1 (FRA)',             false),  -- volta 23/08
+  (94,  2026, 'Primeira Liga (POR)',       false)   -- volta 08/08
+ON CONFLICT (league_id, season) DO NOTHING;
+
+-- ── Fixtures genérica (fonte do settlement multi-liga no F2) ─
+CREATE TABLE IF NOT EXISTS public.fixtures (
+  fixture_id     bigint PRIMARY KEY,          -- id da API-Football
+  league_id      integer NOT NULL,
+  season         integer NOT NULL,
+  round          text,
+  home_team_id   bigint,
+  home_team      text NOT NULL,
+  away_team_id   bigint,
+  away_team      text NOT NULL,
+  kickoff_utc    timestamptz NOT NULL,
+  status_short   text,                        -- NS/1H/HT/2H/ET/P/FT/AET/PEN/PST/CANC...
+  elapsed        integer,
+  goals_home     integer,                     -- placar corrente/final (inclui prorrogação)
+  goals_away     integer,
+  halftime_home  integer,                     -- mercados de 1º tempo (futuro)
+  halftime_away  integer,
+  fulltime_home  integer,                     -- 90' — BASE DE LIQUIDAÇÃO
+  fulltime_away  integer,
+  extratime_home integer,
+  extratime_away integer,
+  penalty_home   integer,
+  penalty_away   integer,
+  winner         text,                        -- 'home' | 'away' | null (empate/indefinido)
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now()
+);
+COMMENT ON TABLE public.fixtures IS
+  'Placares multi-liga do coletor (edge function ingest-fixtures). Liquidação usa fulltime_* (90 min); goals_* inclui prorrogação.';
+CREATE INDEX IF NOT EXISTS idx_fixtures_kickoff ON public.fixtures (kickoff_utc);
+CREATE INDEX IF NOT EXISTS idx_fixtures_league  ON public.fixtures (league_id, season);
+-- trigger de updated_at (função já existe desde a 005; wc_matches não tinha — parecer 2c)
+DROP TRIGGER IF EXISTS update_fixtures_updated_at ON public.fixtures;
+CREATE TRIGGER update_fixtures_updated_at
+  BEFORE UPDATE ON public.fixtures
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+ALTER TABLE public.fixtures ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role (settlement/edge); o front lê pelo schema futebol (DE)
+
+-- ── Apelidos de time por ID (consumidor: matching v2 — F2) ───
+CREATE TABLE IF NOT EXISTS public.team_aliases (
+  api_team_id bigint NOT NULL,
+  alias       text   NOT NULL,   -- normalizado (sem acento, minúsculas)
+  PRIMARY KEY (api_team_id, alias)
+);
+COMMENT ON TABLE public.team_aliases IS
+  'Apelidos/aliases por ID de time da API-Football (ex.: 85→"psg"). Substitui dicionários hardcoded no matching aposta↔jogo.';
+ALTER TABLE public.team_aliases ENABLE ROW LEVEL SECURITY;
+
+-- ── Telemetria do coletor (lacuna nº1 do parecer) ────────────
+CREATE TABLE IF NOT EXISTS public.collector_runs (
+  id              bigserial PRIMARY KEY,
+  ran_at          timestamptz NOT NULL DEFAULT now(),
+  mode            text NOT NULL,              -- 'live' | 'calendar'
+  window_active   boolean,
+  live_fixtures   integer,
+  api_calls       integer,
+  quota_remaining integer,                    -- header x-ratelimit-requests-remaining
+  ok              boolean NOT NULL,
+  error           text
+);
+COMMENT ON TABLE public.collector_runs IS
+  'Cada execução do ingest-fixtures: chamadas feitas, quota restante do plano, sucesso/erro. Alerta admin após falhas consecutivas.';
+CREATE INDEX IF NOT EXISTS idx_collector_runs_ran_at ON public.collector_runs (ran_at DESC);
+ALTER TABLE public.collector_runs ENABLE ROW LEVEL SECURITY;
+
+-- ── Cron 1: live poll a cada 2 min, com GATE SQL ─────────────
+-- Fora de janela de jogo: o SELECT não chama net.http_post → zero invocação.
+-- O gate lê a própria fixtures (populada pelo calendário diário).
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'ingest-fixtures-live') THEN
+    PERFORM cron.unschedule('ingest-fixtures-live');
+  END IF;
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'ingest-fixtures-calendar') THEN
+    PERFORM cron.unschedule('ingest-fixtures-calendar');
+  END IF;
+END $$;
+
+SELECT cron.schedule('ingest-fixtures-live', '*/2 * * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_fixtures_url') || '?mode=live',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_fixtures_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  )
+  WHERE EXISTS (
+    SELECT 1
+    FROM public.fixtures f
+    JOIN public.leagues_config lc
+      ON lc.league_id = f.league_id AND lc.season = f.season AND lc.enabled
+    WHERE now() BETWEEN f.kickoff_utc - interval '10 minutes'
+                    AND f.kickoff_utc + interval '3 hours'
+      AND coalesce(f.status_short, 'NS') NOT IN ('FT','AET','PEN','CANC','ABD','AWD','WO','PST')
+  );
+$job$);
+
+-- ── Cron 2: calendário diário às 07:00 UTC (04:00 BRT) ───────
+-- 1 chamada por liga habilitada — pega jogos novos, remarcações e TBD→NS.
+SELECT cron.schedule('ingest-fixtures-calendar', '0 7 * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_fixtures_url') || '?mode=calendar',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ingest_fixtures_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 120000
+  );
+$job$);


### PR DESCRIPTION
## O que vai
- **feat(futebol)**: coletor de placares multi-liga (#196), oportunidades do dia no Telegram (#194), ingest-fixtures
- **feat(betinho)**: auto-liquidação com correção de 1 toque + handicap asiático (#197), lembrete de liquidação (#190), winback (#192)
- **feat(bolao)**: passagem de bastão do dia da final (#193)
- **fix(bolao)**: pontos das oitavas no "quem avança" (migration 077, backfill=1pt) + fallbacks do front unificados
- **ci**: workflows passam a deployar as funções de cron/futebol (ingest-wc-scores, notify-*, winback-backfill, go, ingest-fixtures)

## Migrations que o CI vai aplicar em prod
073 (kickoff Telegram — nunca aplicada em prod), 078–082 (futebol/betinho). As 071–077 rodadas manualmente foram registradas no histórico via repair.

## Pré-requisito (JÁ FEITO antes deste merge)
Repair do histórico de migrations de prod — remoção da órfã `20260620165726` + registro das 071–077 manuais. Sem isso o passo "Apply DB migrations" falhava desde 28/06.

## Pós-merge (conferir)
1. GitHub Actions → "Deploy Production" verde (primeira vez desde 28/06).
2. Secrets/Vault da notify-kickoff em prod (`notify_kickoff_url`, `notify_kickoff_cron_secret`) — sem eles o cron de kickoff loga erro inofensivo a cada 30min.
3. Secrets das funções novas do futebol (conferir com o Diody o runbook delas).

Staging: verde com tudo isso desde 10/07 ~01:11 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xCEY97mT5oZU7YCePSH71