### PR TITLE
test(functions): testes como gate de deploy + shared/ — Onda 3

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -5,9 +5,21 @@ on:
     branches: [main]
 
 jobs:
+  # Gate: deploy só acontece com os testes das funções passando
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Run function tests
+        run: deno test supabase/functions/tests/
+
   deploy:
     runs-on: ubuntu-latest
     environment: production
+    needs: test
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,9 +5,21 @@ on:
     branches: [develop]
 
 jobs:
+  # Gate: deploy só acontece com os testes das funções passando
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Run function tests
+        run: deno test supabase/functions/tests/
+
   deploy:
     runs-on: ubuntu-latest
     environment: staging
+    needs: test
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-functions.yml
+++ b/.github/workflows/test-functions.yml
@@ -1,0 +1,21 @@
+name: Test Edge Functions
+
+# Roda os testes das funções puras (veredito/matching, faixas do resumo, stake)
+# em TODO pull request — feedback antes do merge. Os deploys (staging/prod)
+# também rodam estes testes como gate (job test, needs: test).
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run function tests
+        run: deno test supabase/functions/tests/

--- a/MAPA_MENSAGENS_BOT.md
+++ b/MAPA_MENSAGENS_BOT.md
@@ -29,6 +29,7 @@ fraco = silêncio; usuário que ignora = para de receber.
 | # | Mensagem | Gatilho |
 |---|---|---|
 | 9 | Alerta de coletor quebrado | 5 falhas consecutivas do ingest-fixtures → DM só pro admin |
+| 11 | Alerta do ops-healthcheck | Cron diário 8h BRT: vault secret faltando em algum cron OU ≥3 falhas/5 execuções → DM só pro admin (`ops_config.admin_telegram_chat_id`). Sem problema = silêncio |
 
 ## O pior dia possível (teste de metralhadora)
 

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -27,6 +27,8 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+import { esc } from "../shared/format.ts";
+import { trackedUrl } from "../shared/links.ts";
 
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
 const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
@@ -80,9 +82,7 @@ function marketPt(market: string): string {
 }
 
 // ── util ─────────────────────────────────────────────────────
-function esc(s: unknown): string {
-  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
+// esc/trackedUrl vivem em shared/ (Onda 3 — estavam duplicados 1:1)
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
 }
