### PR TITLE
fix(retencao): Onda 1 — colisão de segunda 9h30/10h + opt-out do resumo semanal

### DIFF
--- a/MAPA_MENSAGENS_BOT.md
+++ b/MAPA_MENSAGENS_BOT.md
@@ -15,7 +15,7 @@ fraco = silêncio; usuário que ignora = para de receber.
 | 4a | **Registrar aposta** (botão "📋 Registrar" no daily #4) | Usuário toca no botão de um pick | Reativa (resposta ao toque): pergunta o valor por botões [1 unidade][½ unidade][Outro valor]; "Outro valor" = force_reply amarrado. Registra a aposta pendente → entra no loop da auto-liquidação (#1) | Reativa — só responde ao toque | n/a |
 | 5 | **Confirmação de aposta registrada** | Usuário mandou print/texto | Imediato (resposta ao registro) | Reativa — só responde ao que o usuário fez | n/a |
 | 6 | **Aviso de kickoff do bolão** (só pro DONO do bolão) | Jogo da Copa começando | No minuto do kickoff (:00/:30) | 1 por jogo por bolão | opt-in explícito do dono |
-| 10 | **"📊 Seus últimos 7 dias"** (resumo semanal · item 04) | Cron semanal | **Segunda 10h BRT**, 1x/semana — e SÓ pra quem teve **≥2 apostas liquidadas** nos últimos 7 dias (rolling). Sem apostas = sem mensagem. Faixa por resultado (positiva/neutra/negativa); lidera por resultado+ROI, SEM taxa de acerto | 1×/semana por usuário (idempotência `weekly_summary_sent_at`, gap ~6d) | `weekly_summary_muted` |
+| 10 | **"📊 Seus últimos 7 dias"** (resumo semanal · item 04) | Cron semanal | **Segunda 9h30 BRT** (antes do daily das 10h — narrativa passado→futuro), 1x/semana — e SÓ pra quem teve **≥2 apostas liquidadas** nos últimos 7 dias (rolling). Sem apostas = sem mensagem. Faixa por resultado (positiva/neutra/negativa); lidera por resultado+ROI, SEM taxa de acerto | 1×/semana por usuário (idempotência `weekly_summary_sent_at`, gap ~6d) | Botão "Silenciar resumo" na própria DM · `/resumo` reativa |
 
 ## One-shot (disparo manual, 1x por usuário PRA SEMPRE)
 
@@ -41,6 +41,15 @@ Cenário extremo — dia da final, usuário com 3 apostas no jogo, no bolão e n
 **Total no pior caso: ~5 mensagens num dia de final de Copa** — todas com conteúdo
 que o usuário quer receber (resultado das apostas dele + posição final dele). Em dia
 normal: 0 a 2. O silêncio é parte do produto.
+
+## Voz do Betinho (régua de escrita)
+
+- **1:1 sobre UMA aposta do usuário** (liquidação, recibo, correção): **1ª pessoa** —
+  "Fechei sua aposta", "eu fecho pra você". O Betinho é um assistente que age.
+- **Relatório/análise** (daily, resumo semanal): **sóbrio-analítico**, sem 1ª pessoa —
+  os números falam; nada de comemorar por ele nem lamentar por ele.
+- Sempre: disciplina e controle (LC 224/2025), nunca "aposte mais"; emoji com
+  parcimônia no corpo, **nunca em botão**; semana ruim = tom protetivo, sem cutucar métrica.
 
 ## Regras transversais
 

--- a/supabase/functions/notify-weekly-summary/index.ts
+++ b/supabase/functions/notify-weekly-summary/index.ts
@@ -132,7 +132,14 @@ async function sendSummary(chatId: string, text: string, bankUrl: string): Promi
       text,
       parse_mode: "HTML",
       disable_web_page_preview: true,
-      reply_markup: { inline_keyboard: [[{ text: "Ver minha banca", url: bankUrl }]] },
+      // opt-out visível na própria mensagem (regra: recorrente carrega a própria
+      // saída). Callback `mutew` no telegram-webhook grava weekly_summary_muted.
+      reply_markup: {
+        inline_keyboard: [
+          [{ text: "Ver minha banca", url: bankUrl }],
+          [{ text: "Silenciar resumo", callback_data: "mutew" }],
+        ],
+      },
     }),
   });
   if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -487,6 +487,28 @@ async function handleCallbackQuery(
     return ok("reminders muted")
   }
 
