### PR TITLE
feat(futebol): expansão multi-liga + histórico green/red + todas oportunidades por jogo

### DIFF
--- a/src/components/FutebolDayStepper.tsx
+++ b/src/components/FutebolDayStepper.tsx
@@ -1,3 +1,4 @@
+import { useRef, useEffect } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 const TZ = 'America/Sao_Paulo';
@@ -35,11 +36,20 @@ function dayParts(s: string): { wd: string; d: string; mon: string } {
 export default function FutebolDayStepper({
   days, value, onChange, counts, className = '',
 }: { days: string[]; value: string; onChange: (d: string) => void; counts?: Record<string, number>; className?: string }) {
+  const activeRef = useRef<HTMLButtonElement>(null);
+  // Mantém o dia selecionado sempre visível (centralizado) — navegação fluida.
+  useEffect(() => {
+    const reduce = typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    activeRef.current?.scrollIntoView({ inline: 'center', block: 'nearest', behavior: reduce ? 'auto' : 'smooth' });
+  }, [value]);
+
   if (!days.length) return null;
   const today = todayStr();
   const i = days.indexOf(value);
   const hasPrev = i > 0;
   const hasNext = i >= 0 && i < days.length - 1;
+  const isTodayView = value === today;
+  const hasToday = days.includes(today);
   const arrow = 'w-9 h-9 grid place-items-center rounded-md shrink-0 border border-line bg-white text-ink-2 enabled:hover:bg-canvas-2 disabled:opacity-30 disabled:cursor-default transition';
 
   return (
@@ -55,11 +65,16 @@ export default function FutebolDayStepper({
           return (
             <button
               key={s}
+              ref={active ? activeRef : undefined}
               type="button"
               onClick={() => onChange(s)}
               title={dayLabel(s)}
               className={`flex items-center gap-2 rounded-full px-3 h-9 shrink-0 border transition ${
-                active ? 'bg-forest text-canvas border-forest' : 'bg-transparent border-line text-ink hover:bg-canvas-2'
+                active
+                  ? 'bg-forest text-canvas border-forest'
+                  : isToday
+                  ? 'bg-forest-tint border-forest text-forest'
+                  : 'bg-transparent border-line text-ink hover:bg-canvas-2'
               }`}
             >
               <span className="text-[10px] uppercase tracking-[0.16em] font-semibold opacity-70">{wd}</span>
@@ -74,6 +89,16 @@ export default function FutebolDayStepper({
       <button type="button" className={arrow} disabled={!hasNext} onClick={() => hasNext && onChange(days[i + 1])} aria-label="Próximo dia">
         <ChevronRight className="w-4 h-4" />
       </button>
+      {/* Atalho pra voltar pro dia de hoje quando a navegação se afasta */}
+      {!isTodayView && hasToday && (
+        <button
+          type="button"
+          onClick={() => onChange(today)}
+          className="shrink-0 h-9 px-3 rounded-md border border-forest bg-forest-tint text-forest text-[11px] font-bold uppercase tracking-[0.1em] hover:bg-forest hover:text-canvas transition"
+        >
+          Hoje
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/futebol/RegistrarAposta.tsx
+++ b/src/components/futebol/RegistrarAposta.tsx
@@ -15,9 +15,8 @@ import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { createClient } from '@/integrations/supabase/client';
 import { useAuth } from '@/hooks/use-auth';
 import { pickLabel, marketLabel } from '@/utils/futebol-score';
+import { competitionLabel } from '@/utils/futebol-competitions';
 import type { FutebolBetDraft } from './registrar-aposta-utils';
-
-const COMP_LABEL: Record<string, string> = { brasileirao: 'Brasileirão', copa_mundo: 'Copa do Mundo', serie_b: 'Série B' };
 
 function kickoffDate(raw: string | null): string | null {
   if (!raw) return null;
@@ -50,7 +49,7 @@ export function RegistrarApostaModal({
   const pick = draft ? pickLabel(draft.market, draft.outcome, draft.lineValue, draft.homeName, draft.awayName) : '';
   const match = draft ? `${draft.homeName} x ${draft.awayName}` : '';
   const mkt = draft ? marketLabel(draft.market) : '';
-  const league = draft ? (COMP_LABEL[draft.competition] || draft.competition) : '';
+  const league = draft ? competitionLabel(draft.competition) : '';
 
   const stakeN = parseFloat(stake.replace(',', '.'));
   const oddN = parseFloat(odd.replace(',', '.'));

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -1,4 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { useAuth } from '@/hooks/use-auth';
 import {
   futebolDataService,
@@ -46,6 +47,36 @@ export function useFutebolFixtures(competition: Competition, season: number, rou
     gcTime: 15 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
+}
+
+/**
+ * Fixtures de VÁRIAS competições de uma vez (uma query por liga, em paralelo).
+ * Achata tudo taggeando cada jogo com sua `competition`. Usado no /futebol
+ * (Hoje) pra listar jogos de todas as ligas, não só de um allowlist fixo.
+ */
+export function useFutebolFixturesMulti(competitions: string[], season: number) {
+  const results = useQueries({
+    queries: competitions.map((competition) => ({
+      queryKey: ['futebol', 'fixtures', competition, season, 'all'],
+      queryFn: () => futebolDataService.getFixtures(competition, season),
+      staleTime: 5 * 60 * 1000,
+      gcTime: 15 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    })),
+  });
+  const isLoading = results.some((r) => r.isLoading);
+  // react-query faz structural sharing → o ref de r.data só muda quando o dado
+  // muda; memoizar por esses refs evita reflatten a cada render.
+  const dataRefs = results.map((r) => r.data);
+  const data = useMemo(
+    () =>
+      results.flatMap((r, i) =>
+        (r.data ?? []).map((f) => ({ ...f, competition: competitions[i] }))
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [...dataRefs, competitions]
+  );
+  return { data, isLoading };
 }
 
 export function useFutebolFixtureDetail(fixtureId: number | undefined) {

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -4,18 +4,18 @@ import { Zap, ArrowRight, Check, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Seo } from '@/components/Seo';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useFutebolFixtures, useFutebolValueBoard, useFutebolFixtureValue, useFutebolAccess } from '@/hooks/use-futebol-data';
+import { useFutebolFixturesMulti, useFutebolValueBoard, useFutebolFixtureValue, useFutebolAccess } from '@/hooks/use-futebol-data';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
+import { competitionLabel, ALL_COMPETITIONS } from '@/utils/futebol-competitions';
 import {
   pickLabel, marketLabel, fmtEdgeScore, freqEmDez, groupBoardByFixture,
   faixaBadgeCls, faixaWord, faixaTone, topEvidencia, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
-import type { FutebolFixture, FutebolValueBoardRow } from '@/services/futebol-data.service';
+import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
 
 const SAO_PAULO_TZ = 'America/Sao_Paulo';
-const COMP_LABEL: Record<string, string> = { brasileirao: 'Brasileirão', copa_mundo: 'Copa do Mundo', serie_b: 'Série B' };
 // Quantos dias futuros (com jogos) o navegador mostra — janela curta, não a temporada toda.
 const DAY_WINDOW = 8;
 
@@ -108,7 +108,7 @@ function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow
             style={d ? { background: '#fbbf24', color: '#1a1d1a' } : undefined}>
             <Zap className="w-3 h-3" /> {d ? 'Melhor valor do dia' : 'Melhor do dia · Média'}
           </span>
-          <div className={`text-[11px] uppercase tracking-[0.16em] font-semibold mt-5 ${d ? 'text-white/50' : 'text-ink-3'}`}>{marketLabel(o.market)} · {COMP_LABEL[o.competition] || o.competition}</div>
+          <div className={`text-[11px] uppercase tracking-[0.16em] font-semibold mt-5 ${d ? 'text-white/50' : 'text-ink-3'}`}>{marketLabel(o.market)} · {competitionLabel(o.competition)}</div>
           <div className={`text-[28px] md:text-[32px] font-bold tracking-tight leading-[1.1] mt-2 ${d ? '' : 'text-ink'}`}><Blur active={!!locked} strength={9}>{pick}</Blur></div>
           <div className={`flex items-center gap-1.5 text-[13px] mt-2 ${d ? 'text-white/70' : 'text-ink-2'}`}>
             <Crest teamId={o.home_team_id} name={o.home_team_name} size={18} />
@@ -235,21 +235,15 @@ function GameRailRow({ f, best, onClick }: { f: FutebolFixture & { competition?:
 
 export default function FutebolHoje() {
   const navigate = useNavigate();
-  const { data: brasil, isLoading: l1 } = useFutebolFixtures('brasileirao', 2026);
-  const { data: copa, isLoading: l2 } = useFutebolFixtures('copa_mundo', 2026);
-  const { data: serieB, isLoading: l2b } = useFutebolFixtures('serie_b', 2026);
+  // Todas as ligas do mart (data-driven), não mais um allowlist de 3.
+  const { data: allGames, isLoading: lFix } = useFutebolFixturesMulti(ALL_COMPETITIONS, 2026);
   const { data: valueRows, isLoading: l3 } = useFutebolValueBoard();
   const { data: access } = useFutebolAccess();
   const locked = !access?.unlocked;
-  const loading = l1 || l2 || l2b || l3;
+  const loading = lFix || l3;
 
   const todayStr = brtDateStr(new Date());
   const [day, setDay] = useState<string | null>(null);
-
-  const allGames = useMemo(() => {
-    const tag = (arr: FutebolFixture[] | undefined, c: string) => (arr || []).map((f) => ({ ...f, competition: c }));
-    return [...tag(brasil, 'brasileirao'), ...tag(copa, 'copa_mundo'), ...tag(serieB, 'serie_b')];
-  }, [brasil, copa, serieB]);
 
   // dias (BRT) com jogos ainda não começados — base da navegação por dias.
   // Limita aos próximos dias (não varre a temporada inteira do Brasileirão).

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -320,8 +320,8 @@ export default function FutebolHoje() {
     <div className="theme-bolao min-h-screen bg-canvas flex flex-col">
       <Seo
         path="/futebol"
-        title="Futebol Hoje — Oportunidades de Valor no Brasileirão e Copa | Smart Betting"
-        description="Os jogos de hoje com o Score de Confiabilidade: onde a odd da casa paga mais do que o risco real. Brasileirão, Série B e Copa do Mundo, atualizado todo dia."
+        title="Futebol Hoje — Oportunidades de Valor no Brasil, América do Sul e Europa | Smart Betting"
+        description="Os jogos de hoje com o Score de Confiabilidade: onde a odd da casa paga mais do que o risco real. As principais competições do Brasil, América do Sul e Europa, atualizado todo dia."
       />
       <AnalyticsNav variant="rebrand" />
       {!loading && days.length > 0 && (

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -671,6 +671,7 @@ export default function FutebolJogo() {
   const finished = fixture?.status_short === 'FT' || fixture?.status_short === 'AET' || fixture?.status_short === 'PEN';
   // jogo encerrado/iniciado não é mais oportunidade: esconde o "O que olhar" (vira só descritivo)
   const showValue = !finished && !!valueRows && valueRows.length > 0;
+  const hasPlayed = finished && !!valueRows && valueRows.length > 0; // registro pós-jogo
 
   const playerStats = extras?.player_stats || [];
   const statsById = new Map<number, FutebolPlayerStat>(
@@ -743,17 +744,21 @@ export default function FutebolJogo() {
               </div>
             </div>
 
-            {/* Jogo encerrado: registro das oportunidades mapeadas + resultado (green/red) */}
-            {finished && valueRows && valueRows.length > 0 && (
-              <div className="mt-5">
-                <PlayedOpportunities rows={valueRows} homeName={fixture.home_team_name} awayName={fixture.away_team_name} goalsHome={fixture.goals_home} goalsAway={fixture.goals_away} />
+            {/* Jogo ENCERRADO: oportunidades (resultado) + nosso modelo, lado a lado (~40/60) */}
+            {finished && (hasPlayed || tendencies) && (
+              <div className={`mt-5 grid gap-5 items-start ${hasPlayed && tendencies ? 'lg:grid-cols-[2fr_3fr]' : 'grid-cols-1'}`}>
+                {hasPlayed && valueRows && (
+                  <PlayedOpportunities rows={valueRows} homeName={fixture.home_team_name} awayName={fixture.away_team_name} goalsHome={fixture.goals_home} goalsAway={fixture.goals_away} />
+                )}
+                {tendencies && (
+                  <ModelCard tendencies={tendencies} head={head} homeName={fixture.home_team_name} awayName={fixture.away_team_name} />
+                )}
               </div>
             )}
 
-            {showValue && <FutebolAccessBanner access={access} className="mt-5" />}
-
-            {/* Veredito + nosso modelo de gols (lado a lado) */}
-            {(showValue || tendencies) && (
+            {/* Jogo FUTURO: acesso + veredito + nosso modelo, lado a lado */}
+            {!finished && showValue && <FutebolAccessBanner access={access} className="mt-5" />}
+            {!finished && (showValue || tendencies) && (
               <div className={`mt-5 grid gap-5 items-start ${showValue && tendencies ? 'lg:grid-cols-[1.5fr_1fr]' : 'grid-cols-1'}`}>
                 {showValue && valueRows && (
                   <WhatToWatch rows={valueRows} homeName={fixture.home_team_name} awayName={fixture.away_team_name} competition={fixture.competition} kickoffUtc={fixture.kickoff_utc} locked={locked} />
@@ -764,7 +769,7 @@ export default function FutebolJogo() {
               </div>
             )}
 
-            {/* Explorar mercados — largura total */}
+            {/* Explorar mercados — largura total (só pré-jogo, é interativo pra decidir) */}
             {showValue && valueRows && (
               <div className="mt-5">
                 <ResultExplorer rows={valueRows} homeName={fixture.home_team_name} awayName={fixture.away_team_name} locked={locked} />

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -16,6 +16,7 @@ import {
   pickLabel, marketLabel, valorVerdict, fmtEdgeScore,
   faixaWord, faixaBadgeCls, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
+import { settleFutebol, resultBadge, type BetResult } from '@/utils/futebol-settlement';
 import type {
   FutebolEvent, FutebolFormResult, FutebolInjury, FutebolLineupPlayer, FutebolPlayerStat, FutebolTeamStats, FutebolFixtureValueRow, FutebolTeamProfile, Competition,
 } from '@/services/futebol-data.service';
@@ -303,6 +304,48 @@ const CARD = 'bg-white border border-line rounded-rebrand-xl';
 
 // ---------- "O que olhar": Score vem PRONTO do backend (fact_value_opportunities) ----------
 // Síntese "O que olhar neste jogo" — decide e PROVA a melhor aposta (Score do backend)
+// Selo de resultado (jogo encerrado): Green / Meio green / Anulada / Meio red / Red.
+function ResultBadge({ r }: { r: BetResult }) {
+  const b = resultBadge(r);
+  const style = b.tone === 'won' ? { background: '#dcefe2', color: '#0a3d2e' }
+    : b.tone === 'push' ? { background: '#eef0ec', color: '#5a625a' }
+    : { background: '#fbe3e8', color: '#be123c' };
+  return <span className="shrink-0 px-1.5 h-5 inline-flex items-center rounded text-[10px] font-bold uppercase tracking-[0.06em]" style={style}>{b.label}</span>;
+}
+
+// Oportunidades mapeadas de um jogo ENCERRADO + como performaram (green/red).
+function PlayedOpportunities({ rows, homeName, awayName, goalsHome, goalsAway }: {
+  rows: FutebolFixtureValueRow[]; homeName: string; awayName: string; goalsHome: number | null; goalsAway: number | null;
+}) {
+  const valueOpps = [...rows].filter((r) => r.score >= SCORE_MEDIA).sort((a, b) => b.score - a.score);
+  if (!valueOpps.length) return null;
+  return (
+    <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
+      <div className="px-5 py-3 flex items-center justify-between bg-canvas-2 border-b border-line">
+        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Oportunidades deste jogo</div>
+        <span className="text-[11px] text-ink-3">{valueOpps.length} mapeada{valueOpps.length === 1 ? '' : 's'} · como performaram</span>
+      </div>
+      {valueOpps.map((o) => {
+        const res = settleFutebol(o.market, o.outcome, o.line_value, goalsHome, goalsAway);
+        const chance = chancePct(o.prob_justa_fechamento);
+        return (
+          <div key={`${o.market}-${o.outcome}-${o.line_value}`} className="px-5 py-3 border-t border-line flex items-center gap-3">
+            <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[15px] w-9 h-8 shrink-0 ${faixaBadgeCls(o.faixa)}`}>{o.score}</span>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-1.5 min-w-0">
+                <span className="text-[14px] font-semibold text-ink truncate">{pickLabel(o.market, o.outcome, o.line_value, homeName, awayName)}</span>
+                {res && <ResultBadge r={res} />}
+              </div>
+              <div className="text-[11px] text-ink-3 truncate">{marketLabel(o.market)}{chance != null ? ` · ${chance}%` : ''} · odd {o.best_odd.toFixed(2)}</div>
+            </div>
+          </div>
+        );
+      })}
+      <p className="px-5 py-2.5 text-[10px] text-ink-3 border-t border-line">Resultado calculado pelo placar final. Não é recomendação.</p>
+    </div>
+  );
+}
+
 function WhatToWatch({ rows, homeName, awayName, competition, kickoffUtc, locked }: { rows: FutebolFixtureValueRow[]; homeName: string; awayName: string; competition: string; kickoffUtc: string | null; locked?: boolean }) {
   const ranked = [...rows].sort((a, b) => b.score - a.score);
   const valueOpps = ranked.filter((r) => r.score >= SCORE_MEDIA); // todas as mapeadas (com valor)
@@ -674,6 +717,13 @@ export default function FutebolJogo() {
                 </button>
               </div>
             </div>
+
+            {/* Jogo encerrado: registro das oportunidades mapeadas + resultado (green/red) */}
+            {finished && valueRows && valueRows.length > 0 && (
+              <div className="mt-5">
+                <PlayedOpportunities rows={valueRows} homeName={fixture.home_team_name} awayName={fixture.away_team_name} goalsHome={fixture.goals_home} goalsAway={fixture.goals_away} />
+              </div>
+            )}
 
             {showValue && <FutebolAccessBanner access={access} className="mt-5" />}
 

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -16,7 +16,7 @@ import {
   pickLabel, marketLabel, valorVerdict, fmtEdgeScore,
   faixaWord, faixaBadgeCls, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
-import { settleFutebol, resultBadge, type BetResult } from '@/utils/futebol-settlement';
+import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import type {
   FutebolEvent, FutebolFormResult, FutebolInjury, FutebolLineupPlayer, FutebolPlayerStat, FutebolTeamStats, FutebolFixtureValueRow, FutebolTeamProfile, Competition,
 } from '@/services/futebol-data.service';
@@ -305,12 +305,21 @@ const CARD = 'bg-white border border-line rounded-rebrand-xl';
 // ---------- "O que olhar": Score vem PRONTO do backend (fact_value_opportunities) ----------
 // Síntese "O que olhar neste jogo" — decide e PROVA a melhor aposta (Score do backend)
 // Selo de resultado (jogo encerrado): Green / Meio green / Anulada / Meio red / Red.
-function ResultBadge({ r }: { r: BetResult }) {
+// Cor + texto (não só cor) e um ponto pra reforçar o estado à distância.
+function ResultBadge({ r, big }: { r: BetResult; big?: boolean }) {
   const b = resultBadge(r);
-  const style = b.tone === 'won' ? { background: '#dcefe2', color: '#0a3d2e' }
-    : b.tone === 'push' ? { background: '#eef0ec', color: '#5a625a' }
-    : { background: '#fbe3e8', color: '#be123c' };
-  return <span className="shrink-0 px-1.5 h-5 inline-flex items-center rounded text-[10px] font-bold uppercase tracking-[0.06em]" style={style}>{b.label}</span>;
+  const c = b.tone === 'won' ? { bg: '#dcefe2', fg: '#0a3d2e', dot: '#2f7d50' }
+    : b.tone === 'push' ? { bg: '#eef0ec', fg: '#5a625a', dot: '#8a8f86' }
+    : { bg: '#fbe3e8', fg: '#be123c', dot: '#be123c' };
+  return (
+    <span
+      className={`shrink-0 inline-flex items-center gap-1.5 rounded-full font-bold uppercase tracking-[0.06em] ${big ? 'h-7 px-2.5 text-[11px]' : 'h-5 px-1.5 text-[10px]'}`}
+      style={{ background: c.bg, color: c.fg }}
+    >
+      <span className="w-1.5 h-1.5 rounded-full" style={{ background: c.dot }} />
+      {b.label}
+    </span>
+  );
 }
 
 // Oportunidades mapeadas de um jogo ENCERRADO + como performaram (green/red).
@@ -319,28 +328,44 @@ function PlayedOpportunities({ rows, homeName, awayName, goalsHome, goalsAway }:
 }) {
   const valueOpps = [...rows].filter((r) => r.score >= SCORE_MEDIA).sort((a, b) => b.score - a.score);
   if (!valueOpps.length) return null;
+
+  const settled = valueOpps.map((o) => ({ o, r: settleFutebol(o.market, o.outcome, o.line_value, goalsHome, goalsAway) }));
+  const greens = settled.filter((s) => s.r && isHit(s.r)).length;
+  const reds = settled.filter((s) => s.r === 'lost' || s.r === 'half_lost').length;
+  const voids = settled.filter((s) => s.r === 'push').length;
+
   return (
     <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
-      <div className="px-5 py-3 flex items-center justify-between bg-canvas-2 border-b border-line">
-        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Oportunidades deste jogo</div>
-        <span className="text-[11px] text-ink-3">{valueOpps.length} mapeada{valueOpps.length === 1 ? '' : 's'} · como performaram</span>
+      <div className="px-5 py-3.5 flex items-center justify-between gap-3 bg-canvas-2 border-b border-line">
+        <div className="min-w-0">
+          <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Oportunidades deste jogo</div>
+          <div className="text-[11px] text-ink-3 mt-0.5">{valueOpps.length} mapeada{valueOpps.length === 1 ? '' : 's'} · resultado pelo placar</div>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          {greens > 0 && <span className="inline-flex items-center h-6 px-2 rounded-full text-[11px] font-bold tabular-nums" style={{ background: '#dcefe2', color: '#0a3d2e' }}>{greens} green</span>}
+          {reds > 0 && <span className="inline-flex items-center h-6 px-2 rounded-full text-[11px] font-bold tabular-nums" style={{ background: '#fbe3e8', color: '#be123c' }}>{reds} red</span>}
+          {voids > 0 && <span className="inline-flex items-center h-6 px-2 rounded-full text-[11px] font-bold tabular-nums" style={{ background: '#eef0ec', color: '#5a625a' }}>{voids} anul.</span>}
+        </div>
       </div>
-      {valueOpps.map((o) => {
-        const res = settleFutebol(o.market, o.outcome, o.line_value, goalsHome, goalsAway);
-        const chance = chancePct(o.prob_justa_fechamento);
-        return (
-          <div key={`${o.market}-${o.outcome}-${o.line_value}`} className="px-5 py-3 border-t border-line flex items-center gap-3">
-            <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[15px] w-9 h-8 shrink-0 ${faixaBadgeCls(o.faixa)}`}>{o.score}</span>
-            <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-1.5 min-w-0">
-                <span className="text-[14px] font-semibold text-ink truncate">{pickLabel(o.market, o.outcome, o.line_value, homeName, awayName)}</span>
-                {res && <ResultBadge r={res} />}
+      <div className="divide-y divide-line">
+        {settled.map(({ o, r }) => {
+          const chance = chancePct(o.prob_justa_fechamento);
+          const spine = !r ? 'border-l-line-2'
+            : isHit(r) ? 'border-l-[#2f7d50]'
+            : r === 'push' ? 'border-l-line-2'
+            : 'border-l-[#be123c]';
+          return (
+            <div key={`${o.market}-${o.outcome}-${o.line_value}`} className={`px-5 py-3.5 flex items-center gap-3.5 border-l-4 ${spine}`}>
+              <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[15px] w-9 h-9 shrink-0 ${faixaBadgeCls(o.faixa)}`}>{o.score}</span>
+              <div className="min-w-0 flex-1">
+                <div className="text-[14px] font-semibold text-ink truncate leading-tight">{pickLabel(o.market, o.outcome, o.line_value, homeName, awayName)}</div>
+                <div className="text-[11px] text-ink-3 truncate mt-0.5">{marketLabel(o.market)}{chance != null ? ` · ${chance}% chance` : ''} · odd {o.best_odd.toFixed(2)}</div>
               </div>
-              <div className="text-[11px] text-ink-3 truncate">{marketLabel(o.market)}{chance != null ? ` · ${chance}%` : ''} · odd {o.best_odd.toFixed(2)}</div>
+              {r && <ResultBadge r={r} big />}
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
       <p className="px-5 py-2.5 text-[10px] text-ink-3 border-t border-line">Resultado calculado pelo placar final. Não é recomendação.</p>
     </div>
   );

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -305,8 +305,9 @@ const CARD = 'bg-white border border-line rounded-rebrand-xl';
 // Síntese "O que olhar neste jogo" — decide e PROVA a melhor aposta (Score do backend)
 function WhatToWatch({ rows, homeName, awayName, competition, kickoffUtc, locked }: { rows: FutebolFixtureValueRow[]; homeName: string; awayName: string; competition: string; kickoffUtc: string | null; locked?: boolean }) {
   const ranked = [...rows].sort((a, b) => b.score - a.score);
-  const top = ranked[0];
-  const second = ranked[1];
+  const valueOpps = ranked.filter((r) => r.score >= SCORE_MEDIA); // todas as mapeadas (com valor)
+  const top = valueOpps[0];
+  const others = valueOpps.slice(1);
   const note = 'Leitura de risco, não recomendação de aposta.';
 
   if (!top) {
@@ -326,26 +327,13 @@ function WhatToWatch({ rows, homeName, awayName, competition, kickoffUtc, locked
   // Pontos de atenção: contras (premissas que não bateram) + avisos (penalidades)
   const atencao = [...(top.contras ?? []), ...(top.avisos ?? [])];
 
-  // Contexto entre mercados: por que o valor está NESTE mercado e não nos outros
-  const otherMarket = Array.from(new Set(rows.map((r) => r.market))).find((m) => m !== top.market);
-  let crossNote: string | null = null;
-  if (otherMarket) {
-    const ob = rows.filter((r) => r.market === otherMarket).reduce((b, r) => (r.score > b.score ? r : b));
-    const obPick = pickLabel(ob.market, ob.outcome, ob.line_value, homeName, awayName);
-    crossNote =
-      ob.score >= SCORE_MEDIA
-        ? `Neste jogo o valor está em ${marketLabel(top.market)}, mas também há valor em ${marketLabel(otherMarket)}: ${obPick} (score ${ob.score}).`
-        : `Neste jogo o valor está em ${marketLabel(top.market)}. Em ${marketLabel(otherMarket)} as odds estão mais equilibradas — nada se destaca (melhor opção: ${obPick}, score ${ob.score}).`;
-  }
-
   const vColor = verdict.toLowerCase().includes('forte') ? 'text-forest' : 'text-amber-2';
   const chance = chancePct(top.prob_justa_fechamento);
-  const secondChance = second ? chancePct(second.prob_justa_fechamento) : null;
 
   return (
     <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
       <div className="px-5 py-3 flex items-center justify-between bg-canvas-2 border-b border-line">
-        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">O que olhar neste jogo</div>
+        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">O que olhar neste jogo{valueOpps.length > 1 ? ` · ${valueOpps.length} oportunidades` : ''}</div>
         <span className={`text-[11px] font-semibold ${vColor}`}>{verdict}</span>
       </div>
       <div className="p-5 md:p-6 grid md:grid-cols-[1fr_260px] gap-6">
@@ -376,7 +364,6 @@ function WhatToWatch({ rows, homeName, awayName, competition, kickoffUtc, locked
               </ul>
             </div>
           )}
-          {crossNote && <p className="text-[12px] text-ink-3 mt-4 pt-3 border-t border-line"><Blur active={!!locked}>{crossNote}</Blur></p>}
         </div>
 
         {/* Painel de confiabilidade + 2ª opção */}
@@ -392,15 +379,22 @@ function WhatToWatch({ rows, homeName, awayName, competition, kickoffUtc, locked
               <div><div className="text-[9px] uppercase tracking-[0.14em] font-semibold text-white/50">Odd</div><div className="text-[18px] font-semibold tabular-nums leading-none mt-1"><Blur active={!!locked}>{top.best_odd.toFixed(2)}</Blur></div></div>
             </div>
           </div>
-          {second && (
+          {others.length > 0 && (
             <div className="rounded-rebrand-md p-3 bg-canvas-2 border border-line">
-              <div className="text-[9px] uppercase tracking-[0.16em] font-bold mb-1.5 text-ink-3">2ª opção</div>
-              <div className="flex items-center justify-between gap-2">
-                <div className="min-w-0">
-                  <div className="text-[13px] font-semibold tracking-tight text-ink truncate"><Blur active={!!locked}>{pickLabel(second.market, second.outcome, second.line_value, homeName, awayName)}</Blur></div>
-                  <div className="text-[10px] text-ink-3 truncate">{marketLabel(second.market)}<Blur active={!!locked}>{secondChance != null ? ` · ${secondChance}%` : ''} · {second.best_odd.toFixed(2)}</Blur></div>
-                </div>
-                <span className="text-[18px] font-semibold tabular-nums text-forest shrink-0">{second.score}</span>
+              <div className="text-[9px] uppercase tracking-[0.16em] font-bold mb-2 text-ink-3">Outras oportunidades neste jogo</div>
+              <div className="flex flex-col gap-2.5">
+                {others.map((o) => {
+                  const oc = chancePct(o.prob_justa_fechamento);
+                  return (
+                    <div key={`${o.market}-${o.outcome}-${o.line_value}`} className="flex items-center justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="text-[13px] font-semibold tracking-tight text-ink truncate"><Blur active={!!locked}>{pickLabel(o.market, o.outcome, o.line_value, homeName, awayName)}</Blur></div>
+                        <div className="text-[10px] text-ink-3 truncate">{marketLabel(o.market)}<Blur active={!!locked}>{oc != null ? ` · ${oc}%` : ''} · {o.best_odd.toFixed(2)}</Blur></div>
+                      </div>
+                      <span className={`text-[11px] font-bold tabular-nums px-1.5 h-5 inline-flex items-center rounded shrink-0 ${faixaBadgeCls(o.faixa)}`}>{o.score}</span>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -8,13 +8,15 @@ import type { Competition, FutebolFixture, FutebolStandingRow, FutebolLeaders, F
 import { futebolZone, FUTEBOL_ZONE_COLOR as ZONE_COLOR, FUTEBOL_ZONE_LABEL as ZONE_LABEL } from '@/services/futebol-data.service';
 import { getFutebolTeamLogoUrl, getFutebolPlayerPhotoUrl } from '@/utils/futebol-logos';
 import { groupBoardByFixture, faixaWord, faixaBadgeCls } from '@/utils/futebol-score';
+import { competitionLabel, ALL_COMPETITIONS } from '@/utils/futebol-competitions';
 
-const COMPETITIONS: { value: Competition; label: string }[] = [
-  { value: 'brasileirao', label: 'Brasileirão' },
-  { value: 'serie_b', label: 'Série B' },
-  { value: 'copa_mundo', label: 'Copa do Mundo' },
-];
-const SEASONS: Record<Competition, number[]> = { brasileirao: [2024, 2025, 2026], copa_mundo: [2026], serie_b: [2024, 2025, 2026] };
+const COMPETITIONS: { value: Competition; label: string }[] = ALL_COMPETITIONS.map((value) => ({
+  value,
+  label: competitionLabel(value),
+}));
+// Temporadas por competição. Brasileirão/Série B têm histórico; as demais, só 2026.
+const SEASONS_BY_COMP: Record<string, number[]> = { brasileirao: [2024, 2025, 2026], serie_b: [2024, 2025, 2026] };
+const seasonsFor = (c: string): number[] => SEASONS_BY_COMP[c] ?? [2026];
 const SAO_PAULO_TZ = 'America/Sao_Paulo';
 const TODAY = new Date();
 
@@ -225,7 +227,8 @@ export default function FutebolJogos() {
   // recente (SEASONS é crescente — o índice 0 é a mais ANTIGA, ex.: 2024).
   const handleCompetition = (c: Competition) => {
     setCompetition(c);
-    setSeason(SEASONS[c].includes(season) ? season : SEASONS[c][SEASONS[c].length - 1]);
+    const seasons = seasonsFor(c);
+    setSeason(seasons.includes(season) ? season : seasons[seasons.length - 1]);
   };
   const goTeam = (id: number) => navigate(`/futebol/time/${id}?c=${competition}&s=${season}`);
 
@@ -237,14 +240,14 @@ export default function FutebolJogos() {
       <div className="bg-white border-b border-line">
         <div className="max-w-[1480px] w-full mx-auto px-4 md:px-6 py-5 md:py-6 flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
           <div>
-            <div className="text-[11px] uppercase tracking-[0.2em] font-bold text-ink-3">{COMPETITIONS.find((c) => c.value === competition)?.label}</div>
+            <div className="text-[11px] uppercase tracking-[0.2em] font-bold text-ink-3">{competitionLabel(competition)}</div>
             <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{prettyRound(currentRound)}</h1>
             <p className="text-[13px] mt-1 text-ink-2">Rodadas, classificação e artilheiros · temporada {season}</p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             {COMPETITIONS.map((c) => <Pill key={c.value} active={competition === c.value} onClick={() => handleCompetition(c.value)}>{c.label}</Pill>)}
             <span className="w-px h-5 bg-line mx-1" />
-            {SEASONS[competition].map((s) => <Pill key={s} active={season === s} onClick={() => setSeason(s)}>{s}</Pill>)}
+            {seasonsFor(competition).map((s) => <Pill key={s} active={season === s} onClick={() => setSeason(s)}>{s}</Pill>)}
           </div>
         </div>
       </div>

--- a/src/pages/FutebolLP.tsx
+++ b/src/pages/FutebolLP.tsx
@@ -141,7 +141,7 @@ const FutebolLP = () => {
     },
     {
       q: "De onde vêm os dados?",
-      a: "Estatísticas oficiais dos jogos e odds pré-jogo das principais casas, do Brasileirão e da Copa do Mundo, atualizadas ao longo do dia.",
+      a: "Estatísticas oficiais dos jogos e odds pré-jogo das principais casas, das principais competições do Brasil, América do Sul e Europa, atualizadas ao longo do dia.",
     },
     {
       q: "Qual a taxa de acerto de vocês?",
@@ -154,8 +154,8 @@ const FutebolLP = () => {
       <Seo
         jsonLd={faqPageSchema(FAQ)}
         path="/futebol/comecar"
-        title="Aposta de Valor no Futebol — Brasileirão e Copa | Smart Betting"
-        description="Um Score de Confiabilidade que compara a chance real com a odd da casa e mostra onde a odd paga mais do que o risco. Brasileirão e Copa do Mundo. 7 dias grátis, sem cartão."
+        title="Aposta de Valor no Futebol — Brasil, América do Sul e Europa | Smart Betting"
+        description="Um Score de Confiabilidade que compara a chance real com a odd da casa e mostra onde a odd paga mais do que o risco. As principais competições do Brasil, América do Sul e Europa. 7 dias grátis, sem cartão."
       />
 
       {/* Nav */}
@@ -397,7 +397,7 @@ const FutebolLP = () => {
           <span className="hidden sm:inline text-amber-2">·</span>
           <span>Odds pré-jogo (não ao vivo)</span>
           <span className="hidden sm:inline text-amber-2">·</span>
-          <span>Brasileirão + Copa do Mundo</span>
+          <span>Brasil · América do Sul · Europa</span>
         </div>
       </section>
 

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -10,6 +10,7 @@ import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
 import { draftFromBoardRow } from '@/components/futebol/registrar-aposta-utils';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
+import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
 import {
   pickLabel, marketLabel, fmtEdgeScore, groupBoardByFixture,
   faixaBadgeCls, faixaWord, faixaTone, chancePct, SCORE_MEDIA,
@@ -17,7 +18,6 @@ import {
 import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
 
 const SAO_PAULO_TZ = 'America/Sao_Paulo';
-const COMP_LABEL: Record<string, string> = { brasileirao: 'Brasileirão', copa_mundo: 'Copa do Mundo', serie_b: 'Série B' };
 const FINISHED_STATUS = new Set(['FT', 'AET', 'PEN']);
 
 function kickoffMs(raw: string | null): number | null {
@@ -55,7 +55,7 @@ const DAY_WINDOW = 8;
 
 type MarketFilter = 'all' | 'match_winner' | 'goals_over_under' | 'asian_handicap' | 'btts' | 'double_chance';
 type FaixaFilter = 'all' | 'alta' | 'media';
-type CompFilter = 'all' | 'brasileirao' | 'copa_mundo' | 'serie_b';
+type CompFilter = string; // 'all' | slug da competição (data-driven)
 
 function Chip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
   return (
@@ -161,7 +161,7 @@ function OppRow({ o, onClick, muted, locked }: { o: FutebolValueBoardRow; onClic
       </div>
       <div className="min-w-0">
         <span className="px-1.5 h-5 inline-flex items-center rounded text-[10px] font-semibold uppercase tracking-[0.08em] bg-canvas-2 text-ink-2">{marketLabel(o.market)}</span>
-        <div className="text-[10px] mt-1 tabular-nums text-ink-3 truncate">{COMP_LABEL[o.competition] || o.competition} · {fmtHour(o.kickoff_utc)}</div>
+        <div className="text-[10px] mt-1 tabular-nums text-ink-3 truncate">{competitionLabel(o.competition)} · {fmtHour(o.kickoff_utc)}</div>
       </div>
       <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={!!locked}>{chance != null ? `${chance}%` : '—'}</Blur></div>
       <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={!!locked}>{o.best_odd.toFixed(2)}</Blur></div>
@@ -263,9 +263,7 @@ export default function FutebolOportunidades() {
   const faixaOptions = [{ value: 'all', label: 'Todas' }, { value: 'alta', label: 'Alta' }, { value: 'media', label: 'Média' }];
   const compOptions = [
     { value: 'all', label: 'Todas' },
-    ...(compsOnDay.has('brasileirao') ? [{ value: 'brasileirao', label: 'Brasileirão' }] : []),
-    ...(compsOnDay.has('serie_b') ? [{ value: 'serie_b', label: 'Série B' }] : []),
-    ...(compsOnDay.has('copa_mundo') ? [{ value: 'copa_mundo', label: 'Copa' }] : []),
+    ...sortCompetitions([...compsOnDay]).map((c) => ({ value: c, label: competitionLabel(c) })),
   ];
 
   const filtered = useMemo(

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -4,17 +4,18 @@ import { ChevronRight, ChevronDown, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Skeleton } from '@/components/ui/skeleton';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import { useFutebolValueBoard, useFutebolAccess } from '@/hooks/use-futebol-data';
+import { useFutebolValueBoard, useFutebolAccess, useFutebolFixturesMulti } from '@/hooks/use-futebol-data';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
 import { draftFromBoardRow } from '@/components/futebol/registrar-aposta-utils';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
-import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
+import { competitionLabel, sortCompetitions, ALL_COMPETITIONS } from '@/utils/futebol-competitions';
 import {
   pickLabel, marketLabel, fmtEdgeScore, groupBoardByFixture,
   faixaBadgeCls, faixaWord, faixaTone, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
+import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
 
 const SAO_PAULO_TZ = 'America/Sao_Paulo';
@@ -50,8 +51,6 @@ function Crest({ teamId, name, size = 20 }: { teamId: number; name: string; size
 
 const LABEL = 'text-[10px] uppercase tracking-[0.14em] font-bold text-ink-3';
 const GRID = 'grid grid-cols-[56px_64px_1fr_140px_64px_80px_72px_28px] gap-3 items-center';
-// Janela curta da navegação por dias (não varre a temporada inteira).
-const DAY_WINDOW = 8;
 
 type MarketFilter = 'all' | 'match_winner' | 'goals_over_under' | 'asian_handicap' | 'btts' | 'double_chance';
 type FaixaFilter = 'all' | 'alta' | 'media';
@@ -142,9 +141,14 @@ function FilterSelect({ label, value, options, onChange }: {
 }
 
 // Linha da tabela (desktop)
-function OppRow({ o, onClick, muted, locked }: { o: FutebolValueBoardRow; onClick: () => void; muted?: boolean; locked?: boolean }) {
+function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
+  o: FutebolValueBoardRow; onClick: () => void; muted?: boolean; locked?: boolean;
+  result?: BetResult | null; homeGoals?: number | null; awayGoals?: number | null;
+}) {
   const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
+  const showLock = !!locked && !result; // histórico (com resultado) é sempre visível
+  const hasScore = homeGoals != null && awayGoals != null;
   return (
     <button onClick={onClick} className={`${GRID} w-full text-left px-5 py-3 border-t border-line hover:bg-canvas-2 transition ${muted ? 'opacity-60' : ''}`}>
       <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[16px] w-10 h-9 ${faixaBadgeCls(o.faixa)}`}>{o.score}</span>
@@ -155,26 +159,38 @@ function OppRow({ o, onClick, muted, locked }: { o: FutebolValueBoardRow; onClic
           <Crest teamId={o.away_team_id} name={o.away_team_name} size={20} />
         </div>
         <div className="min-w-0">
-          <div className="text-[13px] font-semibold tracking-tight text-ink truncate"><Blur active={!!locked}>{pick}</Blur></div>
-          <div className="text-[11px] text-ink-3 truncate">{o.home_team_name} × {o.away_team_name}</div>
+          <div className="flex items-center gap-1.5 min-w-0">
+            <span className="text-[13px] font-semibold tracking-tight text-ink truncate"><Blur active={showLock}>{pick}</Blur></span>
+            {result && <ResultBadge r={result} />}
+          </div>
+          <div className="text-[11px] text-ink-3 truncate">
+            {hasScore
+              ? `${o.home_team_name} ${homeGoals} × ${awayGoals} ${o.away_team_name}`
+              : `${o.home_team_name} × ${o.away_team_name}`}
+          </div>
         </div>
       </div>
       <div className="min-w-0">
         <span className="px-1.5 h-5 inline-flex items-center rounded text-[10px] font-semibold uppercase tracking-[0.08em] bg-canvas-2 text-ink-2">{marketLabel(o.market)}</span>
         <div className="text-[10px] mt-1 tabular-nums text-ink-3 truncate">{competitionLabel(o.competition)} · {fmtHour(o.kickoff_utc)}</div>
       </div>
-      <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={!!locked}>{chance != null ? `${chance}%` : '—'}</Blur></div>
-      <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={!!locked}>{o.best_odd.toFixed(2)}</Blur></div>
-      <div className="text-right tabular-nums text-[14px] font-bold text-forest"><Blur active={!!locked}>{fmtEdgeScore(o.edge)}</Blur></div>
+      <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={showLock}>{chance != null ? `${chance}%` : '—'}</Blur></div>
+      <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={showLock}>{o.best_odd.toFixed(2)}</Blur></div>
+      <div className="text-right tabular-nums text-[14px] font-bold text-forest"><Blur active={showLock}>{fmtEdgeScore(o.edge)}</Blur></div>
       <ChevronRight className="w-4 h-4 text-ink-3 justify-self-end" />
     </button>
   );
 }
 
 // Card (mobile)
-function OppMobileCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClick: () => void; locked?: boolean }) {
+function OppMobileCard({ o, onClick, locked, result, homeGoals, awayGoals }: {
+  o: FutebolValueBoardRow; onClick: () => void; locked?: boolean;
+  result?: BetResult | null; homeGoals?: number | null; awayGoals?: number | null;
+}) {
   const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
+  const showLock = !!locked && !result;
+  const hasScore = homeGoals != null && awayGoals != null;
   return (
     <button onClick={onClick} className="w-full text-left rounded-rebrand-md p-3.5 bg-white border border-line">
       <div className="flex items-start gap-3">
@@ -183,12 +199,17 @@ function OppMobileCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClic
           <Crest teamId={o.away_team_id} name={o.away_team_name} size={24} />
         </div>
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1.5 flex-wrap">
             <span className="px-1.5 h-5 inline-flex items-center rounded text-[9px] font-semibold uppercase tracking-[0.08em] bg-canvas-2 text-ink-2">{marketLabel(o.market)}</span>
             <span className={`px-1.5 h-5 inline-flex items-center rounded text-[9px] font-bold uppercase tracking-[0.1em] ${faixaBadgeCls(o.faixa)}`}>{faixaWord(o.faixa)}</span>
+            {result && <ResultBadge r={result} />}
           </div>
-          <div className="text-[15px] font-semibold tracking-tight mt-1.5 text-ink"><Blur active={!!locked}>{pick}</Blur></div>
-          <div className="text-[11px] text-ink-3 truncate">{o.home_team_name} × {o.away_team_name} · {fmtHour(o.kickoff_utc)}</div>
+          <div className="text-[15px] font-semibold tracking-tight mt-1.5 text-ink"><Blur active={showLock}>{pick}</Blur></div>
+          <div className="text-[11px] text-ink-3 truncate">
+            {hasScore
+              ? `${o.home_team_name} ${homeGoals} × ${awayGoals} ${o.away_team_name} · ${fmtHour(o.kickoff_utc)}`
+              : `${o.home_team_name} × ${o.away_team_name} · ${fmtHour(o.kickoff_utc)}`}
+          </div>
         </div>
         <div className="text-right shrink-0">
           <div className="text-[8px] uppercase tracking-[0.14em] font-semibold text-ink-3">Score</div>
@@ -199,7 +220,7 @@ function OppMobileCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClic
         {[['Chance', chance != null ? `${chance}%` : '—'], ['Odd', o.best_odd.toFixed(2)], ['Valor', fmtEdgeScore(o.edge)]].map(([l, v], i) => (
           <div key={l}>
             <div className="text-[8px] uppercase tracking-[0.14em] font-semibold text-ink-3">{l}</div>
-            <div className={`text-[13px] font-semibold tabular-nums leading-none mt-0.5 ${i === 2 ? 'text-forest' : 'text-ink'}`}><Blur active={!!locked}>{v}</Blur></div>
+            <div className={`text-[13px] font-semibold tabular-nums leading-none mt-0.5 ${i === 2 ? 'text-forest' : 'text-ink'}`}><Blur active={showLock}>{v}</Blur></div>
           </div>
         ))}
       </div>
@@ -227,9 +248,23 @@ const Regua = () => (
   </div>
 );
 
+// Selo de resultado (histórico): Bateu / Anulada / Não bateu (verde/cinza/vermelho).
+function ResultBadge({ r }: { r: BetResult }) {
+  const b = resultBadge(r);
+  const style = b.tone === 'won' ? { background: '#dcefe2', color: '#0a3d2e' }
+    : b.tone === 'push' ? { background: '#eef0ec', color: '#5a625a' }
+    : { background: '#fbe3e8', color: '#be123c' };
+  return (
+    <span className="shrink-0 px-1.5 h-5 inline-flex items-center rounded text-[10px] font-bold uppercase tracking-[0.06em]" style={style}>
+      {b.label}
+    </span>
+  );
+}
+
 export default function FutebolOportunidades() {
   const navigate = useNavigate();
   const { data: rows, isLoading } = useFutebolValueBoard();
+  const { data: fixtures } = useFutebolFixturesMulti(ALL_COMPETITIONS, 2026);
   const { data: access } = useFutebolAccess();
   const locked = !access?.unlocked;
   const [mercado, setMercado] = useState<MarketFilter>('all');
@@ -237,28 +272,38 @@ export default function FutebolOportunidades() {
   const [comp, setComp] = useState<CompFilter>('all');
   const [day, setDay] = useState<string | null>(null);
 
-  // pré-jogo (só tempo) — base estável da navegação por dias
-  const timeUpcoming = useMemo(() => {
-    if (!rows?.length) return [];
-    const now = Date.now();
-    return rows.filter((r) => {
-      const t = kickoffMs(r.kickoff_utc);
-      return t != null && t > now && !FINISHED_STATUS.has(r.status_short ?? '');
-    });
-  }, [rows]);
+  const allRows = useMemo(() => rows ?? [], [rows]);
 
+  // Placar por fixture (pra liquidar os jogos já encerrados = histórico "bateu/não").
+  const goalsMap = useMemo(() => {
+    const m = new Map<number, { gh: number | null; ga: number | null }>();
+    (fixtures ?? []).forEach((f) => m.set(f.fixture_id, { gh: f.goals_home, ga: f.goals_away }));
+    return m;
+  }, [fixtures]);
+
+  const resultOf = (o: FutebolValueBoardRow): BetResult | null => {
+    if (!FINISHED_STATUS.has(o.status_short ?? '')) return null;
+    const g = goalsMap.get(o.fixture_id);
+    return g ? settleFutebol(o.market, o.outcome, o.line_value, g.gh, g.ga) : null;
+  };
+
+  // Dias com oportunidades (passado + futuro), asc — permite navegar pro histórico.
   const days = useMemo(() => {
     const set = new Set<string>();
-    timeUpcoming.forEach((r) => { const d = brtDayStr(r.kickoff_utc); if (d) set.add(d); });
-    return [...set].sort().slice(0, DAY_WINDOW);
-  }, [timeUpcoming]);
-  const selectedDay = (day && days.includes(day)) ? day : (days.includes(TODAY_BRT) ? TODAY_BRT : days[0]);
+    allRows.forEach((r) => { const d = brtDayStr(r.kickoff_utc); if (d) set.add(d); });
+    return [...set].sort();
+  }, [allRows]);
+  // Default: hoje se houver; senão o próximo dia futuro; senão o último disponível.
+  const selectedDay = (day && days.includes(day))
+    ? day
+    : (days.includes(TODAY_BRT) ? TODAY_BRT : (days.find((d) => d >= TODAY_BRT) ?? days[days.length - 1]));
+  const isPastDay = !!selectedDay && selectedDay < TODAY_BRT;
 
   const compsOnDay = useMemo(() => {
     const s = new Set<string>();
-    timeUpcoming.forEach((r) => { if (brtDayStr(r.kickoff_utc) === selectedDay) s.add(r.competition); });
+    allRows.forEach((r) => { if (brtDayStr(r.kickoff_utc) === selectedDay) s.add(r.competition); });
     return s;
-  }, [timeUpcoming, selectedDay]);
+  }, [allRows, selectedDay]);
 
   const faixaOptions = [{ value: 'all', label: 'Todas' }, { value: 'alta', label: 'Alta' }, { value: 'media', label: 'Média' }];
   const compOptions = [
@@ -267,14 +312,14 @@ export default function FutebolOportunidades() {
   ];
 
   const filtered = useMemo(
-    () => timeUpcoming.filter((r) => {
+    () => allRows.filter((r) => {
       if (brtDayStr(r.kickoff_utc) !== selectedDay) return false;
       if (mercado !== 'all' && r.market !== mercado) return false;
       if (faixa !== 'all' && faixaTone(r.faixa) !== faixa) return false;
       if (comp !== 'all' && r.competition !== comp) return false;
       return true;
     }),
-    [timeUpcoming, selectedDay, mercado, faixa, comp]
+    [allRows, selectedDay, mercado, faixa, comp]
   );
 
   const bestRows = useMemo(() => groupBoardByFixture(filtered).map((bf) => bf.best), [filtered]);
@@ -283,6 +328,36 @@ export default function FutebolOportunidades() {
   const nAlta = bestRows.filter((o) => faixaTone(o.faixa) === 'alta').length;
   const nMedia = bestRows.filter((o) => faixaTone(o.faixa) === 'media').length;
   const nBaixa = bestRows.filter((o) => faixaTone(o.faixa) === 'baixa').length;
+
+  // Contagem de oportunidades COM VALOR por dia (badge do stepper).
+  const countByDay = useMemo(() => {
+    const byDay = new Map<string, FutebolValueBoardRow[]>();
+    allRows.forEach((r) => {
+      const d = brtDayStr(r.kickoff_utc);
+      if (!d) return;
+      if (!byDay.has(d)) byDay.set(d, []);
+      byDay.get(d)!.push(r);
+    });
+    const out: Record<string, number> = {};
+    byDay.forEach((rs, d) => { out[d] = groupBoardByFixture(rs).map((bf) => bf.best).filter((o) => o.score >= SCORE_MEDIA).length; });
+    return out;
+  }, [allRows]);
+
+  // Resumo do dia passado: quantas das "com valor" bateram.
+  const resumo = useMemo(() => {
+    if (!isPastDay) return null;
+    let hit = 0, miss = 0, push = 0, settled = 0;
+    comValor.forEach((o) => {
+      const r = resultOf(o);
+      if (!r) return;
+      settled++;
+      if (r === 'push') push++;
+      else if (isHit(r)) hit++;
+      else miss++;
+    });
+    return { hit, miss, push, settled };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPastDay, comValor, goalsMap]);
 
   const go = (id: number) => navigate(`/futebol/jogo/${id}`);
   const key = (o: FutebolValueBoardRow) => `${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`;
@@ -295,7 +370,7 @@ export default function FutebolOportunidades() {
       {!isLoading && days.length > 0 && (
         <div className="bg-white border-b border-line">
           <div className="max-w-[1480px] w-full mx-auto px-4 md:px-6 py-3">
-            <FutebolDayStepper days={days} value={selectedDay} onChange={setDay} counts={Object.fromEntries(days.map((dd) => [dd, timeUpcoming.filter((r) => brtDayStr(r.kickoff_utc) === dd).length]))} />
+            <FutebolDayStepper days={days} value={selectedDay} onChange={setDay} counts={countByDay} />
           </div>
         </div>
       )}
@@ -304,9 +379,18 @@ export default function FutebolOportunidades() {
       <div className="bg-white border-b border-line">
         <div className="max-w-[1480px] w-full mx-auto px-4 md:px-6 py-5 md:py-6 flex items-end justify-between gap-4">
           <div>
-            <div className={LABEL}>Oportunidades</div>
-            <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{comValor.length} aposta{comValor.length === 1 ? '' : 's'} com valor</h1>
-            <p className="text-[13px] mt-1 text-ink-2">Onde a odd paga acima da chance estimada · ranqueado por confiabilidade</p>
+            <div className={LABEL}>{isPastDay ? 'Histórico' : 'Oportunidades'}</div>
+            {isPastDay && resumo && resumo.settled > 0 ? (
+              <>
+                <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{resumo.hit} de {resumo.settled} bateram</h1>
+                <p className="text-[13px] mt-1 text-ink-2">Resultado das oportunidades com valor deste dia{resumo.push > 0 ? ` · ${resumo.push} anulada${resumo.push === 1 ? '' : 's'}` : ''}</p>
+              </>
+            ) : (
+              <>
+                <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{comValor.length} aposta{comValor.length === 1 ? '' : 's'} com valor</h1>
+                <p className="text-[13px] mt-1 text-ink-2">{isPastDay ? 'Resultado das oportunidades com valor deste dia' : 'Onde a odd paga acima da chance estimada · ranqueado por confiabilidade'}</p>
+              </>
+            )}
           </div>
           {!isLoading && bestRows.length > 0 && (
             <div className="hidden sm:flex items-center gap-2">
@@ -333,10 +417,10 @@ export default function FutebolOportunidades() {
 
         {isLoading ? (
           <div className="space-y-2">{Array.from({ length: 6 }).map((_, i) => <Skeleton key={i} className="h-16 w-full bg-canvas-2 rounded-rebrand-md" />)}</div>
-        ) : bestRows.length === 0 ? (
+        ) : (isPastDay ? comValor.length === 0 : bestRows.length === 0) ? (
           <div className="rounded-rebrand-md bg-white border border-line p-6 text-center">
-            <p className="text-sm text-ink-2">Nenhum jogo com odds nesse filtro.</p>
-            <p className="text-xs text-ink-3 mt-1">As oportunidades aparecem quando há odds coletadas antes do jogo.</p>
+            <p className="text-sm text-ink-2">{isPastDay ? 'Nenhuma oportunidade com valor nesse dia.' : 'Nenhum jogo com odds nesse filtro.'}</p>
+            <p className="text-xs text-ink-3 mt-1">{isPastDay ? 'Só listamos aqui as apostas que sinalizamos com valor.' : 'As oportunidades aparecem quando há odds coletadas antes do jogo.'}</p>
           </div>
         ) : (
           <>
@@ -346,34 +430,42 @@ export default function FutebolOportunidades() {
                 <div>Score ↓</div><div>Faixa</div><div>Aposta</div><div>Mercado</div>
                 <div className="text-right">Chance</div><div className="text-right">Odd</div><div className="text-right">Valor</div><div />
               </div>
-              {comValor.map((o) => (
-                <div key={key(o)}>
-                  <OppRow o={o} onClick={() => go(o.fixture_id)} locked={locked} />
-                  {!locked && (
-                    <div className="px-5 pb-2 -mt-0.5">
-                      <RegistrarApostaCTA variant="text" draft={draftFromBoardRow(o)} />
-                    </div>
-                  )}
-                </div>
-              ))}
-              {semValor.length > 0 && <Regua />}
-              {semValor.map((o) => <OppRow key={key(o)} o={o} onClick={() => go(o.fixture_id)} muted locked={locked} />)}
+              {comValor.map((o) => {
+                const res = resultOf(o);
+                const g = goalsMap.get(o.fixture_id);
+                return (
+                  <div key={key(o)}>
+                    <OppRow o={o} onClick={() => go(o.fixture_id)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
+                    {!isPastDay && !locked && !res && (
+                      <div className="px-5 pb-2 -mt-0.5">
+                        <RegistrarApostaCTA variant="text" draft={draftFromBoardRow(o)} />
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+              {!isPastDay && semValor.length > 0 && <Regua />}
+              {!isPastDay && semValor.map((o) => <OppRow key={key(o)} o={o} onClick={() => go(o.fixture_id)} muted locked={locked} />)}
             </div>
 
             {/* Cards (mobile) */}
             <div className="md:hidden flex flex-col gap-2.5">
-              {comValor.map((o) => (
-                <div key={key(o)}>
-                  <OppMobileCard o={o} onClick={() => go(o.fixture_id)} locked={locked} />
-                  {!locked && <div className="px-1 pt-1.5"><RegistrarApostaCTA variant="text" draft={draftFromBoardRow(o)} /></div>}
-                </div>
-              ))}
-              {semValor.length > 0 && (
+              {comValor.map((o) => {
+                const res = resultOf(o);
+                const g = goalsMap.get(o.fixture_id);
+                return (
+                  <div key={key(o)}>
+                    <OppMobileCard o={o} onClick={() => go(o.fixture_id)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
+                    {!isPastDay && !locked && !res && <div className="px-1 pt-1.5"><RegistrarApostaCTA variant="text" draft={draftFromBoardRow(o)} /></div>}
+                  </div>
+                );
+              })}
+              {!isPastDay && semValor.length > 0 && (
                 <div className="flex items-center gap-2 py-1">
                   <span className="flex-1 h-px bg-line" /><span className="text-[11px] text-ink-3">sem valor claro</span><span className="flex-1 h-px bg-line" />
                 </div>
               )}
-              {semValor.map((o) => <div key={key(o)} className="opacity-60"><OppMobileCard o={o} onClick={() => go(o.fixture_id)} locked={locked} /></div>)}
+              {!isPastDay && semValor.map((o) => <div key={key(o)} className="opacity-60"><OppMobileCard o={o} onClick={() => go(o.fixture_id)} locked={locked} /></div>)}
             </div>
           </>
         )}

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -287,17 +287,29 @@ export default function FutebolOportunidades() {
     return g ? settleFutebol(o.market, o.outcome, o.line_value, g.gh, g.ga) : null;
   };
 
-  // Dias com oportunidades (passado + futuro), asc — permite navegar pro histórico.
+  // Dias no stepper: dias COM oportunidade (board = passado + presente) + dias
+  // FUTUROS com jogos agendados (fixtures, janela curta) — pra navegar pra frente
+  // mesmo antes das odds entrarem (~24h antes do jogo).
   const days = useMemo(() => {
     const set = new Set<string>();
     allRows.forEach((r) => { const d = brtDayStr(r.kickoff_utc); if (d) set.add(d); });
+    const now = Date.now();
+    const horizon = now + 8 * 864e5; // ~8 dias à frente
+    (fixtures ?? []).forEach((f) => {
+      const t = kickoffMs(f.kickoff_utc);
+      if (t != null && t > now && t < horizon && !FINISHED_STATUS.has(f.status_short ?? '')) {
+        const d = brtDayStr(f.kickoff_utc);
+        if (d) set.add(d);
+      }
+    });
     return [...set].sort();
-  }, [allRows]);
+  }, [allRows, fixtures]);
   // Default: hoje se houver; senão o próximo dia futuro; senão o último disponível.
   const selectedDay = (day && days.includes(day))
     ? day
     : (days.includes(TODAY_BRT) ? TODAY_BRT : (days.find((d) => d >= TODAY_BRT) ?? days[days.length - 1]));
   const isPastDay = !!selectedDay && selectedDay < TODAY_BRT;
+  const isFutureDay = !!selectedDay && selectedDay > TODAY_BRT;
 
   const compsOnDay = useMemo(() => {
     const s = new Set<string>();
@@ -420,8 +432,16 @@ export default function FutebolOportunidades() {
           <div className="space-y-2">{Array.from({ length: 6 }).map((_, i) => <Skeleton key={i} className="h-16 w-full bg-canvas-2 rounded-rebrand-md" />)}</div>
         ) : (isPastDay ? comValor.length === 0 : bestRows.length === 0) ? (
           <div className="rounded-rebrand-md bg-white border border-line p-6 text-center">
-            <p className="text-sm text-ink-2">{isPastDay ? 'Nenhuma oportunidade com valor nesse dia.' : 'Nenhum jogo com odds nesse filtro.'}</p>
-            <p className="text-xs text-ink-3 mt-1">{isPastDay ? 'Só listamos aqui as apostas que sinalizamos com valor.' : 'As oportunidades aparecem quando há odds coletadas antes do jogo.'}</p>
+            <p className="text-sm text-ink-2">
+              {isPastDay ? 'Nenhuma oportunidade com valor nesse dia.'
+                : isFutureDay ? 'Ainda sem oportunidades para este dia.'
+                : 'Nenhum jogo com odds nesse filtro.'}
+            </p>
+            <p className="text-xs text-ink-3 mt-1">
+              {isPastDay ? 'Só listamos aqui as apostas que sinalizamos com valor.'
+                : isFutureDay ? 'As odds costumam ser coletadas a partir de ~24h antes do jogo — as oportunidades aparecem aqui quando chegarem.'
+                : 'As oportunidades aparecem quando há odds coletadas antes do jogo.'}
+            </p>
           </div>
         ) : (
           <>

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -12,7 +12,7 @@ import { draftFromBoardRow } from '@/components/futebol/registrar-aposta-utils';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
 import { competitionLabel, sortCompetitions, ALL_COMPETITIONS } from '@/utils/futebol-competitions';
 import {
-  pickLabel, marketLabel, fmtEdgeScore, groupBoardByFixture,
+  pickLabel, marketLabel, fmtEdgeScore,
   faixaBadgeCls, faixaWord, faixaTone, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
@@ -322,7 +322,8 @@ export default function FutebolOportunidades() {
     [allRows, selectedDay, mercado, faixa, comp]
   );
 
-  const bestRows = useMemo(() => groupBoardByFixture(filtered).map((bf) => bf.best), [filtered]);
+  // Uma linha por oportunidade (sem colapsar por jogo), ranqueado por Score.
+  const bestRows = useMemo(() => [...filtered].sort((a, b) => b.score - a.score), [filtered]);
   const comValor = bestRows.filter((o) => o.score >= SCORE_MEDIA);
   const semValor = bestRows.filter((o) => o.score < SCORE_MEDIA);
   const nAlta = bestRows.filter((o) => faixaTone(o.faixa) === 'alta').length;
@@ -339,7 +340,7 @@ export default function FutebolOportunidades() {
       byDay.get(d)!.push(r);
     });
     const out: Record<string, number> = {};
-    byDay.forEach((rs, d) => { out[d] = groupBoardByFixture(rs).map((bf) => bf.best).filter((o) => o.score >= SCORE_MEDIA).length; });
+    byDay.forEach((rs, d) => { out[d] = rs.filter((o) => o.score >= SCORE_MEDIA).length; });
     return out;
   }, [allRows]);
 

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -382,7 +382,7 @@ export default function FutebolOportunidades() {
             <div className={LABEL}>{isPastDay ? 'Histórico' : 'Oportunidades'}</div>
             {isPastDay && resumo && resumo.settled > 0 ? (
               <>
-                <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{resumo.hit} de {resumo.settled} bateram</h1>
+                <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{resumo.hit} de {resumo.settled} deram green</h1>
                 <p className="text-[13px] mt-1 text-ink-2">Resultado das oportunidades com valor deste dia{resumo.push > 0 ? ` · ${resumo.push} anulada${resumo.push === 1 ? '' : 's'}` : ''}</p>
               </>
             ) : (

--- a/src/pages/FutebolTime.tsx
+++ b/src/pages/FutebolTime.tsx
@@ -4,6 +4,7 @@ import AnalyticsNav from '@/components/AnalyticsNav';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useFutebolTeamProfile, useFutebolTeamSeason, useFutebolStandings, useFutebolFixtures } from '@/hooks/use-futebol-data';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
+import { competitionLabel } from '@/utils/futebol-competitions';
 import type { Competition, FutebolScopeResult, FutebolScopeStats } from '@/services/futebol-data.service';
 
 // Paleta do mockup (espelha theme-bolao)
@@ -20,7 +21,6 @@ const C = {
   roseBg: '#fbe3e8', roseFg: '#be123c',
 };
 
-const COMP_LABEL: Record<string, string> = { brasileirao: 'Brasileirão Série A', copa_mundo: 'Copa do Mundo', serie_b: 'Brasileirão Série B' };
 const SCOPE_ORDER = ['geral', 'casa', 'fora'] as const;
 const FINISHED = new Set(['FT', 'AET', 'PEN']);
 const CARD = 'rounded-2xl overflow-hidden bg-white border border-line';
@@ -191,7 +191,7 @@ export default function FutebolTime() {
                 <div className="flex-1 min-w-0">
                   <h1 className="text-xl md:text-[28px] font-extrabold tracking-tight leading-tight text-ink truncate">{profile.team.team_name}</h1>
                   <p className="text-xs mt-1 text-ink-2">
-                    {COMP_LABEL[competition] || competition} · {season}
+                    {competitionLabel(competition)} · {season}
                     {stand?.rank ? <> · <span className="font-semibold text-ink">{stand.rank}º colocado</span></> : null}
                   </p>
                   {raiox?.form && <div className="mt-2"><FormDots form={raiox.form} /></div>}

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -29,7 +29,9 @@ async function withRetry<T>(fn: () => Promise<T>, retries = 2, delay = 1200): Pr
   throw lastError;
 }
 
-export type Competition = 'brasileirao' | 'copa_mundo' | 'serie_b';
+// Slug da competição. String livre (data-driven) — o backend é a fonte de verdade
+// (futebol.fact_fixtures.competition). Rótulos/ordem ficam em utils/futebol-competitions.
+export type Competition = string;
 
 export interface FutebolFixture {
   fixture_id: number;

--- a/src/utils/futebol-competitions.ts
+++ b/src/utils/futebol-competitions.ts
@@ -1,0 +1,51 @@
+// Fonte única das competições do módulo Futebol.
+// Data-driven: o backend define o slug (futebol.fact_fixtures.competition). Aqui
+// só damos nome amigável e a ordem de exibição. Liga nova que o Mateus subir
+// aparece sozinha nas telas (rótulo via fallback humanizado); adicionar aqui é
+// só pra ganhar nome bonito + posição no seletor.
+//
+// Slugs confirmados no mart (season 2026): brasileirao, serie_b, copa_do_brasil,
+// libertadores, sudamericana, la_liga, premier_league, copa_mundo.
+
+export const COMPETITION_LABELS: Record<string, string> = {
+  brasileirao: 'Brasileirão',
+  serie_b: 'Série B',
+  copa_do_brasil: 'Copa do Brasil',
+  libertadores: 'Libertadores',
+  sudamericana: 'Sul-Americana',
+  la_liga: 'La Liga',
+  premier_league: 'Premier League',
+  copa_mundo: 'Copa do Mundo',
+};
+
+// Ordem canônica nos seletores que buscam por slug (pickers). Copa do Mundo por
+// último (encerrada). Ligas desconhecidas caem no fim, em ordem alfabética.
+export const ALL_COMPETITIONS: string[] = [
+  'brasileirao',
+  'serie_b',
+  'copa_do_brasil',
+  'libertadores',
+  'sudamericana',
+  'la_liga',
+  'premier_league',
+  'copa_mundo',
+];
+
+function humanize(slug: string): string {
+  return slug.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/** Nome amigável de uma competição. Cai no humanize se o slug não estiver mapeado. */
+export function competitionLabel(slug: string | null | undefined): string {
+  if (!slug) return '—';
+  return COMPETITION_LABELS[slug] ?? humanize(slug);
+}
+
+/** Ordena uma lista de slugs pela ordem canônica (desconhecidos ao fim, alfabético). */
+export function sortCompetitions(slugs: string[]): string[] {
+  const rank = (s: string) => {
+    const i = ALL_COMPETITIONS.indexOf(s);
+    return i < 0 ? Number.MAX_SAFE_INTEGER : i;
+  };
+  return [...slugs].sort((a, b) => rank(a) - rank(b) || a.localeCompare(b));
+}

--- a/src/utils/futebol-settlement.ts
+++ b/src/utils/futebol-settlement.ts
@@ -1,0 +1,89 @@
+// ============================================================
+// futebol-settlement.ts — liquida uma oportunidade pelo placar final
+// ============================================================
+// Usado no histórico da tela de Oportunidades ("bateu / não bateu"). O placar
+// vem de fact_fixtures (goals_home/goals_away). Convenções (espelham pickLabel):
+//  - asian_handicap / goals_over_under: line_value na ótica do MANDANTE.
+//  - Linhas asiáticas (quarto de gol) → meio-ganho/meio-perda pela regra do "d".
+// ============================================================
+
+export type BetResult = 'won' | 'half_won' | 'push' | 'half_lost' | 'lost';
+
+// Regra genérica de liquidação asiática pelo saldo `d` (o quanto a aposta está
+// à frente da linha). Passos de 0,25 cobrem linha cheia, .5, .25 e .75.
+function mapAsian(dRaw: number): BetResult {
+  const d = Math.round(dRaw * 4) / 4; // evita ruído de ponto flutuante
+  if (d >= 0.5) return 'won';
+  if (d === 0.25) return 'half_won';
+  if (d === 0) return 'push';
+  if (d === -0.25) return 'half_lost';
+  return 'lost';
+}
+
+/**
+ * Liquida a oportunidade. Retorna null se o jogo não tem placar (ainda) ou o
+ * mercado é desconhecido.
+ */
+export function settleFutebol(
+  market: string,
+  outcome: string,
+  line: number | null,
+  goalsHome: number | null | undefined,
+  goalsAway: number | null | undefined,
+): BetResult | null {
+  if (goalsHome == null || goalsAway == null) return null;
+  const diff = goalsHome - goalsAway; // ótica do mandante
+  const total = goalsHome + goalsAway;
+  const res = diff > 0 ? 'Home' : diff < 0 ? 'Away' : 'Draw';
+
+  switch (market) {
+    case 'match_winner':
+      return outcome === res ? 'won' : 'lost';
+
+    case 'btts': {
+      const both = goalsHome > 0 && goalsAway > 0;
+      const yes = outcome === 'Yes';
+      return yes === both ? 'won' : 'lost';
+    }
+
+    case 'double_chance': {
+      const ok =
+        outcome === '1X' ? res === 'Home' || res === 'Draw'
+        : outcome === 'X2' ? res === 'Draw' || res === 'Away'
+        : res === 'Home' || res === 'Away'; // '12'
+      return ok ? 'won' : 'lost';
+    }
+
+    case 'goals_over_under': {
+      if (line == null) return null;
+      const d = outcome === 'Over' ? total - line : line - total;
+      return mapAsian(d);
+    }
+
+    case 'asian_handicap': {
+      if (line == null) return null;
+      // line na ótica do mandante; visitante = oposto (mesma lógica do pickLabel)
+      const d = outcome === 'Home' ? diff + line : -diff - line;
+      return mapAsian(d);
+    }
+
+    default:
+      return null;
+  }
+}
+
+/** Rótulo + tom pro selo de resultado. */
+export function resultBadge(r: BetResult): { label: string; tone: 'won' | 'lost' | 'push' } {
+  switch (r) {
+    case 'won': return { label: 'Bateu', tone: 'won' };
+    case 'half_won': return { label: '½ Bateu', tone: 'won' };
+    case 'push': return { label: 'Anulada', tone: 'push' };
+    case 'half_lost': return { label: '½ Não', tone: 'lost' };
+    case 'lost': return { label: 'Não bateu', tone: 'lost' };
+  }
+}
+
+/** Conta positiva pro resumo do dia (meio-ganho conta como acerto). */
+export function isHit(r: BetResult): boolean {
+  return r === 'won' || r === 'half_won';
+}

--- a/src/utils/futebol-settlement.ts
+++ b/src/utils/futebol-settlement.ts
@@ -75,11 +75,11 @@ export function settleFutebol(
 /** Rótulo + tom pro selo de resultado. */
 export function resultBadge(r: BetResult): { label: string; tone: 'won' | 'lost' | 'push' } {
   switch (r) {
-    case 'won': return { label: 'Bateu', tone: 'won' };
-    case 'half_won': return { label: '½ Bateu', tone: 'won' };
+    case 'won': return { label: 'Green', tone: 'won' };
+    case 'half_won': return { label: 'Meio green', tone: 'won' };
     case 'push': return { label: 'Anulada', tone: 'push' };
-    case 'half_lost': return { label: '½ Não', tone: 'lost' };
-    case 'lost': return { label: 'Não bateu', tone: 'lost' };
+    case 'half_lost': return { label: 'Meio red', tone: 'lost' };
+    case 'lost': return { label: 'Red', tone: 'lost' };
   }
 }
 

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -196,13 +196,8 @@ serve(async (req) => {
       return k.getTime() > now.getTime() && brtDay(k) === today && r.score >= MIN_SCORE;
     });
 
-    // melhor pick por jogo → top N por Score
-    const bestByFixture = new Map<number, BoardRow>();
-    for (const r of todayRows) {
-      const cur = bestByFixture.get(r.fixture_id);
-      if (!cur || r.score > cur.score) bestByFixture.set(r.fixture_id, r);
-    }
-    const picks = [...bestByFixture.values()].sort((a, b) => b.score - a.score).slice(0, MAX_PICKS);
+    // principais oportunidades do dia por Score — pode ter mais de uma do mesmo jogo
+    const picks = [...todayRows].sort((a, b) => b.score - a.score).slice(0, MAX_PICKS);
 
     // 3) dia fraco → silêncio (nada de mensagem "hoje não tem nada")
     if (picks.length === 0) {


### PR DESCRIPTION
## O que entrega

Ajusta o front do futebol para acompanhar a expansão de ligas que o Mateus subiu no mart (8 competições) e melhora o registro/histórico de oportunidades.

### 1. Multi-liga (data-driven) — `e248ecc`
Front estava preso num allowlist de 3 ligas (Brasileirão/Série B/Copa do Mundo). Virou data-driven via nova util `utils/futebol-competitions.ts` (fonte única de rótulos + fallback humanizado + ordenação), `Competition` = `string`, e hook `useFutebolFixturesMulti` (useQueries). Telas ligadas: Oportunidades, Hoje, Jogos (+seasons por competição), Time, RegistrarAposta.
Cobre: `brasileirao`, `serie_b`, `copa_do_brasil`, `libertadores`, `sudamericana`, `la_liga`, `premier_league`, `copa_mundo`. Mata-mata degrada bem (sem tabela de classificação).

### 2. Histórico green/red — `2255101`, `23d8428`
`/futebol/oportunidades` navega dias passados/futuros (stepper com "hoje" claro) e mostra placar + selo **Green / Meio green / Anulada / Meio red / Red** por pick com valor. Nova util `utils/futebol-settlement.ts` liquida por mercado (1X2, Over/Under, handicap asiático com quarto de linha, BTTS, dupla chance) pelo placar de `fact_fixtures`. Resumo "X de Y deram green".

### 3. Todas as oportunidades por jogo — `b4bbdeb`, `92dce77`, `0766dc2`, `19b404f`
O modelo mapeia várias oportunidades por jogo (média 1,77) mas colapsávamos pra 1. Agora: Oportunidades = 1 linha por oportunidade (ranqueado por Score); tela do Jogo = hero + "Outras oportunidades neste jogo"; jogo encerrado mostra o que foi mapeado + como performou (bloco redesenhado, layout 2 colunas oportunidades|modelo ~40/60).

### 4. Dias futuros — `9b876cd`
Oportunidades passou a exibir dias futuros mesmo sem odds ainda (empty state explicando que as odds chegam ~24h antes).

### 5. Copy abrangente — `fc493c0`
LP (`/futebol/comecar`) e `/futebol`: chip, FAQ e `<Seo>` deixam de listar "Brasileirão + Copa do Mundo" e passam a "Brasil · América do Sul · Europa" — não precisa reajuste ao entrar liga nova. FAQPage JSON-LD acompanha (derivado da const).

## Fora deste PR (à parte)
- **`notify-opportunities`**: mudança pra top-do-dia por Score (pode repetir jogo) já está no código, mas o **deploy da edge function é separado** (Mateus).
- **Snapshot do mart** (registro do que foi enviado por janela): task do Mateus no ClickUp — o histórico green/red hoje lê o mart atual.

## Validação
Rodado no worktree (localhost:8081): picker das 8 ligas, Libertadores (com tabela) e Copa do Brasil (mata-mata, sem tabela), histórico com selos, dias futuros, e o chip novo da LP.