### PR TITLE
feat(ops): telemetria dos carteiros + alerta de streak — Onda 4

### DIFF
--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -29,6 +29,7 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 import { generateTraceId, trackEvent } from "../shared/posthog.ts";
 import { esc } from "../shared/format.ts";
 import { trackedUrl } from "../shared/links.ts";
+import { logMessageRun } from "../shared/runs.ts";
 
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
 const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
@@ -198,6 +199,10 @@ serve(async (req) => {
 
     // 3) dia fraco → silêncio (nada de mensagem "hoje não tem nada")
     if (picks.length === 0) {
+      // o dia de silêncio é informação (telemetria); ensaio (report) não loga
+      if (mode === "send") {
+        await logMessageRun(supabase, "notify-opportunities", { candidates: 0, sent: 0, ok: true });
+      }
       return json({ ok: true, mode, picks: 0, sent: 0, motivo: "sem oportunidade acima do corte hoje" });
     }
 
@@ -268,9 +273,15 @@ serve(async (req) => {
       }
     }
 
+    // telemetria — só runs de envio (report é ensaio)
+    await logMessageRun(supabase, "notify-opportunities", { candidates: recipients.length, sent, errors, ok: true });
+
     return json({ ok: true, mode, picks: picks.length, destinatarios: recipients.length, sent, errors });
   } catch (e) {
     console.error("notify-opportunities error:", e);
+    if (mode === "send") {
+      await logMessageRun(supabase, "notify-opportunities", { errors: [(e as Error)?.message ?? "erro"], ok: false });
+    }
     return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
   }
 });

--- a/supabase/functions/notify-settlement/index.ts
+++ b/supabase/functions/notify-settlement/index.ts
@@ -40,6 +40,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { generateTraceId, trackEvent } from "../shared/posthog.ts";
 import { esc } from "../shared/format.ts";
+import { logMessageRun } from "../shared/runs.ts";
 import {
   type Candidate,
   type FinishedMatch,
@@ -438,6 +439,9 @@ serve(async (req) => {
       }
     }
 
+    // telemetria (só runs com candidato chegam aqui — o vazio retorna cedo)
+    await logMessageRun(supabase, "notify-settlement", { candidates: candidates.length, sent, errors, ok: true });
+
     return json({
       ok: true,
       candidates: candidates.length,
@@ -451,6 +455,7 @@ serve(async (req) => {
     });
   } catch (e) {
     console.error("notify-settlement error:", e);
+    await logMessageRun(supabase, "notify-settlement", { errors: [(e as Error)?.message ?? "erro"], ok: false });
     return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
   }
 });

--- a/supabase/functions/notify-weekly-summary/index.ts
+++ b/supabase/functions/notify-weekly-summary/index.ts
@@ -24,6 +24,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { generateTraceId, trackEvent } from "../shared/posthog.ts";
 import { trackedUrl } from "../shared/links.ts";
+import { logMessageRun } from "../shared/runs.ts";
 import { buildMessage, pickTier, type WeeklyCandidate } from "./tiers.ts";
 
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
@@ -131,9 +132,15 @@ serve(async (req) => {
       }
     }
 
+    // telemetria — só runs de envio (mode=report é ensaio, não operação)
+    await logMessageRun(supabase, "notify-weekly-summary", { candidates: rows.length, sent, errors, ok: true });
+
     return json({ ok: true, mode, candidates: rows.length, sent, errors });
   } catch (e) {
     console.error("notify-weekly-summary error:", e);
+    if (mode === "send") {
+      await logMessageRun(supabase, "notify-weekly-summary", { errors: [(e as Error)?.message ?? "erro"], ok: false });
+    }
     return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
   }
 });

--- a/supabase/functions/ops-healthcheck/health.ts
+++ b/supabase/functions/ops-healthcheck/health.ts
@@ -1,0 +1,22 @@
+// health.ts — lógica pura do healthcheck (testada no CI).
+export interface RunRow {
+  fn: string;
+  ok: boolean;
+}
+
+// rows ordenados do MAIS RECENTE pro mais antigo. Devolve as funções cujos
+// últimos `threshold` runs falharam TODOS (streak de falha = alerta).
+// Menos runs que o threshold = sem veredito (função nova não alarma).
+export function failingStreaks(rows: RunRow[], threshold = 3): string[] {
+  const byFn = new Map<string, boolean[]>();
+  for (const r of rows) {
+    const list = byFn.get(r.fn) ?? [];
+    if (list.length < threshold) list.push(r.ok);
+    byFn.set(r.fn, list);
+  }
+  const out: string[] = [];
+  for (const [fn, oks] of byFn) {
+    if (oks.length >= threshold && oks.every((ok) => !ok)) out.push(fn);
+  }
+  return out.sort();
+}

