### PR TITLE
feat(ops): healthcheck de crons — mata a classe de falha 'cron mudo' (Onda 2)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -48,5 +48,6 @@ jobs:
           supabase functions deploy mirror-futebol-player-photos --no-verify-jwt
           supabase functions deploy ingest-fixtures --no-verify-jwt
           supabase functions deploy notify-weekly-summary --no-verify-jwt
+          supabase functions deploy ops-healthcheck --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -48,5 +48,6 @@ jobs:
           supabase functions deploy mirror-futebol-player-photos --no-verify-jwt
           supabase functions deploy ingest-fixtures --no-verify-jwt
           supabase functions deploy notify-weekly-summary --no-verify-jwt
+          supabase functions deploy ops-healthcheck --no-verify-jwt
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/supabase/functions/ops-healthcheck/index.ts
+++ b/supabase/functions/ops-healthcheck/index.ts
@@ -1,0 +1,110 @@
+// ============================================================
+// ops-healthcheck — vigia dos crons (Onda 2 da revisão do Betinho)
+// ============================================================
+// Cron diário (8h BRT; migration 088). Chama get_cron_health() e manda DM pro
+// admin SÓ quando há problema — silêncio = tudo bem (mesma filosofia do produto).
+//
+// O que denuncia:
+//   • cron cujo comando referencia vault secret que NÃO existe (o "cron mudo"
+//     que já aconteceu 3x: kickoff, opportunities/fixtures, quase o weekly)
+//   • cron com >= 3 falhas nas últimas 5 execuções
+//
+// Admin: ops_config['admin_telegram_chat_id'] (tabela, não env — auditável por
+// SQL e sem depender de secret de função que ninguém confere).
+//
+// ?mode=report → só devolve o JSON (não manda DM). ?mode=test → manda uma DM
+// de teste pro admin (valida o canal no ensaio).
+// Proteção: header `x-cron-secret` == env CRON_SECRET.
+// Segredos (env): SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TELEGRAM_BOT_TOKEN, CRON_SECRET.
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
+const FAIL_THRESHOLD = 3; // de 5 execuções recentes
+
+interface JobHealth {
+  jobname: string;
+  active: boolean;
+  missing_secrets: string[];
+  failed_recent: number;
+  total_recent: number;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+async function sendAdminDm(chatId: string, text: string): Promise<void> {
+  const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ chat_id: chatId, text, disable_web_page_preview: true }),
+  });
+  if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
+}
+
+serve(async (req) => {
+  if (!CRON_SECRET || req.headers.get("x-cron-secret") !== CRON_SECRET) return json({ error: "Unauthorized" }, 401);
+  const mode = new URL(req.url).searchParams.get("mode") || "alert";
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  try {
+    const { data: cfg } = await supabase
+      .from("ops_config").select("value").eq("key", "admin_telegram_chat_id").maybeSingle();
+    const adminChat: string | null = cfg?.value ?? null;
+
+    if (mode === "test") {
+      if (!adminChat) return json({ ok: false, motivo: "admin_telegram_chat_id não configurado em ops_config" }, 500);
+      await sendAdminDm(adminChat, "🩺 ops-healthcheck: DM de teste — canal do admin funcionando.");
+      return json({ ok: true, mode, sent: true });
+    }
+
+    const { data, error } = await supabase.rpc("get_cron_health");
+    if (error) throw error;
+    const jobs: JobHealth[] = data ?? [];
+
+    const problems = jobs.filter(
+      (j) => j.active && (j.missing_secrets.length > 0 || j.failed_recent >= FAIL_THRESHOLD)
+    );
+
+    if (mode !== "report" && problems.length > 0) {
+      const lines = ["🚨 ops-healthcheck — crons com problema:", ""];
+      for (const p of problems) {
+        if (p.missing_secrets.length > 0) {
+          lines.push(`• ${p.jobname}: SECRETS FALTANDO no vault → ${p.missing_secrets.join(", ")} (job roda mas não chama nada — o "cron mudo")`);
+        }
+        if (p.failed_recent >= FAIL_THRESHOLD) {
+          lines.push(`• ${p.jobname}: ${p.failed_recent}/${p.total_recent} execuções recentes FALHARAM`);
+        }
+      }
+      lines.push("", "Runbook: criar os secrets (vault.create_secret) ou investigar cron.job_run_details.");
+      if (adminChat) {
+        await sendAdminDm(adminChat, lines.join("\n"));
+      } else {
+        console.error("ops-healthcheck: problemas encontrados mas admin_telegram_chat_id não configurado:", JSON.stringify(problems));
+      }
+    }
+
+    return json({
+      ok: true,
+      mode,
+      jobs_total: jobs.length,
+      problems: problems.map((p) => ({
+        jobname: p.jobname,
+        missing_secrets: p.missing_secrets,
+        failed_recent: p.failed_recent,
+        total_recent: p.total_recent,
+      })),
+      admin_configured: adminChat != null,
+    });
+  } catch (e) {
+    console.error("ops-healthcheck error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});

--- a/supabase/migrations/088_ops_healthcheck.sql
+++ b/supabase/migrations/088_ops_healthcheck.sql
@@ -1,0 +1,105 @@
+-- ============================================================
+-- 088_ops_healthcheck — vigia dos crons (Onda 2 da revisão do Betinho)
+-- ============================================================
+-- Mata a classe de falha "cron mudo": job agendado cujos vault secrets nunca
+-- foram criados falha em SILÊNCIO (net.http_post com url null) — já aconteceu
+-- 3x (notify-kickoff; notify-opportunities + ingest-fixtures semanas mudos em
+-- prod; quase 4ª com o notify-weekly-summary).
+--
+-- Desenho em 2 peças (o bot token vive em env de edge, não no Vault, então o
+-- check não pode ser 100% SQL):
+--   • RPC get_cron_health() — para cada cron.job: extrai por regex os secrets
+--     que o comando referencia e confere existência no vault; conta falhas nas
+--     últimas 5 execuções.
+--   • edge ops-healthcheck (cron diário 8h BRT) — chama a RPC e manda DM pro
+--     admin SÓ se houver problema (silêncio = tudo bem). Se auto-verifica: o
+--     próprio job aparece na listagem.
+--
+-- ops_config guarda o chat do admin (dado operacional, não segredo) — evita
+-- depender de env var que ninguém confirma se foi setada.
+--
+-- PRÉ-REQUISITO POR AMBIENTE (o CI não cria — exatamente o que este vigia pega):
+--   vault.create_secret('<url da função>', 'ops_healthcheck_url', ...);
+--   vault.create_secret('<x-cron-secret>', 'ops_healthcheck_cron_secret', ...);
+--   INSERT INTO ops_config VALUES ('admin_telegram_chat_id', '<chat_id>');
+-- ============================================================
+
+-- ── Config operacional (service-role only) ───────────────────
+CREATE TABLE IF NOT EXISTS public.ops_config (
+  key   text PRIMARY KEY,
+  value text NOT NULL
+);
+COMMENT ON TABLE public.ops_config IS
+  'Config operacional (ex.: admin_telegram_chat_id). Não é segredo — segredo vive no Vault.';
+ALTER TABLE public.ops_config ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role
+
+-- ── Saúde dos crons ──────────────────────────────────────────
+-- missing_secrets: nomes referenciados no comando (padrão vault.decrypted_secrets
+-- WHERE name = 'x') que NÃO existem no vault. failed/total_recent: últimas 5 runs.
+CREATE OR REPLACE FUNCTION public.get_cron_health()
+RETURNS TABLE(jobname text, active boolean, missing_secrets text[], failed_recent int, total_recent int)
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+  WITH jobs AS (
+    SELECT j.jobid, j.jobname, j.active, j.command FROM cron.job j
+  ),
+  refs AS (
+    SELECT j.jobid, m.cap[1] AS secret_name
+    FROM jobs j,
+    LATERAL regexp_matches(j.command, 'decrypted_secrets\s+WHERE\s+name\s*=\s*''([a-z0-9_]+)''', 'g') AS m(cap)
+  ),
+  missing AS (
+    SELECT r.jobid, array_agg(DISTINCT r.secret_name) AS missing
+    FROM refs r
+    WHERE NOT EXISTS (SELECT 1 FROM vault.secrets s WHERE s.name = r.secret_name)
+    GROUP BY r.jobid
+  ),
+  runs AS (
+    SELECT d.jobid,
+           count(*) FILTER (WHERE d.status = 'failed')::int AS failed_recent,
+           count(*)::int AS total_recent
+    FROM (
+      SELECT jobid, status, row_number() OVER (PARTITION BY jobid ORDER BY start_time DESC) AS rn
+      FROM cron.job_run_details
+    ) d
+    WHERE d.rn <= 5
+    GROUP BY d.jobid
+  )
+  SELECT j.jobname, j.active,
+         COALESCE(m.missing, '{}'::text[]),
+         COALESCE(r.failed_recent, 0),
+         COALESCE(r.total_recent, 0)
+  FROM jobs j
+  LEFT JOIN missing m ON m.jobid = j.jobid
+  LEFT JOIN runs r ON r.jobid = j.jobid
+  ORDER BY j.jobname;
+$function$;
+
+REVOKE ALL ON FUNCTION public.get_cron_health() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_cron_health() TO service_role;
+
+-- ── Cron: diário 8h BRT (11:00 UTC) ──────────────────────────
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'ops-healthcheck') THEN
+    PERFORM cron.unschedule('ops-healthcheck');
+  END IF;
+END $$;
+
+SELECT cron.schedule('ops-healthcheck', '0 11 * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ops_healthcheck_url'),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'ops_healthcheck_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 30000
+  );
+$job$);


### PR DESCRIPTION
Onda 2 do plano da revisão. O problema que resolve: **cron agendado cujos vault secrets nunca foram criados falha em silêncio** (`net.http_post` com url null retorna \"succeeded\" no pg_cron). Já aconteceu **3 vezes** — notify-kickoff, notify-opportunities + ingest-fixtures (semanas mudos em produção), e quase a 4ª com o resumo semanal.

## Desenho (2 peças)

**RPC `get_cron_health()`** (migration 088, SECURITY DEFINER, read-only):
- Para cada `cron.job`: extrai por regex os secrets que o comando referencia (`decrypted_secrets WHERE name = 'x'`) e confere existência em `vault.secrets` → `missing_secrets[]`
- Conta falhas nas últimas 5 execuções (`cron.job_run_details`) → `failed_recent/total_recent`
- Teria pego **as 3 ocorrências históricas** no dia seguinte

**Edge `ops-healthcheck`** (cron diário 8h BRT):
- DM pro admin **só quando há problema** (secrets faltando OU ≥3 falhas/5) — silêncio = tudo bem, mesma filosofia do produto
- Admin em `ops_config['admin_telegram_chat_id']` (tabela service-only — dado operacional auditável, não env var que ninguém confere)
- **Se auto-verifica**: o próprio job aparece na listagem que ele checa
- `?mode=report` (só JSON, pro ensaio) · `?mode=test` (DM de teste, valida o canal)

## 🗄️ Supabase — runbook
- Migration 088 aplica sozinha (RPC + ops_config + cron).
- ✅ Vault secrets do healthcheck **já criados em staging e prod** (`ops_healthcheck_url` + `_cron_secret`).
- ⚠️ Pós-deploy por ambiente (1x): `INSERT INTO ops_config VALUES ('admin_telegram_chat_id', '<chat>');` — staging farei no ensaio; **prod entra no runbook do release**.

## Ensaio staging (pós-merge)
1. Inserir admin em ops_config → `?mode=test` (DM de teste chega)
2. `?mode=report` → JSON com todos os jobs e `problems: []` (ou o que achar!)
3. Sabotagem controlada: dropar um secret de teste? Não — validar via job novo sem secret é intrusivo; o report já prova a detecção se listar algo. (A RPC é read-only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)