### PR TITLE
feat(pricing): plano Entrada (R$ 14,90) com só o Betinho

### DIFF
--- a/docs/handoff-paywall-backend.md
+++ b/docs/handoff-paywall-backend.md
@@ -9,16 +9,18 @@
 **Não mergear/deployar esta branch pra PRODUÇÃO antes de plugar o checkout do `/planos`** — senão todo o funil de upgrade do app (que já aponta pra `/planos`) fica sem checkout. Em `develop`/staging, tudo bem.
 
 ## Modelo (decidido)
-3 níveis por **amplitude** — não por esporte:
+4 níveis por **amplitude** — não por esporte:
 
-| | Grátis | Essencial | Completo |
-|---|---|---|---|
-| Futebol | trial 7d | completo | completo |
-| NBA | 2 picks/dia (baseline) | 2 picks/dia (baseline) | completo (prop bets + Análise 360) |
-| Betinho | 3 apostas/dia | ilimitado | ilimitado |
+| | Grátis | Entrada | Essencial | Completo |
+|---|---|---|---|---|
+| Futebol | trial 7d | **não inclui** | completo | completo |
+| NBA | 2 picks/dia (baseline) | 2 picks/dia (baseline) | 2 picks/dia (baseline) | completo (prop bets + Análise 360) |
+| Betinho | 3 apostas/dia | ilimitado | ilimitado | ilimitado |
 
 - **Betinho incluído em todo plano pago.** **NBA só no Completo**, sem avulso. **Bolão fora** (produto de evento, segue `boloes.is_premium` one-time).
-- Preços (placeholders no código, confirmar): Essencial mensal ~~R$49,90~~ **R$39,90** · anual **R$31,90/mês** (R$383/ano, −20%). Completo mensal ~~R$109,90~~ **R$89,90** · anual **R$71,90/mês** (R$863/ano, −20%).
+- **Entrada = Betinho puro**, sem produto de análise. Atenção: ele **mantém o baseline de conta criada** (os 2 picks/dia da NBA), senão o cliente *perde* acesso ao assinar. A página diz isso numa nota embaixo da tabela.
+- Preços (placeholders no código, confirmar): Entrada mensal **R$14,90** · anual **R$11,90/mês** (R$143/ano, −20%) — **fora da promo de lançamento**, sem de/por. Essencial mensal ~~R$49,90~~ **R$39,90** · anual **R$31,90/mês** (R$383/ano, −20%). Completo mensal ~~R$109,90~~ **R$89,90** · anual **R$71,90/mês** (R$863/ano, −20%).
+- **A confirmar:** o front promete "7 dias grátis" pra **todo** plano pago, incluindo o Entrada (lá o trial é o Betinho ilimitado, já que não tem análise). Se o Entrada for sem trial, mudar a nota abaixo dos cards e o FAQ.
 
 ## Estado atual da liberação (o que existe hoje)
 Espalhado em 4 mecanismos:
