### PR TITLE
feat(betinho): botão 'Registrar no Betinho' no daily de oportunidades (item 15)

### DIFF
--- a/MAPA_MENSAGENS_BOT.md
+++ b/MAPA_MENSAGENS_BOT.md
@@ -12,6 +12,7 @@ fraco = silêncio; usuário que ignora = para de receber.
 | 2 | **"🏁 Placar X×Y — como foi?"** (jogo casado, mercado não-computável: múltipla, prop...) | Mesmo gatilho da #1, quando o bot não pode cravar | Mesmo momento da #1 | Mesmo teto da #1 + máx **2 lembretes por aposta** (gap 20h) | 🔕 |
 | 3 | **"⏱️ Seu jogo já deve ter terminado — como foi?"** (genérico, sem placar no banco) | `match_date` passou há 3h+, ou aposta com 24h+ sem data de jogo | Só entre **09h–23h BRT** | Mesmo teto da #1 + máx 2 por aposta (gap 20h) | 🔕 |
 | 4 | **"⚽ As oportunidades de hoje"** (daily) | Cron diário | **10h BRT em ponto**, 1x/dia — e SÓ se houver pick acima do corte (Score ≥ 40). Sem pick = sem mensagem | Reativação (segmento B): **2 envios sem clique → para pra sempre** | 🔕 |
+| 4a | **Registrar aposta** (botão "📋 Registrar" no daily #4) | Usuário toca no botão de um pick | Reativa (resposta ao toque): pergunta o valor por botões [1 unidade][½ unidade][Outro valor]; "Outro valor" = force_reply amarrado. Registra a aposta pendente → entra no loop da auto-liquidação (#1) | Reativa — só responde ao toque | n/a |
 | 5 | **Confirmação de aposta registrada** | Usuário mandou print/texto | Imediato (resposta ao registro) | Reativa — só responde ao que o usuário fez | n/a |
 | 6 | **Aviso de kickoff do bolão** (só pro DONO do bolão) | Jogo da Copa começando | No minuto do kickoff (:00/:30) | 1 por jogo por bolão | opt-in explícito do dono |
 

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -66,6 +66,19 @@ function pickLabel(market: string, outcome: string, line: number | null, homeNam
   return outcomePt(outcome, homeName, awayName);
 }
 
+// mercado → rótulo PT que a auto-liquidação (notify-settlement) reconhece,
+// pra a aposta registrada aqui ser liquidável depois pelo mesmo motor
+function marketPt(market: string): string {
+  switch (market) {
+    case "match_winner": return "Money Line";
+    case "goals_over_under": return "Over/Under";
+    case "asian_handicap": return "Handicap";
+    case "btts": return "Ambas marcam";
+    case "double_chance": return "Dupla chance";
+    default: return market;
+  }
+}
+
 // ── util ─────────────────────────────────────────────────────
 function esc(s: unknown): string {
   return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -141,7 +154,19 @@ async function buildMessage(picks: BoardRow[], userId: string): Promise<string> 
   return lines.join("\n");
 }
 
-async function sendDaily(chatId: string, text: string, boardUrl: string): Promise<void> {
+// botão "Registrar no Betinho" por pick (item 15). label curto pra caber.
+function registerButtons(picks: BoardRow[], pickIdByFixture: Map<number, string>): any[] {
+  const rows: any[] = [];
+  for (const p of picks) {
+    const id = pickIdByFixture.get(p.fixture_id);
+    if (!id) continue;
+    const label = pickLabel(p.market, p.outcome, p.line_value, p.home_team_name, p.away_team_name);
+    rows.push([{ text: `📋 Registrar: ${label.length > 34 ? label.slice(0, 33) + "…" : label}`, callback_data: `regbet:${id}` }]);
+  }
+  return rows;
+}
+
+async function sendDaily(chatId: string, text: string, boardUrl: string, pickRows: any[]): Promise<void> {
   const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -150,7 +175,7 @@ async function sendDaily(chatId: string, text: string, boardUrl: string): Promis
       text,
       parse_mode: "HTML",
       disable_web_page_preview: true,
-      reply_markup: { inline_keyboard: [[{ text: "Ver a análise completa", url: boardUrl }]] },
+      reply_markup: { inline_keyboard: [...pickRows, [{ text: "Ver a análise completa", url: boardUrl }]] },
     }),
   });
   if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
@@ -206,14 +231,36 @@ serve(async (req) => {
       });
     }
 
