### PR TITLE
fix(betinho): limpa pergunta de valor pendente ao seguir em frente

### DIFF
--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -2142,6 +2142,19 @@ serve(async (req) => {
           }
           return new Response(JSON.stringify({ success: true, message: "stake reply handled" }), { headers: { "Content-Type": "application/json" }, status: 200 })
         }
+
+        // Não foi resposta de valor válida. A pergunta pendente não pode ficar
+        // "esperando" e grudar num número futuro — então limpa aqui.
+        await supabase.from("stake_prompts").delete().eq("chat_id", String(chatId))
+
+        if (bareNumber) {
+          // número puro, mas o prompt esfriou (>30min): não vira aposta-lixo —
+          // avisa e encerra (não segue pro fluxo de extração)
+          await sendTelegramMessage(chatId, "Essa oportunidade esfriou 🕑 Toca em *Registrar* de novo numa oportunidade pra lançar o valor.")
+          return new Response(JSON.stringify({ success: true, message: "stale stake prompt cleared" }), { headers: { "Content-Type": "application/json" }, status: 200 })
+        }
+        // qualquer outra coisa (print, aposta em texto...) → pendência limpa e
+        // a mensagem SEGUE o fluxo normal de registro (sem return)
       }
     }
 


### PR DESCRIPTION
## A dor (levantada pelo Victor no ensaio)

A pessoa toca em "Outro valor", o bot pergunta o valor — mas ela **abandona** e volta a usar o Betinho normalmente. O "modo esperando valor" ficava **pendurado** e podia grudar num número futuro (registrar uma aposta velha que ela nem quer).

## Correção — a pendência vira efêmera

Decisão 100% pela **forma da mensagem** (não pelo tempo), então "textão de ajuda" e "aviso gentil" nunca se cruzam:

- **Número puro + fresco (<30min) / reply** → registra o valor (inalterado)
- **Número puro + esfriado (>30min)** → limpa a pendência e avisa *"Essa oportunidade esfriou 🕑 toca em Registrar de novo"* — **não** vira aposta-lixo
- **Print / aposta em texto / qualquer coisa com palavras** → limpa a pendência e **segue o fluxo normal** (registra a aposta, ou manda a ajuda se não reconhecer — como hoje)

Janela de 30min mantida (decisão do Victor — amarrar no início do jogo traria complexidade de fuso/status sem ganho). Só toca no `telegram-webhook`. `tsc` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)