### PR TITLE
perf(bundle): chunk inicial -64% (1.637kB → 520kB) via lazy routes + dynamic import + manualChunks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,11 +6,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AchievementProvider } from "@/components/bolao/AchievementProvider";
 import { BrowserRouter, Routes, Route, Outlet } from "react-router-dom";
 import { BolaoLayout } from "@/components/bolao/BolaoLayout";
+// Única página eager: a landing raiz ("/") — porta de entrada, paint
+// instantâneo sem roundtrip de chunk. Todo o resto é lazy.
 import LandingEcossistema from "./pages/LandingEcossistema";
-import Landing from "./pages/Landing";
-import Auth from "./pages/Auth";
-import Picks from "./pages/Picks";
-import NBADashboard from "./pages/NBADashboard";
 import ProtectedRoute from "./components/ProtectedRoute";
 import PremiumRoute from "./components/PremiumRoute";
 import { PostHogPageView } from "./components/PostHogPageView";
@@ -25,6 +23,12 @@ import { lazyWithRetry } from "./lib/lazy-with-retry";
 // cacheada tenta carregar chunk inexistente -> "Failed to fetch dynamically
 // imported module" -> tela branca). Helper força reload uma vez por sessão
 // pra pegar build novo.
+// Landing/Auth/Picks/NBADashboard eram eager e inflavam o chunk inicial —
+// NBADashboard puxava o recharts (~400kB) pra TODA página do site.
+const Landing = lazyWithRetry(() => import("./pages/Landing"));
+const Auth = lazyWithRetry(() => import("./pages/Auth"));
+const Picks = lazyWithRetry(() => import("./pages/Picks"));
+const NBADashboard = lazyWithRetry(() => import("./pages/NBADashboard"));
 const Betinho = lazyWithRetry(() => import("./pages/Betinho"));
 const Onboarding = lazyWithRetry(() => import("./pages/Onboarding"));
 const Inicio = lazyWithRetry(() => import("./pages/Inicio"));

--- a/src/components/bolao/AchievementProvider.tsx
+++ b/src/components/bolao/AchievementProvider.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
-import html2canvas from 'html2canvas';
 import { Trophy, Target, Medal, Star, Flame, Award, Share2 } from 'lucide-react';
 import { AchievementShareImage } from '@/components/bolao/AchievementShareImage';
 import { shareImage } from '@/components/bolao/share-utils';
@@ -125,6 +124,9 @@ const AchievementBadge: React.FC<{ def: AchievementDef }> = ({ def }) => {
     if (sharing || !captureRef.current) return;
     setSharing(true);
     try {
+      // html2canvas (~200kB) só é usado aqui, no clique de compartilhar — o
+      // dynamic import tira ele do chunk inicial (o Provider envolve o app todo).
+      const { default: html2canvas } = await import('html2canvas');
       const canvas = await html2canvas(captureRef.current, {
         backgroundColor: null,
         scale: 2,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,17 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // Fatia só libs pesadas e estáveis em chunks próprios: hash não muda
+        // entre deploys do app → navegador reaproveita o cache. De propósito
+        // NÃO fatiamos react/react-dom (risco de erro de ordem de inicialização).
+        manualChunks(id) {
+          if (id.includes("node_modules/recharts")) return "recharts";
+          if (id.includes("node_modules/@supabase")) return "supabase";
+        },
+      },
+    },
+  },
 }));


### PR DESCRIPTION
Frente de performance planejada e aprovada: o chunk principal carregava **1.637 kB (470 kB gzip)** em toda página. Diagnóstico achou 3 vilões — todos acidente de import:

| Vilão | Causa | Correção |
|---|---|---|
| `recharts` (~400 kB) no inicial | `NBADashboard` era import estático no App.tsx | rota vira `lazyWithRetry` (padrão das outras 40) |
| `html2canvas` (~200 kB) no inicial | import no topo do `AchievementProvider` (eager, envolve o app), usado só no clique de share | dynamic `import()` dentro do `handleShare` |
| Páginas grandes eager | `Picks` (1.186 linhas, atrás de login!), `Landing`, `Auth` estáticos | viram `lazyWithRetry` |

Mais um `manualChunks` mínimo no vite.config (`recharts`, `supabase`) pra hash estável entre deploys → melhor cache. **React/react-dom ficam de fora de propósito** (evita risco de erro de ordem de inicialização).

`LandingEcossistema` ("/") **continua eager** — porta de entrada, paint instantâneo.

## Resultado (vite build)

| | antes | depois |
|---|---|---|
| chunk principal | 1.637 kB (470 gzip) | **520 kB (170 gzip)** |
| download inicial | 1.637 kB | 520 + 117 (supabase, paralelo/cacheável) |
| recharts | no inicial | chunk lazy 536 kB (só páginas de gráfico) |
| html2canvas | no inicial | chunk 201 kB (só no clique de share) |

## Verificação
- `tsc`: nenhum erro novo nos arquivos tocados (o `LucideIcon` do AchievementProvider é pré-existente, só mudou de linha).
- `vitest`: 88/89 — o 1 que falha (`MatchPredictionCard` debounce) **já falha na base limpa** `origin/develop` (confirmado via stash); pré-existente, não relacionado. Fica o registro pro time.
- Chrome headless nas rotas afetadas: `/` (controle), `/nba`, `/auth` (formulário renderiza), `/nba-dashboard/Nikola Jokic` (recharts carrega sob demanda e desenha). Todas OK.
- Risco de chunk órfão pós-deploy já coberto pelo `lazyWithRetry` existente (reload 1×/sessão).

Sugestão de teste no preview: navegar `/` → `/nba` → `/auth` → um dashboard de jogador, e um fluxo de share de conquista no bolão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)