@@ -32,13 +34,13 @@ Lido por ~6 hooks (`use-betinho-premium`, `use-subscription`, `use-report-access
 ## O que fazer
 
 ### 1. Entitlements unificado
-- Coluna `users.plano` `('free' | 'essencial' | 'completo')`.
-- RPC `get_entitlements(user_id)` → `{ futebol, nba, betinho }` derivado do plano (essencial: futebol full + betinho full + nba baseline; completo: tudo).
+- Coluna `users.plano` `('free' | 'entrada' | 'essencial' | 'completo')`.
+- RPC `get_entitlements(user_id)` → `{ futebol, nba, betinho }` derivado do plano (entrada: betinho full + futebol none + nba baseline; essencial: futebol full + betinho full + nba baseline; completo: tudo).
 - **Não precisa** de coluna `esporte_escolhido` — derrubamos o "escolha o esporte", o plano já determina tudo.
 - Um hook `useEntitlements()` no lugar dos ~6 atuais.
 
 ### 2. Stripe
-- Price IDs por tier×ciclo (env): `essencial_mensal`, `essencial_anual`, `completo_mensal`, `completo_anual`.
+- Price IDs por tier×ciclo (env): `entrada_mensal`, `entrada_anual`, `essencial_mensal`, `essencial_anual`, `completo_mensal`, `completo_anual`.
 - Trocar `startCheckout()` (placeholder em `Planos.tsx`) por `createCheckoutSession(priceId, plano)` — logado vai direto pro gateway; deslogado passa por `/auth` e volta pro checkout.
 - `stripe-webhook/index.ts`: gravar `users.plano` (em vez de `*_subscription_status`).
 - `stripe-create-checkout/index.ts`: hoje detecta produto por `referer.includes('/paywall-platform')` e monta cancel URL `/paywall*` → atualizar pra `/planos`.
@@ -46,6 +48,7 @@ Lido por ~6 hooks (`use-betinho-premium`, `use-subscription`, `use-report-access
 
 ### 3. Migração / grandfather
 - Poucos assinantes → **subir todos os premium atuais** (betinho e/ou analytics) pra `plano='completo'`. Bolão fica separado.
+- O `entrada` **não é destino de migração**: quem já é assinante Betinho sobe pro `completo` (grandfather). O `entrada` é só pra venda nova.
 
 ### 4. Fix do bug do `PremiumRoute`
 - `src/components/PremiumRoute.tsx` gateia `/analise-360` (que é **NBA**) checando `betinho_subscription_status`. Trocar pelo entitlement de NBA. Hoje: assinante Betinho pega análise NBA de graça; assinante NBA-only pode ser bloqueado.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -32,7 +32,7 @@
   </url>
   <url>
     <loc>https://www.smartbetting.app/planos</loc>
-    <lastmod>2026-07-24</lastmod>
+    <lastmod>2026-07-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/src/pages/Planos.tsx
+++ b/src/pages/Planos.tsx
@@ -1,15 +1,21 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Check, Flame } from 'lucide-react';
+import { Check, Flame, X } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { useAuth } from '@/hooks/use-auth';
 import { Seo, SITE_URL } from '@/components/Seo';
 
 type Billing = 'monthly' | 'annual';
