### PR TITLE
feat(daily): CTA 'ver o porquê' com destino inteligente + teto de reativação 2→5

### DIFF
--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -138,7 +138,7 @@ async function buildMessage(picks: BoardRow[], userId: string): Promise<string> 
       ""
     );
   }
-  lines.push(`<i>Score = confiabilidade da oportunidade (0–100), calculado contra a linha sharp do mercado.</i>`);
+  lines.push(`<i>Score 0–100: quanto mais alto, mais confiança na pick.</i>`);
   return lines.join("\n");
 }
 
@@ -154,7 +154,14 @@ function registerButtons(picks: BoardRow[], pickIdByFixture: Map<number, string>
   return rows;
 }
 
-async function sendDaily(chatId: string, text: string, boardUrl: string, pickRows: any[]): Promise<void> {
+// CTA do site com destino inteligente: 1 pick → tela daquele jogo; 2+ → board.
+// Copy promete o "porquê" (a DM traz só 1 evidência; o site tem o raio-x completo).
+function ctaSpec(picks: BoardRow[]): { label: string; dest: string } {
+  if (picks.length === 1) return { label: "Ver o porquê dessa pick →", dest: `jogo-${picks[0].fixture_id}` };
+  return { label: "Ver o porquê de cada pick →", dest: "board" };
+}
+
+async function sendDaily(chatId: string, text: string, ctaUrl: string, ctaLabel: string, pickRows: any[]): Promise<void> {
   const res = await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -163,7 +170,7 @@ async function sendDaily(chatId: string, text: string, boardUrl: string, pickRow
       text,
       parse_mode: "HTML",
       disable_web_page_preview: true,
-      reply_markup: { inline_keyboard: [...pickRows, [{ text: "Ver a análise completa", url: boardUrl }]] },
+      reply_markup: { inline_keyboard: [...pickRows, [{ text: ctaLabel, url: ctaUrl }]] },
     }),
   });
   if (!res.ok) throw new Error(`telegram ${res.status}: ${await res.text()}`);
@@ -251,8 +258,9 @@ serve(async (req) => {
     for (const r of recipients) {
       try {
         const text = await buildMessage(picks, r.user_id);
-        const boardUrl = await trackedUrl(r.user_id, "board");
-        await sendDaily(r.chat_id, text, boardUrl, pickButtonRows);
+        const cta = ctaSpec(picks);
+        const ctaUrl = await trackedUrl(r.user_id, cta.dest);
+        await sendDaily(r.chat_id, text, ctaUrl, cta.label, pickButtonRows);
 
         const { error: upErr } = await supabase.from("opportunity_dispatch_state").upsert({
           user_id: r.user_id,

--- a/supabase/migrations/090_opportunity_reactivation_cap.sql
+++ b/supabase/migrations/090_opportunity_reactivation_cap.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- 090_opportunity_reactivation_cap — afrouxa o teto da reativação (2 → 5)
+-- ============================================================
+-- O daily de oportunidades (08′) tem 2 públicos (ver 081):
+--   A · futebol ativo   — recebe SEMPRE, sem teto.
+--   B · reativação      — Telegram linkado + inativo. Tinha teto de 2 envios
+--                         sem clique; 2 era agressivo demais e cortava gente
+--                         que ainda podia reengajar (ex.: sócios/base fria).
+-- Decisão de produto (2026-07-22): sobe pra 5 envios sem clique antes de parar.
+-- Só muda o número da regra do B — o A segue sem teto.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.get_opportunity_recipients()
+RETURNS TABLE(user_id uuid, chat_id text, user_name text, segment text, sends_without_click integer)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  WITH base AS (
+    SELECT u.id, u.telegram_chat_id, u.name,
+           (coalesce(u.futebol_subscription_status,'free') = 'premium'
+             OR (u.futebol_trial_started_at IS NOT NULL
+                 AND u.futebol_trial_started_at + interval '7 days' > now())) AS futebol_ativo,
+           (SELECT max(b.bet_date) FROM bets b WHERE b.user_id = u.id) AS ultima_aposta
+    FROM users u
+    WHERE u.telegram_chat_id IS NOT NULL
+      AND coalesce(u.settlement_reminders_muted, false) = false
+  )
+  SELECT b.id, b.telegram_chat_id::text, b.name::text,
+         CASE WHEN b.futebol_ativo THEN 'A' ELSE 'B' END AS segment,
+         coalesce(s.sends_without_click, 0)
+  FROM base b
+  LEFT JOIN opportunity_dispatch_state s ON s.user_id = b.id
+  WHERE b.futebol_ativo
+     OR (
+       -- reativação: inativo há 14+ dias (ou nunca apostou) e regra dos 5 envios
+       (b.ultima_aposta IS NULL OR b.ultima_aposta < now() - interval '14 days')
+       AND coalesce(s.sends_without_click, 0) < 5
+     );
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_opportunity_recipients() TO service_role;


### PR DESCRIPTION
Ajustes no **daily de oportunidades (08′)**, a partir da investigação do caso do Lucas (não recebeu por causa do teto de reativação).

## O que muda
1. **CTA do site com destino inteligente + copy provocativa**
   - **1 pick no dia** → botão leva **direto pra tela daquele jogo** (`/futebol/jogo/<id>`): *"Ver o porquê dessa pick →"*
   - **2+ picks** → botão vai pro **board** (`/futebol`): *"Ver o porquê de cada pick →"*
   - Antes era sempre *"Ver a análise completa"* → board, e o único link pro jogo era o título (fácil de não perceber no Telegram).
2. **Linha do Score enxuta**: `Score 0–100: quanto mais alto, mais confiança na pick.` (tirei o "calculado contra a linha sharp do mercado").
3. **Teto da reativação 2 → 5** (migration **090**): o segmento B (reativação: Telegram linkado + inativo) parava depois de 2 envios sem clique — agressivo demais, cortou o Lucas. Agora são 5. O segmento A (futebol ativo) segue **sem teto**.
4. **MAX_PICKS mantém 3** — o "pouco" de alguns dias é **oferta** (poucos jogos acima do corte Score ≥ 40), não teto.

## Por que (contexto)
O sócio Lucas não recebeu o daily: estava no segmento **B** (free + inativo desde jan), recebeu os **2** envios sem clicar → o teto cortou. Não era assinatura — era a régua anti-spam da reativação. Subir pra 5 dá mais chances de reconquistar antes de desistir.

## Validação
- `deno check` da função **OK**; suíte de testes **98/98**.
- Ensaio no Telegram (staging) após o merge.
- ⚠️ A **migration 090 mexe numa função do banco** — só passa a valer em **produção após o release develop→main** (do sócio). Pro Lucas não trava nada (agora é segmento A pelo trial).

## Escopo
- Só `notify-opportunities/index.ts` + migration 090. Sem frontend, sem mexer no motor de valor (lê o mesmo board do site).
- Worktree isolado; nada da sessão paralela de Landing/Flux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)