### PR TITLE
feat(betinho): recibo de registro com botões (Green/Red/Editar/Ver banca)

### DIFF
--- a/src/pages/Bets.tsx
+++ b/src/pages/Bets.tsx
@@ -657,6 +657,10 @@ export default function Bets() {
   const posthog = usePostHog();
   const [searchParams, setSearchParams] = useSearchParams();
   const [bets, setBets] = useState<Bet[]>([]);
+  // Deep-link do Betinho: o recibo de registro traz [✏️ Editar] → /bets?edit=<id>.
+  // Capturamos o id no 1º render (lazy init) porque o efeito de mount limpa os
+  // query params logo em seguida; o modal abre quando a lista de apostas carrega.
+  const [pendingEditBetId, setPendingEditBetId] = useState<string | null>(() => searchParams.get('edit'));
   // Espelho do estado pros callbacks lerem o valor atual sem `bets` nas deps — mantê-lo nas
   // deps recriava os callbacks a cada update e derrotava o React.memo de BetRow/BetCard.
   const betsRef = useRef<Bet[]>([]);
@@ -1262,6 +1266,15 @@ export default function Bets() {
     setIsBettingMarketQueryTouched(false);
     setBettingMarketHighlightIndex(-1);
   }, []);
+
+  // Deep-link ?edit=<id> (botão Editar do recibo do Betinho): assim que a lista
+  // de apostas carrega, abre o modal de edição já preenchido e consome o id.
+  useEffect(() => {
+    if (!pendingEditBetId || bets.length === 0) return;
+    const target = bets.find((b) => b.id === pendingEditBetId);
+    if (target) openEditModal(target);
+    setPendingEditBetId(null);
+  }, [pendingEditBetId, bets, openEditModal]);
 
   const fetchReferralCode = useCallback(async () => {
     if (!user?.id) return;

--- a/supabase/functions/telegram-webhook/keyboards.ts
+++ b/supabase/functions/telegram-webhook/keyboards.ts
@@ -1,0 +1,32 @@
+// ============================================================
+// keyboards.ts — teclados inline do bot (código PURO, sem env)
+// ============================================================
+// Separado de telegram-api.ts pra ser testável sem --allow-env: importar
+// telegram-api.ts puxa config.ts, que lê Deno.env no topo do módulo (o
+// `deno test` do CI roda sem permissões). Mesmo motivo do digest.ts ser
+// auto-contido. Testado no CI: supabase/functions/tests/confirmation.test.ts
+
+// Espelha config.ts BETS_DASHBOARD_URL (constante pura; manter em sincronia).
+const BETS_DASHBOARD_URL = "https://www.smartbetting.app/bets"
+
+// Teclado do recibo de registro: ações direto na mensagem em vez do "textão"
+// com link. [✅ Green][❌ Red] reusam o handler settle:<id>:<won|lost> (o mesmo
+// do lembrete/auto-liquidação — status='pending' guarda contra toque duplo).
+// [✏️ Editar] abre o site JÁ no modal de edição desta aposta (?edit=<id>);
+// [📊 Ver banca] abre o dashboard.
+function confirmationKeyboard(betId: string): { inline_keyboard: Array<Array<Record<string, string>>> } {
+  return {
+    inline_keyboard: [
+      [
+        { text: "✅ Green", callback_data: `settle:${betId}:won` },
+        { text: "❌ Red", callback_data: `settle:${betId}:lost` }
+      ],
+      [
+        { text: "✏️ Editar", url: `${BETS_DASHBOARD_URL}?edit=${betId}` },
+        { text: "📊 Ver banca", url: BETS_DASHBOARD_URL }
+      ]
+    ]
+  }
+}
+
+export { confirmationKeyboard }

--- a/supabase/functions/telegram-webhook/telegram-api.ts
+++ b/supabase/functions/telegram-webhook/telegram-api.ts
@@ -3,6 +3,7 @@
 // ============================================================
 // Extraído de index.ts na Onda 6b da revisão (split mecânico, move-only).
 import { TELEGRAM_BOT_TOKEN, TELEGRAM_API_BASE, DAILY_BET_LIMIT, BETS_DASHBOARD_URL } from "./config.ts"
+import { confirmationKeyboard } from "./keyboards.ts"
 import type { TelegramFile } from "./types.ts"
 
 async function telegramCall<T = any>(method: string, payload: Record<string, unknown>): Promise<T | null> {
@@ -130,6 +131,7 @@ async function sendPaywallMessageTelegram(chatId: string | number): Promise<void
 async function sendConfirmationMessageTelegram(
   chatId: string | number,
   betDetails: {
+    id: string
     bet_type: string
     sport: string
     league?: string | null
@@ -147,8 +149,6 @@ async function sendConfirmationMessageTelegram(
     system: "Sistema"
   }
 
-  const dashboardUrl = "https://www.smartbetting.app/bets"
-
   const confirmationMessage = [
     "🎯 *Aposta Registrada com Sucesso!*",
     "",
@@ -162,15 +162,12 @@ async function sendConfirmationMessageTelegram(
     `• *Retorno Potencial:* R$ ${betDetails.potential_return.toFixed(2)}`,
     ...(streakLine ? ["", streakLine] : []),
     "",
-    "✅ Sua aposta foi salva no dashboard e você pode acompanhar o resultado em tempo real!",
-    "",
-    `🔗 Acesse seu dashboard: ${dashboardUrl}`,
-    "",
-    "⚠️ *IMPORTANTE:*",
-    "Se você enviou uma imagem de aposta e não recebeu esta mensagem, envie a imagem novamente."
+    "Quando o jogo terminar, eu te aviso o resultado. Já deu? Marca aqui 👇"
   ].join("\n")
 
-  await sendTelegramMessage(chatId, confirmationMessage)
+  await sendTelegramMessage(chatId, confirmationMessage, {
+    reply_markup: confirmationKeyboard(betDetails.id)
+  })
 }
 
 // ============================================================

--- a/supabase/functions/tests/confirmation.test.ts
+++ b/supabase/functions/tests/confirmation.test.ts
@@ -1,0 +1,29 @@
+// Testes do teclado do recibo de registro (telegram-webhook/telegram-api.ts).
+// Recibo com botões [✅ Green][❌ Red] / [✏️ Editar][📊 Ver banca]: o Editar
+// deep-linka pro modal de edição (?edit=<id>) e Green/Red reusam o mesmo
+// handler settle:<id>:<won|lost> do lembrete/auto-liquidação.
+import { assert, assertEquals } from "./_assert.ts";
+import { confirmationKeyboard } from "../telegram-webhook/keyboards.ts";
+
+Deno.test("recibo: layout 2x2 (settle em cima, links embaixo)", () => {
+  const kb = confirmationKeyboard("bet-123");
+  assertEquals(kb.inline_keyboard.length, 2, "duas linhas");
+  assertEquals(kb.inline_keyboard[0].length, 2, "linha 1: Green + Red");
+  assertEquals(kb.inline_keyboard[1].length, 2, "linha 2: Editar + Ver banca");
+});
+
+Deno.test("recibo: Green/Red reusam o handler settle:<id>:<outcome>", () => {
+  const kb = confirmationKeyboard("bet-123");
+  const [green, red] = kb.inline_keyboard[0];
+  assertEquals(green.callback_data, "settle:bet-123:won");
+  assertEquals(red.callback_data, "settle:bet-123:lost");
+  assert(!("url" in green), "Green é callback, não link");
+});
+
+Deno.test("recibo: Editar deep-linka pro modal de edição (?edit=<id>)", () => {
+  const kb = confirmationKeyboard("bet-123");
+  const [editar, verBanca] = kb.inline_keyboard[1];
+  assertEquals(editar.url, "https://www.smartbetting.app/bets?edit=bet-123");
+  assertEquals(verBanca.url, "https://www.smartbetting.app/bets");
+  assert(!("callback_data" in editar), "Editar é link, não callback");
+});


### PR DESCRIPTION
## O quê
O recibo de **Aposta Registrada** vinha como um "textão" com link cru. Agora traz **teclado inline** e uma copy enxuta.

**Antes:** extrato + `✅ salva...` + `🔗 Acesse seu dashboard: <link>` + `⚠️ IMPORTANTE: se enviou imagem...`
**Depois:** extrato (mantido) + 1 linha honesta na Voz do Betinho + botões:

```
[✅ Green]   [❌ Red]      ← liquidam na hora (callback)
[✏️ Editar]  [📊 Ver banca] ← abrem o site
```

## Como
- **`keyboards.ts`** (novo, módulo **puro sem env**): `confirmationKeyboard(betId)`. Isolado de `telegram-api.ts` porque este puxa `config.ts`, que lê `Deno.env` no topo — e o `deno test` do CI roda sem `--allow-env`. Mesmo padrão de `digest.ts`.
- **Green/Red** reusam o handler existente **`settle:<id>:<won|lost>`** (mesma guarda otimista `status='pending'` do lembrete e da auto-liquidação — zero código novo de liquidação).
- **Editar** → `smartbetting.app/bets?edit=<id>`.
- **`Bets.tsx`**: captura `?edit=<id>` no 1º render (lazy init de `useState`, porque o efeito de mount limpa os query params logo depois) e abre `openEditModal` já preenchido assim que a lista de apostas carrega, consumindo o id. **Reusa o modal de edição que já está em produção** — sem tela nova.
- Cortado o `⚠️ IMPORTANTE` (contraditório — se recebeu a msg, não precisa reenviar imagem) e o link cru.

## Testes / gate
- `supabase/functions/tests/confirmation.test.ts` (3 novos): layout 2×2, `settle:<id>` correto (won/lost, é callback não link), deep-link `?edit=<id>` no Editar.
- **Gate local:** `deno test supabase/functions/tests/` → **98 passed, 0 failed**; `deno check --node-modules-dir=none .../telegram-webhook/index.ts` → OK.

## Escopo / infra
- **Sem migration, sem cron, sem vault, sem mensagem nova no mapa** — reaproveita `settle:` e o modal de edição existentes.
- Feito em worktree isolado; o PR carrega **apenas** este diff vs `develop` (nada da sessão paralela de Landing/Flux, que está noutra branch não-mergeada).
- Merge em `develop` → CI deploya no **staging** pro ensaio no Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)