+type PaidTier = 'entrada' | 'essencial' | 'completo';
 
 /* Preços — PLACEHOLDERS. Trocar quando o modelo de cobrança fechar.
-   Mensal: preço de lançamento (de/por). Anual: −20% sobre o mensal de lançamento. */
+   Mensal: preço de lançamento (de/por). Anual: −20% sobre o mensal de lançamento.
+   Entrada fica FORA da promo de lançamento (sem de/por): já é o piso da escada. */
 const PRICES = {
+  entrada: {
+    monthly: { amount: '14,90', per: '/mês', billed: '', strike: '' },
+    annual: { amount: '11,90', per: '/mês', billed: 'cobrado R$ 143/ano · economize 20%', strike: '' },
+  },
   essencial: {
     monthly: { amount: '39,90', per: '/mês', billed: '', strike: 'R$ 49,90' },
     annual: { amount: '31,90', per: '/mês', billed: 'cobrado R$ 383/ano · economize 20%', strike: 'R$ 39,90' },
@@ -20,12 +26,23 @@ const PRICES = {
   },
 } as const;
 
-const TH: Record<'essencial' | 'completo', Record<Billing, string>> = {
+const PLAN_NAMES: Record<PaidTier, string> = {
+  entrada: 'Entrada',
+  essencial: 'Essencial',
+  completo: 'Completo',
+};
+
+const TH: Record<PaidTier, Record<Billing, string>> = {
+  entrada: { monthly: 'R$ 14,90/mês', annual: 'R$ 11,90/mês' },
   essencial: { monthly: 'R$ 39,90/mês', annual: 'R$ 31,90/mês' },
   completo: { monthly: 'R$ 89,90/mês', annual: 'R$ 71,90/mês' },
 };
 
 const EYEBROW = 'text-[11px] font-bold uppercase tracking-[0.16em] text-forest-2';
+
+/* Corpo do número do preço. Menor no lg porque lá são 4 colunas: com 40px o
+   preço + "/mês" não cabia numa linha nos cards com preço riscado. */
+const PRICE_NUM = 'font-extrabold text-[40px] lg:text-[34px] leading-none tracking-tight tabular-nums';
 
 // JSON-LD dos planos DERIVADO do PRICES acima — nunca hardcode preço aqui:
 // o Google exige que o structured data bata com o que a página exibe, e
@@ -35,6 +52,12 @@ const annualTotal = (billed: string) => {
   const m = billed.match(/R\$\s*([\d.,]+)\/ano/);
   return m ? brl(m[1]) : null;
 };
+const PLAN_JSONLD_DESC: Record<PaidTier, string> = {
+  entrada: 'Betinho ilimitado no Telegram: registra e liquida suas apostas e manda o resumo semanal da banca. Sem as análises de futebol e NBA.',
+  essencial: 'Futebol completo (Brasileirão e Copa) + Betinho ilimitado. Teste grátis de 7 dias.',
+  completo: 'Tudo do Essencial + análise NBA completa (prop bets e Análise 360). Teste grátis de 7 dias.',
+};
+
 const PLANS_JSONLD = {
   '@context': 'https://schema.org',
   '@type': 'ItemList',
@@ -46,13 +69,10 @@ const PLANS_JSONLD = {
       brand: { '@type': 'Brand', name: 'Smart Betting' },
       offers: { '@type': 'Offer', price: '0', priceCurrency: 'BRL', url: `${SITE_URL}/planos` },
     },
-    ...(['essencial', 'completo'] as const).map((tier) => ({
+    ...(['entrada', 'essencial', 'completo'] as const).map((tier) => ({
       '@type': 'Product',
-      name: `Smart Betting ${tier === 'essencial' ? 'Essencial' : 'Completo'}`,
-      description:
-        tier === 'essencial'
-          ? 'Futebol completo (Brasileirão e Copa) + Betinho ilimitado. Teste grátis de 7 dias.'
-          : 'Tudo do Essencial + análise NBA completa (prop bets e Análise 360). Teste grátis de 7 dias.',
+      name: `Smart Betting ${PLAN_NAMES[tier]}`,
+      description: PLAN_JSONLD_DESC[tier],
       brand: { '@type': 'Brand', name: 'Smart Betting' },
       offers: [
         {
@@ -74,20 +94,22 @@ const PLANS_JSONLD = {
   ],
 };
 
-function PriceBlock({ tier, billing }: { tier: 'essencial' | 'completo'; billing: Billing }) {
+function PriceBlock({ tier, billing }: { tier: PaidTier; billing: Billing }) {
   const p = PRICES[tier][billing];
   return (
     <>
-      <div className="flex items-baseline gap-2 flex-wrap mt-4">
+      {/* Uma linha só (sem flex-wrap): com 4 colunas o "/mês" quebrava e
+          derrubava o botão do card, desalinhando a fileira. */}
+      <div className="flex items-baseline gap-2 whitespace-nowrap mt-4 min-h-[44px]">
         {p.strike && (
           <span className="text-sm text-ink-3 line-through decoration-ink-3 tabular-nums">{p.strike}</span>
         )}
-        <span className="font-extrabold text-[40px] leading-none tracking-tight tabular-nums">
-          <span className="text-xl font-bold opacity-60 mr-0.5">R$</span>{p.amount}
+        <span className={PRICE_NUM}>
+          <span className="text-xl lg:text-lg font-bold opacity-60 mr-0.5">R$</span>{p.amount}
         </span>
         <span className="text-[13px] text-ink-3">{p.per}</span>
       </div>
-      <div className="text-[12.5px] text-ink-3 mt-1.5 min-h-[18px]">{p.billed || ' '}</div>
+      <div className="text-[12.5px] text-ink-3 mt-1.5 min-h-[19px]">{p.billed || ' '}</div>
     </>
   );
 }
@@ -96,6 +118,17 @@ function Feat({ children }: { children: React.ReactNode }) {
   return (
     <li className="flex items-start gap-2.5 text-ink-2">
       <Check className="w-[17px] h-[17px] shrink-0 mt-0.5 text-forest" />
+      <span>{children}</span>
+    </li>
+  );
+}
+
+/* Linha de "não inclui" — só no Entrada, pra ninguém assinar achando que leva
+   as análises. Cinza + X em vez do check verde. */
+function NoFeat({ children }: { children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-2.5 text-ink-3">
+      <X className="w-[17px] h-[17px] shrink-0 mt-0.5 text-ink-3" />
       <span>{children}</span>
     </li>
   );
@@ -114,7 +147,7 @@ export default function Planos() {
   // "Assinar" — placeholder. Quando o checkout unificado estiver plugado, trocar
   // por stripeService.createCheckoutSession(priceId[plan][billing], plan): logado
   // vai direto pro gateway; deslogado passa pelo /auth e volta pro checkout.
-  const startCheckout = (_plan: 'essencial' | 'completo') => {
+  const startCheckout = (_plan: PaidTier) => {
     navigate(user ? '/inicio' : '/auth');
   };
 
@@ -125,7 +158,7 @@ export default function Planos() {
 
       {/* Promo de lançamento */}
       <div className="bg-forest text-white text-[13.5px]">
-        <div className="max-w-6xl mx-auto px-4 md:px-6 py-2.5 flex items-center justify-center gap-2.5 flex-wrap text-center">
+        <div className="max-w-[1240px] mx-auto px-4 md:px-6 py-2.5 flex items-center justify-center gap-2.5 flex-wrap text-center">
           <Flame className="w-[15px] h-[15px] shrink-0" style={{ color: '#ffd873' }} />
           <span><b style={{ color: '#ffd873' }}>Preço de lançamento</b> — valores promocionais por tempo limitado</span>
         </div>
@@ -133,7 +166,7 @@ export default function Planos() {
 
       <main className="flex-1">
         {/* Hero */}
-        <section className="max-w-6xl mx-auto px-4 md:px-6 pt-14 md:pt-16 pb-2">
+        <section className="max-w-[1240px] mx-auto px-4 md:px-6 pt-14 md:pt-16 pb-2">
           <div className={EYEBROW}>Um plano, todo o ecossistema</div>
           <h1 className="text-[34px] md:text-[52px] font-extrabold leading-[1.04] tracking-tight mt-3.5 max-w-[15ch] text-balance">
             Decida com <span className="text-forest">dado</span>. Não&nbsp;com achismo.
@@ -178,20 +211,23 @@ export default function Planos() {
           </div>
         </div>
 
-        {/* Cards */}
-        <section className="max-w-6xl mx-auto px-4 md:px-6 mt-6">
-          <div className="grid md:grid-cols-3 gap-4 items-stretch max-w-[460px] md:max-w-none mx-auto">
+        {/* Faixa da página foi de 1152 pra 1240 (mesmo eixo em hero, cards e
+            tabela) porque com 4 colunas os cards ficavam espremidos. */}
+        <section className="max-w-[1240px] mx-auto px-4 md:px-6 mt-6">
+          {/* 4 níveis: 1 coluna no mobile, 2×2 no tablet, 4 no desktop. gap-y maior
+              fora do desktop porque o selo "MAIS ESCOLHIDO" sobe além do card. */}
+          <div className="grid gap-4 gap-y-8 md:grid-cols-2 lg:grid-cols-4 lg:gap-y-4 items-stretch max-w-[460px] md:max-w-[760px] lg:max-w-none mx-auto">
             {/* GRÁTIS */}
-            <div className="rounded-2xl bg-white border border-line p-6 flex flex-col">
+            <div className="rounded-2xl bg-white border border-line p-6 lg:p-5 flex flex-col">
               <div className="text-[13px] font-bold tracking-[0.02em]">Grátis</div>
-              <div className="text-[13.5px] text-ink-3 mt-1 min-h-[38px]">Pra sentir como funciona, sem pagar nada.</div>
-              <div className="flex items-baseline gap-2 mt-4">
-                <span className="font-extrabold text-[40px] leading-none tracking-tight tabular-nums">
-                  <span className="text-xl font-bold opacity-60 mr-0.5">R$</span>0
+              <div className="text-[13.5px] text-ink-3 mt-1 min-h-[41px]">Pra sentir como funciona, sem pagar nada.</div>
+              <div className="flex items-baseline gap-2 whitespace-nowrap mt-4 min-h-[44px]">
+                <span className={PRICE_NUM}>
+                  <span className="text-xl lg:text-lg font-bold opacity-60 mr-0.5">R$</span>0
                 </span>
                 <span className="text-[13px] text-ink-3">pra sempre</span>
               </div>
-              <div className="text-[12.5px] text-ink-3 mt-1.5 min-h-[18px]">&nbsp;</div>
+              <div className="text-[12.5px] text-ink-3 mt-1.5 min-h-[19px]">&nbsp;</div>
               <button onClick={freeCta.onClick} className="mt-5 w-full h-11 rounded-rebrand-sm text-sm font-bold bg-white border border-line-2 text-ink hover:border-forest hover:text-forest transition">
                 {freeCta.label}
               </button>
@@ -202,10 +238,26 @@ export default function Planos() {
               </ul>
             </div>
 
+            {/* ENTRADA — só o Betinho, sem produto de análise. */}
+            <div className="rounded-2xl bg-white border border-line p-6 lg:p-5 flex flex-col">
+              <div className="text-[13px] font-bold tracking-[0.02em]">Entrada</div>
+              <div className="text-[13.5px] text-ink-3 mt-1 min-h-[41px]">Só o Betinho, sua banca no automático.</div>
+              <PriceBlock tier="entrada" billing={billing} />
+              <button onClick={() => startCheckout('entrada')} className="mt-5 w-full h-11 rounded-rebrand-sm text-sm font-bold bg-white border border-line-2 text-ink hover:border-forest hover:text-forest transition">
+                Assinar Entrada
+              </button>
+              <ul className="mt-5 pt-5 border-t border-line flex flex-col gap-2.5 text-sm">
+                <Feat><b className="text-ink font-semibold">Betinho ilimitado</b>, registra e liquida tudo no Telegram</Feat>
+                <Feat>Resumo semanal da sua banca</Feat>
+                <Feat>Seu histórico e seu lucro à mão</Feat>
+                <NoFeat>Sem as análises de futebol e NBA</NoFeat>
+              </ul>
+            </div>
+
             {/* ESSENCIAL */}
-            <div className="rounded-2xl bg-white border border-line p-6 flex flex-col">
+            <div className="rounded-2xl bg-white border border-line p-6 lg:p-5 flex flex-col">
               <div className="text-[13px] font-bold tracking-[0.02em]">Essencial</div>
-              <div className="text-[13.5px] text-ink-3 mt-1 min-h-[38px]">Futebol completo + a banca no automático.</div>
+              <div className="text-[13.5px] text-ink-3 mt-1 min-h-[41px]">Futebol completo + a banca no automático.</div>
               <PriceBlock tier="essencial" billing={billing} />
               <button onClick={() => startCheckout('essencial')} className="mt-5 w-full h-11 rounded-rebrand-sm text-sm font-bold bg-forest text-white hover:bg-forest-2 transition">
                 Assinar Essencial
@@ -220,7 +272,7 @@ export default function Planos() {
             </div>
 
             {/* COMPLETO — slab forest */}
-            <div className="relative rounded-2xl bg-forest border border-forest p-6 flex flex-col text-[#eaf1ec] shadow-[0_18px_40px_-18px_rgba(10,61,46,0.55)]">
+            <div className="relative rounded-2xl bg-forest border border-forest p-6 lg:p-5 flex flex-col text-[#eaf1ec] shadow-[0_18px_40px_-18px_rgba(10,61,46,0.55)]">
               <span
                 className="absolute -top-3 left-1/2 -translate-x-1/2 text-[11px] font-bold tracking-[0.08em] rounded-full px-3 py-1 whitespace-nowrap shadow-[0_4px_12px_-3px_rgba(212,160,23,0.5)]"
                 style={{ background: '#d4a017', color: '#2a1f00' }}
@@ -228,22 +280,22 @@ export default function Planos() {
                 MAIS ESCOLHIDO
               </span>
               <div className="text-[13px] font-bold tracking-[0.02em] text-white">Completo</div>
-              <div className="text-[13.5px] mt-1 min-h-[38px]" style={{ color: '#a9c4b7' }}>
+              <div className="text-[13.5px] mt-1 min-h-[41px]" style={{ color: '#a9c4b7' }}>
                 Tudo. Futebol, NBA e Betinho no mesmo plano.
               </div>
-              <div className="flex items-baseline gap-2 flex-wrap mt-4">
+              <div className="flex items-baseline gap-2 whitespace-nowrap mt-4 min-h-[44px]">
                 {PRICES.completo[billing].strike && (
                   <span className="text-sm line-through tabular-nums" style={{ color: '#8fb0a2', textDecorationColor: '#8fb0a2' }}>
                     {PRICES.completo[billing].strike}
                   </span>
                 )}
-                <span className="font-extrabold text-[40px] leading-none tracking-tight tabular-nums text-white">
-                  <span className="text-xl font-bold mr-0.5" style={{ color: '#ffd873' }}>R$</span>
+                <span className={`${PRICE_NUM} text-white`}>
+                  <span className="text-xl lg:text-lg font-bold mr-0.5" style={{ color: '#ffd873' }}>R$</span>
                   {PRICES.completo[billing].amount}
                 </span>
                 <span className="text-[13px]" style={{ color: '#9fbcae' }}>{PRICES.completo[billing].per}</span>
               </div>
-              <div className="text-[12.5px] mt-1.5 min-h-[18px]" style={{ color: '#9fbcae' }}>
+              <div className="text-[12.5px] mt-1.5 min-h-[19px]" style={{ color: '#9fbcae' }}>
                 {PRICES.completo[billing].billed || ' '}
               </div>
               <button onClick={() => startCheckout('completo')} className="mt-5 w-full h-11 rounded-rebrand-sm text-sm font-bold transition hover:brightness-95" style={{ background: '#d4a017', color: '#2a1f00' }}>
@@ -266,23 +318,26 @@ export default function Planos() {
           </div>
 
           <p className="text-center text-[13px] text-ink-3 mt-4">
-            Todos os planos pagos incluem o Betinho e o teste grátis de 7 dias.
+            Todos os planos pagos incluem o Betinho ilimitado e o teste grátis de 7 dias.
           </p>
         </section>
 
         {/* Comparação */}
-        <section className="max-w-6xl mx-auto px-4 md:px-6 pt-20">
+        <section className="max-w-[1240px] mx-auto px-4 md:px-6 pt-20">
           <div className="text-center mb-8">
             <div className={EYEBROW}>Comparar</div>
             <h2 className="text-[22px] md:text-[26px] font-extrabold tracking-tight mt-2">Resumo dos planos</h2>
           </div>
           <div className="overflow-x-auto">
-            <table className="w-full border-collapse min-w-[620px]">
+            <table className="w-full border-collapse min-w-[720px]">
               <thead>
                 <tr>
                   <th className="text-left py-4 px-4"></th>
                   <th className="py-4 px-4 text-[13px] font-bold">
                     Grátis<span className="block text-[12px] text-ink-3 font-medium mt-0.5 tabular-nums">R$ 0</span>
+                  </th>
+                  <th className="py-4 px-4 text-[13px] font-bold">
+                    Entrada<span className="block text-[12px] text-ink-3 font-medium mt-0.5 tabular-nums">{TH.entrada[billing]}</span>
                   </th>
                   <th className="py-4 px-4 text-[13px] font-bold">
                     Essencial<span className="block text-[12px] text-ink-3 font-medium mt-0.5 tabular-nums">{TH.essencial[billing]}</span>
@@ -294,30 +349,38 @@ export default function Planos() {
               </thead>
               <tbody className="[&_td]:py-[15px] [&_td]:px-4 [&_td]:text-center [&_td]:text-sm [&_td]:text-ink-2 [&_td]:border-b [&_td]:border-line [&_th]:border-b [&_th]:border-line">
                 <tr>
-                  <th className="text-left px-4 text-sm font-semibold text-ink">Esportes cobertos</th>
-                  <td>Futebol <span className="text-ink-3">(trial 7d)</span></td>
-                  <td>Futebol</td>
-                  <td className="bg-forest-tint !text-forest font-semibold">Futebol + NBA</td>
+                  <th className="text-left px-4 text-sm font-semibold text-ink">Betinho no Telegram</th>
+                  <td>3 apostas/dia</td>
+                  <td>Ilimitado</td>
+                  <td>Ilimitado</td>
+                  <td className="bg-forest-tint">Ilimitado</td>
                 </tr>
                 <tr>
-                  <th className="text-left px-4 text-sm font-semibold text-ink">Profundidade NBA</th>
+                  <th className="text-left px-4 text-sm font-semibold text-ink">Análise de futebol</th>
+                  <td>7 dias grátis</td>
+                  <td className="text-ink-3">Não inclui</td>
+                  <td>Completa</td>
+                  <td className="bg-forest-tint !text-forest font-semibold">Completa</td>
+                </tr>
+                <tr>
+                  <th className="text-left px-4 text-sm font-semibold text-ink">Análise de NBA</th>
+                  <td>2 picks/dia</td>
                   <td>2 picks/dia</td>
                   <td>2 picks/dia</td>
                   <td className="bg-forest-tint !text-forest font-semibold">Prop bets + Análise 360</td>
                 </tr>
-                <tr>
-                  <th className="text-left px-4 text-sm font-semibold text-ink">Betinho no Telegram</th>
-                  <td>3 apostas/dia</td>
-                  <td>Ilimitado</td>
-                  <td className="bg-forest-tint">Ilimitado</td>
-                </tr>
               </tbody>
             </table>
           </div>
+          {/* Os 2 picks da NBA são baseline de conta criada (vale até no grátis).
+              Sem esta nota, o Entrada parece perder acesso ao assinar. */}
+          <p className="text-[12.5px] text-ink-3 mt-3 px-4">
+            Os 2 picks do dia da NBA são liberados em qualquer plano, inclusive no grátis.
+          </p>
         </section>
 
         {/* FAQ */}
-        <section className="max-w-6xl mx-auto px-4 md:px-6 pt-20">
+        <section className="max-w-[1240px] mx-auto px-4 md:px-6 pt-20">
           <div className="text-center mb-8">
             <div className={EYEBROW}>Dúvidas</div>
             <h2 className="text-[24px] md:text-[32px] font-extrabold tracking-tight mt-2">Antes de assinar</h2>
@@ -325,11 +388,15 @@ export default function Planos() {
           <div className="max-w-[760px] mx-auto">
             {[
               {
-                q: 'Por que o NBA só está no plano Completo?',
-                a: (<>O NBA é a nossa análise <b className="text-ink">mais robusta</b> — prop bets, Análise 360 e o que temos de mais avançado. O Essencial já entrega o futebol completo pro seu dia a dia; o Completo é pra quem quer <b className="text-ink">tudo</b> junto. Você não paga por esporte solto: paga por até onde quer ir.</>),
+                q: 'O que vem no plano Entrada?',
+                a: (<>Só o <b className="text-ink">Betinho</b>: você registra suas apostas no Telegram, ele liquida sozinho e te manda o resumo semanal da sua banca, sem limite de apostas por dia. As análises de futebol e NBA não entram no Entrada, elas começam no Essencial.</>),
                 open: true,
               },
-              { q: 'Posso trocar de plano depois?', a: <>Pode, quando quiser. Sobe pro Completo e o valor é ajustado proporcionalmente; desce de volta no fim do ciclo. Sem multa, sem burocracia.</> },
+              {
+                q: 'Por que o NBA só está no plano Completo?',
+                a: (<>O NBA é a nossa análise <b className="text-ink">mais robusta</b> — prop bets, Análise 360 e o que temos de mais avançado. O Essencial já entrega o futebol completo pro seu dia a dia; o Completo é pra quem quer <b className="text-ink">tudo</b> junto. Você não paga por esporte solto: paga por até onde quer ir.</>),
+              },
+              { q: 'Posso trocar de plano depois?', a: <>Pode, quando quiser. Se subir de plano, o valor é ajustado proporcionalmente; se descer, a troca vale no fim do ciclo. Sem multa, sem burocracia.</> },
               { q: 'Como funciona o teste grátis?', a: <>Você cria a conta e tem <b className="text-ink">7 dias</b> de acesso completo pra experimentar de verdade. Só cobra depois — e você decide se continua.</> },
               { q: 'Consigo pagar com Pix?', a: <>Sim. Aceitamos <b className="text-ink">Pix</b> e cartão. No anual, o Pix sai à vista com o desconto de lançamento aplicado.</> },
               { q: 'Como eu cancelo?', a: <>Em dois cliques, na sua conta. O acesso continua até o fim do período que você já pagou — nada de corte no meio.</> },
@@ -346,7 +413,7 @@ export default function Planos() {
         </section>
 
         {/* CTA final */}
-        <section className="max-w-6xl mx-auto px-4 md:px-6 pt-20 pb-14">
+        <section className="max-w-[1240px] mx-auto px-4 md:px-6 pt-20 pb-14">
           <div className="rounded-[20px] bg-forest text-white text-center px-8 py-12">
             <h2 className="text-[26px] md:text-[38px] font-extrabold tracking-tight">Comece grátis hoje</h2>
             <p className="mt-3 mb-7 mx-auto max-w-[46ch]" style={{ color: '#a9c4b7' }}>

--- a/src/seo/public-routes.json
+++ b/src/seo/public-routes.json
@@ -43,8 +43,8 @@
   {
     "path": "/planos",
     "title": "Planos e Preços: Futebol, NBA e Betinho | Smart Betting",
-    "description": "Um plano, todo o ecossistema: comece grátis, assine o Essencial (futebol + Betinho ilimitado) ou o Completo (tudo + NBA). Teste grátis de 7 dias, sem fidelidade.",
-    "sitemap": { "changefreq": "weekly", "priority": "0.8", "lastmod": "2026-07-24" }
+    "description": "Comece grátis, leve só o Betinho por R$ 14,90/mês, ou assine o Essencial (futebol completo) ou o Completo (tudo + NBA). Teste grátis de 7 dias, sem fidelidade.",
+    "sitemap": { "changefreq": "weekly", "priority": "0.8", "lastmod": "2026-07-25" }
   },
   {
     "path": "/bolao",


### PR DESCRIPTION
## O que é

Quarto nível na paywall unificada (`/planos`), entre o Grátis e o Essencial: **Entrada, R$ 14,90/mês**, com o Betinho ilimitado e **nenhum produto de análise**. No anual sai R$ 11,90/mês (R$ 143/ano).

Fica **fora da promo de lançamento** (sem preço riscado), já que é o piso da escada.

| | Grátis | **Entrada** | Essencial | Completo |
|---|---|---|---|---|
| Betinho | 3 apostas/dia | **ilimitado** | ilimitado | ilimitado |
| Futebol | 7 dias grátis | **não inclui** | completo | completo |
| NBA | 2 picks/dia | **2 picks/dia** | 2 picks/dia | prop bets + Análise 360 |

## Decisão que vale revisar

Os 2 picks da NBA são baseline de conta criada. Se a coluna do Entrada dissesse "não inclui", o cliente **pareceria perder acesso ao pagar**, então o Entrada mantém o baseline e uma nota abaixo da tabela explica que aquele picks é de todo mundo. Só o futebol aparece como "Não inclui".

No card tem uma linha cinza com X, "Sem as análises de futebol e NBA", pra ninguém assinar achando que leva o board.

## Layout

Com 4 colunas o `/mês` quebrava linha nos cards com preço riscado e derrubava o botão, desalinhando a fileira. Correções:

- faixa da página de 1152 → **1240px** (hero, cards e tabela no mesmo eixo)
- padding interno menor e preço 40px → 34px **só no desktop**
- preço travado em uma linha (`whitespace-nowrap`) e réguas de altura corrigidas (`min-h` do subtítulo era 38px para um texto de 40,5px)

Resultado: cards de 264 → **286px** e os 4 botões exatamente na mesma altura (medido: 771px nos quatro). Tablet em 2×2 com folga pro selo "MAIS ESCOLHIDO", mobile em 1 coluna, sem rolagem lateral.

## Também entra

- **Tabela comparativa** em 4 colunas; linhas viraram Betinho / Análise de futebol / Análise de NBA (o "Esportes cobertos" antigo não descrevia um plano sem esporte nenhum)
- **FAQ**: "O que vem no plano Entrada?" (aberta por padrão) e a de troca de plano agora fala em subir/descer em vez de "sobe pro Completo"
- **SEO**: description da rota cita o Betinho por R$ 14,90 e o JSON-LD ganhou o Product/Offer do Entrada, derivado do `PRICES` (nada de preço hardcoded). Conferido no browser: 14.90 mensal, 143 anual
- **Handoff do back** atualizado: `users.plano` ganha `'entrada'`, price IDs `entrada_mensal`/`entrada_anual`, e o Entrada **não é destino de migração** (assinante Betinho atual sobe pro `completo`)

## Atenção

⚠️ **Front only**, igual ao resto da `/planos`: `startCheckout()` segue placeholder. Vale o mesmo caveat do handoff, não subir pra produção antes do checkout do Stripe estar plugado.

❓ **A confirmar com o back:** o front promete 7 dias grátis pra todo plano pago, inclusive o Entrada (lá o teste seria o Betinho sem limite). Se o Entrada for sem trial, muda a nota abaixo dos cards e o FAQ.

## Testes

- `npm run build` e `eslint` passando; sem erro de tipo novo em `Planos.tsx`
- Verificado no browser em 1280, 834 e 390px: toggle mensal/anual trocando os 4 preços e os cabeçalhos da tabela, botões alinhados, sem rolagem lateral

🤖 Generated with [Claude Code](https://claude.com/claude-code)