+  // mutew — botão "Silenciar resumo" da DM do resumo semanal (item 04).
+  // Opt-out independente da liquidação; /resumo reativa.
+  if (data === "mutew") {
+    await supabase.from("users").update({ weekly_summary_muted: true }).eq("id", user.id)
+    // remove só a linha do silenciar; "Ver minha banca" continua útil
+    await telegramCall("editMessageReplyMarkup", {
+      chat_id: chatId,
+      message_id: messageId,
+      reply_markup: {
+        inline_keyboard: [[{ text: "Ver minha banca", url: BETS_DASHBOARD_URL }]]
+      }
+    })
+    await answerCallbackQuery(cq.id, "Ok, sem mais resumos semanais. Pra voltar: /resumo")
+    await trackEvent(
+      "weekly_summary_muted",
+      { via: "button", channel: "telegram" },
+      user.id,
+      traceId
+    ).catch(() => {})
+    return ok("weekly summary muted")
+  }
+
   // 📋 regbet:<pick_id> — tocou "Registrar no Betinho" no daily
   if (data.startsWith("regbet:")) {
     const pickId = data.slice("regbet:".length)
@@ -2176,6 +2198,30 @@ serve(async (req) => {
       ).catch(() => {})
       return new Response(
         JSON.stringify({ success: true, message: "Reminder preference updated" }),
+        { headers: { "Content-Type": "application/json" }, status: 200 }
+      )
+    }
+
+    // /resumo — toggle do resumo semanal (par do botão "Silenciar resumo")
+    if (command === "/resumo") {
+      const { data: pref } = await supabase
+        .from("users").select("weekly_summary_muted").eq("id", user.id).maybeSingle()
+      const mute = !(pref?.weekly_summary_muted ?? false)
+      await supabase.from("users").update({ weekly_summary_muted: mute }).eq("id", user.id)
+      await sendTelegramMessage(
+        chatId,
+        mute
+          ? "Ok — parei com o resumo semanal. Pra voltar, é só mandar /resumo de novo."
+          : "📊 Resumo semanal reativado! Toda segunda de manhã eu te mando como fecharam seus últimos 7 dias."
+      )
+      await trackEvent(
+        mute ? "weekly_summary_muted" : "weekly_summary_unmuted",
+        { via: "command", channel: "telegram" },
+        user.id,
+        traceId
+      ).catch(() => {})
+      return new Response(
+        JSON.stringify({ success: true, message: "Weekly summary preference updated" }),
         { headers: { "Content-Type": "application/json" }, status: 200 }
       )
     }

--- a/supabase/migrations/087_weekly_summary_reschedule.sql
+++ b/supabase/migrations/087_weekly_summary_reschedule.sql
@@ -1,0 +1,26 @@
+-- ============================================================
+-- 087_weekly_summary_reschedule — resumo semanal às 9h30 BRT (revisão UX)
+-- ============================================================
+-- A 086 agendou o resumo pra segunda 10h BRT ('0 13 * * 1') — MESMO minuto do
+-- daily de oportunidades ('0 13 * * *'): toda segunda o usuário receberia as
+-- duas DMs juntas, em ordem aleatória. Correção da revisão de UX (2026-07-20):
+-- resumo às 9h30, daily às 10h — narrativa passado→futuro ("sua semana fechou
+-- assim" → "as oportunidades de hoje").
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notify-weekly-summary') THEN
+    PERFORM cron.unschedule('notify-weekly-summary');
+  END IF;
+END $$;
+
+SELECT cron.schedule('notify-weekly-summary', '30 12 * * 1', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_weekly_summary_url'),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_weekly_summary_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+$job$);


### PR DESCRIPTION
Primeira onda do plano da revisão de arquitetura+UX do Betinho (as 2 críticas 🔴 de UX + go-live operacional do resumo).

## O que corrige

| Crítica | Correção |
|---|---|
| **Colisão de segunda 10h** — daily (`0 13 * * *`) e resumo semanal (`0 13 * * 1`) disparavam no MESMO minuto, ordem aleatória | Migration **087**: resumo → **9h30 BRT** (`30 12 * * 1`). Narrativa passado→futuro: 9h30 "sua semana fechou assim", 10h "as oportunidades de hoje" |
| **Resumo sem opt-out visível** — a coluna `weekly_summary_muted` existia, mas nenhum caminho pro usuário acioná-la | Botão **"Silenciar resumo"** na própria DM (callback `mutew`; ao silenciar, remove só essa linha — "Ver minha banca" permanece) + comando **`/resumo`** (toggle re-ativa/desativa). Eventos `weekly_summary_muted/unmuted` no PostHog |

Extra de docs: seção **"Voz do Betinho"** no MAPA (1ª pessoa no 1:1 de aposta; sóbrio-analítico em relatório) + linha #10 atualizada.

## 🗄️ Supabase
- Migration 087 aplica sozinha (unschedule+schedule idempotente).
- ✅ **Vault secrets do weekly JÁ criados em staging e produção** (`notify_weekly_summary_url` + `_cron_secret`) — em prod o cron só nasce quando 086/087 subirem no release, mas o secret proativo elimina a falha silenciosa que pegou kickoff/opportunities/fixtures.

## Ensaio staging (pós-merge)
1. Reenviar resumo pro Victor (reset `weekly_summary_sent_at`) → conferir os 2 botões.
2. Tocar "Silenciar resumo" → some a linha, `weekly_summary_muted=true`, toast com /resumo.
3. `/resumo` → reativa.
4. Conferir `cron.job` do staging com o horário novo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)