### PR TITLE
feat(bets): retorno pago editável + vocabulário custom por usuário no modal

### DIFF
--- a/src/components/bets/CreateBetModal.tsx
+++ b/src/components/bets/CreateBetModal.tsx
@@ -8,6 +8,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { TagSelector } from '@/components/bets/TagSelector';
 import { Calendar as CalendarComponent } from '@/components/ui/calendar';
 import { telegramBotUrl } from '@/config/environment';
+import { canonicalizeVocab, vocabHasValue } from '@/utils/betVocab';
 
 export interface CreateBetTag {
   id: string;
@@ -399,31 +400,43 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
               </div>
               {isCreateSportDropdownOpen && formData.sport && (
                 <div className="theme-rebrand absolute z-50 mt-1 w-full max-h-48 overflow-auto rounded-md border border-line bg-white shadow-[0_10px_30px_-10px_rgba(0,0,0,0.15)]">
-                  {filteredCreateSportsList.length > 0 ? (
-                    filteredCreateSportsList.map((sport, index) => (
-                      <button
-                        key={sport}
-                        type="button"
-                        tabIndex={-1}
-                        ref={(element) => {
-                          createSportItemRefs.current[index] = element;
-                        }}
-                        onMouseDown={(event) => {
-                          event.preventDefault();
-                          setFormData((prev) => ({ ...prev, sport }));
-                          setIsCreateSportDropdownOpen(false);
-                          setIsCreateSportQueryTouched(false);
-                          setCreateSportHighlightIndex(-1);
-                        }}
-                        className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                          index === createSportHighlightIndex ? 'bg-ink-3/40' : ''
-                        }`}
-                      >
-                        {sport}
-                      </button>
-                    ))
-                  ) : (
-                    <div className="px-3 py-2 text-xs text-ink-2">Nenhum esporte encontrado</div>
+                  {filteredCreateSportsList.map((sport, index) => (
+                    <button
+                      key={sport}
+                      type="button"
+                      tabIndex={-1}
+                      ref={(element) => {
+                        createSportItemRefs.current[index] = element;
+                      }}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        setFormData((prev) => ({ ...prev, sport }));
+                        setIsCreateSportDropdownOpen(false);
+                        setIsCreateSportQueryTouched(false);
+                        setCreateSportHighlightIndex(-1);
+                      }}
+                      className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
+                        index === createSportHighlightIndex ? 'bg-ink-3/40' : ''
+                      }`}
+                    >
+                      {sport}
+                    </button>
+                  ))}
+                  {formData.sport.trim() && !vocabHasValue(formData.sport, sportsList) && (
+                    <button
+                      type="button"
+                      tabIndex={-1}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        setFormData((prev) => ({ ...prev, sport: canonicalizeVocab(prev.sport, sportsList) }));
+                        setIsCreateSportDropdownOpen(false);
+                        setIsCreateSportQueryTouched(false);
+                        setCreateSportHighlightIndex(-1);
+                      }}
+                      className="w-full text-left px-3 py-2 text-sm text-forest font-medium hover:bg-forest-tint border-t border-line"
+                    >
+                      ＋ Adicionar "{formData.sport.trim()}"
+                    </button>
                   )}
                 </div>
               )}
@@ -510,31 +523,43 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
               </div>
               {isCreateLeagueDropdownOpen && formData.league && (
                 <div className="theme-rebrand absolute z-50 mt-1 w-full max-h-48 overflow-auto rounded-md border border-line bg-white shadow-[0_10px_30px_-10px_rgba(0,0,0,0.15)]">
-                  {filteredCreateLeaguesList.length > 0 ? (
-                    filteredCreateLeaguesList.map((league, index) => (
-                      <button
-                        key={league}
-                        type="button"
-                        tabIndex={-1}
-                        ref={(element) => {
-                          createLeagueItemRefs.current[index] = element;
-                        }}
-                        onMouseDown={(event) => {
-                          event.preventDefault();
-                          setFormData((prev) => ({ ...prev, league }));
-                          setIsCreateLeagueDropdownOpen(false);
-                          setIsCreateLeagueQueryTouched(false);
-                          setCreateLeagueHighlightIndex(-1);
-                        }}
-                        className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                          index === createLeagueHighlightIndex ? 'bg-ink-3/40' : ''
-                        }`}
-                      >
-                        {league}
-                      </button>
-                    ))
-                  ) : (
-                    <div className="px-3 py-2 text-xs text-ink-2">Nenhuma liga encontrada</div>
+                  {filteredCreateLeaguesList.map((league, index) => (
+                    <button
+                      key={league}
+                      type="button"
+                      tabIndex={-1}
+                      ref={(element) => {
+                        createLeagueItemRefs.current[index] = element;
+                      }}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        setFormData((prev) => ({ ...prev, league }));
+                        setIsCreateLeagueDropdownOpen(false);
+                        setIsCreateLeagueQueryTouched(false);
+                        setCreateLeagueHighlightIndex(-1);
+                      }}
+                      className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
+                        index === createLeagueHighlightIndex ? 'bg-ink-3/40' : ''
+                      }`}
+                    >
+                      {league}
+                    </button>
+                  ))}
+                  {formData.league.trim() && !vocabHasValue(formData.league, leaguesList) && (
+                    <button
+                      type="button"
+                      tabIndex={-1}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        setFormData((prev) => ({ ...prev, league: canonicalizeVocab(prev.league, leaguesList) }));
+                        setIsCreateLeagueDropdownOpen(false);
+                        setIsCreateLeagueQueryTouched(false);
+                        setCreateLeagueHighlightIndex(-1);
+                      }}
+                      className="w-full text-left px-3 py-2 text-sm text-forest font-medium hover:bg-forest-tint border-t border-line"
+                    >
+                      ＋ Adicionar "{formData.league.trim()}"
+                    </button>
                   )}
                 </div>
               )}
