### PR TITLE
release: login com Google via Supabase OAuth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,6 +55,7 @@ const BolaoJoin = lazyWithRetry(() => import("./pages/BolaoJoin"));
 const BolaoWelcome = lazyWithRetry(() => import("./pages/BolaoWelcome"));
 const BolaoLP = lazyWithRetry(() => import("./pages/BolaoLP"));
 const Privacidade = lazyWithRetry(() => import("./pages/Privacidade"));
+const AuthCallback = lazyWithRetry(() => import("./pages/AuthCallback"));
 
 const queryClient = new QueryClient();
 
@@ -93,6 +94,11 @@ const App = () => (
                 <Auth />
               </ProtectedRoute>
             } />
+            {/* Sem ProtectedRoute: o callback do OAuth chega com o usuário
+                "logado" (sessão criada pelo token da URL) e o
+                requireAuth={false} o expulsaria pro /onboarding antes de
+                rodar a própria lógica (criar linha na users, redirect). */}
+            <Route path="/auth/callback" element={<AuthCallback />} />
             <Route path="/onboarding" element={
               <ProtectedRoute>
                 <Onboarding />

--- a/src/lib/oauth-state.ts
+++ b/src/lib/oauth-state.ts
@@ -1,0 +1,6 @@
+// Chaves de sessionStorage pra atravessar o redirect do OAuth (Google).
+// O browser sai do app e volta em /auth/callback, então location.state e o
+// estado React do /auth se perdem — guardamos destino pós-login e código de
+// indicação antes de sair, e o AuthCallback consome (e limpa) na volta.
+export const OAUTH_REDIRECT_KEY = 'oauth_redirect_target';
+export const OAUTH_REFERRAL_KEY = 'oauth_referral_code';

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -11,6 +11,17 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Trophy, Users, Sparkles, Check } from "lucide-react";
 import { toast } from "@/hooks/use-toast";
 import { LanguageToggle } from "@/components/LanguageToggle";
