### PR TITLE
feat(betinho): /mensagens (centro de controle) + reaquecer o esfriou — Onda 6a

### DIFF
--- a/MAPA_MENSAGENS_BOT.md
+++ b/MAPA_MENSAGENS_BOT.md
@@ -58,6 +58,9 @@ normal: 0 a 2. O silêncio é parte do produto.
   de liquidação e o winback/handoff também respeitam. `/lembretes` reativa.
 - `users.weekly_summary_muted` é opt-out **independente** do resumo semanal (#10) —
   cala só ele, não a liquidação. (Cadência semanal ≠ diária, não soma metralhadora.)
+- **`/mensagens`** é o centro de controle: lista os recorrentes com estado e toggles
+  (liquidação e resumo; o daily é automático — para sozinho sem clique). Embrião do
+  item 17 (preferências). `/silenciar`, `/lembretes` e `/resumo` seguem como atalhos.
 - Toda mensagem tem evento no PostHog (enviada + clicada/corrigida) — a "taxa de
   incômodo" (mute + correções) é métrica acompanhável.
 - Novas mensagens DEVEM entrar neste mapa antes de ir pra develop.

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -3,6 +3,7 @@ import { createClient } from "npm:@supabase/supabase-js@2"
 import { normalizePhoneNumber, normalizePhoneCandidates, maskPhone } from "../shared/phone.ts"
 import { generateTraceId, identifyUser, trackEvent, trackLLMGeneration } from "../shared/posthog.ts"
 import { isBareNumber, parseStake } from "./stake.ts"
+import { prefsKeyboard, prefsText } from "./prefs.ts"
 
 const OPENAI_API_KEY = Deno.env.get("OPENAI_API_KEY")
 const OPENAI_API_URL = "https://api.openai.com/v1"
@@ -502,6 +503,45 @@ async function handleCallbackQuery(
       traceId
     ).catch(() => {})
     return ok("weekly summary muted")
+  }
+
+  // prefliq / prefres — toggles do centro de controle /mensagens (Onda 6).
+  // Alterna a preferência e REESCREVE a própria mensagem com o estado novo.
+  if (data === "prefliq" || data === "prefres") {
+    const { data: cur } = await supabase
+      .from("users").select("settlement_reminders_muted, weekly_summary_muted").eq("id", user.id).maybeSingle()
+    const p = {
+      settlementMuted: cur?.settlement_reminders_muted ?? false,
+      weeklyMuted: cur?.weekly_summary_muted ?? false,
+    }
+    let toast: string
+    if (data === "prefliq") {
+      p.settlementMuted = !p.settlementMuted
+      await supabase.from("users").update({ settlement_reminders_muted: p.settlementMuted }).eq("id", user.id)
+      toast = p.settlementMuted ? "🔕 Liquidação silenciada." : "🔔 Liquidação reativada."
+      await trackEvent(
+        p.settlementMuted ? "settlement_reminders_muted" : "settlement_reminders_unmuted",
+        { via: "prefs", channel: "telegram" }, user.id, traceId
+      ).catch(() => {})
+    } else {
+      p.weeklyMuted = !p.weeklyMuted
+      await supabase.from("users").update({ weekly_summary_muted: p.weeklyMuted }).eq("id", user.id)
+      toast = p.weeklyMuted ? "Resumo semanal silenciado." : "📊 Resumo semanal reativado."
+      await trackEvent(
+        p.weeklyMuted ? "weekly_summary_muted" : "weekly_summary_unmuted",
+        { via: "prefs", channel: "telegram" }, user.id, traceId
+      ).catch(() => {})
+    }
+    await telegramCall("editMessageText", {
+      chat_id: chatId,
+      message_id: messageId,
+      text: prefsText(p),
+      parse_mode: "HTML",
+      disable_web_page_preview: true,
+      reply_markup: { inline_keyboard: prefsKeyboard(p) },
+    })
+    await answerCallbackQuery(cq.id, toast)
+    return ok("prefs toggled")
   }
 
   // 📋 regbet:<pick_id> — tocou "Registrar no Betinho" no daily
@@ -2221,6 +2261,27 @@ serve(async (req) => {
       )
     }
 