@@ -618,31 +643,43 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
               </div>
               {isCreateBettingMarketDropdownOpen && formData.betting_market && (
                 <div className="theme-rebrand absolute z-50 mt-1 w-full max-h-48 overflow-auto rounded-md border border-line bg-white shadow-[0_10px_30px_-10px_rgba(0,0,0,0.15)]">
-                  {filteredCreateBettingMarketsList.length > 0 ? (
-                    filteredCreateBettingMarketsList.map((market, index) => (
-                      <button
-                        key={market}
-                        type="button"
-                        tabIndex={-1}
-                        ref={(element) => {
-                          createBettingMarketItemRefs.current[index] = element;
-                        }}
-                        onMouseDown={(event) => {
-                          event.preventDefault();
-                          setFormData((prev) => ({ ...prev, betting_market: market }));
-                          setIsCreateBettingMarketDropdownOpen(false);
-                          setIsCreateBettingMarketQueryTouched(false);
-                          setCreateBettingMarketHighlightIndex(-1);
-                        }}
-                        className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                          index === createBettingMarketHighlightIndex ? 'bg-ink-3/40' : ''
-                        }`}
-                      >
-                        {market}
-                      </button>
-                    ))
-                  ) : (
-                    <div className="px-3 py-2 text-xs text-ink-2">Nenhum mercado encontrado</div>
+                  {filteredCreateBettingMarketsList.map((market, index) => (
+                    <button
+                      key={market}
+                      type="button"
+                      tabIndex={-1}
+                      ref={(element) => {
+                        createBettingMarketItemRefs.current[index] = element;
+                      }}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        setFormData((prev) => ({ ...prev, betting_market: market }));
+                        setIsCreateBettingMarketDropdownOpen(false);
+                        setIsCreateBettingMarketQueryTouched(false);
+                        setCreateBettingMarketHighlightIndex(-1);
+                      }}
+                      className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
+                        index === createBettingMarketHighlightIndex ? 'bg-ink-3/40' : ''
+                      }`}
+                    >
+                      {market}
+                    </button>
+                  ))}
+                  {formData.betting_market.trim() && !vocabHasValue(formData.betting_market, bettingMarketsList) && (
+                    <button
+                      type="button"
+                      tabIndex={-1}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        setFormData((prev) => ({ ...prev, betting_market: canonicalizeVocab(prev.betting_market, bettingMarketsList) }));
+                        setIsCreateBettingMarketDropdownOpen(false);
+                        setIsCreateBettingMarketQueryTouched(false);
+                        setCreateBettingMarketHighlightIndex(-1);
+                      }}
+                      className="w-full text-left px-3 py-2 text-sm text-forest font-medium hover:bg-forest-tint border-t border-line"
+                    >
+                      ＋ Adicionar "{formData.betting_market.trim()}"
+                    </button>
                   )}
                 </div>
               )}

--- a/src/pages/Bets.tsx
+++ b/src/pages/Bets.tsx
@@ -14,6 +14,7 @@ import { useCapitalMovements } from '@/hooks/use-capital-movements';
 import { useBetinhoPremium } from '@/hooks/use-betinho-premium';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { mergeVocab, canonicalizeVocab, vocabHasValue } from '@/utils/betVocab';
 import { usePostHog } from '@posthog/react';
 import { SETTLED } from '@/utils/dashboardAggregations';
 import { MultiSelectFilter } from '../components/ui/multi-select-filter';