+import { OAUTH_REDIRECT_KEY, OAUTH_REFERRAL_KEY } from "@/lib/oauth-state";
+
+// lucide não tem ícones de marca; SVG oficial multicolor do Google inline.
+const GoogleIcon = () => (
+  <svg className="w-4 h-4" viewBox="0 0 24 24" aria-hidden>
+    <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+    <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+    <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+    <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+  </svg>
+);
 
 /**
  * Determina pra onde redirecionar o user após login/signup bem-sucedido.
@@ -55,6 +66,7 @@ const Auth = () => {
   const [referralCode, setReferralCode] = useState("");
   const [phoneCountryCode, setPhoneCountryCode] = useState("+55");
   const [phoneNumber, setPhoneNumber] = useState("");
+  const [googleLoading, setGoogleLoading] = useState(false);
 
   const supabase = createClient();
 
@@ -102,6 +114,47 @@ const Auth = () => {
       toast({ title: "Erro", description: "Ocorreu um erro inesperado", variant: "destructive" });
     } finally {
       setLoading(false);
+    }
+  };
+
+  /**
+   * Login/signup com Google via Supabase OAuth. O browser sai pro Google e
+   * volta em /auth/callback (AuthCallback.tsx), que cria a linha na `users`
+   * se for primeira entrada e resolve o redirect. Como location.state e o
+   * estado React se perdem no redirect, destino e código de indicação vão
+   * via sessionStorage (chaves em @/lib/oauth-state).
+   */
+  const handleGoogleSignIn = async () => {
+    setGoogleLoading(true);
+    try {
+      const from = (location.state as { from?: { pathname?: string; search?: string } } | null)?.from;
+      if (from?.pathname && from.pathname.startsWith("/") && !from.pathname.startsWith("//")) {
+        sessionStorage.setItem(OAUTH_REDIRECT_KEY, from.pathname + (from.search || ""));
+      } else {
+        sessionStorage.removeItem(OAUTH_REDIRECT_KEY);
+      }
+      const normalizedReferralCode = referralCode.trim() ? referralCode.toUpperCase().trim() : null;
+      if (normalizedReferralCode) {
+        sessionStorage.setItem(OAUTH_REFERRAL_KEY, normalizedReferralCode);
+      } else {
+        sessionStorage.removeItem(OAUTH_REFERRAL_KEY);
+      }
+
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback`,
+        },
+      });
+
+      if (error) {
+        toast({ title: "Erro", description: error.message, variant: "destructive" });
+        setGoogleLoading(false);
+      }
+      // Em sucesso o browser navega pro Google — não resetamos o loading.
+    } catch (error) {
+      toast({ title: "Erro", description: "Ocorreu um erro inesperado", variant: "destructive" });
+      setGoogleLoading(false);
     }
   };
 
@@ -332,6 +385,22 @@ const Auth = () => {
                   <p className="text-[13px] text-ink-2 mb-5">
                     Bom te ver de volta. Coloca os dados aí.
                   </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="lg"
+                    disabled={googleLoading}
+                    onClick={handleGoogleSignIn}
+                    className="w-full rounded-rebrand-md h-11 bg-white border-line text-ink hover:bg-canvas gap-2 font-semibold"
+                  >
+                    <GoogleIcon />
+                    {googleLoading ? "Redirecionando..." : "Continuar com o Google"}
+                  </Button>
+                  <div className="flex items-center gap-3 my-4">
+                    <div className="h-px flex-1 bg-line" />
+                    <span className="text-[11px] uppercase tracking-wide text-ink-3">ou</span>
+                    <div className="h-px flex-1 bg-line" />
+                  </div>
                   <form onSubmit={handleSignIn} className="space-y-4">
                     <div className="space-y-1.5">
                       <Label htmlFor="email" className="text-[12px] font-semibold text-ink-2 uppercase tracking-wide">
@@ -382,6 +451,22 @@ const Auth = () => {
                   <p className="text-[13px] text-ink-2 mb-5">
                     Grátis. Sem cartão. Você cria o bolão logo em seguida.
                   </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="lg"
+                    disabled={googleLoading}
+                    onClick={handleGoogleSignIn}
+                    className="w-full rounded-rebrand-md h-11 bg-white border-line text-ink hover:bg-canvas gap-2 font-semibold"
+                  >
+                    <GoogleIcon />
+                    {googleLoading ? "Redirecionando..." : "Continuar com o Google"}
+                  </Button>
+                  <div className="flex items-center gap-3 my-4">
+                    <div className="h-px flex-1 bg-line" />
+                    <span className="text-[11px] uppercase tracking-wide text-ink-3">ou</span>
+                    <div className="h-px flex-1 bg-line" />
+                  </div>
                   <form onSubmit={handleSignUp} className="space-y-4">
                     <div className="space-y-1.5">
                       <Label htmlFor="signup-name" className="text-[12px] font-semibold text-ink-2 uppercase tracking-wide">

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { usePostHog } from "@posthog/react";
+import type { User } from "@supabase/supabase-js";
+import { createClient } from "@/integrations/supabase/client";
+import { toast } from "@/hooks/use-toast";
+import { OAUTH_REDIRECT_KEY, OAUTH_REFERRAL_KEY } from "@/lib/oauth-state";
+
+/**
+ * Destino pós-OAuth. Prioridade:
+ * 1. Destino guardado em sessionStorage antes do redirect (state.from do
+ *    ProtectedRoute — ex: link de convite de bolão). Mesma validação de
+ *    open redirect do getRedirectTarget em Auth.tsx.
+ * 2. Usuário novo → onboarding (mesmo fallback do signup por email).
+ * 3. Usuário existente → /bolao (mesmo fallback do login por email).
+ */
+function resolveTarget(stored: string | null, isNewUser: boolean): string {
+  if (stored && stored.startsWith("/") && !stored.startsWith("//")) {
+    return stored;
+  }
+  return isNewUser ? "/onboarding?src=signup" : "/bolao";
+}
+
+/** Espera o supabase-js processar os tokens do hash da URL e emitir sessão. */
+function waitForUser(
+  supabase: ReturnType<typeof createClient>,
+  timeoutMs = 8000
+): Promise<User | null> {
+  return new Promise((resolve) => {
+    let subscription: { unsubscribe: () => void } | null = null;
+    const timeout = setTimeout(() => {
+      subscription?.unsubscribe();
+      resolve(null);
+    }, timeoutMs);
+
+    ({ data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        clearTimeout(timeout);
+        subscription?.unsubscribe();
+        resolve(session.user);
+      }
+    }));
+
+    // Sessão pode já estar pronta antes do listener montar
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.user) {
+        clearTimeout(timeout);
+        subscription?.unsubscribe();
+        resolve(session.user);
+      }
+    });
+  });
+}
+
+const AuthCallback = () => {
+  const navigate = useNavigate();
+  const posthog = usePostHog();
+  // StrictMode monta o componente 2x em dev; sem o guard o fluxo roda em
+  // dobro (insert duplicado na users, capture duplicado no PostHog).
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    ranRef.current = true;
+
+    const supabase = createClient();
+
+    const run = async () => {
+      // Provider pode voltar com erro no hash/query (usuário cancelou, etc.)
+      const params = new URLSearchParams(
+        window.location.hash.replace(/^#/, "") || window.location.search
+      );
+      const providerError = params.get("error_description") || params.get("error");
+      if (providerError) {
+        toast({ title: "Erro no login", description: providerError, variant: "destructive" });
+        navigate("/auth", { replace: true });
+        return;
+      }
+
+      const user = await waitForUser(supabase);
+      if (!user) {
+        toast({
+          title: "Erro no login",
+          description: "Não foi possível completar o login com o Google. Tenta de novo.",
+          variant: "destructive",
+        });
+        navigate("/auth", { replace: true });
+        return;
+      }
+
+      const storedTarget = sessionStorage.getItem(OAUTH_REDIRECT_KEY);
+      const referralCode = sessionStorage.getItem(OAUTH_REFERRAL_KEY);
+      sessionStorage.removeItem(OAUTH_REDIRECT_KEY);
+      sessionStorage.removeItem(OAUTH_REFERRAL_KEY);
+
+      // Signup por email cria a linha na `users` manualmente (Auth.tsx);
+      // no OAuth fazemos o equivalente aqui na primeira entrada.
+      const { data: existing } = await supabase
+        .from("users")
+        .select("id")
+        .eq("id", user.id)
+        .maybeSingle();
+
+      const isNewUser = !existing;
+      const displayName =
+        user.user_metadata?.full_name ||
+        user.user_metadata?.name ||
+        user.email?.split("@")[0] ||
+        null;
+
+      if (isNewUser) {
+        const { error: userError } = await supabase.from("users").insert({
+          id: user.id,
+          email: user.email!,
+          name: displayName,
+          referred_by: referralCode,
+        });
+
+        if (userError) {
+          console.error("Error creating user record:", userError);
+        } else if (referralCode) {
+          try {
+            const { data: referrerData, error: referrerError } = await supabase
+              .from("users")
+              .select("id")
+              .eq("referral_code", referralCode)
+              .single();
+
+            if (!referrerError && referrerData && referrerData.id !== user.id) {
+              await supabase.from("referrals").insert({
+                referrer_id: referrerData.id,
+                referred_id: user.id,
+                referral_code: referralCode,
+              });
+            }
+          } catch (err) {
+            console.error("Error creating referral record:", err);
+          }
+        }
+
+        if (typeof window !== "undefined" && (window as any).fbq) {
+          (window as any).fbq("track", "CompleteRegistration");
+        }
+      }
+
+      if (posthog) {
+        posthog.identify(user.id, {
+          email: user.email,
+          name: displayName,
+          ...(isNewUser && referralCode ? { referred_by_code: referralCode } : {}),
+        });
+        posthog.capture(isNewUser ? "signed_up" : "signed_in", {
+          email: user.email,
+          method: "google",
+          ...(isNewUser && referralCode ? { referred_by_code: referralCode } : {}),
+        });
+      }
+
+      toast({ title: isNewUser ? "Conta criada!" : "Bem-vindo de volta!" });
+      navigate(resolveTarget(storedTarget, isNewUser), { replace: true });
+    };
+
+    run();
+  }, [navigate, posthog]);
+
+  return (
+    <div className="theme-bolao min-h-screen bg-canvas flex flex-col items-center justify-center gap-4">
+      <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-forest" />
+      <p className="text-[14px] text-ink-2">Entrando com o Google...</p>
+    </div>
+  );
+};
+
+export default AuthCallback;


### PR DESCRIPTION
Reabertura do #210 com branch `release/*` (guard do repo só aceita develop, hotfix/* ou release/* contra main). Conteúdo idêntico: só o login com Google (cherry-pick do `4ae0da0` da develop, sem o resto do release #207).

## O que faz

- Botão **"Continuar com o Google"** nas abas Entrar e Criar conta do `/auth`
- Nova rota `/auth/callback` (`AuthCallback.tsx`): processa o retorno do OAuth, cria o registro na tabela `users` na primeira entrada (nome vem do perfil Google, telefone fica nulo) e registra referral se houver
- Destino pós-login e código de indicação atravessam o redirect via `sessionStorage` (`src/lib/oauth-state.ts`)
- Redirects iguais ao fluxo por email: usuário novo → `/onboarding?src=signup`, existente → `/bolao`, `state.from` (convite de bolão) vence os dois
- Analytics mantidos: PostHog `signed_up`/`signed_in` com `method: google` + `fbq CompleteRegistration`

## Config (já feita ✅)

- Provider Google habilitado no Supabase de produção com client ID/secret — validado: `/auth/v1/authorize?provider=google` redireciona pro Google com o client correto e sem `redirect_uri_mismatch`
- `https://www.smartbetting.app/auth/callback` nas Redirect URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAW72rcauX2jt5GDRzS6fe