--- a/supabase/functions/ops-healthcheck/index.ts
+++ b/supabase/functions/ops-healthcheck/index.ts
@@ -19,6 +19,7 @@
 // ============================================================
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import { failingStreaks, type RunRow } from "./health.ts";
 
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
 const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
@@ -73,21 +74,34 @@ serve(async (req) => {
       (j) => j.active && (j.missing_secrets.length > 0 || j.failed_recent >= FAIL_THRESHOLD)
     );
 
-    if (mode !== "report" && problems.length > 0) {
-      const lines = ["🚨 ops-healthcheck — crons com problema:", ""];
+    // Onda 4: carteiros com streak de falha (message_runs, migration 089).
+    // O cron pode dizer "succeeded" (o http_post saiu) e a FUNÇÃO ter falhado —
+    // esta é a visão de dentro.
+    const { data: runData } = await supabase
+      .from("message_runs")
+      .select("fn, ok")
+      .order("ran_at", { ascending: false })
+      .limit(60);
+    const failingFns = failingStreaks((runData ?? []) as RunRow[], FAIL_THRESHOLD);
+
+    if (mode !== "report" && (problems.length > 0 || failingFns.length > 0)) {
+      const lines = ["🚨 ops-healthcheck — problemas encontrados:", ""];
       for (const p of problems) {
         if (p.missing_secrets.length > 0) {
           lines.push(`• ${p.jobname}: SECRETS FALTANDO no vault → ${p.missing_secrets.join(", ")} (job roda mas não chama nada — o "cron mudo")`);
         }
         if (p.failed_recent >= FAIL_THRESHOLD) {
-          lines.push(`• ${p.jobname}: ${p.failed_recent}/${p.total_recent} execuções recentes FALHARAM`);
+          lines.push(`• ${p.jobname}: ${p.failed_recent}/${p.total_recent} execuções recentes FALHARAM (cron)`);
         }
       }
-      lines.push("", "Runbook: criar os secrets (vault.create_secret) ou investigar cron.job_run_details.");
+      for (const fn of failingFns) {
+        lines.push(`• ${fn}: últimos ${FAIL_THRESHOLD} runs da FUNÇÃO falharam (message_runs)`);
+      }
+      lines.push("", "Runbook: criar os secrets (vault.create_secret), investigar cron.job_run_details ou message_runs.errors.");
       if (adminChat) {
         await sendAdminDm(adminChat, lines.join("\n"));
       } else {
-        console.error("ops-healthcheck: problemas encontrados mas admin_telegram_chat_id não configurado:", JSON.stringify(problems));
+        console.error("ops-healthcheck: problemas encontrados mas admin_telegram_chat_id não configurado:", JSON.stringify({ problems, failingFns }));
       }
     }
 
@@ -101,6 +115,7 @@ serve(async (req) => {
         failed_recent: p.failed_recent,
         total_recent: p.total_recent,
       })),
+      failing_message_fns: failingFns,
       admin_configured: adminChat != null,
     });
   } catch (e) {

--- a/supabase/functions/shared/runs.ts
+++ b/supabase/functions/shared/runs.ts
@@ -1,0 +1,22 @@
+// shared/runs.ts — telemetria dos carteiros (Onda 4).
+// Grava o resumo do run em public.message_runs (migration 089). O consumidor
+// é o ops-healthcheck: 3 runs consecutivos ok=false → DM pro admin.
+// Telemetria NUNCA quebra o run — qualquer erro aqui é engolido.
+
+export async function logMessageRun(
+  supabase: any,
+  fn: string,
+  r: { candidates?: number; sent?: number; errors?: unknown[]; ok: boolean }
+): Promise<void> {
+  try {
+    await supabase.from("message_runs").insert({
+      fn,
+      candidates: r.candidates ?? null,
+      sent: r.sent ?? null,
+      errors: r.errors && r.errors.length > 0 ? r.errors : null,
+      ok: r.ok,
+    });
+  } catch (e) {
+    console.error(`logMessageRun(${fn}):`, (e as Error)?.message);
+  }
+}

--- a/supabase/functions/tests/health.test.ts
+++ b/supabase/functions/tests/health.test.ts
@@ -1,0 +1,31 @@
+// Testes da lógica de streak do ops-healthcheck (health.ts).
+import { assertEquals } from "./_assert.ts";
+import { failingStreaks, type RunRow } from "../ops-healthcheck/health.ts";
+
+const r = (fn: string, ok: boolean): RunRow => ({ fn, ok });
+
+Deno.test("3 falhas seguidas → alerta", () => {
+  assertEquals(failingStreaks([r("a", false), r("a", false), r("a", false)]), ["a"]);
+});
+Deno.test("2 falhas → sem alerta (abaixo do threshold)", () => {
+  assertEquals(failingStreaks([r("a", false), r("a", false)]), []);
+});
+Deno.test("falha-ok-falha → sem alerta (não é streak)", () => {
+  assertEquals(failingStreaks([r("a", false), r("a", true), r("a", false)]), []);
+});
+Deno.test("recuperou (ok mais recente) → sem alerta mesmo com falhas antigas", () => {
+  assertEquals(failingStreaks([r("a", true), r("a", false), r("a", false), r("a", false)]), []);
+});
+Deno.test("só os 3 mais recentes contam (4ª falha antiga irrelevante)", () => {
+  // mais recente primeiro: fail, fail, fail, ok → streak de 3 → alerta
+  assertEquals(failingStreaks([r("a", false), r("a", false), r("a", false), r("a", true)]), ["a"]);
+});
+Deno.test("funções independentes: uma falhando, outra saudável", () => {
+  const rows = [
+    r("b", true), r("a", false), r("b", true), r("a", false), r("b", true), r("a", false),
+  ];
+  assertEquals(failingStreaks(rows), ["a"]);
+});
+Deno.test("função nova (1 run) nunca alarma", () => {
+  assertEquals(failingStreaks([r("nova", false)]), []);
+});

--- a/supabase/migrations/089_message_runs.sql
+++ b/supabase/migrations/089_message_runs.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- 089_message_runs — telemetria dos carteiros (Onda 4 da revisão)
+-- ============================================================
+-- Espelho do collector_runs (082) pras funções de MENSAGEM: cada execução de
+-- notify-settlement / notify-opportunities / notify-weekly-summary grava um
+-- resumo (candidatos, enviados, erros). Antes, os erros voltavam num JSON de
+-- cron que ninguém lê — um 429 do Telegram numa segunda-feira passaria batido.
+--
+-- Quem CONSOME é o ops-healthcheck (088): 3 runs consecutivos com ok=false
+-- numa função → entra na DM diária do admin. Um ponto único de alerta.
+--
+-- Regra de registro (anti-ruído): settlement só loga run com candidato ou
+-- falha (roda 96x/dia, maioria vazia); daily/weekly logam todo run de envio
+-- (baixa frequência, e o "dia de silêncio" é informação); mode=report NUNCA
+-- loga (ensaio não é operação).
+CREATE TABLE IF NOT EXISTS public.message_runs (
+  id         bigserial PRIMARY KEY,
+  fn         text NOT NULL,               -- 'notify-settlement' | 'notify-opportunities' | 'notify-weekly-summary'
+  ran_at     timestamptz NOT NULL DEFAULT now(),
+  candidates integer,
+  sent       integer,
+  errors     jsonb,                       -- array de mensagens de erro (null = nenhum)
+  ok         boolean NOT NULL
+);
+COMMENT ON TABLE public.message_runs IS
+  'Resumo de cada execução das funções de mensagem do Betinho. Consumido pelo ops-healthcheck (alerta após falhas consecutivas).';
+CREATE INDEX IF NOT EXISTS idx_message_runs_fn_ran ON public.message_runs (fn, ran_at DESC);
+ALTER TABLE public.message_runs ENABLE ROW LEVEL SECURITY;
+-- sem policy: só service_role


### PR DESCRIPTION
Onda 4 do plano da revisão — observabilidade das funções de mensagem, espelhando o que o coletor já tinha (`collector_runs` + alerta).

## O problema
`notify-settlement`/`notify-opportunities`/`notify-weekly-summary` retornavam `errors[]` num JSON de cron **que ninguém lê**. Um 429 do Telegram, uma RPC quebrada ou um token expirado passariam despercebidos por dias. E o `cron.job_run_details` não ajuda: o cron marca "succeeded" se o `http_post` saiu — mesmo com a função retornando 500.

## O que muda
- **Migration 089**: tabela `message_runs` (fn, candidates, sent, errors, ok) — RLS service-only, índice por (fn, ran_at).
- **`shared/runs.ts`**: `logMessageRun` — telemetria **nunca** quebra o run (erros engolidos com log).
- **Os 3 carteiros gravam o resumo de cada run** com regra anti-ruído: settlement só loga run com candidato ou falha (roda 96×/dia, maioria vazia); daily/weekly logam todo envio (o **dia de silêncio é informação**); `mode=report` nunca loga (ensaio ≠ operação).
- **ops-healthcheck** ganha a visão de dentro: `failingStreaks` (lógica pura, `health.ts`) — **3 runs consecutivos com `ok=false` → entra na DM diária do admin**. Um ponto único de alerta (nada de espalhar `maybeAlertAdmin` por função).
- **+7 testes** no gate de CI (streak, recuperação, função nova não alarma, funções independentes) → total 58.

## Ensaio staging (pós-merge)
1. Disparar weekly `mode=send` → conferir linha em `message_runs` (com o erro do usuário fake registrado em `errors`)
2. `ops-healthcheck?mode=report` → JSON com `failing_message_fns: []`

🤖 Generated with [Claude Code](https://claude.com/claude-code)