@@ -208,6 +209,27 @@ const BETTING_MARKETS_LIST = [
   'Dupla Chance',
   'Ambas Marcam',
 ];
+
+// Vínculo de mão dupla stake ⇄ odd ⇄ retorno no modal de edição (Request bônus
+// de odd alta): a casa às vezes paga diferente de stake×odd. O usuário edita o
+// RETORNO final e a odd se reajusta pra enquadrar (odd efetiva = retorno/stake).
+// Retornam null quando não dá pra calcular — aí não mexemos no campo dependente
+// (não apaga o que o usuário está digitando).
+const round2 = (n: number) => Math.round(n * 100) / 100;
+function calcReturnStr(stakeStr: string, oddsStr: string, credit: boolean): string | null {
+  const s = parseFloat(stakeStr);
+  const o = parseFloat(oddsStr);
+  if (!isFinite(s) || !isFinite(o)) return null;
+  const r = credit ? s * (o - 1) : s * o;
+  return isFinite(r) ? String(round2(r)) : null;
+}
+function calcOddsStr(stakeStr: string, returnStr: string, credit: boolean): string | null {
+  const s = parseFloat(stakeStr);
+  const r = parseFloat(returnStr);
+  if (!isFinite(s) || s <= 0 || !isFinite(r)) return null;
+  const o = credit ? r / s + 1 : r / s;
+  return isFinite(o) && o > 0 ? String(round2(o)) : null;
+}
 
 type BetRowProps = {
   bet: Bet;
@@ -718,6 +740,7 @@ export default function Bets() {
       betting_market: string;
       odds: string;
       stake_amount: string;
+      potential_return: string;
       bet_date: string;
       match_date: string;
       status: 'pending' | 'won' | 'lost' | 'void' | 'cashout' | 'half_won' | 'half_lost';
@@ -734,6 +757,7 @@ export default function Bets() {
       betting_market: '',
       odds: '',
       stake_amount: '',
+      potential_return: '',
       bet_date: '',
       match_date: '',
       status: 'pending',
@@ -1078,7 +1102,17 @@ export default function Bets() {
     const odds = parseFloat(editModal.formData.odds);
     const stakeAmount = parseFloat(editModal.formData.stake_amount);
     const isCreditBet = editModal.formData.is_credit_bet;
-    const potentialReturn = isCreditBet ? stakeAmount * (odds - 1) : stakeAmount * odds;
+    // Retorno editável (bônus de odd alta): usa o valor que o usuário deixou no
+    // campo; só cai no cálculo padrão se estiver vazio/inválido. Lucro/ROI leem
+    // potential_return em todo lugar, então o override fica consistente.
+    const parsedReturn = parseFloat(editModal.formData.potential_return);
+    const potentialReturn = isFinite(parsedReturn)
+      ? round2(parsedReturn)
+      : (isCreditBet ? stakeAmount * (odds - 1) : stakeAmount * odds);
+    // Encaixa esporte/liga/mercado no valor canônico existente (anti-fragmentação).
+    const sport = canonicalizeVocab(editModal.formData.sport, sportOptions);
+    const league = canonicalizeVocab(editModal.formData.league, leagueOptions);
+    const bettingMarket = canonicalizeVocab(editModal.formData.betting_market, marketOptions);
     const updatedAt = new Date().toISOString();
 
     // Convert yyyy-MM-dd to local midnight ISO so the calendar day is preserved in all timezones
@@ -1097,9 +1131,9 @@ export default function Bets() {
     const updateData: any = {
       bet_description: editModal.formData.bet_description,
       match_description: editModal.formData.match_description || null,
-      sport: editModal.formData.sport,
-      league: editModal.formData.league || null,
-      betting_market: editModal.formData.betting_market || null,
+      sport: sport,
+      league: league || null,
+      betting_market: bettingMarket || null,
       odds: odds,
       stake_amount: stakeAmount,
       potential_return: potentialReturn,
@@ -1167,6 +1201,10 @@ export default function Bets() {
       }
       const isCreditBet = data.is_credit_bet ?? false;
       const potentialReturn = isCreditBet ? stakeAmount * (odds - 1) : stakeAmount * odds;
+      // Encaixa no vocabulário canônico do usuário (anti-fragmentação).
+      const sport = canonicalizeVocab(data.sport, sportOptions) || 'Outros';
+      const league = canonicalizeVocab(data.league, leagueOptions);
+      const bettingMarket = canonicalizeVocab(data.betting_market, marketOptions);
 
       const { data: newBet, error } = await supabase
         .from('bets')
@@ -1175,9 +1213,9 @@ export default function Bets() {
           bet_type: 'single',
           bet_description: data.bet_description,
           match_description: data.match_description || null,
-          sport: data.sport || 'Outros',
-          league: data.league || null,
-          betting_market: data.betting_market || null,
+          sport: sport,
+          league: league || null,
+          betting_market: bettingMarket || null,
           odds: odds,
           stake_amount: stakeAmount,
           potential_return: potentialReturn,
@@ -1199,7 +1237,7 @@ export default function Bets() {
         product: 'betinho',
         channel: 'web',
         bet_type: 'single',
-        sport: data.sport || 'Outros',
+        sport: sport,
         is_credit_bet: isCreditBet,
       });
 
@@ -1250,6 +1288,7 @@ export default function Bets() {
         betting_market: bet.betting_market || '',
         odds: bet.odds?.toString() || '',
         stake_amount: bet.stake_amount?.toString() || '',
+        potential_return: bet.potential_return != null ? String(round2(bet.potential_return)) : '',
         bet_date: bet.bet_date ? String(bet.bet_date).split('T')[0] : '',
         match_date: bet.match_date ? String(bet.match_date).split('T')[0] : '',
         status: bet.status || 'pending',
@@ -1710,32 +1749,38 @@ export default function Bets() {
     }
   }, [selectedBetIds, supabase, toast, clearSelection, fetchBets]);
 
+  // Vocabulário per-user: base curada ∪ os valores que ESTE usuário já usou
+  // (deriva das apostas em memória; o custom de um não vaza pro dropdown de outro).
+  const sportOptions = useMemo(() => mergeVocab(SPORTS_LIST, bets.map((b) => b.sport)), [bets]);
+  const leagueOptions = useMemo(() => mergeVocab(LEAGUES_LIST, bets.map((b) => b.league)), [bets]);
+  const marketOptions = useMemo(() => mergeVocab(BETTING_MARKETS_LIST, bets.map((b) => b.betting_market)), [bets]);
+
   const filteredSportsList = useMemo(() => {
     if (!isSportQueryTouched) {
-      return SPORTS_LIST;
+      return sportOptions;
     }
     const query = editModal.formData.sport.trim().toLowerCase();
-    if (!query) return SPORTS_LIST;
-    return SPORTS_LIST.filter((sport) => sport.toLowerCase().includes(query));
-  }, [editModal.formData.sport, isSportQueryTouched]);
+    if (!query) return sportOptions;
+    return sportOptions.filter((sport) => sport.toLowerCase().includes(query));
+  }, [editModal.formData.sport, isSportQueryTouched, sportOptions]);
 
   const filteredLeaguesList = useMemo(() => {
     if (!isLeagueQueryTouched) {
-      return LEAGUES_LIST;
+      return leagueOptions;
     }
     const query = editModal.formData.league.trim().toLowerCase();
-    if (!query) return LEAGUES_LIST;
-    return LEAGUES_LIST.filter((league) => league.toLowerCase().includes(query));
-  }, [editModal.formData.league, isLeagueQueryTouched]);
+    if (!query) return leagueOptions;
+    return leagueOptions.filter((league) => league.toLowerCase().includes(query));
+  }, [editModal.formData.league, isLeagueQueryTouched, leagueOptions]);
 
   const filteredBettingMarketsList = useMemo(() => {
     if (!isBettingMarketQueryTouched) {
-      return BETTING_MARKETS_LIST;
+      return marketOptions;
     }
     const query = editModal.formData.betting_market.trim().toLowerCase();
-    if (!query) return BETTING_MARKETS_LIST;
-    return BETTING_MARKETS_LIST.filter((market) => market.toLowerCase().includes(query));
-  }, [editModal.formData.betting_market, isBettingMarketQueryTouched]);
+    if (!query) return marketOptions;
+    return marketOptions.filter((market) => market.toLowerCase().includes(query));
+  }, [editModal.formData.betting_market, isBettingMarketQueryTouched, marketOptions]);
 
   useEffect(() => {
     if (!isSportDropdownOpen || filteredSportsList.length === 0) {
@@ -3777,30 +3822,46 @@ export default function Bets() {
                     />
                     {isSportDropdownOpen && (
                       <div className="theme-rebrand absolute z-50 mt-1 w-full max-h-48 overflow-auto rounded-md border border-line bg-white shadow-[0_10px_30px_-10px_rgba(0,0,0,0.15)]">
-                        {filteredSportsList.length > 0 ? (
-                          filteredSportsList.map((sport, index) => (
-                            <button
-                              key={sport}
-                              type="button"
-                              tabIndex={-1}
-                              ref={(element) => {
-                                sportItemRefs.current[index] = element;
-                              }}
-                              onMouseDown={(event) => {
-                                event.preventDefault();
-                                setEditModal(prev => ({ ...prev, formData: { ...prev.formData, sport } }));
-                                setIsSportDropdownOpen(false);
-                                setIsSportQueryTouched(false);
-                                setSportHighlightIndex(-1);
-                              }}
-                              className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                                index === sportHighlightIndex ? 'bg-ink-3/40' : ''
-                              }`}
-                            >
-                              {sport}
-                            </button>
-                          ))
-                        ) : (
+                        {filteredSportsList.map((sport, index) => (
+                          <button
+                            key={sport}
+                            type="button"
+                            tabIndex={-1}
+                            ref={(element) => {
+                              sportItemRefs.current[index] = element;
+                            }}
+                            onMouseDown={(event) => {
+                              event.preventDefault();
+                              setEditModal(prev => ({ ...prev, formData: { ...prev.formData, sport } }));
+                              setIsSportDropdownOpen(false);
+                              setIsSportQueryTouched(false);
+                              setSportHighlightIndex(-1);
+                            }}
+                            className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
+                              index === sportHighlightIndex ? 'bg-ink-3/40' : ''
+                            }`}
+                          >
+                            {sport}
+                          </button>
+                        ))}
+                        {editModal.formData.sport.trim() && !vocabHasValue(editModal.formData.sport, sportOptions) && (
+                          <button
+                            type="button"
+                            tabIndex={-1}
+                            onMouseDown={(event) => {
+                              event.preventDefault();
+                              const added = canonicalizeVocab(editModal.formData.sport, sportOptions);
+                              setEditModal(prev => ({ ...prev, formData: { ...prev.formData, sport: added } }));
+                              setIsSportDropdownOpen(false);
+                              setIsSportQueryTouched(false);
+                              setSportHighlightIndex(-1);
+                            }}
+                            className="w-full text-left px-3 py-2 text-sm text-forest font-medium hover:bg-forest-tint border-t border-line"
+                          >
+                            ＋ Adicionar "{editModal.formData.sport.trim()}"
+                          </button>
+                        )}
+                        {filteredSportsList.length === 0 && !editModal.formData.sport.trim() && (
                           <div className="px-3 py-2 text-xs text-ink-2">
                             Nenhum esporte encontrado
                           </div>
@@ -3884,30 +3945,46 @@ export default function Bets() {
                     />
                     {isLeagueDropdownOpen && (
                       <div className="theme-rebrand absolute z-50 mt-1 w-full max-h-48 overflow-auto rounded-md border border-line bg-white shadow-[0_10px_30px_-10px_rgba(0,0,0,0.15)]">
-                        {filteredLeaguesList.length > 0 ? (
-                          filteredLeaguesList.map((league, index) => (
-                            <button
-                              key={league}
-                              type="button"
-                              tabIndex={-1}
-                              ref={(element) => {
-                                leagueItemRefs.current[index] = element;
-                              }}
-                              onMouseDown={(event) => {
-                                event.preventDefault();
-                                setEditModal(prev => ({ ...prev, formData: { ...prev.formData, league } }));
-                                setIsLeagueDropdownOpen(false);
-                                setIsLeagueQueryTouched(false);
-                                setLeagueHighlightIndex(-1);
-                              }}
-                              className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                                index === leagueHighlightIndex ? 'bg-ink-3/40' : ''
-                              }`}
-                            >
-                              {league}
-                            </button>
-                          ))
-                        ) : (
+                        {filteredLeaguesList.map((league, index) => (
+                          <button
+                            key={league}
+                            type="button"
+                            tabIndex={-1}
+                            ref={(element) => {
+                              leagueItemRefs.current[index] = element;
+                            }}
+                            onMouseDown={(event) => {
+                              event.preventDefault();
+                              setEditModal(prev => ({ ...prev, formData: { ...prev.formData, league } }));
+                              setIsLeagueDropdownOpen(false);
+                              setIsLeagueQueryTouched(false);
+                              setLeagueHighlightIndex(-1);
+                            }}
+                            className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
+                              index === leagueHighlightIndex ? 'bg-ink-3/40' : ''
+                            }`}
+                          >
+                            {league}
+                          </button>
+                        ))}
+                        {editModal.formData.league.trim() && !vocabHasValue(editModal.formData.league, leagueOptions) && (
+                          <button
+                            type="button"
+                            tabIndex={-1}
+                            onMouseDown={(event) => {
+                              event.preventDefault();
+                              const added = canonicalizeVocab(editModal.formData.league, leagueOptions);
+                              setEditModal(prev => ({ ...prev, formData: { ...prev.formData, league: added } }));
+                              setIsLeagueDropdownOpen(false);
+                              setIsLeagueQueryTouched(false);
+                              setLeagueHighlightIndex(-1);
+                            }}
+                            className="w-full text-left px-3 py-2 text-sm text-forest font-medium hover:bg-forest-tint border-t border-line"
+                          >
+                            ＋ Adicionar "{editModal.formData.league.trim()}"
+                          </button>
+                        )}
+                        {filteredLeaguesList.length === 0 && !editModal.formData.league.trim() && (
                           <div className="px-3 py-2 text-xs text-ink-2">
                             Nenhuma liga encontrada
                           </div>
@@ -3987,30 +4064,46 @@ export default function Bets() {
                     />
                     {isBettingMarketDropdownOpen && (
                       <div className="theme-rebrand absolute z-50 mt-1 w-full max-h-48 overflow-auto rounded-md border border-line bg-white shadow-[0_10px_30px_-10px_rgba(0,0,0,0.15)]">
-                        {filteredBettingMarketsList.length > 0 ? (
-                          filteredBettingMarketsList.map((market, index) => (
-                            <button
-                              key={market}
-                              type="button"
-                              tabIndex={-1}
-                              ref={(element) => {
-                                bettingMarketItemRefs.current[index] = element;
-                              }}
-                              onMouseDown={(event) => {
-                                event.preventDefault();
-                                setEditModal(prev => ({ ...prev, formData: { ...prev.formData, betting_market: market } }));
-                                setIsBettingMarketDropdownOpen(false);
-                                setIsBettingMarketQueryTouched(false);
-                                setBettingMarketHighlightIndex(-1);
-                              }}
-                              className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                                index === bettingMarketHighlightIndex ? 'bg-ink-3/40' : ''
-                              }`}
-                            >
-                              {market}
-                            </button>
-                          ))
-                        ) : (
+                        {filteredBettingMarketsList.map((market, index) => (
+                          <button
+                            key={market}
+                            type="button"
+                            tabIndex={-1}
+                            ref={(element) => {
+                              bettingMarketItemRefs.current[index] = element;
+                            }}
+                            onMouseDown={(event) => {
+                              event.preventDefault();
+                              setEditModal(prev => ({ ...prev, formData: { ...prev.formData, betting_market: market } }));
+                              setIsBettingMarketDropdownOpen(false);
+                              setIsBettingMarketQueryTouched(false);
+                              setBettingMarketHighlightIndex(-1);
+                            }}
+                            className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
+                              index === bettingMarketHighlightIndex ? 'bg-ink-3/40' : ''
+                            }`}
+                          >
+                            {market}
+                          </button>
+                        ))}
+                        {editModal.formData.betting_market.trim() && !vocabHasValue(editModal.formData.betting_market, marketOptions) && (
+                          <button
+                            type="button"
+                            tabIndex={-1}
+                            onMouseDown={(event) => {
+                              event.preventDefault();
+                              const added = canonicalizeVocab(editModal.formData.betting_market, marketOptions);
+                              setEditModal(prev => ({ ...prev, formData: { ...prev.formData, betting_market: added } }));
+                              setIsBettingMarketDropdownOpen(false);
+                              setIsBettingMarketQueryTouched(false);
+                              setBettingMarketHighlightIndex(-1);
+                            }}
+                            className="w-full text-left px-3 py-2 text-sm text-forest font-medium hover:bg-forest-tint border-t border-line"
+                          >
+                            ＋ Adicionar "{editModal.formData.betting_market.trim()}"
+                          </button>
+                        )}
+                        {filteredBettingMarketsList.length === 0 && !editModal.formData.betting_market.trim() && (
                           <div className="px-3 py-2 text-xs text-ink-2">
                             Nenhum mercado encontrado
                           </div>
@@ -4027,7 +4120,11 @@ export default function Bets() {
                   <Input
                     type="number"
                     value={editModal.formData.stake_amount}
-                    onChange={(e) => setEditModal(prev => ({ ...prev, formData: { ...prev.formData, stake_amount: e.target.value } }))}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      const ret = calcReturnStr(v, editModal.formData.odds, editModal.formData.is_credit_bet);
+                      setEditModal(prev => ({ ...prev, formData: { ...prev.formData, stake_amount: v, ...(ret !== null ? { potential_return: ret } : {}) } }));
+                    }}
                     className="h-10 bg-canvas border-line text-ink rounded-md focus:border-forest focus:bg-white tabular"
                   />
                 </div>
@@ -4036,17 +4133,44 @@ export default function Bets() {
                   <Input
                     type="number"
                     value={editModal.formData.odds}
-                    onChange={(e) => setEditModal(prev => ({ ...prev, formData: { ...prev.formData, odds: e.target.value } }))}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      const ret = calcReturnStr(editModal.formData.stake_amount, v, editModal.formData.is_credit_bet);
+                      setEditModal(prev => ({ ...prev, formData: { ...prev.formData, odds: v, ...(ret !== null ? { potential_return: ret } : {}) } }));
+                    }}
                     className="h-10 bg-canvas border-line text-ink rounded-md focus:border-forest focus:bg-white tabular"
                   />
                 </div>
+              </div>
+
+              {/* Retorno pago editável — casa às vezes paga diferente de stake×odd
+                  (bônus de odd alta). Editar o retorno reajusta a odd pra enquadrar. */}
+              <div className="space-y-2">
+                <Label className="text-[10px] uppercase tracking-[0.12em] text-ink-2 font-semibold">Retorno pago (R$)</Label>
+                <Input
+                  type="number"
+                  value={editModal.formData.potential_return}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    const od = calcOddsStr(editModal.formData.stake_amount, v, editModal.formData.is_credit_bet);
+                    setEditModal(prev => ({ ...prev, formData: { ...prev.formData, potential_return: v, ...(od !== null ? { odds: od } : {}) } }));
+                  }}
+                  className="h-10 bg-canvas border-line text-ink rounded-md focus:border-forest focus:bg-white tabular"
+                />
+                <p className="text-[11px] leading-snug text-ink-2">
+                  A casa pagou diferente por causa de bônus? Ajuste o valor pago aqui — a odd se reajusta sozinha pra bater com a banca.
+                </p>
               </div>
 
               <div className="flex items-center gap-3">
                 <Label className="text-[10px] uppercase tracking-[0.12em] text-ink-2 font-semibold">Crédito de apostas</Label>
                 <button
                   type="button"
-                  onClick={() => setEditModal(prev => ({ ...prev, formData: { ...prev.formData, is_credit_bet: !prev.formData.is_credit_bet } }))}
+                  onClick={() => setEditModal(prev => {
+                    const nextCredit = !prev.formData.is_credit_bet;
+                    const ret = calcReturnStr(prev.formData.stake_amount, prev.formData.odds, nextCredit);
+                    return { ...prev, formData: { ...prev.formData, is_credit_bet: nextCredit, ...(ret !== null ? { potential_return: ret } : {}) } };
+                  })}
                   style={{ backgroundColor: editModal.formData.is_credit_bet ? 'var(--forest)' : '#d1d5db' }}
                   className="relative w-10 h-5 rounded-full transition-colors flex-shrink-0"
                 >
@@ -4145,9 +4269,9 @@ export default function Bets() {
         open={isCreateModalOpen}
         onOpenChange={setIsCreateModalOpen}
         onCreate={createBet}
-        sportsList={SPORTS_LIST}
-        leaguesList={LEAGUES_LIST}
-        bettingMarketsList={BETTING_MARKETS_LIST}
+        sportsList={sportOptions}
+        leaguesList={leagueOptions}
+        bettingMarketsList={marketOptions}
         userTags={userTags}
         onTagsUpdated={fetchUserTags}
       />

--- a/src/utils/betVocab.ts
+++ b/src/utils/betVocab.ts
@@ -1,0 +1,56 @@
+// ============================================================
+// betVocab.ts — vocabulário de esporte/liga/mercado das apostas
+// ============================================================
+// Os campos sport/league/betting_market são texto livre no banco. Pra o usuário
+// poder criar valores próprios SEM fragmentar o dashboard dele, a lista de cada
+// combobox é: base curada ∪ os valores que ELE já usou (por usuário — o custom
+// de um não aparece pro outro). E ao salvar, "encaixamos" no canônico existente
+// (mesmo valor com caixa/espaço diferente vira o mesmo balde). Isso evita que
+// "Over/Under", "over under" e "Over/under" virem 3 mercados distintos.
+
+// Normaliza pra comparação: minúsculas, sem acento, espaços colapsados.
+function normKey(s: string): string {
+  return s
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// Lista final do dropdown: base curada primeiro (na ordem original), depois os
+// valores próprios do usuário que não existem na base — ordenados. Dedupe é
+// case/acento-insensível, sempre preferindo a grafia canônica da base.
+export function mergeVocab(curated: string[], used: Array<string | null | undefined>): string[] {
+  const seen = new Set(curated.map(normKey));
+  const extras: string[] = [];
+  const extrasSeen = new Set<string>();
+  for (const raw of used) {
+    const value = (raw ?? "").trim().replace(/\s+/g, " ");
+    if (!value) continue;
+    const key = normKey(value);
+    if (seen.has(key) || extrasSeen.has(key)) continue;
+    extrasSeen.add(key);
+    extras.push(value);
+  }
+  extras.sort((a, b) => a.localeCompare(b, "pt-BR"));
+  return [...curated, ...extras];
+}
+
+// Ao salvar: limpa o valor e, se já existir um equivalente na lista, encaixa na
+// grafia canônica dele; senão mantém o que o usuário digitou (trim). É o que
+// impede a fragmentação por caixa/acento/espaço.
+export function canonicalizeVocab(value: string, options: string[]): string {
+  const clean = (value ?? "").trim().replace(/\s+/g, " ");
+  if (!clean) return "";
+  const key = normKey(clean);
+  const match = options.find((o) => normKey(o) === key);
+  return match ?? clean;
+}
+
+// Existe um valor equivalente (case/acento-insensível) na lista?
+export function vocabHasValue(value: string, options: string[]): boolean {
+  const key = normKey(value.trim());
+  if (!key) return false;
+  return options.some((o) => normKey(o) === key);
+}


### PR DESCRIPTION
Duas melhorias pedidas por usuários, no modal de aposta (**editar** e **criar**). Tudo **frontend**, sem migration/backend.

## 1) Retorno pago editável (bônus de odd alta)
Algumas casas pagam **diferente de stake×odd** num bônus sem lógica fixa. Agora, no modal de edição, o campo **Retorno pago (R$)** é editável e a **odd se reajusta sozinha** pra enquadrar (odd efetiva = `retorno/stake`; `retorno/stake+1` em freebet). Vínculo de mão dupla: editar stake/odd recalcula o retorno; editar o retorno recalcula a odd.

Por que é seguro: **lucro/ROI leem `potential_return` em todo lugar** do app, então gravar o retorno editado deixa tudo consistente. Reusa as colunas `odds`/`potential_return` — **sem migration**.

## 2) Esporte / liga / mercado custom **por usuário** (sem fragmentar o dashboard)
Os campos já eram texto livre no banco, mas a UI travava a criação e, se solta, fragmentaria o dashboard da pessoa. Solução:
- **lista do combobox = base curada ∪ os valores que ESTE usuário já usou** (deriva das apostas em memória; **o custom de um não aparece pro outro** — per-user);
- **"＋ Adicionar 'X'"** quando o valor não existe (afordância explícita — resolve a queixa de "não dá pra criar");
- **`canonicalizeVocab` ao salvar**: encaixa no valor equivalente existente (case/acento/espaço) pra `over/under` e `Over/Under` não virarem 2 baldes.

Vale pro modal de **editar e criar**.

## Arquivos
- `src/utils/betVocab.ts` (novo): helper puro — `mergeVocab` / `canonicalizeVocab` / `vocabHasValue`.
- `src/pages/Bets.tsx`: campo Retorno + vínculo stake⇄odd⇄retorno; dropdowns com "＋ Adicionar"; canonização no `updateBetData` e no `createBet`; opções mescladas passadas ao CreateBetModal.
- `src/components/bets/CreateBetModal.tsx`: dropdowns com "＋ Adicionar" (listas já chegam mescladas via props).

## Validação
- **`tsc --noEmit` limpo** (EXIT=0).
- **Ensaio no dev server apontando pro staging** (conta real, 99 apostas): editar retorno 292,5 → **350** recalculou a **odd pra 2,33**; **"＋ Adicionar"** aparece nos 3 campos (o Playwright pegou que eu tinha esquecido o campo Mercado no modal de criar — corrigido); deep-link `?edit=` reabriu o modal certinho.

## Escopo / risco
- Feito em worktree isolado; o PR carrega **apenas** este diff vs develop (nada da sessão paralela de Landing/Flux).
- **Fragmentação é por usuário** (não global): o custom de um não vaza pro dropdown de outro; a base curada segue igual pra todos. A metodologia/Score de futebol não lê `bets.betting_market`, então fica insulada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)