### PR TITLE
feat(retencao): resumo semanal de desempenho no Telegram (item 04, Marco 2)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -47,5 +47,6 @@ jobs:
           supabase functions deploy mirror-futebol-team-logos --no-verify-jwt
           supabase functions deploy mirror-futebol-player-photos --no-verify-jwt
           supabase functions deploy ingest-fixtures --no-verify-jwt
+          supabase functions deploy notify-weekly-summary --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -47,5 +47,6 @@ jobs:
           supabase functions deploy mirror-futebol-team-logos --no-verify-jwt
           supabase functions deploy mirror-futebol-player-photos --no-verify-jwt
           supabase functions deploy ingest-fixtures --no-verify-jwt
+          supabase functions deploy notify-weekly-summary --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/MAPA_MENSAGENS_BOT.md
+++ b/MAPA_MENSAGENS_BOT.md
@@ -15,6 +15,7 @@ fraco = silêncio; usuário que ignora = para de receber.
 | 4a | **Registrar aposta** (botão "📋 Registrar" no daily #4) | Usuário toca no botão de um pick | Reativa (resposta ao toque): pergunta o valor por botões [1 unidade][½ unidade][Outro valor]; "Outro valor" = force_reply amarrado. Registra a aposta pendente → entra no loop da auto-liquidação (#1) | Reativa — só responde ao toque | n/a |
 | 5 | **Confirmação de aposta registrada** | Usuário mandou print/texto | Imediato (resposta ao registro) | Reativa — só responde ao que o usuário fez | n/a |
 | 6 | **Aviso de kickoff do bolão** (só pro DONO do bolão) | Jogo da Copa começando | No minuto do kickoff (:00/:30) | 1 por jogo por bolão | opt-in explícito do dono |
+| 10 | **"📊 Seus últimos 7 dias"** (resumo semanal · item 04) | Cron semanal | **Segunda 10h BRT**, 1x/semana — e SÓ pra quem teve **≥2 apostas liquidadas** nos últimos 7 dias (rolling). Sem apostas = sem mensagem. Faixa por resultado (positiva/neutra/negativa); lidera por resultado+ROI, SEM taxa de acerto | 1×/semana por usuário (idempotência `weekly_summary_sent_at`, gap ~6d) | `weekly_summary_muted` |
 
 ## One-shot (disparo manual, 1x por usuário PRA SEMPRE)
 
@@ -45,6 +46,8 @@ normal: 0 a 2. O silêncio é parte do produto.
 
 - `users.settlement_reminders_muted` (🔕/`/silenciar`) cala **tudo** que é recorrente
   de liquidação e o winback/handoff também respeitam. `/lembretes` reativa.
+- `users.weekly_summary_muted` é opt-out **independente** do resumo semanal (#10) —
+  cala só ele, não a liquidação. (Cadência semanal ≠ diária, não soma metralhadora.)
 - Toda mensagem tem evento no PostHog (enviada + clicada/corrigida) — a "taxa de
   incômodo" (mute + correções) é métrica acompanhável.
 - Novas mensagens DEVEM entrar neste mapa antes de ir pra develop.

--- a/supabase/functions/go/index.ts
+++ b/supabase/functions/go/index.ts
@@ -6,8 +6,11 @@
 // e ZERA o contador da regra de reativação (2 envios sem clique = para,
 // do notify-opportunities) — e mandamos a pessoa pro destino num 302.
 //
-// URL: /go?u=<user_id>&d=<dest>&s=<hmac>
+// URL: /go?u=<user_id>&d=<dest>&s=<hmac>&c=<campanha?>
 //   dest permitidos: "board" → /futebol · "jogo-<id>" → /futebol/jogo/<id>
+//                    · "bank" → /bets (resumo semanal, item 04)
+//   c = campanha (default "daily_opportunities" p/ retrocompat). Só a campanha
+//       do daily zera a régua de reativação (opportunity_dispatch_state).
 //   s = HMAC-SHA256(CRON_SECRET, "<u>:<d>") — impede forjar clique de outro
 //       usuário. Assinatura inválida → redireciona mesmo assim (usuário
 //       nunca vê erro), só não registra.
@@ -21,12 +24,14 @@ import { generateTraceId, trackEvent } from "../shared/posthog.ts";
 
 const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
 const SITE = "https://www.smartbetting.app";
-const CAMPAIGN = "daily_opportunities";
+const DAILY_CAMPAIGN = "daily_opportunities";
 
-function destUrl(dest: string): string {
-  if (dest === "board") return `${SITE}/futebol?utm_source=telegram&utm_campaign=${CAMPAIGN}`;
+function destUrl(dest: string, campaign: string): string {
+  const utm = `utm_source=telegram&utm_campaign=${encodeURIComponent(campaign)}`;
+  if (dest === "board") return `${SITE}/futebol?${utm}`;
+  if (dest === "bank") return `${SITE}/bets?${utm}`;
   const jogo = dest.match(/^jogo-(\d+)$/);
-  if (jogo) return `${SITE}/futebol/jogo/${jogo[1]}?utm_source=telegram&utm_campaign=${CAMPAIGN}`;
+  if (jogo) return `${SITE}/futebol/jogo/${jogo[1]}?${utm}`;
   return SITE; // destino desconhecido → home (nunca mostrar erro pro usuário)
 }
 
@@ -43,7 +48,8 @@ serve(async (req) => {
   const u = url.searchParams.get("u") || "";
   const d = url.searchParams.get("d") || "";
   const s = url.searchParams.get("s") || "";
-  const target = destUrl(d);
+  const campaign = url.searchParams.get("c") || DAILY_CAMPAIGN;
+  const target = destUrl(d, campaign);
 
   // registra o clique só com assinatura válida — mas SEMPRE redireciona
   try {
@@ -52,15 +58,17 @@ serve(async (req) => {
         Deno.env.get("SUPABASE_URL") || "",
         Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
       );
-      await supabase.from("notification_clicks").insert({ user_id: u, campaign: CAMPAIGN, destination: d });
-      // clique = engajou → zera a régua da reativação
-      await supabase
-        .from("opportunity_dispatch_state")
-        .update({ sends_without_click: 0, last_click_at: new Date().toISOString() })
-        .eq("user_id", u);
+      await supabase.from("notification_clicks").insert({ user_id: u, campaign, destination: d });
+      // clique no daily = engajou → zera a régua da reativação (só p/ o daily)
+      if (campaign === DAILY_CAMPAIGN) {
+        await supabase
+          .from("opportunity_dispatch_state")
+          .update({ sends_without_click: 0, last_click_at: new Date().toISOString() })
+          .eq("user_id", u);
+      }
       await trackEvent(
-        "daily_opportunities_click",
-        { destination: d, channel: "telegram" },
+        campaign === DAILY_CAMPAIGN ? "daily_opportunities_click" : "weekly_summary_clicked",
+        { destination: d, campaign, channel: "telegram" },
         u, generateTraceId()
       ).catch(() => {});
     }

--- a/supabase/functions/notify-weekly-summary/index.ts
+++ b/supabase/functions/notify-weekly-summary/index.ts
@@ -1,0 +1,220 @@
+// ============================================================
+// notify-weekly-summary — resumo semanal de desempenho (item 04, Marco 2)
+// ============================================================
+// Cron semanal (segunda 10h BRT; migration 086). DM no Telegram (Betinho) com o
+// desempenho dos ÚLTIMOS 7 DIAS (rolling). Recompensa recorrente → hábito.
+//
+// A RPC get_weekly_recap_candidates() faz o trabalho pesado (agregados por
+// usuário elegível: resultado/stake/melhor mercado/unidade). Aqui só escolhemos
+// a FAIXA (positiva/neutra/negativa), formatamos e enviamos.
+//
+// Regras de produto (2026-07-15): rolling 7d · >=2 apostas liquidadas · lidera
+// por RESULTADO+ROI (SEM taxa de acerto — acerto sozinho engana) · R$ sempre +
+// unidades quando configurado · tom disciplina/controle (LC 224) · CTA único
+// "Ver minha banca" (rastreado pelo `go`, campanha weekly_summary) · sem emoji
+// em botão. Idempotência via users.weekly_summary_sent_at; opt-out via
+// users.weekly_summary_muted. Entra no MAPA_MENSAGENS_BOT.md.
+//
+// ?mode=report → não envia; devolve os candidatos + faixa (ensaio).
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN, CRON_SECRET.
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
+const BETS_URL = "https://www.smartbetting.app/bets";
+const CAMPAIGN = "weekly_summary";
+
+// thresholds da faixa: com unidade, em u; sem unidade, em ROI
+const POS_U = 0.5, NEG_U = -1.0;
+const POS_ROI = 0.05, NEG_ROI = -0.10;
+
+type Tier = "positive" | "neutral" | "negative";
+
+interface Candidate {
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+  n_settled: number;
+  total_stake: number;
+  total_profit: number;
+  unit_value_rs: number | null;
+  best_market: string | null;
+  best_market_profit: number | null;
+}
+
+function esc(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+const sign = (v: number) => (v > 0 ? "+" : v < 0 ? "−" : "");
+const moneyAbs = (v: number) => `R$ ${Math.abs(v).toFixed(2).replace(".", ",")}`;
+const unitAbs = (v: number) => `${Math.abs(v).toFixed(1).replace(".", ",")}u`;
+const pctAbs = (v: number) => `${Math.abs(v * 100).toFixed(0)}%`;
+
+function pickTier(profit: number, roi: number, unitRs: number | null): Tier {
+  if (unitRs && unitRs > 0) {
+    const u = profit / unitRs;
+    if (u > POS_U) return "positive";
+    if (u < NEG_U) return "negative";
+    return "neutral";
+  }
+  if (roi > POS_ROI) return "positive";
+  if (roi < NEG_ROI) return "negative";
+  return "neutral";
+}
+
+function resultLine(c: Candidate, roi: number): string {
+  const p = c.total_profit;
+  const sg = sign(p);
+  if (c.unit_value_rs && c.unit_value_rs > 0) {
+    return `Resultado: <b>${sg}${unitAbs(p / c.unit_value_rs)}</b> (${sg}${moneyAbs(p)}) · ROI <b>${sg}${pctAbs(roi)}</b>`;
+  }
+  return `Resultado: <b>${sg}${moneyAbs(p)}</b> · ROI <b>${sg}${pctAbs(roi)}</b>`;
+}
+
+function buildMessage(c: Candidate, tier: Tier, roi: number): string {
+  const head = `📊 <b>Seus últimos 7 dias</b>`;
+  const mkt = c.best_market ? ` · melhor mercado: <b>${esc(c.best_market)}</b>` : "";
+  const vol = `${c.n_settled} apostas liquidadas`;
+
+  if (tier === "positive") {
+    return [
+      head,
+      resultLine(c, roi),
+      `${vol}${mkt}`,
+      "",
+      `Fechou no positivo. O que importa agora é entender <b>o que sustentou isso</b> — quais mercados e stakes puxaram o resultado — pra repetir com consistência, não por sorte.`,
+    ].join("\n");
+  }
+  if (tier === "neutral") {
+    return [
+      head,
+      resultLine(c, roi),
+      `${vol}${mkt}`,
+      "",
+      `Variação controlada — nem lucro nem prejuízo relevante. Bom momento pra <b>afinar</b>: onde você foi eficiente e onde deixou valor na mesa.`,
+    ].join("\n");
+  }
+  // negative — sem destacar "melhor mercado"; foco em processo e proteção
+  return [
+    head,
+    resultLine(c, roi),
+    vol,
+    "",
+    `Semana negativa faz parte — o que separa quem evolui é o <b>processo</b>, não o placar de 7 dias. Antes da próxima sequência, vale revisar <b>stake, volume e escolha de mercado</b> com calma. Sem correr atrás do prejuízo.`,
+  ].join("\n");
+}
+
+// link rastreado: /functions/v1/go?u=&d=&s=&c=weekly_summary (HMAC sobre u:d)
+async function trackedUrl(userId: string, dest: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw", new TextEncoder().encode(CRON_SECRET), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${userId}:${dest}`));
+  const s = [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("").slice(0, 16);
+  return `${SUPABASE_URL}/functions/v1/go?u=${userId}&d=${dest}&s=${s}&c=${CAMPAIGN}`;
+}
+
+async function sendSummary(chatId: string, text: string, bankUrl: string): Promise<void> {
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text,
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      reply_markup: { inline_keyboard: [[{ text: "Ver minha banca", url: bankUrl }]] },
+    }),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
+}
+
+serve(async (req) => {
+  if (!CRON_SECRET || req.headers.get("x-cron-secret") !== CRON_SECRET) return json({ error: "Unauthorized" }, 401);
+  const mode = new URL(req.url).searchParams.get("mode") || "send";
+  if (mode === "send" && !TELEGRAM_BOT_TOKEN) return json({ error: "TELEGRAM_BOT_TOKEN not set" }, 500);
+
+  const supabase = createClient(SUPABASE_URL, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "");
+  const traceId = generateTraceId();
+
+  try {
+    const { data, error } = await supabase.rpc("get_weekly_recap_candidates");
+    if (error) throw error;
+    const candidates: Candidate[] = (data ?? []).map((r: any) => ({
+      user_id: r.user_id,
+      chat_id: r.chat_id,
+      user_name: r.user_name,
+      n_settled: Number(r.n_settled),
+      total_stake: Number(r.total_stake),
+      total_profit: Number(r.total_profit),
+      unit_value_rs: r.unit_value_rs == null ? null : Number(r.unit_value_rs),
+      best_market: r.best_market,
+      best_market_profit: r.best_market_profit == null ? null : Number(r.best_market_profit),
+    }));
+
+    const rows = candidates.map((c) => {
+      const roi = c.total_stake > 0 ? c.total_profit / c.total_stake : 0;
+      const tier = pickTier(c.total_profit, roi, c.unit_value_rs);
+      return { c, roi, tier };
+    });
+
+    if (mode === "report") {
+      return json({
+        ok: true, mode, candidates: rows.length,
+        preview: rows.map(({ c, roi, tier }) => ({
+          user: c.user_name, n: c.n_settled, tier,
+          profit: Number(c.total_profit.toFixed(2)), roi: Number((roi * 100).toFixed(1)),
+          has_unit: c.unit_value_rs != null, best_market: c.best_market,
+          text: buildMessage(c, tier, roi),
+        })),
+      });
+    }
+
+    let sent = 0;
+    const errors: string[] = [];
+    for (const { c, roi, tier } of rows) {
+      try {
+        const text = buildMessage(c, tier, roi);
+        const bankUrl = await trackedUrl(c.user_id, "bank");
+        await sendSummary(c.chat_id, text, bankUrl);
+
+        // marca envio só depois de mandar (run que falha tenta de novo na próxima)
+        const { error: upErr } = await supabase
+          .from("users")
+          .update({ weekly_summary_sent_at: new Date().toISOString() })
+          .eq("id", c.user_id);
+        if (upErr) throw upErr;
+
+        sent++;
+        await trackEvent(
+          "weekly_summary_sent",
+          {
+            tier,
+            result_bucket: tier,
+            has_unit: c.unit_value_rs != null,
+            volume: c.n_settled,
+            roi_pct: Number((roi * 100).toFixed(1)),
+            channel: "telegram",
+          },
+          c.user_id, traceId
+        ).catch(() => {});
+      } catch (e) {
+        errors.push(`${c.user_id}: ${(e as Error)?.message}`);
+      }
+    }
+
+    return json({ ok: true, mode, candidates: rows.length, sent, errors });
+  } catch (e) {
+    console.error("notify-weekly-summary error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});

--- a/supabase/migrations/086_weekly_summary.sql
+++ b/supabase/migrations/086_weekly_summary.sql
@@ -1,0 +1,126 @@
+-- ============================================================
+-- 086_weekly_summary — Resumo semanal de desempenho (item 04, Marco 2)
+-- ============================================================
+-- DM no Telegram (Betinho) 1x/semana com o desempenho dos ÚLTIMOS 7 DIAS
+-- (rolling, não semana-calendário — decisão de produto 2026-07-15). Recompensa
+-- recorrente que vira hábito. Entregue por edge function `notify-weekly-summary`.
+--
+-- NÃO confundir com o legado WhatsApp (010 weekly_performance / 015
+-- performance_semanal): aquele é semana-calendário, por esporte, canal morto e
+-- lucro incompleto (ignora half/void). Esta RPC é sob medida:
+--   • janela rolling 7d por bet_date, só apostas LIQUIDADAS
+--   • lucro pelo mesmo profitForBet do app (inclui cashout/half_won/half_lost/void)
+--   • melhor mercado por lucro (não por esporte)
+--   • unidade efetiva (R$) igual ao effectiveUnit do telegram-webhook (item 15)
+--   • elegível: >= 2 apostas liquidadas na janela
+--
+-- Segredos do cron (Vault, criar 1x por ambiente — o CI NÃO cria):
+--   vault.create_secret('<url da função>', 'notify_weekly_summary_url', ...);
+--   vault.create_secret('<x-cron-secret>', 'notify_weekly_summary_cron_secret', ...);
+-- ============================================================
+
+-- ── Opt-out + idempotência (por usuário) ─────────────────────
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS weekly_summary_muted   boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS weekly_summary_sent_at timestamptz;
+
+COMMENT ON COLUMN public.users.weekly_summary_muted IS
+  'Opt-out do resumo semanal (item 04). Independente do settlement_reminders_muted.';
+COMMENT ON COLUMN public.users.weekly_summary_sent_at IS
+  'Último envio do resumo semanal — idempotência (não reenviar dentro de ~6 dias).';
+
+-- ── Candidatos do resumo semanal ─────────────────────────────
+-- Devolve, por usuário elegível, os agregados prontos pra edge só formatar/enviar.
+-- Espelha get_settlement_reminder_candidates. Lucro = profitForBet (app).
+CREATE OR REPLACE FUNCTION public.get_weekly_recap_candidates()
+RETURNS TABLE(
+  user_id uuid,
+  chat_id text,
+  user_name text,
+  n_settled integer,
+  total_stake numeric,
+  total_profit numeric,
+  unit_value_rs numeric,
+  best_market text,
+  best_market_profit numeric
+)
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  WITH settled AS (
+    SELECT
+      b.user_id,
+      b.stake_amount::numeric AS stake,
+      COALESCE(NULLIF(b.betting_market, ''), 'Outros')::text AS market,
+      -- profitForBet (src/utils/dashboardAggregations.ts) — fonte de verdade do app
+      CASE b.status
+        WHEN 'won'       THEN b.potential_return - b.stake_amount
+        WHEN 'lost'      THEN -b.stake_amount
+        WHEN 'cashout'   THEN (CASE WHEN b.cashout_amount IS NOT NULL THEN b.cashout_amount - b.stake_amount ELSE 0 END)
+        WHEN 'half_won'  THEN (b.stake_amount + b.potential_return) / 2.0 - b.stake_amount
+        WHEN 'half_lost' THEN b.stake_amount / 2.0 - b.stake_amount
+        ELSE 0  -- void
+      END::numeric AS profit
+    FROM public.bets b
+    WHERE b.status IN ('won','lost','cashout','half_won','half_lost','void')
+      AND b.bet_date > now() - interval '7 days'
+  ),
+  agg AS (
+    SELECT s.user_id, count(*)::int AS n, sum(s.stake) AS stake, sum(s.profit) AS profit
+    FROM settled s GROUP BY s.user_id
+  ),
+  bymkt AS (
+    SELECT s.user_id, s.market,
+           sum(s.profit) AS p,
+           row_number() OVER (PARTITION BY s.user_id ORDER BY sum(s.profit) DESC, count(*) DESC) AS rn
+    FROM settled s GROUP BY s.user_id, s.market
+  )
+  SELECT
+    a.user_id,
+    u.telegram_chat_id::text,
+    u.name::text,
+    a.n,
+    a.stake,
+    a.profit,
+    -- effectiveUnit (telegram-webhook): direct = unit_value; percentual = banca * u/100
+    (CASE
+       WHEN COALESCE(u.unit_value, 0) <= 0 THEN NULL
+       WHEN u.unit_calculation_method = 'percentual'
+         THEN (CASE WHEN COALESCE(u.bank_amount, 0) <= 0 THEN NULL
+                    ELSE round(u.bank_amount * (u.unit_value / 100.0), 2) END)
+       ELSE u.unit_value
+     END)::numeric AS unit_value_rs,
+    m.market::text,
+    m.p::numeric
+  FROM agg a
+  JOIN public.users u ON u.id = a.user_id
+    AND u.telegram_chat_id IS NOT NULL
+    AND COALESCE(u.weekly_summary_muted, false) = false
+    AND (u.weekly_summary_sent_at IS NULL OR u.weekly_summary_sent_at < now() - interval '6 days')
+  LEFT JOIN bymkt m ON m.user_id = a.user_id AND m.rn = 1
+  WHERE a.n >= 2;
+$function$;
+
+-- ── Cron: segunda 10h BRT (13:00 UTC) ────────────────────────
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notify-weekly-summary') THEN
+    PERFORM cron.unschedule('notify-weekly-summary');
+  END IF;
+END $$;
+
+SELECT cron.schedule('notify-weekly-summary', '0 13 * * 1', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_weekly_summary_url'),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_weekly_summary_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+$job$);


### PR DESCRIPTION
Primeiro item do **Marco 2** (relevância e hábito): uma DM semanal com o desempenho dos **últimos 7 dias** — a recompensa recorrente que transforma retorno em rotina. Base: exercício de mensagens do sócio (`docs/Mensagens_usuário_Betinho.xlsx`, Bloco D), **reenquadrado** pelas críticas.

## O que sobe
- **Migration 086** — RPC `get_weekly_recap_candidates()` (faz o trabalho pesado: agregados por usuário elegível) + colunas `weekly_summary_muted` (opt-out) / `weekly_summary_sent_at` (idempotência) + cron semanal.
- **Edge `notify-weekly-summary`** — escolhe a faixa, formata e envia. `?mode=report` pra ensaiar sem mandar.
- **`go`** estendido — campanha parametrizável (`?c=`) + destino `bank` → `/bets`, **sem efeito colateral** na régua de reativação do daily.
- CI (staging+prod) + `MAPA_MENSAGENS_BOT.md` (#10).

## Decisões de produto (travadas)
| Decisão | Valor |
|---|---|
| Janela | **rolling 7 dias** (não semana calendário — evita quem começou domingo já receber "a semana") |
| Elegibilidade | **≥2 apostas liquidadas** na janela |
| Métrica-estrela | **resultado + ROI** — **SEM taxa de acerto** (pelo PDCA: acerto sozinho engana) |
| Valor | **R$ sempre + unidades** quando `unit_value` configurado (reusa `effectiveUnit`) |
| CTA | só **"Ver minha banca"** (rastreado); cross-sell futebol = Fase 2 |
| Canal | **Telegram** (a planilha estava em WhatsApp, descontinuado) |

## As 3 faixas (copy aprovada pelo Victor)
- **Positiva** (>+0,5u / ROI+): reforça consistência ("o que sustentou isso?")
- **Neutra** (±0,5u): afinar
- **Negativa** (<−1u): protetiva/anti-tilt ("processo, não o placar de 7 dias; sem correr atrás do prejuízo") — não destaca "melhor mercado"

Lucro = `profitForBet` do app (inclui cashout/half_won/half_lost/void), pra a banca do resumo bater com a do site. Sem unidade → faixa por ROI%.

## 🗄️ Supabase / operação
- Migration 086 aplica sozinha no deploy. **NÃO confundir** com o legado WhatsApp `weekly_performance`/`performance_semanal` (010/015) — semana-calendário, por esporte, canal morto; esta é sob medida.
- ⚠️ **Cron só dispara após criar os 2 vault secrets por ambiente** (o CI não cria — lição dos releases anteriores): `notify_weekly_summary_url` + `notify_weekly_summary_cron_secret`.

## Ensaio staging
Pendente pós-merge: seed de apostas liquidadas (3 perfis: positivo/neutro/negativo) → `?mode=report` e DM real no Telegram do Victor.

## Testes
Lógica de faixa + copy renderizada: **11/11** (5 cenários × 3 faixas + 6 thresholds), incluindo variante sem unidade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)