### PR TITLE
feat(seo): SEO da /planos — <Seo> + Product/Offer + sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -31,6 +31,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://www.smartbetting.app/planos</loc>
+    <lastmod>2026-07-24</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://www.smartbetting.app/bolao</loc>
     <lastmod>2026-07-22</lastmod>
     <changefreq>weekly</changefreq>

--- a/scripts/gen-sitemap.mjs
+++ b/scripts/gen-sitemap.mjs
@@ -24,6 +24,7 @@ const ROUTES = [
   { path: "/futebol", changefreq: "daily", priority: "0.9", lastmod: "2026-07-22" },
   { path: "/futebol/comecar", changefreq: "weekly", priority: "0.8", lastmod: "2026-07-22" },
   { path: "/betinho", changefreq: "weekly", priority: "0.8", lastmod: "2026-07-22" },
+  { path: "/planos", changefreq: "weekly", priority: "0.8", lastmod: "2026-07-24" },
   { path: "/bolao", changefreq: "weekly", priority: "0.7", lastmod: "2026-07-22" },
   { path: "/bolao/comecar", changefreq: "weekly", priority: "0.7", lastmod: "2026-07-22" },
   { path: "/como-usar", changefreq: "monthly", priority: "0.6", lastmod: "2026-07-22" },

--- a/src/pages/Planos.tsx
+++ b/src/pages/Planos.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Check, Flame } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { useAuth } from '@/hooks/use-auth';
+import { Seo, SITE_URL } from '@/components/Seo';
 
 type Billing = 'monthly' | 'annual';
 
@@ -25,6 +26,53 @@ const TH: Record<'essencial' | 'completo', Record<Billing, string>> = {
 };
 
 const EYEBROW = 'text-[11px] font-bold uppercase tracking-[0.16em] text-forest-2';
+
+// JSON-LD dos planos DERIVADO do PRICES acima — nunca hardcode preço aqui:
+// o Google exige que o structured data bata com o que a página exibe, e
+// derivando não tem drift quando os valores (hoje placeholders) mudarem.
+const brl = (s: string) => s.replace(/\./g, '').replace(',', '.');
+const annualTotal = (billed: string) => {
+  const m = billed.match(/R\$\s*([\d.,]+)\/ano/);
+  return m ? brl(m[1]) : null;
+};
+const PLANS_JSONLD = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  itemListElement: [
+    {
+      '@type': 'Product',
+      name: 'Smart Betting Grátis',
+      description: 'Porta de entrada do ecossistema: registre apostas com o Betinho e acompanhe o futebol com limites do plano grátis.',
+      brand: { '@type': 'Brand', name: 'Smart Betting' },
+      offers: { '@type': 'Offer', price: '0', priceCurrency: 'BRL', url: `${SITE_URL}/planos` },
+    },
+    ...(['essencial', 'completo'] as const).map((tier) => ({
+      '@type': 'Product',
+      name: `Smart Betting ${tier === 'essencial' ? 'Essencial' : 'Completo'}`,
+      description:
+        tier === 'essencial'
+          ? 'Futebol completo (Brasileirão e Copa) + Betinho ilimitado. Teste grátis de 7 dias.'
+          : 'Tudo do Essencial + análise NBA completa (prop bets e Análise 360). Teste grátis de 7 dias.',
+      brand: { '@type': 'Brand', name: 'Smart Betting' },
+      offers: [
+        {
+          '@type': 'Offer',
+          name: 'Mensal',
+          price: brl(PRICES[tier].monthly.amount),
+          priceCurrency: 'BRL',
+          url: `${SITE_URL}/planos`,
+        },
+        {
+          '@type': 'Offer',
+          name: 'Anual',
+          price: annualTotal(PRICES[tier].annual.billed) ?? brl(PRICES[tier].annual.amount),
+          priceCurrency: 'BRL',
+          url: `${SITE_URL}/planos`,
+        },
+      ],
+    })),
+  ],
+};
 
 function PriceBlock({ tier, billing }: { tier: 'essencial' | 'completo'; billing: Billing }) {
   const p = PRICES[tier][billing];
@@ -72,6 +120,12 @@ export default function Planos() {
 
   return (
     <div className="theme-bolao min-h-screen bg-canvas flex flex-col">
+      <Seo
+        path="/planos"
+        title="Planos e Preços — Futebol, NBA e Betinho | Smart Betting"
+        description="Um plano, todo o ecossistema: comece grátis, assine o Essencial (futebol + Betinho ilimitado) ou o Completo (tudo + NBA). Teste grátis de 7 dias, sem fidelidade."
+        jsonLd={PLANS_JSONLD}
+      />
       <AnalyticsNav variant="rebrand" />
 
       {/* Promo de lançamento */}


### PR DESCRIPTION
Conferi: a `/planos` entrou no develop pelo **#227** sem tratamento de SEO — sem `<Seo>` (nada de title/description/canonical próprios), sem structured data e fora do sitemap. Como página de preço é **busca de alta intenção** ("smartbetting planos", "smart betting preço"), vale ligar. Invisível na UI, só `<head>`.

## O que entra
- **`<Seo>`** na [Planos.tsx](src/pages/Planos.tsx): title "Planos e Preços — Futebol, NBA e Betinho", description e canonical `/planos`.
- **JSON-LD `ItemList`** com os 3 `Product` (Grátis / Essencial / Completo) e `Offer` mensal + anual → o preço pode aparecer direto no resultado do Google.
- **`/planos` no `gen-sitemap.mjs`** (10 → 11 URLs).

## Decisão importante: preço derivado, não duplicado
Os preços do JSON-LD são **derivados do `const PRICES`** que a página já renderiza — não estão hardcoded no schema. Dois motivos:
1. O Google exige que o structured data **bata com o conteúdo visível**; divergência = "mismatch" e ele descarta.
2. Os valores hoje são **placeholders** (comentário no arquivo: "Trocar quando o modelo de cobrança fechar"). Derivando, quando o preço mudar o schema acompanha sozinho — sem risco de ficar desatualizado.

## Verificação
Build de produção servido localmente + Chrome headless em `/planos`:
- `<title>` e `<link rel="canonical">` corretos.
- 3 blocos `ld+json` (Organization + WebApplication do index.html, + o ItemList novo).
- Preços parseados: Essencial `39.90` mensal / `383` anual; Completo `89.90` / `863`; Grátis `0` — todos BRL, batendo com a tela.
- `tsc` limpo nos arquivos tocados; sitemap com 11 URLs.

Sugestão pós-deploy: rodar a URL no **Rich Results Test** do Google e conferir a aba Produtos no Search Console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)