### PR TITLE
feat(retencao): sequência de disciplina flag-gated — item 18 (Onda 7)

### DIFF
--- a/MAPA_MENSAGENS_BOT.md
+++ b/MAPA_MENSAGENS_BOT.md
@@ -61,6 +61,11 @@ normal: 0 a 2. O silêncio é parte do produto.
 - **`/mensagens`** é o centro de controle: lista os recorrentes com estado e toggles
   (liquidação e resumo; o daily é automático — para sozinho sem clique). Embrião do
   item 17 (preferências). `/silenciar`, `/lembretes` e `/resumo` seguem como atalhos.
+- **Sequência de disciplina (item 18, flag `ops_config.streak_enabled` — nasce OFF):**
+  não é mensagem nova — é UMA linha embutida nos recibos de registro (#5/#4a, só em
+  milestone 5/10/20/30/50/100, 1x por dia) e no resumo semanal (#10, streak ≥5, nunca
+  na semana negativa). Semântica anti-"aposte mais": dia sem aposta é NEUTRO (só >7
+  dias vazios reseta); copy celebra CONTROLE ("banca em dia"), nunca volume.
 - Toda mensagem tem evento no PostHog (enviada + clicada/corrigida) — a "taxa de
   incômodo" (mute + correções) é métrica acompanhável.
 - Novas mensagens DEVEM entrar neste mapa antes de ir pra develop.

--- a/supabase/functions/notify-weekly-summary/index.ts
+++ b/supabase/functions/notify-weekly-summary/index.ts
@@ -25,6 +25,7 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 import { generateTraceId, trackEvent } from "../shared/posthog.ts";
 import { trackedUrl } from "../shared/links.ts";
 import { logMessageRun } from "../shared/runs.ts";
+import { getStreak, isStreakEnabled } from "../shared/streak.ts";
 import { buildMessage, pickTier, type WeeklyCandidate } from "./tiers.ts";
 
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
@@ -81,29 +82,34 @@ serve(async (req) => {
       best_market_profit: r.best_market_profit == null ? null : Number(r.best_market_profit),
     }));
 