+    // /mensagens — centro de controle: o que o Betinho manda + toggles num
+    // lugar só (Onda 6 da revisão; embrião do item 17 do Marco 2)
+    if (command === "/mensagens") {
+      const { data: pref } = await supabase
+        .from("users").select("settlement_reminders_muted, weekly_summary_muted").eq("id", user.id).maybeSingle()
+      const p = {
+        settlementMuted: pref?.settlement_reminders_muted ?? false,
+        weeklyMuted: pref?.weekly_summary_muted ?? false,
+      }
+      await sendTelegramMessage(chatId, prefsText(p), {
+        parse_mode: "HTML",
+        disable_web_page_preview: true,
+        reply_markup: { inline_keyboard: prefsKeyboard(p) },
+      })
+      await trackEvent("message_prefs_viewed", { channel: "telegram" }, user.id, traceId).catch(() => {})
+      return new Response(
+        JSON.stringify({ success: true, message: "Prefs shown" }),
+        { headers: { "Content-Type": "application/json" }, status: 200 }
+      )
+    }
+
     // Resposta ao "Outro valor" (force_reply do registrar-oportunidade).
     // ROBUSTO: nem todo cliente Telegram anexa reply_to_message ao force_reply,
     // então intercepta se (a) é reply ao nosso prompt OU (b) é um NÚMERO PURO