@@ -95,19 +95,6 @@ function brtDay(d: Date): string {
 }
 function brtHourMin(d: Date): string {
   return new Intl.DateTimeFormat("pt-BR", { timeZone: "America/Sao_Paulo", hour: "2-digit", minute: "2-digit" }).format(d);
-}
-
-// link rastreado: /functions/v1/go?u=<user>&d=<dest>&s=<hmac>
-async function hmacHex(msg: string): Promise<string> {
-  const key = await crypto.subtle.importKey(
-    "raw", new TextEncoder().encode(CRON_SECRET), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
-  );
-  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(msg));
-  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("").slice(0, 16);
-}
-async function trackedUrl(userId: string, dest: string): Promise<string> {
-  const s = await hmacHex(`${userId}:${dest}`);
-  return `${SUPABASE_URL}/functions/v1/go?u=${userId}&d=${encodeURIComponent(dest)}&s=${s}`;
 }
 
 interface BoardRow {

--- a/supabase/functions/notify-settlement/index.ts
+++ b/supabase/functions/notify-settlement/index.ts
@@ -25,6 +25,9 @@
 //     Respeita janela de silêncio (09h–23h BRT); a do jogo casado sai na hora do
 //     apito (quem apostou no jogo está acordado assistindo).
 //
+// Matching + veredito vivem em ./verdict.ts (código puro, testado no CI —
+// supabase/functions/tests/verdict.test.ts).
+//
 // Cadência: teto de 2 lembretes por aposta com gap de 20h (RPC), máx. 3
 // mensagens por usuário por run. Veredito NUNCA é dado em múltiplas/sistema,
 // nem em mercados de classificação/prorrogação (regras de casa divergem).
@@ -36,6 +39,17 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+import { esc } from "../shared/format.ts";
+import {
+  type Candidate,
+  type FinishedMatch,
+  type Verdict,
+  computeVerdict,
+  fixtureTeamNames,
+  hasTeam,
+  norm,
+  teamNames,
+} from "./verdict.ts";
 
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
 const BETS_URL = "https://www.smartbetting.app/bets";
@@ -44,10 +58,6 @@ const QUIET_START = 9; // genéricas só entre 09:00–22:59 BRT
 const QUIET_END = 23;
 
 // ── Telegram ─────────────────────────────────────────────────
-function esc(s: unknown): string {
-  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
 async function sendReminder(chatId: string, text: string, betId: string): Promise<void> {
   const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
     method: "POST",
@@ -74,143 +84,6 @@ async function sendReminder(chatId: string, text: string, betId: string): Promis
   if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
 }
 
-// ── Normalização e casamento de times ────────────────────────
-function norm(s: unknown): string {
-  return String(s ?? "")
-    .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "") // remove acentos (marcas combinantes)
-    .toLowerCase()
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-
-// Nome em inglês (print de casa gringa) → nome PT usado em wc_matches.
-// Chaves e valores já normalizados (sem acento, minúsculas).
-const EN_ALIASES: Record<string, string> = {
-  "brazil": "brasil",
-  "france": "franca",
-  "germany": "alemanha",
-  "spain": "espanha",
-  "netherlands": "holanda",
-  "england": "inglaterra",
-  "portugal": "portugal",
-  "argentina": "argentina",
-  "uruguay": "uruguai",
-  "colombia": "colombia",
-  "ecuador": "equador",
-  "paraguay": "paraguai",
-  "mexico": "mexico",
-  "united states": "estados unidos",
-  "usa": "estados unidos",
-  "canada": "canada",
-  "belgium": "belgica",
-  "croatia": "croacia",
-  "switzerland": "suica",
-  "italy": "italia",
-  "poland": "polonia",
-  "austria": "austria",
-  "denmark": "dinamarca",
-  "norway": "noruega",
-  "sweden": "suecia",
-  "scotland": "escocia",
-  "turkey": "turquia",
-  "turkiye": "turquia",
-  "morocco": "marrocos",
-  "senegal": "senegal",
-  "ghana": "gana",
-  "egypt": "egito",
-  "algeria": "argelia",
-  "tunisia": "tunisia",
-  "nigeria": "nigeria",
-  "cameroon": "camaroes",
-  "ivory coast": "costa do marfim",
-  "cote d'ivoire": "costa do marfim",
-  "south africa": "africa do sul",
-  "japan": "japao",
-  "south korea": "coreia do sul",
-  "korea republic": "coreia do sul",
-  "saudi arabia": "arabia saudita",
-  "iran": "ira",
-  "qatar": "catar",
-  "jordan": "jordania",
-  "uzbekistan": "uzbequistao",
-  "australia": "australia",
-  "new zealand": "nova zelandia",
-  "panama": "panama",
-  "costa rica": "costa rica",
-  "haiti": "haiti",
-  "curacao": "curacao",
-  "cape verde": "cabo verde",
-};
-
-// true se ALGUM dos nomes aparece como palavra inteira no texto normalizado
-function hasTeam(textNorm: string, names: string[]): boolean {
-  return names.some((n) => {
-    if (!n || n.length < 3) return false;
-    return new RegExp(`(^|[^a-z])${escapeRegex(n)}([^a-z]|$)`).test(textNorm);
-  });
-}
-
-// Variações reconhecíveis de um time de wc_matches (nome PT + aliases EN + código)
-function teamNames(namePt: string, code: string): string[] {
-  const base = norm(namePt);
-  const names = [base, norm(code)];
-  for (const [en, pt] of Object.entries(EN_ALIASES)) if (pt === base) names.push(en);
-  return names;
-}
-
-// ── Aliases de clube pro coletor multi-liga (F2) ─────────────
-// A tabela public.fixtures traz o nome como a API-Football escreve (ex.:
-// "Atletico-MG", "RB Bragantino"). O casamento primário é pelo próprio nome
-// normalizado; aqui só as VARIAÇÕES ESTRUTURAIS que divergem do que o
-// usuário/print costuma trazer (prefixo "rb", "da gama", forma por extenso do
-// "-MG/-PR"). Apelidos/torcida (galo, verdão) ficam de fora de propósito: risco
-// de falso-positivo > ganho. Curadoria fina futura entra em public.team_aliases
-// (por api_team_id), carregada abaixo.
-// CHAVE = nome da API normalizado (norm(); mantém o hífen). Valores normalizados.
-const CLUB_ALIASES: Record<string, string[]> = {
-  "rb bragantino": ["bragantino", "red bull bragantino"],
-  "vasco da gama": ["vasco"],
-  "atletico-mg": ["atletico mineiro"],
-  "atletico-go": ["atletico goianiense"],
-  "athletico-pr": ["athletico paranaense", "atletico paranaense"],
-  "america-mg": ["america mineiro"],
-  "sao paulo": ["sao paulo fc"],
-  "gremio": ["gremio fbpa"],
-};
-
-// Nomes reconhecíveis de um time do coletor: nome da API + variações estruturais
-// + aliases curados por id (team_aliases). Descarta tokens curtos (<3) e o
-// perigoso "atletico"/"america" sozinho (colide entre clubes).
-function fixtureTeamNames(apiName: string, teamId: number | null, aliasById: Map<number, string[]>): string[] {
-  const base = norm(apiName);
-  const out = new Set<string>([base]);
-  for (const a of CLUB_ALIASES[base] ?? []) out.add(a);
-  if (teamId != null) for (const a of aliasById.get(teamId) ?? []) out.add(norm(a));
-  return [...out].filter((n) => n.length >= 3);
-}
-
-// ── Fonte de placar unificada (wc_matches ∪ fixtures) ────────
-// O motor de veredito e as mensagens operam sobre esta forma, agnóstica à fonte.
-// ft_*  = placar dos 90' (BASE de liquidação). score_* = final (inclui prorrog.),
-// só pra exibição. Copa aparece nas DUAS fontes na janela de dual-run → 'wc'
-// tem prioridade no dedup (fonte provada do Marco 0).
-interface FinishedMatch {
-  source: "wc" | "fixtures";
-  id: string; // rótulo de evidência ("wc_matches 123" / "fixtures 456")
-  home_team: string;
-  away_team: string;
-  home_names: string[];
-  away_names: string[];
-  ft_home: number | null;
-  ft_away: number | null;
-  score_home: number | null;
-  score_away: number | null;
-  kickoff: number; // epoch ms
-}
-
 interface WcMatch {
   id: number;
   stage: string;
@@ -225,136 +98,6 @@ interface WcMatch {
   fulltime_home: number | null;
   fulltime_away: number | null;
   is_finished: boolean;
-}
-
-interface Candidate {
-  bet_id: string;
-  user_id: string;
-  chat_id: string;
-  user_name: string | null;
-  bet_type: string | null;
-  sport: string | null;
-  league: string | null;
-  betting_market: string | null;
-  match_description: string | null;
-  bet_description: string | null;
-  odds: number;
-  stake_amount: number;
-  potential_return: number;
-  bet_date: string;
-  match_date: string | null;
-  reminder_count: number;
-}
-
-// ── Veredito pelo placar dos 90' ─────────────────────────────
-// Só para mercados diretos; qualquer ambiguidade → null (pergunta sem afirmar).
-// Handicap asiático (quick win do parecer do coletor) pode devolver void
-// (push em linha inteira) e meio-resultados (linha quarter ±0.25/±0.75) —
-// os status half_won/half_lost/void já existem no banco e no dashboard.
-type Verdict = "won" | "lost" | "void" | "half_won" | "half_lost" | null;
-
-// meia-aposta do handicap: ajustado >0 ganha, <0 perde, =0 devolve (push)
-function settleAhHalf(adjusted: number): "won" | "lost" | "void" {
-  if (adjusted > 0.001) return "won";
-  if (adjusted < -0.001) return "lost";
-  return "void";
-}
-
-// Handicap asiático pelos 90': margin = gols do time apostado − adversário;
-// line = handicap NA ÓTICA do time apostado (como escrito na aposta).
-// Linha quarter (x.25/x.75) decompõe em duas metades — padrão do mercado.
-function settleAsianHandicap(margin: number, line: number): Verdict {
-  const isQuarter = Math.abs((line * 4) % 2) === 1;
-  if (!isQuarter) return settleAhHalf(margin + line);
-  const a = settleAhHalf(margin + (line - 0.25));
-  const b = settleAhHalf(margin + (line + 0.25));
-  if (a === b) return a;                              // won+won / lost+lost
-  if (a === "won" || b === "won") return "half_won";  // won + push
-  return "half_lost";                                 // push + lost
-}
-
-function computeVerdict(bet: Candidate, m: FinishedMatch): Verdict {
-  // múltipla/sistema: pernas em jogos diversos, nunca decidível por 1 placar
-  const type = norm(bet.bet_type);
-  if (type === "multiple" || type === "system") return null;
-
-  const ftH = m.ft_home;
-  const ftA = m.ft_away;
-  if (ftH == null || ftA == null) return null; // sem placar de 90' → sem veredito
-
-  const desc = norm(bet.bet_description);
-  const market = norm(bet.betting_market);
-
-  // mercados fora do tempo normal / com regra própria → não arriscar
-  if (
-    /classific|avanc|qualif|prorrog|penalt|penalti|escanteio|cartao|cartoes|chute|finalizac|jogador|marca a qualquer|primeiro gol/.test(desc) ||
-    /1[oº°]?\s*tempo|2[oº°]?\s*tempo|primeiro tempo|segundo tempo|intervalo|halftime|1st half|2nd half/.test(desc)
-  ) {
-    return null;
-  }
-
-  const total = ftH + ftA;
-
-  // Over/Under de gols — "mais de 2,5", "over 2.5", "menos de 3"
-  const over = desc.match(/(?:mais de|over|acima de)\s*(\d+(?:[.,]\d+)?)/);
-  const under = desc.match(/(?:menos de|under|abaixo de)\s*(\d+(?:[.,]\d+)?)/);
-  if (over || under) {
-    // precisa ser de GOLS (explícito ou pelo mercado classificado)
-    const isGoals = /gol/.test(desc) || market === "over/under";
-    if (!isGoals) return null;
-    const line = parseFloat((over ?? under)![1].replace(",", "."));
-    if (Number.isNaN(line)) return null;
-    if (total === line) return null; // linha exata = push/void → usuário decide
-    if (over) return total > line ? "won" : "lost";
-    return total < line ? "won" : "lost";
-  }
-
-  // Ambas marcam (BTTS) — "não" explícito vira aposta no NÃO; cuidado com o
-  // "no" preposição do PT ("gols no jogo"): só conta como negativa em fim de
-  // frase ou depois de dois-pontos ("Ambas marcam: No")
-  if (market === "ambas marcam" || /ambas\s+(as\s+)?(equipes\s+)?marcam|btts|both teams to score/.test(desc)) {
-    const both = ftH > 0 && ftA > 0;
-    const betNo = /\bnao\b/.test(desc) || /:\s*no\b/.test(desc) || /\bno\s*$/.test(desc);
-    return (betNo ? !both : both) ? "won" : "lost";
-  }
-
-  // linha com sinal ("−1,5", "-0.5", "+0,25") — presença dela indica handicap;
-  // também desarma o ML (um "Vencedor: Belgium -1.5" não é money line puro)
-  const lineMatch = desc.replace(/−/g, "-").match(/([+-])\s*(\d+(?:[.,]\d+)?)/);
-
-  // Money Line / 1x2 — em qual time a aposta foi?
-  if (!lineMatch && (market === "money line" || /\bml\b|money\s?line|vencedor|para vencer|vence\b|1x2/.test(desc))) {
-    const homeNames = m.home_names;
-    const awayNames = m.away_names;
-    const isDraw = /empate/.test(desc);
-    const pickedHome = hasTeam(desc, homeNames);
-    const pickedAway = hasTeam(desc, awayNames);
-
-    if (isDraw && !pickedHome && !pickedAway) return ftH === ftA ? "won" : "lost";
-    if (pickedHome && !pickedAway) return ftH > ftA ? "won" : "lost";
-    if (pickedAway && !pickedHome) return ftA > ftH ? "won" : "lost";
-    return null; // ambíguo (dois times citados / nenhum) → não afirmar
-  }
-
-  // Handicap asiático — "Belgium −1,5", "Handicap -0.5 Atletico" (aritmética
-  // dos 90' como os demais). Europeu ("empate (-1)") fica fora: regra diverge.
-  if (lineMatch && !/empate/.test(desc)) {
-    const raw = parseFloat(lineMatch[2].replace(",", "."));
-    const line = (lineMatch[1] === "-" ? -1 : 1) * raw;
-    // sanidade: linha múltipla de 0.25 e dentro do plausível
-    if (!Number.isInteger(line * 4) || Math.abs(line) > 6) return null;
-
-    const homeNames = m.home_names;
-    const awayNames = m.away_names;
-    const pickedHome = hasTeam(desc, homeNames);
-    const pickedAway = hasTeam(desc, awayNames);
-    if (pickedHome === pickedAway) return null; // nenhum ou os dois → ambíguo
-
-    const margin = pickedHome ? ftH - ftA : ftA - ftH;
-    return settleAsianHandicap(margin, line);
-  }
-
-  return null;
 }
 
 // ── Mensagens ────────────────────────────────────────────────

--- a/supabase/functions/notify-settlement/verdict.ts
+++ b/supabase/functions/notify-settlement/verdict.ts
@@ -1,0 +1,274 @@
+// ============================================================
+// verdict.ts — matching aposta↔jogo + veredito pelos 90' (código PURO)
+// ============================================================
+// Extraído de index.ts na Onda 3 da revisão (move-only, zero mudança de
+// lógica) pra ser testável: supabase/functions/tests/verdict.test.ts roda
+// estes casos no CI antes de qualquer deploy. NÃO importar nada com side
+// effects aqui — este módulo precisa rodar offline no `deno test`.
+
+// ── Normalização e casamento de times ────────────────────────
+export function norm(s: unknown): string {
+  return String(s ?? "")
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "") // remove acentos (marcas combinantes)
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Nome em inglês (print de casa gringa) → nome PT usado em wc_matches.
+// Chaves e valores já normalizados (sem acento, minúsculas).
+const EN_ALIASES: Record<string, string> = {
+  "brazil": "brasil",
+  "france": "franca",
+  "germany": "alemanha",
+  "spain": "espanha",
+  "netherlands": "holanda",
+  "england": "inglaterra",
+  "portugal": "portugal",
+  "argentina": "argentina",
+  "uruguay": "uruguai",
+  "colombia": "colombia",
+  "ecuador": "equador",
+  "paraguay": "paraguai",
+  "mexico": "mexico",
+  "united states": "estados unidos",
+  "usa": "estados unidos",
+  "canada": "canada",
+  "belgium": "belgica",
+  "croatia": "croacia",
+  "switzerland": "suica",
+  "italy": "italia",
+  "poland": "polonia",
+  "austria": "austria",
+  "denmark": "dinamarca",
+  "norway": "noruega",
+  "sweden": "suecia",
+  "scotland": "escocia",
+  "turkey": "turquia",
+  "turkiye": "turquia",
+  "morocco": "marrocos",
+  "senegal": "senegal",
+  "ghana": "gana",
+  "egypt": "egito",
+  "algeria": "argelia",
+  "tunisia": "tunisia",
+  "nigeria": "nigeria",
+  "cameroon": "camaroes",
+  "ivory coast": "costa do marfim",
+  "cote d'ivoire": "costa do marfim",
+  "south africa": "africa do sul",
+  "japan": "japao",
+  "south korea": "coreia do sul",
+  "korea republic": "coreia do sul",
+  "saudi arabia": "arabia saudita",
+  "iran": "ira",
+  "qatar": "catar",
+  "jordan": "jordania",
+  "uzbekistan": "uzbequistao",
+  "australia": "australia",
+  "new zealand": "nova zelandia",
+  "panama": "panama",
+  "costa rica": "costa rica",
+  "haiti": "haiti",
+  "curacao": "curacao",
+  "cape verde": "cabo verde",
+};
+
+// true se ALGUM dos nomes aparece como palavra inteira no texto normalizado
+export function hasTeam(textNorm: string, names: string[]): boolean {
+  return names.some((n) => {
+    if (!n || n.length < 3) return false;
+    return new RegExp(`(^|[^a-z])${escapeRegex(n)}([^a-z]|$)`).test(textNorm);
+  });
+}
+
+// Variações reconhecíveis de um time de wc_matches (nome PT + aliases EN + código)
+export function teamNames(namePt: string, code: string): string[] {
+  const base = norm(namePt);
+  const names = [base, norm(code)];
+  for (const [en, pt] of Object.entries(EN_ALIASES)) if (pt === base) names.push(en);
+  return names;
+}
+
+// ── Aliases de clube pro coletor multi-liga (F2) ─────────────
+// A tabela public.fixtures traz o nome como a API-Football escreve (ex.:
+// "Atletico-MG", "RB Bragantino"). O casamento primário é pelo próprio nome
+// normalizado; aqui só as VARIAÇÕES ESTRUTURAIS que divergem do que o
+// usuário/print costuma trazer (prefixo "rb", "da gama", forma por extenso do
+// "-MG/-PR"). Apelidos/torcida (galo, verdão) ficam de fora de propósito: risco
+// de falso-positivo > ganho. Curadoria fina futura entra em public.team_aliases
+// (por api_team_id), carregada abaixo.
+// CHAVE = nome da API normalizado (norm(); mantém o hífen). Valores normalizados.
+const CLUB_ALIASES: Record<string, string[]> = {
+  "rb bragantino": ["bragantino", "red bull bragantino"],
+  "vasco da gama": ["vasco"],
+  "atletico-mg": ["atletico mineiro"],
+  "atletico-go": ["atletico goianiense"],
+  "athletico-pr": ["athletico paranaense", "atletico paranaense"],
+  "america-mg": ["america mineiro"],
+  "sao paulo": ["sao paulo fc"],
+  "gremio": ["gremio fbpa"],
+};
+
+// Nomes reconhecíveis de um time do coletor: nome da API + variações estruturais
+// + aliases curados por id (team_aliases). Descarta tokens curtos (<3) e o
+// perigoso "atletico"/"america" sozinho (colide entre clubes).
+export function fixtureTeamNames(apiName: string, teamId: number | null, aliasById: Map<number, string[]>): string[] {
+  const base = norm(apiName);
+  const out = new Set<string>([base]);
+  for (const a of CLUB_ALIASES[base] ?? []) out.add(a);
+  if (teamId != null) for (const a of aliasById.get(teamId) ?? []) out.add(norm(a));
+  return [...out].filter((n) => n.length >= 3);
+}
+
+// ── Fonte de placar unificada (wc_matches ∪ fixtures) ────────
+// O motor de veredito e as mensagens operam sobre esta forma, agnóstica à fonte.
+// ft_*  = placar dos 90' (BASE de liquidação). score_* = final (inclui prorrog.),
+// só pra exibição. Copa aparece nas DUAS fontes na janela de dual-run → 'wc'
+// tem prioridade no dedup (fonte provada do Marco 0).
+export interface FinishedMatch {
+  source: "wc" | "fixtures";
+  id: string; // rótulo de evidência ("wc_matches 123" / "fixtures 456")
+  home_team: string;
+  away_team: string;
+  home_names: string[];
+  away_names: string[];
+  ft_home: number | null;
+  ft_away: number | null;
+  score_home: number | null;
+  score_away: number | null;
+  kickoff: number; // epoch ms
+}
+
+export interface Candidate {
+  bet_id: string;
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+  bet_type: string | null;
+  sport: string | null;
+  league: string | null;
+  betting_market: string | null;
+  match_description: string | null;
+  bet_description: string | null;
+  odds: number;
+  stake_amount: number;
+  potential_return: number;
+  bet_date: string;
+  match_date: string | null;
+  reminder_count: number;
+}
+
+// ── Veredito pelo placar dos 90' ─────────────────────────────
+// Só para mercados diretos; qualquer ambiguidade → null (pergunta sem afirmar).
+// Handicap asiático (quick win do parecer do coletor) pode devolver void
+// (push em linha inteira) e meio-resultados (linha quarter ±0.25/±0.75) —
+// os status half_won/half_lost/void já existem no banco e no dashboard.
+export type Verdict = "won" | "lost" | "void" | "half_won" | "half_lost" | null;
+
+// meia-aposta do handicap: ajustado >0 ganha, <0 perde, =0 devolve (push)
+function settleAhHalf(adjusted: number): "won" | "lost" | "void" {
+  if (adjusted > 0.001) return "won";
+  if (adjusted < -0.001) return "lost";
+  return "void";
+}
+
+// Handicap asiático pelos 90': margin = gols do time apostado − adversário;
+// line = handicap NA ÓTICA do time apostado (como escrito na aposta).
+// Linha quarter (x.25/x.75) decompõe em duas metades — padrão do mercado.
+export function settleAsianHandicap(margin: number, line: number): Verdict {
+  const isQuarter = Math.abs((line * 4) % 2) === 1;
+  if (!isQuarter) return settleAhHalf(margin + line);
+  const a = settleAhHalf(margin + (line - 0.25));
+  const b = settleAhHalf(margin + (line + 0.25));
+  if (a === b) return a;                              // won+won / lost+lost
+  if (a === "won" || b === "won") return "half_won";  // won + push
+  return "half_lost";                                 // push + lost
+}
+
+export function computeVerdict(bet: Candidate, m: FinishedMatch): Verdict {
+  // múltipla/sistema: pernas em jogos diversos, nunca decidível por 1 placar
+  const type = norm(bet.bet_type);
+  if (type === "multiple" || type === "system") return null;
+
+  const ftH = m.ft_home;
+  const ftA = m.ft_away;
+  if (ftH == null || ftA == null) return null; // sem placar de 90' → sem veredito
+
+  const desc = norm(bet.bet_description);
+  const market = norm(bet.betting_market);
+
+  // mercados fora do tempo normal / com regra própria → não arriscar
+  if (
+    /classific|avanc|qualif|prorrog|penalt|penalti|escanteio|cartao|cartoes|chute|finalizac|jogador|marca a qualquer|primeiro gol/.test(desc) ||
+    /1[oº°]?\s*tempo|2[oº°]?\s*tempo|primeiro tempo|segundo tempo|intervalo|halftime|1st half|2nd half/.test(desc)
+  ) {
+    return null;
+  }
+
+  const total = ftH + ftA;
+
+  // Over/Under de gols — "mais de 2,5", "over 2.5", "menos de 3"
+  const over = desc.match(/(?:mais de|over|acima de)\s*(\d+(?:[.,]\d+)?)/);
+  const under = desc.match(/(?:menos de|under|abaixo de)\s*(\d+(?:[.,]\d+)?)/);
+  if (over || under) {
+    // precisa ser de GOLS (explícito ou pelo mercado classificado)
+    const isGoals = /gol/.test(desc) || market === "over/under";
+    if (!isGoals) return null;
+    const line = parseFloat((over ?? under)![1].replace(",", "."));
+    if (Number.isNaN(line)) return null;
+    if (total === line) return null; // linha exata = push/void → usuário decide
+    if (over) return total > line ? "won" : "lost";
+    return total < line ? "won" : "lost";
+  }
+
+  // Ambas marcam (BTTS) — "não" explícito vira aposta no NÃO; cuidado com o
+  // "no" preposição do PT ("gols no jogo"): só conta como negativa em fim de
+  // frase ou depois de dois-pontos ("Ambas marcam: No")
+  if (market === "ambas marcam" || /ambas\s+(as\s+)?(equipes\s+)?marcam|btts|both teams to score/.test(desc)) {
+    const both = ftH > 0 && ftA > 0;
+    const betNo = /\bnao\b/.test(desc) || /:\s*no\b/.test(desc) || /\bno\s*$/.test(desc);
+    return (betNo ? !both : both) ? "won" : "lost";
+  }
+
+  // linha com sinal ("−1,5", "-0.5", "+0,25") — presença dela indica handicap;
+  // também desarma o ML (um "Vencedor: Belgium -1.5" não é money line puro)
+  const lineMatch = desc.replace(/−/g, "-").match(/([+-])\s*(\d+(?:[.,]\d+)?)/);
+
+  // Money Line / 1x2 — em qual time a aposta foi?
+  if (!lineMatch && (market === "money line" || /\bml\b|money\s?line|vencedor|para vencer|vence\b|1x2/.test(desc))) {
+    const homeNames = m.home_names;
+    const awayNames = m.away_names;
+    const isDraw = /empate/.test(desc);
+    const pickedHome = hasTeam(desc, homeNames);
+    const pickedAway = hasTeam(desc, awayNames);
+
+    if (isDraw && !pickedHome && !pickedAway) return ftH === ftA ? "won" : "lost";
+    if (pickedHome && !pickedAway) return ftH > ftA ? "won" : "lost";
+    if (pickedAway && !pickedHome) return ftA > ftH ? "won" : "lost";
+    return null; // ambíguo (dois times citados / nenhum) → não afirmar
+  }
+
+  // Handicap asiático — "Belgium −1,5", "Handicap -0.5 Atletico" (aritmética
+  // dos 90' como os demais). Europeu ("empate (-1)") fica fora: regra diverge.
+  if (lineMatch && !/empate/.test(desc)) {
+    const raw = parseFloat(lineMatch[2].replace(",", "."));
+    const line = (lineMatch[1] === "-" ? -1 : 1) * raw;
+    // sanidade: linha múltipla de 0.25 e dentro do plausível
+    if (!Number.isInteger(line * 4) || Math.abs(line) > 6) return null;
+
+    const homeNames = m.home_names;
+    const awayNames = m.away_names;
+    const pickedHome = hasTeam(desc, homeNames);
+    const pickedAway = hasTeam(desc, awayNames);
+    if (pickedHome === pickedAway) return null; // nenhum ou os dois → ambíguo
+
+    const margin = pickedHome ? ftH - ftA : ftA - ftH;
+    return settleAsianHandicap(margin, line);
+  }
+
+  return null;
+}

--- a/supabase/functions/notify-weekly-summary/index.ts
+++ b/supabase/functions/notify-weekly-summary/index.ts
@@ -1,19 +1,20 @@
 // ============================================================
 // notify-weekly-summary — resumo semanal de desempenho (item 04, Marco 2)
 // ============================================================
-// Cron semanal (segunda 10h BRT; migration 086). DM no Telegram (Betinho) com o
-// desempenho dos ÚLTIMOS 7 DIAS (rolling). Recompensa recorrente → hábito.
+// Cron semanal (segunda 9h30 BRT — antes do daily das 10h; migrations 086/087).
+// DM no Telegram (Betinho) com o desempenho dos ÚLTIMOS 7 DIAS (rolling).
+// Recompensa recorrente → hábito.
 //
 // A RPC get_weekly_recap_candidates() faz o trabalho pesado (agregados por
-// usuário elegível: resultado/stake/melhor mercado/unidade). Aqui só escolhemos
-// a FAIXA (positiva/neutra/negativa), formatamos e enviamos.
+// usuário elegível). A faixa e a copy vivem em ./tiers.ts (código puro,
+// testado no CI — supabase/functions/tests/weekly.test.ts).
 //
 // Regras de produto (2026-07-15): rolling 7d · >=2 apostas liquidadas · lidera
-// por RESULTADO+ROI (SEM taxa de acerto — acerto sozinho engana) · R$ sempre +
-// unidades quando configurado · tom disciplina/controle (LC 224) · CTA único
-// "Ver minha banca" (rastreado pelo `go`, campanha weekly_summary) · sem emoji
-// em botão. Idempotência via users.weekly_summary_sent_at; opt-out via
-// users.weekly_summary_muted. Entra no MAPA_MENSAGENS_BOT.md.
+// por RESULTADO+ROI (SEM taxa de acerto) · R$ sempre + unidades quando
+// configurado · tom disciplina (LC 224) · CTA "Ver minha banca" rastreado +
+// botão "Silenciar resumo" (opt-out na própria mensagem; /resumo reativa).
+// Idempotência via users.weekly_summary_sent_at; opt-out via
+// users.weekly_summary_muted. Mapa: MAPA_MENSAGENS_BOT.md #10.
 //
 // ?mode=report → não envia; devolve os candidatos + faixa (ensaio).
 // Proteção: header `x-cron-secret` == env CRON_SECRET.
@@ -22,105 +23,16 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+import { trackedUrl } from "../shared/links.ts";
+import { buildMessage, pickTier, type WeeklyCandidate } from "./tiers.ts";
 
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
 const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
-const BETS_URL = "https://www.smartbetting.app/bets";
 const CAMPAIGN = "weekly_summary";
 
-// thresholds da faixa: com unidade, em u; sem unidade, em ROI
-const POS_U = 0.5, NEG_U = -1.0;
-const POS_ROI = 0.05, NEG_ROI = -0.10;
-
-type Tier = "positive" | "neutral" | "negative";
-
-interface Candidate {
-  user_id: string;
-  chat_id: string;
-  user_name: string | null;
-  n_settled: number;
-  total_stake: number;
-  total_profit: number;
-  unit_value_rs: number | null;
-  best_market: string | null;
-  best_market_profit: number | null;
-}
-
-function esc(s: unknown): string {
-  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
-}
-
-const sign = (v: number) => (v > 0 ? "+" : v < 0 ? "−" : "");
-const moneyAbs = (v: number) => `R$ ${Math.abs(v).toFixed(2).replace(".", ",")}`;
-const unitAbs = (v: number) => `${Math.abs(v).toFixed(1).replace(".", ",")}u`;
-const pctAbs = (v: number) => `${Math.abs(v * 100).toFixed(0)}%`;
-
-function pickTier(profit: number, roi: number, unitRs: number | null): Tier {
-  if (unitRs && unitRs > 0) {
-    const u = profit / unitRs;
-    if (u > POS_U) return "positive";
-    if (u < NEG_U) return "negative";
-    return "neutral";
-  }
-  if (roi > POS_ROI) return "positive";
-  if (roi < NEG_ROI) return "negative";
-  return "neutral";
-}
-
-function resultLine(c: Candidate, roi: number): string {
-  const p = c.total_profit;
-  const sg = sign(p);
-  if (c.unit_value_rs && c.unit_value_rs > 0) {
-    return `Resultado: <b>${sg}${unitAbs(p / c.unit_value_rs)}</b> (${sg}${moneyAbs(p)}) · ROI <b>${sg}${pctAbs(roi)}</b>`;
-  }
-  return `Resultado: <b>${sg}${moneyAbs(p)}</b> · ROI <b>${sg}${pctAbs(roi)}</b>`;
-}
-
-function buildMessage(c: Candidate, tier: Tier, roi: number): string {
-  const head = `📊 <b>Seus últimos 7 dias</b>`;
-  const mkt = c.best_market ? ` · melhor mercado: <b>${esc(c.best_market)}</b>` : "";
-  const vol = `${c.n_settled} apostas liquidadas`;
-
-  if (tier === "positive") {
-    return [
-      head,
-      resultLine(c, roi),
-      `${vol}${mkt}`,
-      "",
-      `Fechou no positivo. O que importa agora é entender <b>o que sustentou isso</b> — quais mercados e stakes puxaram o resultado — pra repetir com consistência, não por sorte.`,
-    ].join("\n");
-  }
-  if (tier === "neutral") {
-    return [
-      head,
-      resultLine(c, roi),
-      `${vol}${mkt}`,
-      "",
-      `Variação controlada — nem lucro nem prejuízo relevante. Bom momento pra <b>afinar</b>: onde você foi eficiente e onde deixou valor na mesa.`,
-    ].join("\n");
-  }
-  // negative — sem destacar "melhor mercado"; foco em processo e proteção
-  return [
-    head,
-    resultLine(c, roi),
-    vol,
-    "",
-    `Semana negativa faz parte — o que separa quem evolui é o <b>processo</b>, não o placar de 7 dias. Antes da próxima sequência, vale revisar <b>stake, volume e escolha de mercado</b> com calma. Sem correr atrás do prejuízo.`,
-  ].join("\n");
-}
-
-// link rastreado: /functions/v1/go?u=&d=&s=&c=weekly_summary (HMAC sobre u:d)
-async function trackedUrl(userId: string, dest: string): Promise<string> {
-  const key = await crypto.subtle.importKey(
-    "raw", new TextEncoder().encode(CRON_SECRET), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
-  );
-  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(`${userId}:${dest}`));
-  const s = [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("").slice(0, 16);
-  return `${SUPABASE_URL}/functions/v1/go?u=${userId}&d=${dest}&s=${s}&c=${CAMPAIGN}`;
 }
 
 async function sendSummary(chatId: string, text: string, bankUrl: string): Promise<void> {
@@ -156,7 +68,7 @@ serve(async (req) => {
   try {
     const { data, error } = await supabase.rpc("get_weekly_recap_candidates");
     if (error) throw error;
-    const candidates: Candidate[] = (data ?? []).map((r: any) => ({
+    const candidates: WeeklyCandidate[] = (data ?? []).map((r: any) => ({
       user_id: r.user_id,
       chat_id: r.chat_id,
       user_name: r.user_name,
@@ -191,7 +103,7 @@ serve(async (req) => {
     for (const { c, roi, tier } of rows) {
       try {
         const text = buildMessage(c, tier, roi);
-        const bankUrl = await trackedUrl(c.user_id, "bank");
+        const bankUrl = await trackedUrl(c.user_id, "bank", CAMPAIGN);
         await sendSummary(c.chat_id, text, bankUrl);
 
         // marca envio só depois de mandar (run que falha tenta de novo na próxima)

--- a/supabase/functions/notify-weekly-summary/tiers.ts
+++ b/supabase/functions/notify-weekly-summary/tiers.ts
@@ -1,0 +1,83 @@
+// ============================================================
+// tiers.ts — faixa e copy do resumo semanal (código PURO)
+// ============================================================
+// Extraído de index.ts na Onda 3 (move-only) pra ser testável no CI
+// (supabase/functions/tests/weekly.test.ts). Sem side effects.
+import { esc } from "../shared/format.ts";
+
+// thresholds da faixa: com unidade, em u; sem unidade, em ROI
+const POS_U = 0.5, NEG_U = -1.0;
+const POS_ROI = 0.05, NEG_ROI = -0.10;
+
+export type Tier = "positive" | "neutral" | "negative";
+
+export interface WeeklyCandidate {
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+  n_settled: number;
+  total_stake: number;
+  total_profit: number;
+  unit_value_rs: number | null;
+  best_market: string | null;
+  best_market_profit: number | null;
+}
+
+const sign = (v: number) => (v > 0 ? "+" : v < 0 ? "−" : "");
+const moneyAbs = (v: number) => `R$ ${Math.abs(v).toFixed(2).replace(".", ",")}`;
+const unitAbs = (v: number) => `${Math.abs(v).toFixed(1).replace(".", ",")}u`;
+const pctAbs = (v: number) => `${Math.abs(v * 100).toFixed(0)}%`;
+
+export function pickTier(profit: number, roi: number, unitRs: number | null): Tier {
+  if (unitRs && unitRs > 0) {
+    const u = profit / unitRs;
+    if (u > POS_U) return "positive";
+    if (u < NEG_U) return "negative";
+    return "neutral";
+  }
+  if (roi > POS_ROI) return "positive";
+  if (roi < NEG_ROI) return "negative";
+  return "neutral";
+}
+
+function resultLine(c: WeeklyCandidate, roi: number): string {
+  const p = c.total_profit;
+  const sg = sign(p);
+  if (c.unit_value_rs && c.unit_value_rs > 0) {
+    return `Resultado: <b>${sg}${unitAbs(p / c.unit_value_rs)}</b> (${sg}${moneyAbs(p)}) · ROI <b>${sg}${pctAbs(roi)}</b>`;
+  }
+  return `Resultado: <b>${sg}${moneyAbs(p)}</b> · ROI <b>${sg}${pctAbs(roi)}</b>`;
+}
+
+export function buildMessage(c: WeeklyCandidate, tier: Tier, roi: number): string {
+  const head = `📊 <b>Seus últimos 7 dias</b>`;
+  const mkt = c.best_market ? ` · melhor mercado: <b>${esc(c.best_market)}</b>` : "";
+  const vol = `${c.n_settled} apostas liquidadas`;
+
+  if (tier === "positive") {
+    return [
+      head,
+      resultLine(c, roi),
+      `${vol}${mkt}`,
+      "",
+      `Fechou no positivo. O que importa agora é entender <b>o que sustentou isso</b> — quais mercados e stakes puxaram o resultado — pra repetir com consistência, não por sorte.`,
+    ].join("\n");
+  }
+  if (tier === "neutral") {
+    return [
+      head,
+      resultLine(c, roi),
+      `${vol}${mkt}`,
+      "",
+      `Variação controlada — nem lucro nem prejuízo relevante. Bom momento pra <b>afinar</b>: onde você foi eficiente e onde deixou valor na mesa.`,
+    ].join("\n");
+  }
+  // negative — sem destacar "melhor mercado"; foco em processo e proteção
+  return [
+    head,
+    resultLine(c, roi),
+    vol,
+    "",
+    `Semana negativa faz parte — o que separa quem evolui é o <b>processo</b>, não o placar de 7 dias. Antes da próxima sequência, vale revisar <b>stake, volume e escolha de mercado</b> com calma. Sem correr atrás do prejuízo.`,
+  ].join("\n");
+}

--- a/supabase/functions/shared/format.ts
+++ b/supabase/functions/shared/format.ts
@@ -1,0 +1,8 @@
+// shared/format.ts — helpers de formatação idênticos entre as funções de
+// mensagem (Onda 3: consolidação do que estava duplicado 1:1; deriva entre
+// cópias já quase causou bug — ver revisão 2026-07-20).
+
+// Escapa HTML pro parse_mode: "HTML" do Telegram.
+export function esc(s: unknown): string {
+  return String(s ?? "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/supabase/functions/shared/links.ts
+++ b/supabase/functions/shared/links.ts
@@ -1,0 +1,23 @@
+// shared/links.ts — links rastreados das DMs (Onda 3: estava duplicado 1:1 em
+// notify-opportunities e notify-weekly-summary).
+//
+// O link passa pelo redirecionador `go`: /go?u=<user>&d=<dest>&s=<hmac>[&c=<campanha>]
+// s = HMAC-SHA256(CRON_SECRET, "<u>:<d>") — impede forjar clique de outro usuário.
+// `campaign` omitida = daily_opportunities (retrocompat do go).
+
+const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
+
+export async function hmacHex(msg: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw", new TextEncoder().encode(CRON_SECRET), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(msg));
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("").slice(0, 16);
+}
+
+export async function trackedUrl(userId: string, dest: string, campaign?: string): Promise<string> {
+  const s = await hmacHex(`${userId}:${dest}`);
+  const c = campaign ? `&c=${encodeURIComponent(campaign)}` : "";
+  return `${SUPABASE_URL}/functions/v1/go?u=${userId}&d=${encodeURIComponent(dest)}&s=${s}${c}`;
+}

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from "npm:@supabase/supabase-js@2"
 import { normalizePhoneNumber, normalizePhoneCandidates, maskPhone } from "../shared/phone.ts"
 import { generateTraceId, identifyUser, trackEvent, trackLLMGeneration } from "../shared/posthog.ts"
+import { isBareNumber, parseStake } from "./stake.ts"
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY")
 const OPENAI_API_URL = "https://api.openai.com/v1"
@@ -421,13 +422,7 @@ async function sendStakePrompt(supabase: any, chatId: string | number, userId: s
   }
 }
 
-// número do texto do usuário (força reply do "Outro valor"): "R$ 50", "50,00", "50 reais"
-function parseStake(text: string): number | null {
-  const m = String(text ?? "").replace(",", ".").match(/(\d+(?:\.\d+)?)/)
-  if (!m) return null
-  const v = parseFloat(m[1])
-  return v > 0 && v <= 1_000_000 ? v : null
-}
+// parseStake/isBareNumber vivem em ./stake.ts (Onda 3 — testados no CI)
 
 async function handleCallbackQuery(
   supabase: any,
@@ -2242,7 +2237,7 @@ serve(async (req) => {
       if (prompt) {
         const replyToId = updateMessage.reply_to_message?.message_id
         const isReply = replyToId != null && Number(replyToId) === Number(prompt.message_id)
-        const bareNumber = /^\s*r?\$?\s*\d+(?:[.,]\d+)?\s*(reais|conto|pila|paus)?\s*$/i.test(text)
+        const bareNumber = isBareNumber(text)
         const fresh = Date.now() - new Date(prompt.created_at).getTime() < 30 * 60_000
         if (isReply || (bareNumber && fresh)) {
           const stake = parseStake(text)

--- a/supabase/functions/telegram-webhook/stake.ts
+++ b/supabase/functions/telegram-webhook/stake.ts
@@ -1,0 +1,22 @@
+// ============================================================
+// stake.ts — parsing do valor da aposta (código PURO)
+// ============================================================
+// Extraído de index.ts na Onda 3 (move-only) pra ser testável no CI
+// (supabase/functions/tests/stake.test.ts). Regra-mestra do fluxo de valor
+// (item 15): a decisão é pela FORMA da mensagem — número puro × resto —
+// nunca pelo tempo. Um registro de aposta real nunca é só um número.
+
+// número do texto do usuário (force reply do "Outro valor"): "R$ 50", "50,00", "50 reais"
+export function parseStake(text: string): number | null {
+  const m = String(text ?? "").replace(",", ".").match(/(\d+(?:\.\d+)?)/)
+  if (!m) return null
+  const v = parseFloat(m[1])
+  return v > 0 && v <= 1_000_000 ? v : null
+}
+
+// número PURO (com enfeites monetários no máximo): candidato a resposta de
+// valor. Qualquer palavra além de reais/conto/pila/paus desarma — print e
+// aposta em texto seguem pro fluxo normal de extração.
+export function isBareNumber(text: string): boolean {
+  return /^\s*r?\$?\s*\d+(?:[.,]\d+)?\s*(reais|conto|pila|paus)?\s*$/i.test(String(text ?? ""))
+}

--- a/supabase/functions/tests/_assert.ts
+++ b/supabase/functions/tests/_assert.ts
@@ -1,0 +1,10 @@
+// mini-assert local — mantém os testes 100% offline (sem baixar std/jsr no CI)
+export function assertEquals(got: unknown, expected: unknown, label = ""): void {
+  const g = JSON.stringify(got);
+  const e = JSON.stringify(expected);
+  if (g !== e) throw new Error(`${label ? label + ": " : ""}esperado ${e}, veio ${g}`);
+}
+
+export function assert(cond: boolean, label = "assert"): void {
+  if (!cond) throw new Error(label);
+}

--- a/supabase/functions/tests/stake.test.ts
+++ b/supabase/functions/tests/stake.test.ts
@@ -1,0 +1,29 @@
+// Testes do parsing de valor do item 15 (telegram-webhook/stake.ts).
+// Regra-mestra: decisão pela FORMA (número puro × resto) — um registro de
+// aposta real nunca é interceptado.
+import { assert, assertEquals } from "./_assert.ts";
+import { isBareNumber, parseStake } from "../telegram-webhook/stake.ts";
+
+// ── parseStake ──
+Deno.test("parseStake: '75' → 75", () => assertEquals(parseStake("75"), 75));
+Deno.test("parseStake: 'R$ 50' → 50", () => assertEquals(parseStake("R$ 50"), 50));
+Deno.test("parseStake: '50,00' → 50 (vírgula)", () => assertEquals(parseStake("50,00"), 50));
+Deno.test("parseStake: '12.5' → 12.5", () => assertEquals(parseStake("12.5"), 12.5));
+Deno.test("parseStake: sem dígito → null", () => assertEquals(parseStake("cinquenta reais"), null));
+Deno.test("parseStake: zero → null", () => assertEquals(parseStake("0"), null));
+Deno.test("parseStake: acima do teto (1M) → null", () => assertEquals(parseStake("2000000"), null));
+
+// ── isBareNumber (o portão do interceptador) ──
+Deno.test("bare: '75' ✓", () => assert(isBareNumber("75")));
+Deno.test("bare: 'r$ 50,5' ✓", () => assert(isBareNumber("r$ 50,5")));
+Deno.test("bare: '50 reais' ✓", () => assert(isBareNumber("50 reais")));
+Deno.test("bare: '30 conto' ✓", () => assert(isBareNumber("30 conto")));
+Deno.test("NÃO bare: aposta real nunca intercepta", () => {
+  assert(!isBareNumber("Palmeiras ML 50"));
+  assert(!isBareNumber("ganhei 50 na bet"));
+  assert(!isBareNumber("Mais de 2.5 gols, odd 1.80, R$ 50"));
+});
+Deno.test("NÃO bare: vazio/ruído", () => {
+  assert(!isBareNumber(""));
+  assert(!isBareNumber("ok"));
+});

--- a/supabase/functions/tests/verdict.test.ts
+++ b/supabase/functions/tests/verdict.test.ts
@@ -1,0 +1,138 @@
+// Testes do matching aposta↔jogo + veredito pelos 90' (notify-settlement).
+// Rodam no CI ANTES de qualquer deploy (gate). Casos portados dos ensaios do
+// F2 (PR #208) + handicap asiático (PR #197) — incluem os anti-falso-positivo
+// críticos e a regressão do decimal que quase subiu (fix 545ccbb).
+import { assert, assertEquals } from "./_assert.ts";
+import {
+  type Candidate,
+  type FinishedMatch,
+  computeVerdict,
+  fixtureTeamNames,
+  hasTeam,
+  norm,
+  settleAsianHandicap,
+  teamNames,
+} from "../notify-settlement/verdict.ts";
+
+// helpers de construção
+function fx(home: string, away: string, ftH: number | null, ftA: number | null,
+  homeId: number | null = null, awayId: number | null = null,
+  aliasById: Map<number, string[]> = new Map()): FinishedMatch {
+  return {
+    source: "fixtures", id: "fixtures 1", home_team: home, away_team: away,
+    home_names: fixtureTeamNames(home, homeId, aliasById),
+    away_names: fixtureTeamNames(away, awayId, aliasById),
+    ft_home: ftH, ft_away: ftA, score_home: ftH, score_away: ftA, kickoff: 1000,
+  };
+}
+function bet(desc: string, market: string | null, type = "single"): Candidate {
+  return {
+    bet_id: "b1", user_id: "u1", chat_id: "c1", user_name: null, bet_type: type,
+    sport: "Futebol", league: null, betting_market: market,
+    match_description: null, bet_description: desc,
+    odds: 2, stake_amount: 10, potential_return: 20, bet_date: "", match_date: null, reminder_count: 0,
+  };
+}
+function matches(matchDesc: string, betDesc: string, m: FinishedMatch): boolean {
+  const text = norm(`${matchDesc} ${betDesc}`);
+  return hasTeam(text, m.home_names) && hasTeam(text, m.away_names);
+}
+
+// ── norm: NÃO normaliza hífen/ponto (regressão 545ccbb — quebrava "2.5") ──
+Deno.test("norm preserva pontuação de linha decimal", () => {
+  assertEquals(norm("Mais de 2.5 Gols"), "mais de 2.5 gols");
+  assertEquals(norm("Atlético-MG"), "atletico-mg");
+});
+
+// ── matching multi-liga (fixtures) ──
+Deno.test("Palmeiras x Vasco casa com fixture Vasco da Gama", () => {
+  assert(matches("Palmeiras x Vasco", "Vitória do Palmeiras", fx("Palmeiras", "Vasco da Gama", 2, 1)));
+});
+Deno.test("Corinthians x RB Bragantino casa", () => {
+  assert(matches("Corinthians vs RB Bragantino", "RB Bragantino +0.5", fx("Corinthians", "RB Bragantino", 1, 1)));
+});
+Deno.test("usuário 'Bragantino' casa fixture 'RB Bragantino'", () => {
+  assert(matches("Corinthians x Bragantino", "Bragantino vence", fx("Corinthians", "RB Bragantino", 1, 1)));
+});
+Deno.test("usuário 'Atlético-MG' casa fixture 'Atletico-MG'", () => {
+  assert(matches("Cruzeiro x Atlético-MG", "Atlético-MG vence", fx("Cruzeiro", "Atletico-MG", 0, 1)));
+});
+Deno.test("usuário 'Atlético Mineiro' casa 'Atletico-MG'", () => {
+  assert(matches("Cruzeiro x Atlético Mineiro", "vitória do Atlético Mineiro", fx("Cruzeiro", "Atletico-MG", 0, 1)));
+});
+Deno.test("Athletico Paranaense casa 'Athletico-PR'", () => {
+  assert(matches("Athletico Paranaense x Coritiba", "Athletico Paranaense", fx("Athletico-PR", "Coritiba", 2, 0)));
+});
+Deno.test("anti-falso-positivo: Atlético-MG NÃO casa Atlético-GO", () => {
+  assert(!matches("Vila Nova x Atlético-GO", "Atlético-GO", fx("Cruzeiro", "Atletico-MG", 0, 1)));
+});
+Deno.test("anti-falso-positivo: Atlético de Madrid NÃO vira Atlético-MG", () => {
+  assert(!matches("Arsenal x Atlético de Madrid", "Atlético Madrid", fx("Cruzeiro", "Atletico-MG", 0, 1)));
+});
+Deno.test("um time só presente → não casa", () => {
+  assert(!matches("Palmeiras x Santos", "Palmeiras vence", fx("Palmeiras", "Vasco da Gama", 2, 1)));
+});
+Deno.test("alias curado por id (team_aliases)", () => {
+  const ab = new Map([[100, ["galo"]]]);
+  assert(matches("Cruzeiro x Galo", "Galo vence", fx("Cruzeiro", "XYZ", 0, 1, null, 100, ab)));
+});
+Deno.test("matching da Copa: seleção PT + alias EN + código", () => {
+  const names = teamNames("Inglaterra", "ENG");
+  assert(hasTeam(norm("England vence"), names));
+  assert(hasTeam(norm("aposta na ENG"), names));
+  assert(!hasTeam(norm("Argentina vence"), names));
+});
+
+// ── veredito: money line / over-under / btts ──
+Deno.test("ML: Palmeiras vence 2-1 → won", () => {
+  assertEquals(computeVerdict(bet("Vitória do Palmeiras", "Money Line"), fx("Palmeiras", "Vasco da Gama", 2, 1)), "won");
+});
+Deno.test("O/U: 'Mais de 1.5 gols' com 1-1 → won (decimal intacto)", () => {
+  assertEquals(computeVerdict(bet("Mais de 1.5 gols", "Over/Under"), fx("Corinthians", "RB Bragantino", 1, 1)), "won");
+});
+Deno.test("O/U: 'Menos de 2.5 gols' com total 3 → lost", () => {
+  assertEquals(computeVerdict(bet("Menos de 2.5 gols", "Over/Under"), fx("A FC", "B FC", 2, 1)), "lost");
+});
+Deno.test("O/U: linha exata (2.0 com total 2) → null (push, usuário decide)", () => {
+  assertEquals(computeVerdict(bet("Mais de 2.0 gols", "Over/Under"), fx("A FC", "B FC", 1, 1)), null);
+});
+Deno.test("BTTS sim com 1-1 → won", () => {
+  assertEquals(computeVerdict(bet("Ambas marcam", "Ambas Marcam"), fx("A FC", "B FC", 1, 1)), "won");
+});
+Deno.test("BTTS 'não' com 1-0 → won", () => {
+  assertEquals(computeVerdict(bet("Ambas marcam: não", "Ambas Marcam"), fx("A FC", "B FC", 1, 0)), "won");
+});
+
+// ── veredito: handicap asiático (sinal desarma ML; quarters) ──
+Deno.test("handicap 'Palmeiras -1.5' vence por 2 → won", () => {
+  assertEquals(computeVerdict(bet("Palmeiras -1.5", "Handicap"), fx("Palmeiras", "Vasco da Gama", 2, 0)), "won");
+});
+Deno.test("handicap 'Palmeiras -1.5' vence por 1 → lost", () => {
+  assertEquals(computeVerdict(bet("Palmeiras -1.5", "Handicap"), fx("Palmeiras", "Vasco da Gama", 2, 1)), "lost");
+});
+Deno.test("AH -0.75 vence por 1 → half_won (quarter decompõe)", () => {
+  assertEquals(computeVerdict(bet("Palmeiras -0.75", "Handicap Asiático"), fx("Palmeiras", "Vasco da Gama", 2, 1)), "half_won");
+});
+Deno.test("AH linha inteira -1 vence por 1 → void (push)", () => {
+  assertEquals(settleAsianHandicap(1, -1), "void");
+});
+Deno.test("AH +0.25 empate → half_won", () => {
+  assertEquals(settleAsianHandicap(0, 0.25), "half_won");
+});
+
+// ── veredito: conservadorismo (nunca chutar) ──
+Deno.test("escanteios → null (mercado exótico)", () => {
+  assertEquals(computeVerdict(bet("Mais de 9.5 escanteios", "Over/Under"), fx("A FC", "B FC", 1, 1)), null);
+});
+Deno.test("1º tempo → null", () => {
+  assertEquals(computeVerdict(bet("Mais de 0.5 gols no 1º tempo", "Over/Under"), fx("A FC", "B FC", 2, 0)), null);
+});
+Deno.test("múltipla → null sempre", () => {
+  assertEquals(computeVerdict(bet("Palmeiras vence", "Múltipla", "multiple"), fx("Palmeiras", "Vasco da Gama", 2, 1)), null);
+});
+Deno.test("ML ambíguo (dois times citados) → null", () => {
+  assertEquals(computeVerdict(bet("Palmeiras x Vasco vencedor", "Money Line"), fx("Palmeiras", "Vasco da Gama", 2, 1)), null);
+});
+Deno.test("sem placar de 90' → null", () => {
+  assertEquals(computeVerdict(bet("Vitória do Palmeiras", "Money Line"), fx("Palmeiras", "Vasco da Gama", null, null)), null);
+});

--- a/supabase/functions/tests/weekly.test.ts
+++ b/supabase/functions/tests/weekly.test.ts
@@ -1,0 +1,57 @@
+// Testes da faixa + copy do resumo semanal (notify-weekly-summary/tiers.ts).
+// Casos do ensaio do item 04 (PR #212): 3 faixas × com/sem unidade + thresholds.
+import { assert, assertEquals } from "./_assert.ts";
+import { buildMessage, pickTier, type WeeklyCandidate } from "../notify-weekly-summary/tiers.ts";
+
+function cand(over: Partial<WeeklyCandidate>): WeeklyCandidate {
+  return {
+    user_id: "u1", chat_id: "c1", user_name: "Teste",
+    n_settled: 3, total_stake: 100, total_profit: 0,
+    unit_value_rs: null, best_market: null, best_market_profit: null,
+    ...over,
+  };
+}
+
+// ── thresholds (com unidade em u; sem unidade em ROI) ──
+Deno.test("com unidade: +0.6u → positive", () => assertEquals(pickTier(30, 0.02, 50), "positive"));
+Deno.test("com unidade: +0.4u → neutral", () => assertEquals(pickTier(20, 0.02, 50), "neutral"));
+Deno.test("com unidade: -1.2u → negative", () => assertEquals(pickTier(-60, -0.04, 50), "negative"));
+Deno.test("sem unidade: ROI 4% → neutral", () => assertEquals(pickTier(40, 0.04, null), "neutral"));
+Deno.test("sem unidade: ROI 6% → positive", () => assertEquals(pickTier(60, 0.06, null), "positive"));
+Deno.test("sem unidade: ROI -12% → negative", () => assertEquals(pickTier(-120, -0.12, null), "negative"));
+
+// ── copy: conteúdo-chave por faixa ──
+Deno.test("positiva com unidade: mostra u, R$, ROI e melhor mercado", () => {
+  const c = cand({ n_settled: 11, total_stake: 1500, total_profit: 210, unit_value_rs: 50, best_market: "Over/Under gols" });
+  const t = buildMessage(c, "positive", 0.14);
+  assert(t.includes("+4,2u"), "unidades");
+  assert(t.includes("+R$ 210,00"), "reais");
+  assert(t.includes("ROI <b>+14%"), "roi");
+  assert(t.includes("melhor mercado: <b>Over/Under gols"), "mercado");
+  assert(t.includes("o que sustentou isso"), "narrativa consistência");
+  assert(!t.includes("acerto"), "NUNCA taxa de acerto");
+});
+Deno.test("neutra: narrativa de ajuste fino", () => {
+  const c = cand({ n_settled: 8, total_stake: 1200, total_profit: 15, unit_value_rs: 50, best_market: "Money Line" });
+  const t = buildMessage(c, "neutral", 0.0125);
+  assert(t.includes("Variação controlada"), "narrativa neutra");
+  assert(t.includes("+0,3u"), "unidades");
+});
+Deno.test("negativa: protetiva, SEM melhor mercado, sem correr atrás", () => {
+  const c = cand({ n_settled: 9, total_stake: 1290, total_profit: -155, unit_value_rs: 50, best_market: "Handicap" });
+  const t = buildMessage(c, "negative", -0.12);
+  assert(t.includes("−3,1u"), "sinal de menos tipográfico");
+  assert(!t.includes("melhor mercado"), "negativa não cutuca métrica");
+  assert(t.includes("Sem correr atrás do prejuízo"), "anti-tilt");
+});
+Deno.test("sem unidade: cai pra R$ puro (sem 'u')", () => {
+  const c = cand({ n_settled: 6, total_stake: 600, total_profit: 90, best_market: "Ambas marcam" });
+  const t = buildMessage(c, "positive", 0.15);
+  assert(t.includes("Resultado: <b>+R$ 90,00</b>"), "R$ direto");
+  assert(!/\d,\du/.test(t), "sem unidades");
+});
+Deno.test("melhor mercado escapa HTML", () => {
+  const c = cand({ total_profit: 90, best_market: "A <b> & C" });
+  const t = buildMessage(c, "positive", 0.15);
+  assert(t.includes("A &lt;b&gt; &amp; C"), "esc aplicado");
+});


### PR DESCRIPTION
Onda 3 do plano da revisão — a rede de segurança automatizada das edge functions.

## O problema
A lógica que mexe com dinheiro (veredito da auto-liquidação, faixas do resumo, parsing de stake) tinha testes que **viviam em scripts ad-hoc fora do repo** (23/23, 11/11 rodados uma vez e perdidos). E helpers idênticos duplicados em 4 funções já quase causaram bug por deriva (o norm/decimal, fix 545ccbb).

## O que muda
**1. Testes commitados + gate de deploy**
- `supabase/functions/tests/` — verdict (27), weekly (11), stake (13) — **51 casos**, 100% offline (mini-assert local, sem download)
- Job `test` nos DOIS workflows de deploy com `needs: test` → **deploy só com teste verde**
- Workflow novo `test-functions.yml` roda em todo PR

**2. Refactor move-only** (zero mudança de lógica — diff é recorte+import):
- `notify-settlement/verdict.ts` · `notify-weekly-summary/tiers.ts` · `telegram-webhook/stake.ts`
- `shared/format.ts` (esc) + `shared/links.ts` (hmacHex/trackedUrl) — só o que estava duplicado 1:1

**3. MAPA**: alerta do ops-healthcheck na seção Interno.

## Cobertura dos testes (o que protege)
- Anti-falso-positivo do matching: Atlético-MG ≠ Atlético-GO ≠ Atlético de Madrid
- A regressão do decimal ("2.5" → "2 5") que quase subiu no F2
- AH quarters (half_won/void), BTTS "não", conservadorismo (múltipla/escanteios/1ºT/ambíguo → null)
- "Aposta real nunca intercepta" (regra-mestra do item 15)
- Copy do resumo: nunca taxa de acerto; negativa sem "melhor mercado"

## Risco & verificação
É o PR mais sensível do plano (toca 4 funções em prod). Mitigação: os testes rodam NESTE PR antes do merge; pós-deploy, ensaio staging dos `mode=report` (daily/weekly) pra confirmar comportamento idêntico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)