-    const rows = candidates.map((c) => {
+    // item 18: sequência de disciplina (flag-gated; 1 flag-check por run)
+    const streakOn = await isStreakEnabled(supabase);
+    const rows = [];
+    for (const c of candidates) {
       const roi = c.total_stake > 0 ? c.total_profit / c.total_stake : 0;
       const tier = pickTier(c.total_profit, roi, c.unit_value_rs);
-      return { c, roi, tier };
-    });
+      const streakDays = streakOn ? (await getStreak(supabase, c.user_id)).days : null;
+      rows.push({ c, roi, tier, streakDays });
+    }
 
     if (mode === "report") {
       return json({
         ok: true, mode, candidates: rows.length,
-        preview: rows.map(({ c, roi, tier }) => ({
+        preview: rows.map(({ c, roi, tier, streakDays }) => ({
           user: c.user_name, n: c.n_settled, tier,
           profit: Number(c.total_profit.toFixed(2)), roi: Number((roi * 100).toFixed(1)),
           has_unit: c.unit_value_rs != null, best_market: c.best_market,
-          text: buildMessage(c, tier, roi),
+          streak_days: streakDays,
+          text: buildMessage(c, tier, roi, streakDays),
         })),
       });
     }
 
     let sent = 0;
     const errors: string[] = [];
-    for (const { c, roi, tier } of rows) {
+    for (const { c, roi, tier, streakDays } of rows) {
       try {
-        const text = buildMessage(c, tier, roi);
+        const text = buildMessage(c, tier, roi, streakDays);
         const bankUrl = await trackedUrl(c.user_id, "bank", CAMPAIGN);
         await sendSummary(c.chat_id, text, bankUrl);
 
@@ -123,6 +129,7 @@ serve(async (req) => {
             has_unit: c.unit_value_rs != null,
             volume: c.n_settled,
             roi_pct: Number((roi * 100).toFixed(1)),
+            streak_days: streakDays,
             channel: "telegram",
           },
           c.user_id, traceId

--- a/supabase/functions/notify-weekly-summary/tiers.ts
+++ b/supabase/functions/notify-weekly-summary/tiers.ts
@@ -4,6 +4,7 @@
 // Extraído de index.ts na Onda 3 (move-only) pra ser testável no CI
 // (supabase/functions/tests/weekly.test.ts). Sem side effects.
 import { esc } from "../shared/format.ts";
+import { weeklyStreakLine } from "../shared/streak.ts";
 
 // thresholds da faixa: com unidade, em u; sem unidade, em ROI
 const POS_U = 0.5, NEG_U = -1.0;
@@ -49,16 +50,20 @@ function resultLine(c: WeeklyCandidate, roi: number): string {
   return `Resultado: <b>${sg}${moneyAbs(p)}</b> · ROI <b>${sg}${pctAbs(roi)}</b>`;
 }
 
-export function buildMessage(c: WeeklyCandidate, tier: Tier, roi: number): string {
+export function buildMessage(c: WeeklyCandidate, tier: Tier, roi: number, streakDays: number | null = null): string {
   const head = `📊 <b>Seus últimos 7 dias</b>`;
   const mkt = c.best_market ? ` · melhor mercado: <b>${esc(c.best_market)}</b>` : "";
   const vol = `${c.n_settled} apostas liquidadas`;
+  // item 18: sequência só nas faixas positiva/neutra — na negativa NUNCA
+  // (mesma régua do "melhor mercado": semana ruim não é hora de cutucar métrica)
+  const streak = tier === "negative" ? null : weeklyStreakLine(streakDays);
 
   if (tier === "positive") {
     return [
       head,
       resultLine(c, roi),
       `${vol}${mkt}`,
+      ...(streak ? [streak] : []),
       "",
       `Fechou no positivo. O que importa agora é entender <b>o que sustentou isso</b> — quais mercados e stakes puxaram o resultado — pra repetir com consistência, não por sorte.`,
     ].join("\n");
@@ -68,6 +73,7 @@ export function buildMessage(c: WeeklyCandidate, tier: Tier, roi: number): strin
       head,
       resultLine(c, roi),
       `${vol}${mkt}`,
+      ...(streak ? [streak] : []),
       "",
       `Variação controlada — nem lucro nem prejuízo relevante. Bom momento pra <b>afinar</b>: onde você foi eficiente e onde deixou valor na mesa.`,
     ].join("\n");

--- a/supabase/functions/shared/streak.ts
+++ b/supabase/functions/shared/streak.ts
@@ -1,0 +1,98 @@
+// ============================================================
+// shared/streak.ts — Sequência de disciplina (item 18, Marco 2)
+// ============================================================
+// REGRA DE OURO (decisão de produto 2026-07-21, anti-LC224): o streak mede
+// DISCIPLINA DE REGISTRO, não frequência de aposta. Dia sem aposta é NEUTRO
+// (descansar não pune — streak nunca empurra "aposte todo dia"). Exceção
+// anti-streak-eterno: mais de GAP_MAX_DAYS dias vazios seguidos = recomeço
+// ("descansos de até uma semana não quebram").
+//
+// Aparece SÓ embutido em mensagens existentes (recibos em milestone; resumo
+// semanal com streak >= 5 e nunca na semana negativa). Ligado por flag
+// ops_config['streak_enabled'] — nasce DESLIGADO até o resumo (04) provar
+// tração em prod (gate do roadmap).
+//
+// Parte pura testada no CI: tests/streak.test.ts (atenção à fronteira de dia
+// BRT: aposta 23h30 BRT = 02h30 UTC do dia seguinte).
+
+export const MILESTONES = [5, 10, 20, 30, 50, 100];
+export const GAP_MAX_DAYS = 7;   // dias vazios tolerados entre dias-com-aposta
+export const WEEKLY_MIN = 5;     // resumo só mostra streak a partir daqui
+const BRT = "America/Sao_Paulo";
+
+// dia-calendário BRT (YYYY-MM-DD) de um timestamp
+export function brtDay(d: string | Date): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: BRT }).format(new Date(d));
+}
+
+const dayDiff = (a: string, b: string) => Math.round((Date.parse(a) - Date.parse(b)) / 86_400_000);
+
+export interface StreakInfo {
+  days: number;           // dias-com-aposta consecutivos (gap <= GAP_MAX_DAYS)
+  firstBetOfDay: boolean; // a aposta mais recente é a 1ª do dia? (anti-repetição de milestone)
+}
+
+// betDates: bet_date de TODAS as apostas recentes do usuário (inclui a recém-criada,
+// quando chamado do recibo). now: referência de "hoje".
+export function computeStreak(betDates: (string | Date)[], now: Date = new Date()): StreakInfo {
+  if (betDates.length === 0) return { days: 0, firstBetOfDay: false };
+  const today = brtDay(now);
+  const dayList = betDates.map(brtDay);
+  const todayCount = dayList.filter((d) => d === today).length;
+  const distinct = [...new Set(dayList)].sort().reverse(); // mais recente primeiro
+
+  // vivacidade: último dia-com-aposta longe demais de hoje → sequência morta
+  if (dayDiff(today, distinct[0]) > GAP_MAX_DAYS) return { days: 0, firstBetOfDay: false };
+
+  let days = 1;
+  for (let i = 1; i < distinct.length; i++) {
+    const emptyBetween = dayDiff(distinct[i - 1], distinct[i]) - 1;
+    if (emptyBetween > GAP_MAX_DAYS) break;
+    days++;
+  }
+  return { days, firstBetOfDay: todayCount === 1 };
+}
+
+// milestone alcançado AGORA (só na 1ª aposta do dia — não repete no mesmo dia)
+export function milestoneReached(s: StreakInfo): number | null {
+  return s.firstBetOfDay && MILESTONES.includes(s.days) ? s.days : null;
+}
+
+// linha do recibo (texto puro — funciona em Markdown e HTML). Celebra CONTROLE.
+export function receiptStreakLine(s: StreakInfo): string | null {
+  const m = milestoneReached(s);
+  return m ? `🔥 ${m}º dia seguido com a banca em dia` : null;
+}
+
+// linha do resumo semanal (HTML). null abaixo do patamar — e o chamador NUNCA
+// mostra na semana negativa (mesma régua do "melhor mercado").
+export function weeklyStreakLine(days: number | null): string | null {
+  if (days == null || days < WEEKLY_MIN) return null;
+  return `🔥 Sequência viva: <b>${days} dias</b> de banca em dia`;
+}
+
+// ── IO (flag + busca) ────────────────────────────────────────
+export async function isStreakEnabled(supabase: any): Promise<boolean> {
+  const { data } = await supabase.from("ops_config").select("value").eq("key", "streak_enabled").maybeSingle();
+  return data?.value === "true";
+}
+
+export async function getStreak(supabase: any, userId: string, now: Date = new Date()): Promise<StreakInfo> {
+  const { data } = await supabase
+    .from("bets")
+    .select("bet_date")
+    .eq("user_id", userId)
+    .gte("bet_date", new Date(now.getTime() - 120 * 86_400_000).toISOString())
+    .limit(2000);
+  return computeStreak((data ?? []).map((r: any) => r.bet_date), now);
+}
+
+// atalho pros recibos: flag + busca + milestone numa chamada (null = nada a mostrar)
+export async function receiptStreakLineFor(supabase: any, userId: string): Promise<string | null> {
+  try {
+    if (!(await isStreakEnabled(supabase))) return null;
+    return receiptStreakLine(await getStreak(supabase, userId));
+  } catch (_) {
+    return null; // streak NUNCA quebra um recibo
+  }
+}

--- a/supabase/functions/telegram-webhook/callbacks.ts
+++ b/supabase/functions/telegram-webhook/callbacks.ts
@@ -11,6 +11,7 @@ import { effectiveUnit, registerPickBet, pickReceiptHtml, sendStakePrompt } from
 import { findUserByTelegram } from "./users.ts"
 import { prefsKeyboard, prefsText } from "./prefs.ts"
 import { trackEvent } from "../shared/posthog.ts"
+import { receiptStreakLineFor } from "../shared/streak.ts"
 
 async function handleCallbackQuery(
   supabase: any,
@@ -193,7 +194,8 @@ async function handleCallbackQuery(
       await answerCallbackQuery(cq.id, "Deu ruim ao registrar — tenta de novo.")
       return ok("stk: insert failed")
     }
-    await editSettledMessage(chatId, messageId, pickReceiptHtml(pick, stake))
+    const streakLine = await receiptStreakLineFor(supabase, user.id) // item 18 (flag-gated)
+    await editSettledMessage(chatId, messageId, pickReceiptHtml(pick, stake, streakLine))
     await answerCallbackQuery(cq.id, "✅ Registrado!")
     await trackEvent(
       "opportunity_bet_registered",

--- a/supabase/functions/telegram-webhook/extraction.ts
+++ b/supabase/functions/telegram-webhook/extraction.ts
@@ -8,6 +8,7 @@ import {
   sendHelpMessageTelegram, sendPaywallMessageTelegram, sendConfirmationMessageTelegram,
 } from "./telegram-api.ts"
 import { trackEvent, trackLLMGeneration } from "../shared/posthog.ts"
+import { receiptStreakLineFor } from "../shared/streak.ts"
 
 // JSON Schema for structured outputs (parity with WhatsApp)
 const BETTING_INFO_SCHEMA = {
@@ -1089,7 +1090,12 @@ async function processMessage(
         .eq("id", messageId)
 
       console.log("bet_sending_confirmation", { message_id: messageId, bet_id: bet.id, chat_id: chatId })
-      await sendConfirmationMessageTelegram(chatId, bet)
+      // item 18: milestone da sequência de disciplina no recibo (flag-gated)
+      const streakLine = await receiptStreakLineFor(supabase, userId)
+      if (streakLine) {
+        await trackEvent("streak_milestone", { line: streakLine, channel: "telegram" }, userId, traceId).catch(() => {})
+      }
+      await sendConfirmationMessageTelegram(chatId, bet, streakLine)
       console.log("bet_confirmation_sent", { message_id: messageId, bet_id: bet.id })
     } else {
       await trackEvent(

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -19,6 +19,7 @@ import {
   sendTelegramMessage, getTelegramFileUrl, sendContactRequest, sendWelcomeMessageTelegram,
 } from "./telegram-api.ts"
 import { registerPickBet, pickReceiptHtml } from "./picks.ts"
+import { receiptStreakLineFor } from "../shared/streak.ts"
 import { handleCallbackQuery } from "./callbacks.ts"
 import { transcribeAudio, processImage, processMessage } from "./extraction.ts"
 import { findUserByTelegram, findUserByPhone } from "./users.ts"
@@ -423,7 +424,8 @@ serve(async (req) => {
             if (error || !bet) {
               await sendTelegramMessage(chatId, "Deu ruim ao registrar — tenta de novo.")
             } else {
-              await sendTelegramMessage(chatId, pickReceiptHtml(pick, stake), { parse_mode: "HTML", disable_web_page_preview: true })
+              const streakLine = await receiptStreakLineFor(supabase, user.id) // item 18 (flag-gated)
+              await sendTelegramMessage(chatId, pickReceiptHtml(pick, stake, streakLine), { parse_mode: "HTML", disable_web_page_preview: true })
               await trackEvent(
                 "opportunity_bet_registered",
                 { bet_id: bet.id, pick_id: prompt.pick_id, stake, via: isReply ? "force_reply" : "bare_number", channel: "telegram" },

--- a/supabase/functions/telegram-webhook/picks.ts
+++ b/supabase/functions/telegram-webhook/picks.ts
@@ -55,7 +55,7 @@ async function registerPickBet(supabase: any, userId: string, pick: any, stake: 
     .maybeSingle()
 }
 
-function pickReceiptHtml(pick: any, stake: number): string {
+function pickReceiptHtml(pick: any, stake: number, streakLine?: string | null): string {
   const odds = Number(pick.odds)
   return [
     `✅ <b>Registrado no Betinho!</b>`,
@@ -63,6 +63,7 @@ function pickReceiptHtml(pick: any, stake: number): string {
     `<b>${escHtml(pick.bet_description)}</b>`,
     `${escHtml(pick.match_description)}`,
     `${formatBRL(stake)} · odd ${odds} · retorno ${formatBRL(Math.round(stake * odds * 100) / 100)}`,
+    ...(streakLine ? ["", streakLine] : []), // item 18: milestone da sequência (flag-gated)
     "",
     `Tá pendente — quando o jogo acabar, eu fecho pra você. 📊 ${BETS_DASHBOARD_URL}`
   ].join("\n")

--- a/supabase/functions/telegram-webhook/telegram-api.ts
+++ b/supabase/functions/telegram-webhook/telegram-api.ts
@@ -138,7 +138,8 @@ async function sendConfirmationMessageTelegram(
     odds: number
     stake_amount: number
     potential_return: number
-  }
+  },
+  streakLine?: string | null // item 18: linha de milestone da sequência (flag-gated)
 ): Promise<void> {
   const betTypeText: Record<string, string> = {
     single: "Simples",
@@ -159,6 +160,7 @@ async function sendConfirmationMessageTelegram(
     `• *Odds:* ${betDetails.odds}`,
     `• *Valor:* R$ ${betDetails.stake_amount.toFixed(2)}`,
     `• *Retorno Potencial:* R$ ${betDetails.potential_return.toFixed(2)}`,
+    ...(streakLine ? ["", streakLine] : []),
     "",
     "✅ Sua aposta foi salva no dashboard e você pode acompanhar o resultado em tempo real!",
     "",

--- a/supabase/functions/tests/streak.test.ts
+++ b/supabase/functions/tests/streak.test.ts
@@ -1,0 +1,83 @@
+// Testes da Sequência de disciplina (shared/streak.ts, item 18 / Onda 7).
+// Regra de ouro: dia sem aposta é NEUTRO (só >GAP_MAX_DAYS vazios reseta).
+import { assert, assertEquals } from "./_assert.ts";
+import {
+  brtDay,
+  computeStreak,
+  milestoneReached,
+  receiptStreakLine,
+  weeklyStreakLine,
+} from "../shared/streak.ts";
+
+// "agora": 2026-07-21 15:00 BRT (18:00 UTC)
+const NOW = new Date("2026-07-21T18:00:00Z");
+// helper: timestamp UTC do meio-dia BRT de N dias atrás
+const daysAgo = (n: number, hourUtc = 15) =>
+  new Date(NOW.getTime() - n * 86_400_000).toISOString().slice(0, 10) + `T${String(hourUtc).padStart(2, "0")}:00:00Z`;
+
+// ── fronteira de dia BRT ──
+Deno.test("brtDay: 02h30 UTC é 23h30 BRT do dia ANTERIOR", () => {
+  assertEquals(brtDay("2026-07-21T02:30:00Z"), "2026-07-20");
+});
+Deno.test("brtDay: 15h UTC é o mesmo dia em BRT", () => {
+  assertEquals(brtDay("2026-07-21T15:00:00Z"), "2026-07-21");
+});
+
+// ── streak básico ──
+Deno.test("3 dias corridos apostando → streak 3, 1ª do dia", () => {
+  const s = computeStreak([daysAgo(0), daysAgo(1), daysAgo(2)], NOW);
+  assertEquals(s, { days: 3, firstBetOfDay: true });
+});
+Deno.test("várias apostas no mesmo dia contam 1 dia (e não é 1ª do dia)", () => {
+  const s = computeStreak([daysAgo(0), daysAgo(0, 12), daysAgo(1)], NOW);
+  assertEquals(s.days, 2);
+  assertEquals(s.firstBetOfDay, false);
+});
+
+// ── dias vazios neutros (a regra de ouro) ──
+Deno.test("descanso de 4 dias NÃO quebra (gap <= 7)", () => {
+  const s = computeStreak([daysAgo(0), daysAgo(5)], NOW);
+  assertEquals(s.days, 2);
+});
+Deno.test("descanso de 8+ dias vazios reseta a contagem anterior", () => {
+  const s = computeStreak([daysAgo(0), daysAgo(9)], NOW);
+  assertEquals(s.days, 1);
+});
+Deno.test("sequência morta: última aposta há 10 dias (sem aposta hoje) → 0", () => {
+  const s = computeStreak([daysAgo(10), daysAgo(11)], NOW);
+  assertEquals(s.days, 0);
+});
+Deno.test("sequência viva sem aposta hoje: última há 3 dias → conta, não é 1ª do dia", () => {
+  const s = computeStreak([daysAgo(3), daysAgo(4)], NOW);
+  assertEquals(s, { days: 2, firstBetOfDay: false });
+});
+Deno.test("sem apostas → 0", () => {
+  assertEquals(computeStreak([], NOW), { days: 0, firstBetOfDay: false });
+});
+
+// ── milestones (anti-repetição no mesmo dia) ──
+Deno.test("5º dia + 1ª aposta do dia → milestone 5", () => {
+  const dates = [0, 1, 2, 3, 4].map((n) => daysAgo(n));
+  assertEquals(milestoneReached(computeStreak(dates, NOW)), 5);
+});
+Deno.test("5º dia mas 2ª aposta do dia → sem milestone (não repete)", () => {
+  const dates = [daysAgo(0), daysAgo(0, 12), daysAgo(1), daysAgo(2), daysAgo(3), daysAgo(4)];
+  assertEquals(milestoneReached(computeStreak(dates, NOW)), null);
+});
+Deno.test("6º dia → sem milestone (só 5/10/20/30/50/100)", () => {
+  const dates = [0, 1, 2, 3, 4, 5].map((n) => daysAgo(n));
+  assertEquals(milestoneReached(computeStreak(dates, NOW)), null);
+});
+
+// ── linhas (copy: celebra CONTROLE) ──
+Deno.test("recibo: linha só em milestone", () => {
+  const m5 = computeStreak([0, 1, 2, 3, 4].map((n) => daysAgo(n)), NOW);
+  assertEquals(receiptStreakLine(m5), "🔥 5º dia seguido com a banca em dia");
+  const m3 = computeStreak([0, 1, 2].map((n) => daysAgo(n)), NOW);
+  assertEquals(receiptStreakLine(m3), null);
+});
+Deno.test("resumo: linha só com streak >= 5", () => {
+  assertEquals(weeklyStreakLine(4), null);
+  assert(weeklyStreakLine(7)!.includes("<b>7 dias</b>"));
+  assertEquals(weeklyStreakLine(null), null);
+});

--- a/supabase/functions/tests/weekly.test.ts
+++ b/supabase/functions/tests/weekly.test.ts
@@ -50,6 +50,23 @@ Deno.test("sem unidade: cai pra R$ puro (sem 'u')", () => {
   assert(t.includes("Resultado: <b>+R$ 90,00</b>"), "R$ direto");
   assert(!/\d,\du/.test(t), "sem unidades");
 });
+// ── item 18: streak no resumo ──
+Deno.test("streak: aparece na positiva com >=5 dias", () => {
+  const c = cand({ total_profit: 90, best_market: "Money Line" });
+  const t = buildMessage(c, "positive", 0.15, 7);
+  assert(t.includes("Sequência viva: <b>7 dias</b>"), "linha do streak");
+});
+Deno.test("streak: NUNCA na semana negativa (mesmo com streak alto)", () => {
+  const c = cand({ total_profit: -100 });
+  const t = buildMessage(c, "negative", -0.2, 30);
+  assert(!t.includes("Sequência"), "negativa não cutuca");
+});
+Deno.test("streak: ausente sem dado (flag off) e abaixo do patamar", () => {
+  const c = cand({ total_profit: 90 });
+  assert(!buildMessage(c, "positive", 0.15, null).includes("Sequência"), "null");
+  assert(!buildMessage(c, "positive", 0.15, 4).includes("Sequência"), "<5");
+});
+
 Deno.test("melhor mercado escapa HTML", () => {
   const c = cand({ total_profit: 90, best_market: "A <b> & C" });
   const t = buildMessage(c, "positive", 0.15);


### PR DESCRIPTION
Item 18 do Marco 2, no padrão das ondas. **A decisão de produto que define tudo** (Victor, 21/07): o streak mede **disciplina de registro**, não frequência de aposta — **dia sem aposta é neutro** (só >7 dias vazios reseta). Um streak diário clássico empurraria \"aposte todo dia\", violando a LC 224 e a régua do próprio item (\"sempre como controle, nunca como apostar mais\").

## Onde aparece (zero mensagem nova, zero cron, zero migration)
| Touchpoint | Regra |
|---|---|
| Recibos de registro (LLM + item 15) | linha **só em milestone** (5/10/20/30/50/100), 1× por dia: *\"🔥 5º dia seguido com a banca em dia\"* |
| Resumo semanal | streak ≥5, faixas positiva/neutra — **nunca na negativa** (mesma régua do \"melhor mercado\") |

## Flag (gate do roadmap respeitado)
`ops_config['streak_enabled']` — **nasce DESLIGADO**. O item 18 só deveria entrar \"se o resumo semanal (04) mostrar tração\"; o 04 nem chegou em prod. Runbook: 1 UPDATE liga quando houver ~2-3 semanas de dado bom (clique ok, mute <2%).

## Arquitetura
- `shared/streak.ts`: parte pura (dias BRT com cuidado na fronteira — aposta 23h30 BRT = 02h30 UTC do dia seguinte; dedupe; gap ≤7; vivacidade; anti-repetição de milestone no mesmo dia) + IO (`isStreakEnabled`/`getStreak` on-the-fly em `bets` 120d — sem coluna nova, sem estado que deriva). **Streak nunca quebra um recibo** (try/catch → null).
- Integrações mínimas graças ao split da 6b: `telegram-api.ts`, `picks.ts`, `callbacks.ts`, `index.ts` (webhook) e `tiers.ts`/`index.ts` (weekly).
- PostHog: `streak_milestone` + `streak_days` no `weekly_summary_sent`.
- **+17 testes** (total 94 no gate), cobrindo a fronteira BRT e a semântica neutra.

## Ensaio staging (pós-merge)
Flag ON no staging → seed de apostas em 4 dias anteriores → Victor registra aposta real → recibo com **\"🔥 5º dia seguido com a banca em dia\"** → resumo reenviado com a linha de sequência.

🤖 Generated with [Claude Code](https://claude.com/claude-code)