-    // 5) envio + estado de cadência
+    // 5) persiste os picks do dia (referência dos botões "Registrar no Betinho")
+    // — uma vez, compartilhado entre todos; upsert idempotente por (dia,jogo,aposta)
+    const pickRows = picks.map((p) => ({
+      fixture_id: p.fixture_id,
+      sport: "Futebol",
+      league: p.competition,
+      betting_market: marketPt(p.market),
+      match_description: `${p.home_team_name} × ${p.away_team_name}`,
+      bet_description: pickLabel(p.market, p.outcome, p.line_value, p.home_team_name, p.away_team_name),
+      odds: p.best_odd,
+      match_date: kickoffDate(p.kickoff_utc).toISOString(),
+    }));
+    const { data: savedPicks, error: pErr } = await supabase
+      .from("daily_opportunity_picks")
+      .upsert(pickRows, { onConflict: "sent_date,fixture_id,bet_description" })
+      .select("id, fixture_id");
+    if (pErr) throw pErr;
+    const pickIdByFixture = new Map<number, string>(
+      (savedPicks ?? []).map((r: any) => [Number(r.fixture_id), r.id as string])
+    );
+    const pickButtonRows = registerButtons(picks, pickIdByFixture);
+
+    // 6) envio + estado de cadência
     let sent = 0;
     const errors: string[] = [];
     for (const r of recipients) {
       try {
         const text = await buildMessage(picks, r.user_id);
         const boardUrl = await trackedUrl(r.user_id, "board");
-        await sendDaily(r.chat_id, text, boardUrl);
+        await sendDaily(r.chat_id, text, boardUrl, pickButtonRows);
 
         const { error: upErr } = await supabase.from("opportunity_dispatch_state").upsert({
           user_id: r.user_id,

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -50,6 +50,8 @@ interface TelegramMessage {
   document?: TelegramFile
   // Telegram sends thumbnails as "thumbnail" in documents; not used directly
   thumbnail?: TelegramFile
+  // resposta a uma mensagem do bot (force_reply do "Outro valor")
+  reply_to_message?: { message_id: number }
 }
 
 // Toque num botão inline (lembrete de liquidação do notify-settlement)
@@ -341,6 +343,77 @@ function settledHtml(bet: any, status: string): string {
   return `Registrada como <b>${escHtml(status)}</b>.\n\n${base}`
 }
 
+// ============================================================
+// Registrar aposta da "oportunidade do dia" (item 15) — botões de stake
+// ============================================================
+
+// Unidade efetiva do usuário em R$ (fixo = valor; percentual = % da banca).
+// null = não configurada → só oferece "Outro valor".
+async function effectiveUnit(supabase: any, userId: string): Promise<number | null> {
+  const { data } = await supabase
+    .from("users")
+    .select("unit_value, unit_calculation_method, bank_amount")
+    .eq("id", userId)
+    .maybeSingle()
+  const u = Number(data?.unit_value)
+  if (!u || u <= 0) return null
+  if (data.unit_calculation_method === "percentual") {
+    const bank = Number(data.bank_amount)
+    if (!bank || bank <= 0) return null
+    return Math.round(bank * (u / 100) * 100) / 100
+  }
+  return u
+}
+
+// Cria a aposta pendente a partir de um pick do daily. channel 'futebol' marca
+// a origem (loop Análise→Betinho); processed_data guarda o pick pra auditoria.
+async function registerPickBet(supabase: any, userId: string, pick: any, stake: number) {
+  const odds = Number(pick.odds)
+  return await supabase
+    .from("bets")
+    .insert({
+      user_id: userId,
+      bet_type: "single",
+      sport: pick.sport || "Futebol",
+      league: pick.league || null,
+      betting_market: pick.betting_market || null,
+      match_description: pick.match_description,
+      bet_description: pick.bet_description,
+      odds,
+      stake_amount: stake,
+      potential_return: Math.round(stake * odds * 100) / 100,
+      status: "pending",
+      bet_date: new Date().toISOString(),
+      match_date: pick.match_date || null,
+      channel: "futebol",
+      raw_input: "[oportunidade do dia]",
+      processed_data: { source: "daily_opportunity", pick_id: pick.id }
+    })
+    .select("id")
+    .maybeSingle()
+}
+
+function pickReceiptHtml(pick: any, stake: number): string {
+  const odds = Number(pick.odds)
+  return [
+    `✅ <b>Registrado no Betinho!</b>`,
+    "",
+    `<b>${escHtml(pick.bet_description)}</b>`,
+    `${escHtml(pick.match_description)}`,
+    `${formatBRL(stake)} · odd ${odds} · retorno ${formatBRL(Math.round(stake * odds * 100) / 100)}`,
+    "",
+    `Tá pendente — quando o jogo acabar, eu fecho pra você. 📊 ${BETS_DASHBOARD_URL}`
+  ].join("\n")
+}
+
+// número do texto do usuário (força reply do "Outro valor"): "R$ 50", "50,00", "50 reais"
+function parseStake(text: string): number | null {
+  const m = String(text ?? "").replace(",", ".").match(/(\d+(?:\.\d+)?)/)
+  if (!m) return null
+  const v = parseFloat(m[1])
+  return v > 0 && v <= 1_000_000 ? v : null
+}
+
 async function handleCallbackQuery(
   supabase: any,
   cq: TelegramCallbackQuery,
@@ -397,6 +470,83 @@ async function handleCallbackQuery(
       traceId
     ).catch(() => {})
     return ok("reminders muted")
+  }
+
+  // 📋 regbet:<pick_id> — tocou "Registrar no Betinho" no daily: abre os
+  // botões de valor (1 unidade / ½ unidade / Outro valor)
+  if (data.startsWith("regbet:")) {
+    const pickId = data.slice("regbet:".length)
+    const { data: pick } = await supabase
+      .from("daily_opportunity_picks").select("id, bet_description, odds").eq("id", pickId).maybeSingle()
+    if (!pick) {
+      await answerCallbackQuery(cq.id, "Essa oportunidade expirou 🕑")
+      return ok("regbet: pick not found")
+    }
+    const unit = await effectiveUnit(supabase, user.id)
+    const rows: any[] = []
+    if (unit) {
+      rows.push([
+        { text: `1 unidade · ${formatBRL(unit)}`, callback_data: `stk:${pickId}:u1` },
+        { text: `½ unidade · ${formatBRL(unit / 2)}`, callback_data: `stk:${pickId}:uh` }
+      ])
+    }
+    rows.push([{ text: "Outro valor", callback_data: `stk:${pickId}:ot` }])
+    await telegramCall("sendMessage", {
+      chat_id: chatId,
+      text: `📋 Registrar <b>${escHtml(pick.bet_description)}</b> (odd ${Number(pick.odds)})\nQuanto você vai colocar?`,
+      parse_mode: "HTML",
+      reply_markup: { inline_keyboard: rows }
+    })
+    await answerCallbackQuery(cq.id)
+    return ok("regbet: asked stake")
+  }
+
+  // 💰 stk:<pick_id>:<u1|uh|ot> — escolha do valor
+  if (data.startsWith("stk:")) {
+    const [, pickId, code] = data.split(":")
+    const { data: pick } = await supabase
+      .from("daily_opportunity_picks").select("*").eq("id", pickId).maybeSingle()
+    if (!pick) {
+      await answerCallbackQuery(cq.id, "Essa oportunidade expirou 🕑")
+      return ok("stk: pick not found")
+    }
+
+    // "Outro valor" → force_reply amarrado (a resposta NÃO cai no fluxo de aposta nova)
+    if (code === "ot") {
+      const sent = await telegramCall<{ result?: { message_id: number } }>("sendMessage", {
+        chat_id: chatId,
+        text: `Quanto você colocou em "${escHtml(pick.bet_description)}"? Responde aqui 👇 (só o número)`,
+        reply_markup: { force_reply: true }
+      })
+      const promptId = sent?.result?.message_id
+      if (promptId) {
+        await supabase.from("stake_prompts").insert({
+          chat_id: String(chatId), message_id: promptId, pick_id: pickId, user_id: user.id
+        })
+      }
+      await answerCallbackQuery(cq.id)
+      return ok("stk: force reply")
+    }
+
+    const unit = await effectiveUnit(supabase, user.id)
+    if (!unit) {
+      await answerCallbackQuery(cq.id, "Configure sua unidade no site ou toque em Outro valor.")
+      return ok("stk: no unit")
+    }
+    const stake = code === "uh" ? Math.round((unit / 2) * 100) / 100 : unit
+    const { data: bet, error } = await registerPickBet(supabase, user.id, pick, stake)
+    if (error || !bet) {
+      await answerCallbackQuery(cq.id, "Deu ruim ao registrar — tenta de novo.")
+      return ok("stk: insert failed")
+    }
+    await editSettledMessage(chatId, messageId, pickReceiptHtml(pick, stake))
+    await answerCallbackQuery(cq.id, "✅ Registrado!")
+    await trackEvent(
+      "opportunity_bet_registered",
+      { bet_id: bet.id, pick_id: pickId, stake, via: "unit_button", channel: "telegram" },
+      user.id, traceId
+    ).catch(() => {})
+    return ok("stk: registered")
   }
 
   // ↩️ fix:<bet_id> — desfaz a AUTO-liquidação (notify-settlement): volta pra
@@ -1936,6 +2086,43 @@ serve(async (req) => {
         JSON.stringify({ success: true, message: "Reminder preference updated" }),
         { headers: { "Content-Type": "application/json" }, status: 200 }
       )
+    }
+
+    // Resposta ao "Outro valor" (force_reply do registrar-oportunidade): se a
+    // mensagem é reply a um stake_prompt nosso, interpreta como VALOR daquele
+    // pick — e sai antes do fluxo de "extrair aposta nova" (nada de textão).
+    const replyToId = updateMessage.reply_to_message?.message_id
+    if (replyToId) {
+      const { data: prompt } = await supabase
+        .from("stake_prompts")
+        .select("pick_id")
+        .eq("chat_id", String(chatId))
+        .eq("message_id", replyToId)
+        .maybeSingle()
+      if (prompt) {
+        const stake = parseStake(text)
+        if (stake == null) {
+          await sendTelegramMessage(chatId, "Não entendi o valor 🤔 Manda só o número, ex: 50")
+          return new Response(JSON.stringify({ success: true, message: "stake reply invalid" }), { headers: { "Content-Type": "application/json" }, status: 200 })
+        }
+        const { data: pick } = await supabase
+          .from("daily_opportunity_picks").select("*").eq("id", prompt.pick_id).maybeSingle()
+        if (pick) {
+          const { data: bet, error } = await registerPickBet(supabase, user.id, pick, stake)
+          if (error || !bet) {
+            await sendTelegramMessage(chatId, "Deu ruim ao registrar — tenta de novo.")
+          } else {
+            await supabase.from("stake_prompts").delete().eq("chat_id", String(chatId)).eq("message_id", replyToId)
+            await sendTelegramMessage(chatId, pickReceiptHtml(pick, stake), { parse_mode: "HTML", disable_web_page_preview: true })
+            await trackEvent(
+              "opportunity_bet_registered",
+              { bet_id: bet.id, pick_id: prompt.pick_id, stake, via: "force_reply", channel: "telegram" },
+              user.id, traceId
+            ).catch(() => {})
+          }
+        }
+        return new Response(JSON.stringify({ success: true, message: "stake reply handled" }), { headers: { "Content-Type": "application/json" }, status: 200 })
+      }
     }
 
     let actualContent = text

--- a/supabase/migrations/084_opportunity_bet_logging.sql
+++ b/supabase/migrations/084_opportunity_bet_logging.sql
@@ -1,0 +1,53 @@
+-- ============================================================
+-- 084_opportunity_bet_logging — registrar aposta da "oportunidade do dia"
+-- ============================================================
+-- Item 15 do Marco 1: o daily de oportunidades (notify-opportunities) ganha,
+-- por pick, um botão "📋 Registrar no Betinho". Um toque cria a aposta pendente
+-- — fechando o loop Análise → Betinho → auto-liquidação, sem digitar nada.
+--
+-- O bot já sabe o pick (jogo/mercado/odd) e quem tocou; o único dado que falta
+-- é o STAKE. Resolvido por BOTÕES (decisão de produto 10/07): [1 unidade]
+-- [½ unidade] [Outro valor]. "Outro valor" usa force_reply do Telegram — a
+-- resposta vem AMARRADA à pergunta (stake_prompts), então o webhook a
+-- interpreta como valor daquele pick, e NÃO cai no fluxo de "extrair aposta
+-- nova" (evita o textão de ajuda). Sem orquestrador de estado conversacional.
+--
+-- 083 está reservada pela branch feat/onboarding-betinho → esta é a 084.
+-- ============================================================
+
+-- Picks oferecidos no daily (referenciados pelo callback_data regbet:<id>).
+-- Compartilhados entre usuários (o daily manda os mesmos top-3 pra todos), então
+-- 1 linha por pick por dia — upsert idempotente por (dia, jogo, aposta).
+CREATE TABLE IF NOT EXISTS public.daily_opportunity_picks (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sent_date         date NOT NULL DEFAULT (now() AT TIME ZONE 'America/Sao_Paulo')::date,
+  fixture_id        bigint,
+  sport             text NOT NULL DEFAULT 'Futebol',
+  league            text,
+  betting_market    text,
+  match_description text NOT NULL,
+  bet_description   text NOT NULL,
+  odds              numeric NOT NULL,
+  match_date        timestamptz,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (sent_date, fixture_id, bet_description)
+);
+COMMENT ON TABLE public.daily_opportunity_picks IS
+  'Picks do daily de oportunidades, referenciados pelo botão "Registrar no Betinho" (callback regbet:<id>).';
+ALTER TABLE public.daily_opportunity_picks ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role (edge functions)
+
+-- Mapa force_reply → pick: quando o bot pergunta "quanto?" (Outro valor),
+-- guarda a mensagem da pergunta; a resposta do usuário chega como reply a ela.
+CREATE TABLE IF NOT EXISTS public.stake_prompts (
+  chat_id    text NOT NULL,
+  message_id bigint NOT NULL,
+  pick_id    uuid NOT NULL REFERENCES public.daily_opportunity_picks(id) ON DELETE CASCADE,
+  user_id    uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (chat_id, message_id)
+);
+COMMENT ON TABLE public.stake_prompts IS
+  'Amarra a resposta de force_reply ("quanto?") ao pick, pra o webhook não tratar o valor como aposta nova.';
+ALTER TABLE public.stake_prompts ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role


### PR DESCRIPTION
## O que é (item 15 do Marco 1)

Cada pick do daily de oportunidades ganha um botão **"📋 Registrar"** — um toque fecha o loop **Análise → Betinho → auto-liquidação**, sem digitar nada:

```
⚽ As oportunidades de hoje · 2 jogos com valor
Avaí × Náutico · 16:00
Avaí +0,25 · odd 1.78 · Score 42 · Média
...
[📋 Registrar: Avaí +0,25]
[📋 Registrar: Flamengo -1]
[Ver a análise completa]
```

O bot já sabe o pick (jogo/mercado/odd) e quem tocou; o único dado que falta — **o valor** — vem por **botões**, não por texto livre:

> 📋 Registrar **Avaí +0,25** (odd 1.78) — quanto você vai colocar?
> `[1 unidade · R$ 50]` `[½ unidade · R$ 25]`
> `[Outro valor]`

## A decisão de robustez (evitar o "textão")

O webhook do Betinho trata todo texto como aposta nova (extrai via LLM; se falha, cospe o help). Se o bot perguntasse o valor em texto aberto, a resposta "50" cairia nesse fluxo. **Solução: valor por botões (zero texto)**, e o "Outro valor" usa o **force_reply nativo do Telegram** — a resposta vem *amarrada* à pergunta (tabela `stake_prompts`), então o webhook a lê como valor daquele pick e **sai antes** do fluxo de aposta nova. **Sem orquestrador de estado conversacional** (fica pro Marco 2, como combinado).

## Detalhes

- **Unidade** = `users.unit_value` (método fixo → valor; percentual → % da `bank_amount`). Sem unidade configurada → só "Outro valor".
- A aposta entra com `channel: 'futebol'` (marca o loop Análise→Betinho) e `betting_market` mapeado pro rótulo que a **auto-liquidação reconhece** → a mesma aposta é liquidada sozinha depois (Copa hoje; Brasileirão via F2).
- Migration **084**: `daily_opportunity_picks` (referência dos botões, upsert idempotente/dia) + `stake_prompts` (mapa force_reply→pick). Ambas RLS service-only. **083 é da branch de onboarding** — por isso 084.
- Métrica: `opportunity_bet_registered` {via: unit_button|force_reply} → fecha o funil enviado → clicou → **registrou**.

## Mudanças
- `notify-opportunities`: botão por pick + persistência dos picks
- `telegram-webhook`: handlers `regbet:` / `stk:` + tratamento do reply de force_reply
- Migration 084 + mapa de mensagens atualizado (linha 4a)

## Validação
- `tsc` limpo nas 2 funções · `parseStake` 8 testes ✅
- Ensaio no staging após merge (tem 1.144 jogos carregados): registrar um pick do daily, ver a aposta pendente no `/bets`, e — se for jogo da Copa — a auto-liquidação fechar depois

🤖 Generated with [Claude Code](https://claude.com/claude-code)