@@ -2272,7 +2333,11 @@ serve(async (req) => {
         if (bareNumber) {
           // número puro, mas o prompt esfriou (>30min): não vira aposta-lixo —
           // avisa e encerra (não segue pro fluxo de extração)
-          await sendTelegramMessage(chatId, "Essa oportunidade esfriou 🕑 Toca em *Registrar* de novo numa oportunidade pra lançar o valor.")
+          // reaquecimento (Onda 6): reenvia o botão do pick aqui mesmo — sem
+          // obrigar o usuário a rolar o histórico atrás do Registrar original
+          await sendTelegramMessage(chatId, "Essa oportunidade esfriou 🕑 Se ainda quiser registrar, toca abaixo que eu te pergunto o valor de novo.", {
+            reply_markup: { inline_keyboard: [[{ text: "📋 Registrar de novo", callback_data: `regbet:${prompt.pick_id}` }]] },
+          })
           return new Response(JSON.stringify({ success: true, message: "stale stake prompt cleared" }), { headers: { "Content-Type": "application/json" }, status: 200 })
         }
         // qualquer outra coisa (print, aposta em texto...) → pendência limpa e

--- a/supabase/functions/telegram-webhook/prefs.ts
+++ b/supabase/functions/telegram-webhook/prefs.ts
@@ -1,0 +1,36 @@
+// ============================================================
+// prefs.ts — centro de controle /mensagens (código PURO)
+// ============================================================
+// Onda 6 da revisão / embrião do item 17 (preferências): o usuário pergunta
+// "o que eu recebo do Betinho?" e controla cada recorrente num lugar só.
+// O mute continuava existindo espalhado (🔕 na liquidação, botão no resumo);
+// aqui é a visão consolidada. Testado no CI: tests/prefs.test.ts
+export interface MessagePrefs {
+  settlementMuted: boolean;
+  weeklyMuted: boolean;
+}
+
+export function prefsText(p: MessagePrefs): string {
+  const liq = p.settlementMuted ? "silenciada 🔕" : "ativada";
+  const res = p.weeklyMuted ? "silenciado 🔕" : "ativado";
+  return [
+    `📬 <b>O que eu te mando</b>`,
+    "",
+    `🔔 Liquidação de apostas — <b>${liq}</b>`,
+    `<i>Quando um jogo seu termina: fecho a aposta sozinho quando dá, ou te pergunto o resultado.</i>`,
+    "",
+    `📊 Resumo semanal — <b>${res}</b>`,
+    `<i>Segunda de manhã: como fecharam seus últimos 7 dias.</i>`,
+    "",
+    `⚽ Oportunidades do dia — <b>automático</b>`,
+    `<i>Só em dia com pick bom. Se você não clica, ele para sozinho.</i>`,
+  ].join("\n");
+}
+
+// Rótulo do botão reflete a AÇÃO (o que acontece ao tocar), não o estado.
+export function prefsKeyboard(p: MessagePrefs): unknown[][] {
+  return [
+    [{ text: p.settlementMuted ? "Reativar liquidação" : "Silenciar liquidação", callback_data: "prefliq" }],
+    [{ text: p.weeklyMuted ? "Reativar resumo semanal" : "Silenciar resumo semanal", callback_data: "prefres" }],
+  ];
+}

--- a/supabase/functions/tests/prefs.test.ts
+++ b/supabase/functions/tests/prefs.test.ts
@@ -1,0 +1,35 @@
+// Testes do centro de controle /mensagens (telegram-webhook/prefs.ts, Onda 6).
+import { assert, assertEquals } from "./_assert.ts";
+import { prefsKeyboard, prefsText } from "../telegram-webhook/prefs.ts";
+
+Deno.test("texto: tudo ativado", () => {
+  const t = prefsText({ settlementMuted: false, weeklyMuted: false });
+  assert(t.includes("Liquidação de apostas — <b>ativada</b>"), "liq ativada");
+  assert(t.includes("Resumo semanal — <b>ativado</b>"), "resumo ativado");
+  assert(t.includes("Oportunidades do dia — <b>automático</b>"), "daily informativo");
+});
+Deno.test("texto: estados silenciados refletidos", () => {
+  const t = prefsText({ settlementMuted: true, weeklyMuted: true });
+  assert(t.includes("Liquidação de apostas — <b>silenciada 🔕</b>"), "liq silenciada");
+  assert(t.includes("Resumo semanal — <b>silenciado 🔕</b>"), "resumo silenciado");
+});
+Deno.test("teclado: rótulo é a AÇÃO (ativado → Silenciar)", () => {
+  const rows = prefsKeyboard({ settlementMuted: false, weeklyMuted: false }) as any[];
+  assertEquals(rows[0][0].text, "Silenciar liquidação");
+  assertEquals(rows[1][0].text, "Silenciar resumo semanal");
+});
+Deno.test("teclado: rótulo inverte quando silenciado", () => {
+  const rows = prefsKeyboard({ settlementMuted: true, weeklyMuted: true }) as any[];
+  assertEquals(rows[0][0].text, "Reativar liquidação");
+  assertEquals(rows[1][0].text, "Reativar resumo semanal");
+});
+Deno.test("teclado: callbacks estáveis", () => {
+  const rows = prefsKeyboard({ settlementMuted: true, weeklyMuted: false }) as any[];
+  assertEquals(rows[0][0].callback_data, "prefliq");
+  assertEquals(rows[1][0].callback_data, "prefres");
+});
+Deno.test("teclado: estados independentes", () => {
+  const rows = prefsKeyboard({ settlementMuted: true, weeklyMuted: false }) as any[];
+  assertEquals(rows[0][0].text, "Reativar liquidação");
+  assertEquals(rows[1][0].text, "Silenciar resumo semanal");
+});


### PR DESCRIPTION
Onda 6a do plano da revisão — as duas entregas **de produto** da onda. (A modularização do webhook — 6b — vai em PR dedicado; refactor move-only de 2.300 linhas merece diff isolado.)

## 1. `/mensagens` — centro de controle (embrião do item 17)
O mute estava espalhado (🔕 na liquidação, botão no resumo, régua implícita no daily) e o usuário não tinha como responder \"o que eu recebo do Betinho?\". Agora:

> 📬 **O que eu te mando**
> 🔔 Liquidação de apostas — **ativada**
> 📊 Resumo semanal — **ativado**
> ⚽ Oportunidades do dia — **automático** *(para sozinho sem clique)*
> `[Silenciar liquidação]` `[Silenciar resumo semanal]`

- Rótulo do botão é a **ação** (não o estado); ao tocar, a própria mensagem se reescreve com o estado novo (callbacks `prefliq`/`prefres`)
- `prefs.ts` puro + **6 testes** (total 77 no gate)
- `/silenciar`, `/lembretes`, `/resumo` continuam como atalhos
- Evento novo: `message_prefs_viewed`; os toggles emitem os eventos de mute existentes com `via: \"prefs\"`

## 2. Reaquecer o \"esfriou\"
Número frio (>30min) avisava \"toca em Registrar de novo\" — mas o botão original podia estar telas acima. Agora a própria mensagem traz **[📋 Registrar de novo]** (`regbet:<pick_id>` — reusa o handler existente, que pergunta o valor de novo).

## Ensaio staging (pós-merge)
1. `/mensagens` → card com estados + 2 botões
2. Tocar \"Silenciar resumo semanal\" → mensagem reescreve (\"silenciado 🔕\", botão vira \"Reativar\") + toast
3. Tocar \"Reativar\" → volta
4. Esfriou: mandar número puro com prompt >30min → mensagem com botão que reabre a pergunta de valor

🤖 Generated with [Claude Code](https://claude.com/claude-code)