### PR TITLE
feat(futebol): histórico mostra a oportunidade que existiu no dia, não só a de fechamento

### DIFF
--- a/src/components/futebol/registrar-aposta-utils.ts
+++ b/src/components/futebol/registrar-aposta-utils.ts
@@ -13,8 +13,17 @@ export interface FutebolBetDraft {
   bestOdd: number;
 }
 
-/** Monta o draft a partir de uma linha do board de oportunidades. */
-export function draftFromBoardRow(o: FutebolValueBoardRow): FutebolBetDraft {
+/**
+ * Monta o draft a partir de uma linha do board de oportunidades. Aceita
+ * qualquer linha que tenha estes campos (o histórico monta linha de
+ * oportunidade registrada, sem Score/faixa/edge — ver FutebolOportunidades).
+ */
+type DraftSource = Pick<
+  FutebolValueBoardRow,
+  'home_team_name' | 'away_team_name' | 'competition' | 'kickoff_utc' | 'market' | 'outcome' | 'line_value' | 'best_odd'
+>;
+
+export function draftFromBoardRow(o: DraftSource): FutebolBetDraft {
   return {
     homeName: o.home_team_name,
     awayName: o.away_team_name,

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -21,6 +21,7 @@ import {
   type FutebolLeaders,
   type FutebolValueBoardRow,
   type FutebolFixtureValueRow,
+  type FutebolAlertedPick,
 } from '@/services/futebol-data.service';
 
 /**
@@ -197,6 +198,21 @@ export function useFutebolValueBoard() {
   return useQuery<FutebolValueBoardRow[]>({
     queryKey: ['futebol', 'value-board'],
     queryFn: () => futebolDataService.getValueBoard(),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/**
+ * Tudo que foi alertado no Telegram nos últimos 90 dias (poucas linhas: 1 a 3
+ * picks por dia). Buscado de uma vez porque o seletor de dias precisa saber
+ * quais dias tiveram alerta, inclusive os que o mart já não guarda. Ver 091.
+ */
+export function useFutebolAlertedPicks() {
+  return useQuery<FutebolAlertedPick[]>({
+    queryKey: ['futebol', 'alerted-picks'],
+    queryFn: () => futebolDataService.getAlertedPicks(),
     staleTime: 5 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
     refetchOnWindowFocus: false,

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -4,7 +4,7 @@ import { ChevronRight, ChevronDown, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Skeleton } from '@/components/ui/skeleton';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import { useFutebolValueBoard, useFutebolAccess, useFutebolFixturesMulti } from '@/hooks/use-futebol-data';
+import { useFutebolValueBoard, useFutebolAccess, useFutebolFixturesMulti, useFutebolAlertedPicks } from '@/hooks/use-futebol-data';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
@@ -16,10 +16,68 @@ import {
   faixaBadgeCls, faixaWord, faixaTone, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
-import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
+import type { FutebolValueBoardRow, FutebolAlertedPick, FutebolFixture } from '@/services/futebol-data.service';
 
 const SAO_PAULO_TZ = 'America/Sao_Paulo';
 const FINISHED_STATUS = new Set(['FT', 'AET', 'PEN']);
+
+/**
+ * Linha da lista. O board (mart) sempre traz Score, faixa, chance e valor; uma
+ * oportunidade REGISTRADA (que existiu no dia e o board não tem mais, porque o
+ * mart é full-refresh e re-escolhe a janela de odds) pode não ter esses números
+ * do instante em que era oportunidade — nas enviadas antes da migration 091 não
+ * foram guardados. Ela continua sendo oportunidade do dia; só esses campos ficam
+ * vazios. FutebolValueBoardRow é atribuível a isto (number → number | null).
+ */
+type OppLike = Omit<FutebolValueBoardRow, 'score' | 'faixa' | 'edge' | 'prob_justa_fechamento'> & {
+  score: number | null;
+  faixa: string | null;
+  edge: number | null;
+  prob_justa_fechamento: number | null;
+};
+
+/** Chave de uma oportunidade — casa board com registro do que foi enviado. */
+const oppKey = (fixtureId: number, market: string | null, outcome: string | null, line: number | null) =>
+  `${fixtureId}|${market ?? ''}|${outcome ?? ''}|${line ?? ''}`;
+
+/**
+ * Monta a linha de uma oportunidade registrada (enviada no daily) com os valores
+ * do momento do envio. Sem fixture casado, cai pro "Casa × Fora" do registro:
+ * é melhor manter a oportunidade na lista sem escudo do que perder o registro.
+ */
+function oppFromAlerted(a: FutebolAlertedPick, fx?: FutebolFixture): OppLike {
+  const [rawHome, rawAway] = a.match_description.split('×');
+  return {
+    fixture_id: a.fixture_id,
+    home_team_id: fx?.home_team_id ?? 0,
+    away_team_id: fx?.away_team_id ?? 0,
+    home_team_name: fx?.home_team_name ?? (rawHome?.trim() || 'Casa'),
+    away_team_name: fx?.away_team_name ?? (rawAway?.trim() || 'Fora'),
+    competition: a.league ?? '',
+    kickoff_utc: fx?.kickoff_utc ?? null,
+    status_short: fx?.status_short ?? null,
+    market: a.market!,
+    outcome: a.outcome!,
+    line_value: a.line_value,
+    best_odd: Number(a.odds),
+    best_book: '',
+    avg_odd: Number(a.odds),
+    n_casas: 0,
+    janela_usada: a.janela_usada ?? '',
+    pts_valor: 0,
+    pts_premissas: 0,
+    pts_corroboracao: 0,
+    penalidades: 0,
+    evidencias: [],
+    // Números do instante em que era oportunidade. Null nas enviadas antes da
+    // migration 091 (o pipeline sobrescreve a janela e destrói chance/valor/Score
+    // da manhã); daí em diante vêm preenchidos e a linha fica igual à do board.
+    score: a.score,
+    faixa: a.faixa,
+    edge: a.edge,
+    prob_justa_fechamento: a.prob_justa_fechamento,
+  };
+}
 
 function kickoffMs(raw: string | null): number | null {
   if (!raw) return null;
@@ -142,17 +200,20 @@ function FilterSelect({ label, value, options, onChange }: {
 
 // Linha da tabela (desktop)
 function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
-  o: FutebolValueBoardRow; onClick: () => void; muted?: boolean; locked?: boolean;
+  o: OppLike; onClick: () => void; muted?: boolean; locked?: boolean;
   result?: BetResult | null; homeGoals?: number | null; awayGoals?: number | null;
 }) {
   const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
   const showLock = !!locked && !result; // histórico (com resultado) é sempre visível
   const hasScore = homeGoals != null && awayGoals != null;
+  // Sem os números do instante em que era oportunidade, mostra "—" em vez de
+  // chutar faixa (faixaWord de vazio diria "Baixa", que seria falso).
+  const badgeCls = o.faixa != null ? faixaBadgeCls(o.faixa) : 'bg-canvas-2 text-ink-3 border border-line';
   return (
     <button onClick={onClick} className={`${GRID} w-full text-left px-5 py-3 border-t border-line hover:bg-canvas-2 transition ${muted ? 'opacity-60' : ''}`}>
-      <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[16px] w-10 h-9 ${faixaBadgeCls(o.faixa)}`}>{o.score}</span>
-      <span className={`px-1.5 h-5 w-fit inline-flex items-center rounded text-[10px] font-bold uppercase tracking-[0.1em] ${faixaBadgeCls(o.faixa)}`}>{faixaWord(o.faixa)}</span>
+      <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[16px] w-10 h-9 ${badgeCls}`}>{o.score ?? '—'}</span>
+      <span className={`px-1.5 h-5 w-fit inline-flex items-center rounded text-[10px] font-bold uppercase tracking-[0.1em] ${badgeCls}`}>{o.faixa != null ? faixaWord(o.faixa) : '—'}</span>
       <div className="flex items-center gap-2.5 min-w-0">
         <div className="flex items-center gap-1 shrink-0">
           <Crest teamId={o.home_team_id} name={o.home_team_name} size={20} />
@@ -176,7 +237,7 @@ function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
       </div>
       <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={showLock}>{chance != null ? `${chance}%` : '—'}</Blur></div>
       <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={showLock}>{o.best_odd.toFixed(2)}</Blur></div>
-      <div className="text-right tabular-nums text-[14px] font-bold text-forest"><Blur active={showLock}>{fmtEdgeScore(o.edge)}</Blur></div>
+      <div className="text-right tabular-nums text-[14px] font-bold text-forest"><Blur active={showLock}>{o.edge != null ? fmtEdgeScore(o.edge) : '—'}</Blur></div>
       <ChevronRight className="w-4 h-4 text-ink-3 justify-self-end" />
     </button>
   );
@@ -184,7 +245,7 @@ function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
 
 // Card (mobile)
 function OppMobileCard({ o, onClick, locked, result, homeGoals, awayGoals }: {
-  o: FutebolValueBoardRow; onClick: () => void; locked?: boolean;
+  o: OppLike; onClick: () => void; locked?: boolean;
   result?: BetResult | null; homeGoals?: number | null; awayGoals?: number | null;
 }) {
   const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
@@ -201,7 +262,9 @@ function OppMobileCard({ o, onClick, locked, result, homeGoals, awayGoals }: {
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-1.5 flex-wrap">
             <span className="px-1.5 h-5 inline-flex items-center rounded text-[9px] font-semibold uppercase tracking-[0.08em] bg-canvas-2 text-ink-2">{marketLabel(o.market)}</span>
-            <span className={`px-1.5 h-5 inline-flex items-center rounded text-[9px] font-bold uppercase tracking-[0.1em] ${faixaBadgeCls(o.faixa)}`}>{faixaWord(o.faixa)}</span>
+            {o.faixa != null && (
+              <span className={`px-1.5 h-5 inline-flex items-center rounded text-[9px] font-bold uppercase tracking-[0.1em] ${faixaBadgeCls(o.faixa)}`}>{faixaWord(o.faixa)}</span>
+            )}
             {result && <ResultBadge r={result} />}
           </div>
           <div className="text-[15px] font-semibold tracking-tight mt-1.5 text-ink"><Blur active={showLock}>{pick}</Blur></div>
@@ -213,11 +276,11 @@ function OppMobileCard({ o, onClick, locked, result, homeGoals, awayGoals }: {
         </div>
         <div className="text-right shrink-0">
           <div className="text-[8px] uppercase tracking-[0.14em] font-semibold text-ink-3">Score</div>
-          <div className="text-[22px] font-bold tabular-nums tracking-tight leading-none text-forest">{o.score}</div>
+          <div className="text-[22px] font-bold tabular-nums tracking-tight leading-none text-forest">{o.score ?? '—'}</div>
         </div>
       </div>
       <div className="grid grid-cols-3 gap-1 mt-3 pt-2.5 border-t border-line">
-        {[['Chance', chance != null ? `${chance}%` : '—'], ['Odd', o.best_odd.toFixed(2)], ['Valor', fmtEdgeScore(o.edge)]].map(([l, v], i) => (
+        {[['Chance', chance != null ? `${chance}%` : '—'], ['Odd', o.best_odd.toFixed(2)], ['Valor', o.edge != null ? fmtEdgeScore(o.edge) : '—']].map(([l, v], i) => (
           <div key={l}>
             <div className="text-[8px] uppercase tracking-[0.14em] font-semibold text-ink-3">{l}</div>
             <div className={`text-[13px] font-semibold tabular-nums leading-none mt-0.5 ${i === 2 ? 'text-forest' : 'text-ink'}`}><Blur active={showLock}>{v}</Blur></div>
@@ -280,12 +343,34 @@ export default function FutebolOportunidades() {
     (fixtures ?? []).forEach((f) => m.set(f.fixture_id, { gh: f.goals_home, ga: f.goals_away }));
     return m;
   }, [fixtures]);
+  // Fixture completo (escudo, nome, status) pra montar a linha de uma
+  // oportunidade registrada que o board não tem mais.
+  const fixtureMap = useMemo(() => {
+    const m = new Map<number, FutebolFixture>();
+    (fixtures ?? []).forEach((f) => m.set(f.fixture_id, f));
+    return m;
+  }, [fixtures]);
 
-  const resultOf = (o: FutebolValueBoardRow): BetResult | null => {
+  const resultOf = (o: OppLike): BetResult | null => {
     if (!FINISHED_STATUS.has(o.status_short ?? '')) return null;
     const g = goalsMap.get(o.fixture_id);
     return g ? settleFutebol(o.market, o.outcome, o.line_value, g.gh, g.ga) : null;
   };
+
+  // ── Oportunidades REGISTRADAS ─────────────────────────────────────────────
+  // O mart é full-refresh e escolhe UMA janela de odds por jogo (t24h de manhã →
+  // t15m no fechamento), então uma oportunidade que existiu durante o dia pode
+  // não estar mais lá — foi o caso do "Palmeiras −0,25" de 22/07, que saiu no
+  // daily e deu green. Ela FOI oportunidade de fato, então o registro entra na
+  // lista do dia como qualquer outra, com os valores do momento em que era.
+  // Fonte: daily_opportunity_picks via get_futebol_alerted_picks (migration 091).
+  const { data: alertedRaw } = useFutebolAlertedPicks();
+  // Sem market/outcome não há como casar com o board nem liquidar (linhas
+  // anteriores ao 091 podem vir sem).
+  const registradasAll = useMemo(
+    () => (alertedRaw ?? []).filter((a) => !!a.market && !!a.outcome),
+    [alertedRaw]
+  );
 
   // Dias no stepper: dias COM oportunidade (board = passado + presente) + dias
   // FUTUROS com jogos agendados (fixtures, janela curta) — pra navegar pra frente
@@ -293,6 +378,9 @@ export default function FutebolOportunidades() {
   const days = useMemo(() => {
     const set = new Set<string>();
     allRows.forEach((r) => { const d = brtDayStr(r.kickoff_utc); if (d) set.add(d); });
+    // Dias que tiveram oportunidade registrada: o mart larga dia antigo (o 22/07
+    // já não tem nenhuma linha lá), e sem isto o dia ficaria inalcançável.
+    registradasAll.forEach((a) => set.add(a.game_day));
     const now = Date.now();
     const horizon = now + 8 * 864e5; // ~8 dias à frente
     (fixtures ?? []).forEach((f) => {
@@ -303,7 +391,7 @@ export default function FutebolOportunidades() {
       }
     });
     return [...set].sort();
-  }, [allRows, fixtures]);
+  }, [allRows, fixtures, registradasAll]);
   // Default: hoje se houver; senão o próximo dia futuro; senão o último disponível.
   const selectedDay = (day && days.includes(day))
     ? day
@@ -314,8 +402,9 @@ export default function FutebolOportunidades() {
   const compsOnDay = useMemo(() => {
     const s = new Set<string>();
     allRows.forEach((r) => { if (brtDayStr(r.kickoff_utc) === selectedDay) s.add(r.competition); });
+    registradasAll.forEach((a) => { if (a.game_day === selectedDay && a.league) s.add(a.league); });
     return s;
-  }, [allRows, selectedDay]);
+  }, [allRows, selectedDay, registradasAll]);
 
   const faixaOptions = [{ value: 'all', label: 'Todas' }, { value: 'alta', label: 'Alta' }, { value: 'media', label: 'Média' }];
   const compOptions = [
@@ -323,24 +412,49 @@ export default function FutebolOportunidades() {
     ...sortCompetitions([...compsOnDay]).map((c) => ({ value: c, label: competitionLabel(c) })),
   ];
 
+  // Lista do dia = board + oportunidades registradas que o board não tem mais.
+  // Uma lista só: as duas são oportunidade daquele dia, a diferença é de onde
+  // veio o número, não de natureza.
+  const dayRows = useMemo<OppLike[]>(() => {
+    const board: OppLike[] = allRows.filter((r) => brtDayStr(r.kickoff_utc) === selectedDay);
+    const noBoard = new Set(board.map((r) => oppKey(r.fixture_id, r.market, r.outcome, r.line_value)));
+    const registradas = registradasAll
+      .filter((a) => a.game_day === selectedDay)
+      .filter((a) => !noBoard.has(oppKey(a.fixture_id, a.market, a.outcome, a.line_value)))
+      .map((a) => oppFromAlerted(a, fixtureMap.get(a.fixture_id)));
+    return [...board, ...registradas];
+  }, [allRows, selectedDay, registradasAll, fixtureMap]);
+
   const filtered = useMemo(
-    () => allRows.filter((r) => {
-      if (brtDayStr(r.kickoff_utc) !== selectedDay) return false;
+    () => dayRows.filter((r) => {
       if (mercado !== 'all' && r.market !== mercado) return false;
-      if (faixa !== 'all' && faixaTone(r.faixa) !== faixa) return false;
+      // Sem faixa não dá pra classificar, então o filtro de faixa a esconde.
+      if (faixa !== 'all' && (r.faixa == null || faixaTone(r.faixa) !== faixa)) return false;
       if (comp !== 'all' && r.competition !== comp) return false;
       return true;
     }),
-    [allRows, selectedDay, mercado, faixa, comp]
+    [dayRows, mercado, faixa, comp]
   );
 
   // Uma linha por oportunidade (sem colapsar por jogo), ranqueado por Score.
-  const bestRows = useMemo(() => [...filtered].sort((a, b) => b.score - a.score), [filtered]);
-  const comValor = bestRows.filter((o) => o.score >= SCORE_MEDIA);
-  const semValor = bestRows.filter((o) => o.score < SCORE_MEDIA);
-  const nAlta = bestRows.filter((o) => faixaTone(o.faixa) === 'alta').length;
-  const nMedia = bestRows.filter((o) => faixaTone(o.faixa) === 'media').length;
-  const nBaixa = bestRows.filter((o) => faixaTone(o.faixa) === 'baixa').length;
+  // Registro sem Score vai primeiro: o daily só manda pick acima do corte e do
+  // topo do ranking, então na hora do envio ela era das melhores do dia — o
+  // número exato daquele instante é que não foi guardado.
+  const bestRows = useMemo(
+    () => [...filtered].sort((a, b) => {
+      if (a.score == null && b.score == null) return 0;
+      if (a.score == null) return -1;
+      if (b.score == null) return 1;
+      return b.score - a.score;
+    }),
+    [filtered]
+  );
+  // Registro sem Score conta como com valor: foi enviado acima do corte.
+  const comValor = bestRows.filter((o) => o.score == null || o.score >= SCORE_MEDIA);
+  const semValor = bestRows.filter((o) => o.score != null && o.score < SCORE_MEDIA);
+  const nAlta = bestRows.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'alta').length;
+  const nMedia = bestRows.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'media').length;
+  const nBaixa = bestRows.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'baixa').length;
 
   // Contagem de oportunidades COM VALOR por dia (badge do stepper).
   const countByDay = useMemo(() => {
@@ -353,8 +467,16 @@ export default function FutebolOportunidades() {
     });
     const out: Record<string, number> = {};
     byDay.forEach((rs, d) => { out[d] = rs.filter((o) => o.score >= SCORE_MEDIA).length; });
+    // Registrada que o board não tem entra na conta, senão dia que só tem
+    // registro apareceria zerado no seletor.
+    registradasAll.forEach((a) => {
+      const naLista = (byDay.get(a.game_day) ?? []).some(
+        (r) => oppKey(r.fixture_id, r.market, r.outcome, r.line_value) === oppKey(a.fixture_id, a.market, a.outcome, a.line_value)
+      );
+      if (!naLista) out[a.game_day] = (out[a.game_day] ?? 0) + 1;
+    });
     return out;
-  }, [allRows]);
+  }, [allRows, registradasAll]);
 
   // Resumo do dia passado: quantas das "com valor" bateram.
   const resumo = useMemo(() => {
@@ -373,7 +495,7 @@ export default function FutebolOportunidades() {
   }, [isPastDay, comValor, goalsMap]);
 
   const go = (id: number) => navigate(`/futebol/jogo/${id}`);
-  const key = (o: FutebolValueBoardRow) => `${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`;
+  const key = (o: OppLike) => `${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`;
 
   return (
     <div className="theme-bolao min-h-screen bg-canvas flex flex-col">

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -366,6 +366,32 @@ export interface FutebolValueBoardRow {
   evidencias: string[];    // "por quê" (montado no backend); usar a 1ª na lista
 }
 
+// ── O que foi ALERTADO no Telegram (public.daily_opportunity_picks, ver 091) ──
+// Fonte separada do board de propósito: o mart é full-refresh e re-escolhe a
+// janela de odds, então o pick que saiu às 10h pode não estar mais lá à noite.
+// Isto é o registro do que a pessoa recebeu, não do que fechou.
+export interface FutebolAlertedPick {
+  game_day: string;           // YYYY-MM-DD (dia do jogo, BRT)
+  fixture_id: number;
+  market: string | null;      // null nas linhas antigas sem pick estruturado
+  outcome: string | null;
+  line_value: number | null;
+  bet_description: string;    // rótulo exatamente como foi enviado
+  betting_market: string | null;
+  league: string | null;      // slug da competição (mesmo do board)
+  match_description: string;  // "Coritiba × Palmeiras" (fallback de nome)
+  odds: number;               // odd do momento do envio
+  janela_usada: string | null;
+  // Números do instante do envio. Vêm null nas enviadas antes da migration 091:
+  // o pipeline sobrescreve a janela e destrói chance/valor/Score da manhã, então
+  // não há de onde recuperar — a tela mostra "—" nesses casos.
+  score: number | null;
+  faixa: string | null;
+  edge: number | null;
+  prob_justa_fechamento: number | null;
+  sent_at: string;
+}
+
 export interface FutebolFixtureValueRow {
   market: string;            // 'match_winner' | 'goals_over_under'
   outcome: string;
@@ -582,6 +608,22 @@ export const futebolDataService = {
       const { data, error } = await supabaseClient.rpc('get_futebol_value_board');
       if (error) throw error;
       return (data || []) as FutebolValueBoardRow[];
+    });
+  },
+
+  /**
+   * O que foi ALERTADO no Telegram nos últimos 90 dias (dia do jogo, BRT).
+   * Sem dia = todos, porque o front precisa saber QUAIS dias tiveram alerta pra
+   * montar o seletor de dias (o mart não guarda dia antigo). São poucas linhas.
+   * Ver migration 091.
+   */
+  async getAlertedPicks(day?: string): Promise<FutebolAlertedPick[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_futebol_alerted_picks', {
+        p_day: day ?? null,
+      });
+      if (error) throw error;
+      return (data || []) as FutebolAlertedPick[];
     });
   },
 

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -111,6 +111,9 @@ interface BoardRow {
   best_odd: number;
   score: number;
   faixa: string;
+  janela_usada: string | null;
+  edge: number | null;
+  prob_justa_fechamento: number | null;
   evidencias: string[] | null;
 }
 
@@ -225,8 +228,17 @@ serve(async (req) => {
       });
     }
 
-    // 5) persiste os picks do dia (referência dos botões "Registrar no Betinho")
+    // 5) persiste os picks do dia (referência dos botões "Registrar no Betinho"
+    // e do histórico "enviado no Telegram" da tela de Oportunidades)
     // — uma vez, compartilhado entre todos; upsert idempotente por (dia,jogo,aposta)
+    //
+    // O pick vai TAMBÉM estruturado, com os números deste instante (ver migration
+    // 091): o mart é full-refresh e re-escolhe a janela de odds, então em algumas
+    // horas este pick pode não existir mais lá — e chance/valor/Score da janela da
+    // manhã são DESTRUÍDOS quando a de fechamento entra (conferido: a devig só
+    // guarda t24h enquanto o jogo é futuro). Se não gravar aqui, morre: o histórico
+    // passa a mostrar o pick de fechamento em vez do que a pessoa recebeu, e não há
+    // como liquidar green/red (não se liquida "Palmeiras −0,25" em texto).
     const pickRows = picks.map((p) => ({
       fixture_id: p.fixture_id,
       sport: "Futebol",
@@ -236,6 +248,14 @@ serve(async (req) => {
       bet_description: pickLabel(p.market, p.outcome, p.line_value, p.home_team_name, p.away_team_name),
       odds: p.best_odd,
       match_date: kickoffDate(p.kickoff_utc).toISOString(),
+      market: p.market,
+      outcome: p.outcome,
+      line_value: p.line_value,
+      janela_usada: p.janela_usada,
+      score: p.score,
+      faixa: p.faixa,
+      edge: p.edge,
+      prob_justa_fechamento: p.prob_justa_fechamento,
     }));
     const { data: savedPicks, error: pErr } = await supabase
       .from("daily_opportunity_picks")

--- a/supabase/migrations/091_opportunity_alerted_history.sql
+++ b/supabase/migrations/091_opportunity_alerted_history.sql
@@ -1,0 +1,148 @@
+-- ============================================================
+-- 091_opportunity_alerted_history — histórico fiel do que foi ALERTADO
+-- ============================================================
+-- Contexto (task wdx6zet45g): o mart do futebol (fact_value_opportunities) é
+-- full-refresh e escolhe UMA janela por jogo (t24h → t1h → t15m). O daily sai
+-- às 10h BRT com a janela da manhã; até o jogo, o pick de valor pode virar.
+-- Resultado: a tela de Oportunidades mostra o pick de FECHAMENTO, não o que a
+-- pessoa recebeu no Telegram.
+--
+-- Caso real (22/07, Coritiba 1 × 3 Palmeiras): enviamos "Palmeiras −0,25", que
+-- deu GREEN. O board fechou com Under 2,25 e Under 2,5, as duas RED. Ou seja,
+-- hoje o histórico mostra red num dia em que o que mandamos deu green.
+--
+-- O registro do que foi enviado NÃO se perde: daily_opportunity_picks (085) já
+-- guarda desde 21/07. Faltava só (a) o pick ESTRUTURADO, porque não se liquida
+-- green/red a partir de texto ("Palmeiras −0,25"), e (b) uma RPC pro front ler
+-- (a tabela é service_role-only).
+--
+-- O snapshot por janela no BigQuery (fact_value_opportunities_hist) é a outra
+-- frente e está com o Mateus. Hoje ele não captura a janela da manhã (t24h =
+-- 2 de 888 linhas), então não serve ainda pra reproduzir o alerta. Quando
+-- capturar, entra como complemento: TODAS as oportunidades como estavam no
+-- momento do envio, não só o pick que foi enviado.
+-- ============================================================
+
+-- ── 1. Pick estruturado + números do momento do envio ────────
+-- Por que gravar Score/faixa/chance/valor aqui, se "já estão no mart": porque
+-- NÃO estão. Tudo no pipeline é full-refresh e guarda uma janela por jogo, e a
+-- janela da manhã é substituída pela de fechamento. Conferido em 29/07/2026:
+-- `int_futebol_odds_devig` (onde vivem chance e edge por janela) tem t24h só
+-- pros jogos FUTUROS; de jogo passado sobra apenas t15m. E `message_runs`
+-- (telemetria do envio, que guardava top_score) não existe em produção. Ou seja,
+-- se não gravar no instante do envio, o número morre.
+ALTER TABLE public.daily_opportunity_picks
+  ADD COLUMN IF NOT EXISTS market                text,
+  ADD COLUMN IF NOT EXISTS outcome               text,
+  ADD COLUMN IF NOT EXISTS line_value            double precision,
+  ADD COLUMN IF NOT EXISTS janela_usada          text,
+  ADD COLUMN IF NOT EXISTS score                 integer,
+  ADD COLUMN IF NOT EXISTS faixa                 text,
+  ADD COLUMN IF NOT EXISTS edge                  double precision,
+  ADD COLUMN IF NOT EXISTS prob_justa_fechamento double precision;
+
+COMMENT ON COLUMN public.daily_opportunity_picks.market IS
+  'market do mart (match_winner, goals_over_under, asian_handicap, btts, double_chance). Liquidação em src/utils/futebol-settlement.ts.';
+COMMENT ON COLUMN public.daily_opportunity_picks.outcome IS
+  'outcome do mart (Home/Away/Draw, Over/Under, Yes/No, 1X/X2/12).';
+COMMENT ON COLUMN public.daily_opportunity_picks.line_value IS
+  'Linha na ótica do MANDANTE — mesma convenção do mart e do pickLabel (pro visitante o rótulo mostra o oposto).';
+COMMENT ON COLUMN public.daily_opportunity_picks.janela_usada IS
+  'Janela de odds que gerou o alerta (t24h/t1h/t15m). É exatamente o dado que o mart perde ao sobrescrever.';
+COMMENT ON COLUMN public.daily_opportunity_picks.score IS
+  'Score do pick no momento do envio (o do mart muda quando a janela vira).';
+COMMENT ON COLUMN public.daily_opportunity_picks.faixa IS
+  'Faixa (Alta/Média/Baixa) no momento do envio. Gravada em vez de derivada do score pra não depender dos limiares do front.';
+COMMENT ON COLUMN public.daily_opportunity_picks.edge IS
+  'Valor (edge, fração: 0.088 = +8,8%) no momento do envio. Não é recuperável depois: a devig sobrescreve a janela.';
+COMMENT ON COLUMN public.daily_opportunity_picks.prob_justa_fechamento IS
+  'Chance (prob justa devigada, 0..1) no momento do envio. Também não é recuperável depois.';
+
+-- Nas 8 linhas anteriores a esta migration estes 4 campos ficam NULL: o dado do
+-- instante do envio já não existe em nenhuma fonte (ver bloco acima). A tela
+-- mostra "—" nelas em vez de exibir o número do fechamento, que contaria outra
+-- história (o "Palmeiras −0,25" de 22/07, enviado como valor positivo, fechou
+-- com edge −2,8% — foi por isso que saiu do board).
+
+-- ── 2. Backfill das linhas anteriores a esta migration ───────
+-- Derivado do bet_description à mão: o mart já não tem o pick do 1492294, então
+-- não há de onde puxar por join. Chave usada: (sent_date, fixture_id) — única em
+-- todas elas. Guardado por `market is null` pra ser idempotente e nunca
+-- sobrescrever o que o envio gravar daqui pra frente.
+-- São 6 linhas em prod e 8 em staging (as duas de 13/07 e 19/07 só existem lá;
+-- em prod esses UPDATEs não casam com nada e viram no-op).
+--
+-- Convenção da linha (ótica do mandante), conferida contra o placar real:
+--   1520781 Avai 2×1 America   · Menos de 2,25   → Under  2.25  (total 3  → red)
+--   1492294 Coritiba 1×3 Palm. · Palmeiras −0,25 → Away  +0.25  (diff −2 → GREEN)
+--   1520783 Ceara 0×1 CRB      · Ceara −1,5      → Home  −1.5   (diff −1 → red)
+--   1520796 Londrina 1×4 Novo. · Novorizontino +0,5 → Away −0.5 (diff −3 → GREEN)
+--   1520795 Juventude × Avai   · Menos de 2,25   → Under  2.25  (jogo do dia)
+--   1547787 Tigre × Nacional   · Menos de 2,25   → Under  2.25  (jogo do dia)
+--   1581821 Spain × Belgium    · Vitória: Spain  → Home   (só staging)
+--   1591866 Spain × Argentina  · Vitória: Spain  → Home   (só staging)
+UPDATE public.daily_opportunity_picks SET market = 'match_winner', outcome = 'Home'
+  WHERE market IS NULL AND sent_date = '2026-07-13' AND fixture_id = 1581821;
+UPDATE public.daily_opportunity_picks SET market = 'match_winner', outcome = 'Home'
+  WHERE market IS NULL AND sent_date = '2026-07-19' AND fixture_id = 1591866;
+UPDATE public.daily_opportunity_picks SET market = 'goals_over_under', outcome = 'Under', line_value = 2.25
+  WHERE market IS NULL AND sent_date = '2026-07-21' AND fixture_id = 1520781;
+UPDATE public.daily_opportunity_picks SET market = 'asian_handicap', outcome = 'Away', line_value = 0.25
+  WHERE market IS NULL AND sent_date = '2026-07-22' AND fixture_id = 1492294;
+UPDATE public.daily_opportunity_picks SET market = 'asian_handicap', outcome = 'Home', line_value = -1.5
+  WHERE market IS NULL AND sent_date = '2026-07-22' AND fixture_id = 1520783;
+UPDATE public.daily_opportunity_picks SET market = 'asian_handicap', outcome = 'Away', line_value = -0.5
+  WHERE market IS NULL AND sent_date = '2026-07-26' AND fixture_id = 1520796;
+UPDATE public.daily_opportunity_picks SET market = 'goals_over_under', outcome = 'Under', line_value = 2.25
+  WHERE market IS NULL AND sent_date = '2026-07-28' AND fixture_id = 1520795;
+UPDATE public.daily_opportunity_picks SET market = 'goals_over_under', outcome = 'Under', line_value = 2.25
+  WHERE market IS NULL AND sent_date = '2026-07-28' AND fixture_id = 1547787;
+
+-- ── 3. RPC: o que foi alertado ───────────────────────────────
+-- A tabela é service_role-only (RLS sem policy), então o front lê por aqui.
+-- Sem gate de assinatura de propósito: o histórico com resultado já é visível
+-- pra quem não assina (é a prova de entrega), igual ao resto da tela.
+--
+-- p_day null = todos os dias da janela (90d). É assim que o front usa: são
+-- poucas linhas (1 a 3 picks por dia) e ele precisa saber QUAIS dias tiveram
+-- alerta pra montar o seletor de dias. Isso importa porque o mart é
+-- full-refresh e joga dias antigos fora — o 22/07, por exemplo, já não tem
+-- nenhuma linha lá, e sem isto o dia do "Palmeiras −0,25" ficaria inalcançável.
+CREATE OR REPLACE FUNCTION public.get_futebol_alerted_picks(p_day date DEFAULT NULL)
+RETURNS TABLE(
+  game_day              date,
+  fixture_id            bigint,
+  market                text,
+  outcome               text,
+  line_value            double precision,
+  bet_description       text,
+  betting_market        text,
+  league                text,
+  match_description     text,
+  odds                  numeric,
+  janela_usada          text,
+  score                 integer,
+  faixa                 text,
+  edge                  double precision,
+  prob_justa_fechamento double precision,
+  sent_at               timestamptz
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO ''
+AS $function$
+  select coalesce((p.match_date at time zone 'America/Sao_Paulo')::date, p.sent_date) as game_day,
+         p.fixture_id, p.market, p.outcome, p.line_value,
+         p.bet_description, p.betting_market, p.league, p.match_description, p.odds,
+         p.janela_usada, p.score, p.faixa, p.edge, p.prob_justa_fechamento, p.created_at
+  from public.daily_opportunity_picks p
+  where p.sport = 'Futebol'
+    and coalesce((p.match_date at time zone 'America/Sao_Paulo')::date, p.sent_date)
+        >= (now() at time zone 'America/Sao_Paulo')::date - 90
+    and (p_day is null
+         or coalesce((p.match_date at time zone 'America/Sao_Paulo')::date, p.sent_date) = p_day)
+  order by game_day, p.created_at;
+$function$;
+
+COMMENT ON FUNCTION public.get_futebol_alerted_picks(date) IS
+  'Picks do daily de oportunidades enviados nos últimos 90 dias (dia do JOGO, fuso BRT). p_day null = todos. Fonte do selo "enviado no Telegram" e do pick que saiu do board no histórico da tela de Oportunidades.';
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_alerted_picks(date) TO anon, authenticated, service_role;

--- a/supabase/migrations/091_opportunity_alerted_history.sql
+++ b/supabase/migrations/091_opportunity_alerted_history.sql
@@ -17,20 +17,27 @@
 -- (a tabela é service_role-only).
 --
 -- O snapshot por janela no BigQuery (fact_value_opportunities_hist) é a outra
--- frente e está com o Mateus. Hoje ele não captura a janela da manhã (t24h =
--- 2 de 888 linhas), então não serve ainda pra reproduzir o alerta. Quando
--- capturar, entra como complemento: TODAS as oportunidades como estavam no
--- momento do envio, não só o pick que foi enviado.
+-- frente e está com o Mateus (task wdx6zeumpz). Ele fotografa o MART; nós
+-- guardamos o que foi ENVIADO. São perguntas diferentes: o snapshot responde
+-- "o que o board tinha naquele instante", este registro responde "qual pick nós
+-- mandamos e com que números". Um não substitui o outro, e o nosso não depende
+-- do ritmo do pipeline dele.
+--
+-- Nota sobre a janela t24h, pra não repetir um erro de leitura: t24h de jogo
+-- noturno é materializada na NOITE ANTERIOR (~24h antes do jogo), não na manhã
+-- do dia do jogo. As duas linhas t24h que existem no hist foram capturadas em
+-- 27/07 22:02 e 22:32 UTC, para jogos de 28/07 19:00 e 19:30 BRT — e são
+-- exatamente os dois picks que o daily enviou em 28/07.
 -- ============================================================
 
 -- ── 1. Pick estruturado + números do momento do envio ────────
 -- Por que gravar Score/faixa/chance/valor aqui, se "já estão no mart": porque
--- NÃO estão. Tudo no pipeline é full-refresh e guarda uma janela por jogo, e a
--- janela da manhã é substituída pela de fechamento. Conferido em 29/07/2026:
--- `int_futebol_odds_devig` (onde vivem chance e edge por janela) tem t24h só
--- pros jogos FUTUROS; de jogo passado sobra apenas t15m. E `message_runs`
--- (telemetria do envio, que guardava top_score) não existe em produção. Ou seja,
--- se não gravar no instante do envio, o número morre.
+-- NÃO estão. Tudo no pipeline é full-refresh e guarda uma janela por jogo: a
+-- janela vigente é substituída pela mais próxima do jogo conforme ele chega.
+-- Conferido em 29 e 30/07/2026 na `int_futebol_odds_devig` (onde vivem chance e
+-- edge por janela): jogo que ainda não começou tem t24h; de jogo passado sobra
+-- apenas t15m. E `message_runs` (telemetria do envio, que guardava top_score)
+-- não existe em produção. Ou seja, se não gravar no instante do envio, morre.
 ALTER TABLE public.daily_opportunity_picks
   ADD COLUMN IF NOT EXISTS market                text,
   ADD COLUMN IF NOT EXISTS outcome               text,


### PR DESCRIPTION
## O problema

O mart (`fact_value_opportunities`) é full-refresh e escolhe **uma** janela de odds por jogo, trocando pela mais próxima do jogo conforme ele chega. Uma oportunidade que existiu durante o dia pode não estar mais lá quando o jogo acaba, então o histórico da tela mostrava só o pick de fechamento.

**Caso real, 22/07, Coritiba 1 × 3 Palmeiras:** o daily das 10h mandou "Palmeiras −0,25", que deu **GREEN**. O board fechou com Under 2,25 e Under 2,5, as duas **RED**. O dia aparecia como "0 de 2 green" num dia em que o que a pessoa recebeu deu green.

## A decisão de produto

A oportunidade registrada entra na **mesma lista**, ranqueada junto com as outras, **sem nenhuma tag** de "saiu do board" ou "a linha mudou". Em algum momento do dia ela foi oportunidade de fato — não é exceção a ser sinalizada, é o registro do dia.

| Score | Faixa | Aposta | Mercado | Chance | Odd | Valor |
|---|---|---|---|---|---|---|
| — | — | Palmeiras −0,25 · **GREEN** · Coritiba 1 × 3 Palmeiras | Handicap | — | 1.69 | — |
| 53 | Média | Operario-PR · GREEN | Vencedor | 72% | 1.40 | +0.7% |
| 44 | Média | Menos de 2,5 gols · RED | Gols | 60% | 1.69 | +1.7% |

O resumo do dia passou de "0 de 2" para **"5 de 7 deram green"**.

## Por que os "—" (e por que não vão existir daqui pra frente)

Nas 8 apostas enviadas antes desta migration, Score/faixa/chance/valor do instante do envio **não existem em nenhuma fonte**. Verificado em 29 e 30/07:

- `int_futebol_odds_devig`, onde vivem chance e edge **por janela**, é sobrescrita: jogo que ainda não começou tem `t24h`; de jogo passado sobra `t15m`
- `message_runs`, que gravava o `top_score` do envio, **não existe em produção**

Dava pra preencher com os números do **fechamento** — aquele pick fechou com chance 53,7% e edge **−2,8%**, e foi por isso que saiu do board. Mas aí a tela mostraria valor negativo numa aposta enviada como valor positivo. Preferi "—" a contar a história errada.

**A partir do próximo envio** o registro nasce completo: testei inserindo uma linha com os campos preenchidos e ela renderiza idêntica a uma do board (Score 58 · MÉDIA · 55% · 1.95 · +7.0%).

## O que entra

- **091**: `daily_opportunity_picks` (085) ganha o pick estruturado (`market`/`outcome`/`line_value`) e os números do envio (`janela_usada`, `score`, `faixa`, `edge`, `prob_justa_fechamento`). Sem o pick estruturado não há como liquidar green/red — não se liquida `"Palmeiras −0,25"` em texto.
- **RPC `get_futebol_alerted_picks(p_day default null)`**: últimos 90 dias, security definer (a tabela é service_role-only). Devolve **todos** os dias de propósito: o mart larga dia antigo, o 22/07 já não tem nenhuma linha lá, e sem isso o dia ficaria inalcançável no seletor.
- **notify-opportunities**: grava tudo isso no instante do envio. O board já chegava na função com esses números; só não eram persistidos.
- **Tela**: tipo `OppLike` aceita score/faixa/edge/chance nulos e mostra "—". A linha registrada entra no resumo do dia, na contagem do seletor e no **blur do paywall** pelo mesmo caminho do board (nada de regra separada).
- **Backfill** das 8 linhas existentes (6 em prod, 8 em staging), derivado do `bet_description` à mão e conferido contra o placar real de cada jogo.

## Relação com o snapshot do BigQuery (task wdx6zeumpz)

São coisas complementares, e este PR **não depende** daquela task:

- o snapshot dele fotografa o **mart**: responde "o que o board tinha naquele instante"
- este registro é do **envio**: responde "qual pick nós mandamos e com que números"

Uma correção de leitura que fiz no caminho (commit `6298828`): eu havia escrito que o snapshot "não captura a janela da manhã". Errado — `t24h` de jogo noturno é materializada na **noite anterior**, ~24h antes do jogo, não na manhã. As duas linhas `t24h` do hist foram capturadas em 27/07 22:02 e 22:32 UTC, para jogos de 28/07 19:00 e 19:30 BRT, e são exatamente os dois picks enviados em 28/07. Não muda código, só a justificativa.

## Testes

- `npm run build` e `eslint` limpos; sem erro de tipo novo
- Migration aplicada e validada em **staging** (é onde o dev aponta): 8 de 8 backfilled, RPC respondendo
- Verificado em 1440px e 390px: lista unificada, mobile em 1 coluna sem rolagem lateral, e blur correto para quem não tem acesso
- `withRetry` já trata "função não existe" como não-retentável, então se a 091 ainda não estiver em prod o front degrada limpo (uma falha, sem retry, tela igual à de hoje)

## Ordem de deploy

1. aplicar a **091** em produção
2. mergear o front
3. **deployar a edge function `notify-opportunities`** — sem este passo as colunas novas nunca são preenchidas e o histórico continua com "—" para sempre

## ⚠️ Achado que não é deste PR

Produção está com migrations até a **085**. Faltam **086** (weekly_summary), **087**, **088** (ops_healthcheck), **089** (message_runs) e **090** (teto de reativação 2 → 5). Confirmado em prod: nenhuma função de weekly summary, nenhum cron de resumo semanal, `message_runs` inexistente e o teto de reativação ainda em 2. Não toquei em nada disso — precisa de decisão, porque 086/087 ligam um cron que envia mensagem para usuário real.

Colateral: como `message_runs` não existe, quando o daily fica silencioso (está assim desde 28/07) não há como saber se rodou e não achou nada ou se falhou.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
