### PR TITLE
feat(futebol): agenda por dia, leitura por premissas, campeonatos e o areia no app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,8 @@ const FutebolHoje = lazyWithRetry(() => import("./pages/FutebolHoje"));
 const FutebolOportunidades = lazyWithRetry(() => import("./pages/FutebolOportunidades"));
 const FutebolJogos = lazyWithRetry(() => import("./pages/FutebolJogos"));
 const FutebolJogo = lazyWithRetry(() => import("./pages/FutebolJogo"));
+const FutebolCampeonatos = lazyWithRetry(() => import("./pages/FutebolCampeonatos"));
+const FutebolCampeonato = lazyWithRetry(() => import("./pages/FutebolCampeonato"));
 const FutebolTime = lazyWithRetry(() => import("./pages/FutebolTime"));
 const FutebolAssinar = lazyWithRetry(() => import("./pages/FutebolAssinar"));
 const FutebolLP = lazyWithRetry(() => import("./pages/FutebolLP"));
@@ -160,6 +162,10 @@ const App = () => (
             <Route path="/futebol/oportunidades" element={<FutebolOportunidades />} />
             <Route path="/futebol/jogos" element={<FutebolJogos />} />
             <Route path="/futebol/jogo/:fixtureId" element={<FutebolJogo />} />
+            {/* Rodada, tabela e artilheiros saíram da agenda (/futebol/jogos) e
+                moraram aqui, porque são conceitos por liga. */}
+            <Route path="/futebol/campeonatos" element={<FutebolCampeonatos />} />
+            <Route path="/futebol/campeonato/:slug" element={<FutebolCampeonato />} />
             <Route path="/futebol/time/:teamId" element={<FutebolTime />} />
             <Route path="/futebol/assinar" element={<FutebolAssinar />} />
             <Route path="/nba-dashboard/:playerName" element={<NBADashboard />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,7 +77,7 @@ const AuthCallback = lazyWithRetry(() => import("./pages/AuthCallback"));
 const queryClient = new QueryClient();
 
 const LazyFallback = () => (
-  <div className="min-h-screen bg-canvas flex items-center justify-center">
+  <div className="theme-bolao min-h-screen bg-canvas flex items-center justify-center">
     <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-forest"></div>
   </div>
 );

--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -60,6 +60,9 @@ const FUTEBOL_ITEMS: SubItem[] = [
   { name: 'Hoje', href: '/futebol', icon: LayoutGrid },
   { name: 'Oportunidades', href: '/futebol/oportunidades', icon: Zap },
   { name: 'Jogos', href: '/futebol/jogos', icon: Calendar },
+  // "Jogos" é a agenda por dia (todas as ligas); "Campeonatos" é a navegação por
+  // liga, com rodada, tabela e artilheiros.
+  { name: 'Campeonatos', href: '/futebol/campeonatos', icon: Trophy },
 ];
 
 const BETINHO_ITEMS: SubItem[] = [

--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -113,9 +113,21 @@ export default function AnalyticsNav({
   const path = location.pathname;
   const isActive = (href: string) => path === href;
 
+  /**
+   * A tela pertence à seção? Vale a rota exata e as filhas dela. A faixa 2 usava
+   * só igualdade, então bastava abrir um detalhe para o contexto sumir: em
+   * /analise-360/1 e em /game/:id o cabeçalho ficava com uma faixa só, e a
+   * pessoa perdia a navegação da NBA no meio do caminho. O futebol nunca teve
+   * esse problema porque já testava por prefixo.
+   */
+  const daSecao = (href: string) => path === href || path.startsWith(`${href}/`);
+  // Rotas de detalhe da NBA que não moram embaixo de nenhum item do menu.
+  const NBA_DETALHES = ['/game/', '/nba-dashboard/'];
+
   const futebolActive = path.startsWith('/futebol');
-  const nbaActive = NBA_ITEMS.some((i) => isActive(i.href));
-  const betinhoActive = BETINHO_ITEMS.some((i) => isActive(i.href));
+  const nbaActive =
+    NBA_ITEMS.some((i) => daSecao(i.href)) || NBA_DETALHES.some((p) => path.startsWith(p));
+  const betinhoActive = BETINHO_ITEMS.some((i) => daSecao(i.href));
   const bolaoActive = path.startsWith('/bolao');
   const analisesActive = futebolActive || nbaActive;
 

--- a/src/components/PremiumRoute.tsx
+++ b/src/components/PremiumRoute.tsx
@@ -61,7 +61,7 @@ export default function PremiumRoute({
 
   if (authLoading || isCheckingSubscription) {
     return (
-      <div className="theme-rebrand min-h-screen bg-canvas flex items-center justify-center">
+      <div className="theme-bolao min-h-screen bg-canvas flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-2 border-forest border-t-transparent" />
       </div>
     );
@@ -79,7 +79,7 @@ export default function PremiumRoute({
 
   if (subscriptionStatus !== 'premium') {
     return (
-      <div className="theme-rebrand min-h-screen bg-canvas flex items-center justify-center">
+      <div className="theme-bolao min-h-screen bg-canvas flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-2 border-forest border-t-transparent" />
       </div>
     );

--- a/src/components/bets/BankrollEvolutionChart.tsx
+++ b/src/components/bets/BankrollEvolutionChart.tsx
@@ -200,7 +200,7 @@ export const BankrollEvolutionChart: React.FC<BankrollEvolutionChartProps> = ({
                 type="button"
                 onClick={() => setPeriod(p)}
                 className={`px-2.5 h-7 rounded-md font-medium transition-colors ${
-                  p === period ? 'bg-ink-3 text-ink' : 'text-ink-2 hover:text-ink hover:bg-ink-3/60'
+                  p === period ? 'bg-canvas-2 text-ink' : 'text-ink-2 hover:text-ink hover:bg-canvas-2'
                 }`}
               >
                 {p === 'all' ? 'Tudo' : p}
@@ -394,7 +394,7 @@ export const BankrollEvolutionChart: React.FC<BankrollEvolutionChartProps> = ({
                   <DropdownMenuSeparator className="bg-line" />
                   <DropdownMenuItem
                     onClick={() => setIsEditing(true)}
-                    className="cursor-pointer focus:bg-ink-3/60"
+                    className="cursor-pointer focus:bg-canvas-2"
                   >
                     <Edit2 className="w-4 h-4 mr-2 text-ink-2" />
                     Editar banca inicial

--- a/src/components/bets/CashFlowTable.tsx
+++ b/src/components/bets/CashFlowTable.tsx
@@ -279,7 +279,7 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
       case 'half_loss':
         return 'bg-rose-50/70 text-rose-700';
       case 'void':
-        return 'bg-ink-3 text-ink-2';
+        return 'bg-canvas-2 text-ink-2';
       case 'initial':
         return 'bg-forest-tint text-forest';
       case 'deposit':
@@ -321,7 +321,7 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
       {/* Filters bar */}
       <div className="px-5 py-3 border-b border-line flex flex-col md:flex-row md:items-center gap-3">
         {/* Search */}
-        <div className="flex items-center gap-2 px-2.5 h-9 bg-ink-3/40 border border-line rounded-md w-full md:w-[240px] shrink-0">
+        <div className="flex items-center gap-2 px-2.5 h-9 bg-canvas-2 border border-line rounded-md w-full md:w-[240px] shrink-0">
           <Search className="w-4 h-4 text-ink-2 shrink-0" />
           <input
             type="text"
@@ -420,11 +420,11 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
                 numberOfMonths={1}
                 classNames={{
                   caption_label: 'text-sm font-semibold text-ink',
-                  nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                  nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                   head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                  day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                  day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                   day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                  day_today: 'bg-ink-3 text-ink font-semibold',
+                  day_today: 'bg-canvas-2 text-ink font-semibold',
                   day_outside: 'text-ink-2 opacity-40',
                   day_disabled: 'text-ink-2 opacity-30',
                   day_range_middle: 'aria-selected:bg-forest-tint aria-selected:text-forest aria-selected:rounded-none',
@@ -477,7 +477,7 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
       {/* Desktop Table */}
       <div className="hidden md:block overflow-x-auto">
         <table className="w-full text-[12px]">
-          <thead className="bg-ink-3/40">
+          <thead className="bg-canvas-2">
             <tr className="text-left text-[10px] uppercase tracking-[0.1em] text-ink-2 font-semibold">
               <th className="py-2.5 px-3">Data</th>
               <th className="py-2.5 px-3">Descrição</th>
@@ -494,7 +494,7 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
               <tr
                 key={entry.id}
                 className={`border-b border-line transition-colors last:border-0 ${
-                  entry.type === 'initial' ? 'bg-forest-tint/30' : 'hover:bg-ink-3/30'
+                  entry.type === 'initial' ? 'bg-forest-tint/30' : 'hover:bg-canvas-2'
                 }`}
               >
                 <td className="py-2.5 px-3 tabular text-ink-2">{entry.date}</td>
@@ -537,7 +537,7 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
                         {onEditCapitalMovement && canEdit(entry.id) && (
                           <button
                             type="button"
-                            className="w-9 h-9 grid place-items-center text-ink-2 hover:text-ink hover:bg-ink-3/60 rounded transition-colors"
+                            className="w-9 h-9 grid place-items-center text-ink-2 hover:text-ink hover:bg-canvas-2 rounded transition-colors"
                             onClick={() => onEditCapitalMovement(entry.id)}
                             title="Editar movimento"
                             aria-label="Editar movimento"
@@ -588,7 +588,7 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
                     {onEditCapitalMovement && canEdit(entry.id) && (
                       <button
                         type="button"
-                        className="w-9 h-9 grid place-items-center text-ink-2 hover:text-ink hover:bg-ink-3/60 rounded transition-colors"
+                        className="w-9 h-9 grid place-items-center text-ink-2 hover:text-ink hover:bg-canvas-2 rounded transition-colors"
                         onClick={() => onEditCapitalMovement(entry.id)}
                         title="Editar movimento"
                         aria-label="Editar movimento"
@@ -654,7 +654,7 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
               onClick={() => handlePageChange(currentPage - 1)}
               disabled={currentPage === 1}
               aria-label="Página anterior"
-              className="h-8 w-8 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-ink-3/40 rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              className="h-8 w-8 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-canvas-2 rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <ChevronLeft className="w-4 h-4" />
             </button>
@@ -684,7 +684,7 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
                     className={`h-8 w-8 inline-flex items-center justify-center text-[12px] rounded-md font-medium transition-colors ${
                       p === currentPage
                         ? 'bg-forest text-white'
-                        : 'text-ink-2 hover:text-ink hover:bg-ink-3/40'
+                        : 'text-ink-2 hover:text-ink hover:bg-canvas-2'
                     }`}
                   >
                     {p}
@@ -697,7 +697,7 @@ export const CashFlowTable: React.FC<CashFlowTableProps> = ({
               onClick={() => handlePageChange(currentPage + 1)}
               disabled={currentPage === totalPages}
               aria-label="Próxima página"
-              className="h-8 w-8 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-ink-3/40 rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              className="h-8 w-8 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-canvas-2 rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <ChevronRight className="w-4 h-4" />
             </button>

--- a/src/components/bets/CreateBetModal.tsx
+++ b/src/components/bets/CreateBetModal.tsx
@@ -415,8 +415,8 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
                         setIsCreateSportQueryTouched(false);
                         setCreateSportHighlightIndex(-1);
                       }}
-                      className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                        index === createSportHighlightIndex ? 'bg-ink-3/40' : ''
+                      className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-canvas-2 ${
+                        index === createSportHighlightIndex ? 'bg-canvas-2' : ''
                       }`}
                     >
                       {sport}
@@ -538,8 +538,8 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
                         setIsCreateLeagueQueryTouched(false);
                         setCreateLeagueHighlightIndex(-1);
                       }}
-                      className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                        index === createLeagueHighlightIndex ? 'bg-ink-3/40' : ''
+                      className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-canvas-2 ${
+                        index === createLeagueHighlightIndex ? 'bg-canvas-2' : ''
                       }`}
                     >
                       {league}
@@ -658,8 +658,8 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
                         setIsCreateBettingMarketQueryTouched(false);
                         setCreateBettingMarketHighlightIndex(-1);
                       }}
-                      className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                        index === createBettingMarketHighlightIndex ? 'bg-ink-3/40' : ''
+                      className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-canvas-2 ${
+                        index === createBettingMarketHighlightIndex ? 'bg-canvas-2' : ''
                       }`}
                     >
                       {market}
@@ -796,11 +796,11 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
                   className="bg-white"
                   classNames={{
                     caption_label: 'text-sm font-semibold text-ink',
-                    nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                    nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                     head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                    day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                    day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                     day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                    day_today: 'bg-ink-3 text-ink font-semibold',
+                    day_today: 'bg-canvas-2 text-ink font-semibold',
                     day_outside: 'text-ink-2 opacity-40',
                     day_disabled: 'text-ink-2 opacity-30',
                   }}
@@ -860,11 +860,11 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
                   className="bg-white"
                   classNames={{
                     caption_label: 'text-sm font-semibold text-ink',
-                    nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                    nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                     head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                    day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                    day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                     day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                    day_today: 'bg-ink-3 text-ink font-semibold',
+                    day_today: 'bg-canvas-2 text-ink font-semibold',
                     day_outside: 'text-ink-2 opacity-40',
                     day_disabled: 'text-ink-2 opacity-30',
                   }}
@@ -942,7 +942,7 @@ export const CreateBetModal: React.FC<CreateBetModalProps> = ({
               type="button"
               variant="ghost"
               onClick={() => handleOpenChange(false)}
-              className="h-10 px-4 text-[13px] font-medium text-ink-2 hover:bg-ink-3/60 hover:text-ink rounded-md"
+              className="h-10 px-4 text-[13px] font-medium text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md"
             >
               Cancelar
             </Button>

--- a/src/components/bets/ProfitByTagChart.tsx
+++ b/src/components/bets/ProfitByTagChart.tsx
@@ -128,7 +128,7 @@ export const ProfitByTagChart: React.FC<ProfitByTagChartProps> = ({
       {displayEntries.length > 0 && (
         <div className="flex items-center justify-end gap-3 text-[10px] text-ink-2 mb-2 -mt-1">
           <span className="inline-flex items-center gap-1">
-            <span className="w-2 h-2 rounded-full bg-ink-3 border border-line" /> identidade da etiqueta
+            <span className="w-2 h-2 rounded-full bg-canvas-2 border border-line" /> identidade da etiqueta
           </span>
           <span className="inline-flex items-center gap-1">
             <span className="w-2.5 h-1.5 rounded-sm bg-forest" /> lucro
@@ -164,7 +164,7 @@ export const ProfitByTagChart: React.FC<ProfitByTagChartProps> = ({
                     )}
                     <span className="truncate">{entry.name}</span>
                   </div>
-                  <div className="relative h-5 bg-ink-3/40 rounded overflow-hidden">
+                  <div className="relative h-5 bg-canvas-2 rounded overflow-hidden">
                     <div className="absolute top-0 bottom-0 left-1/2 w-px bg-line" />
                     {positive ? (
                       <div
@@ -218,7 +218,7 @@ export const ProfitByTagChart: React.FC<ProfitByTagChartProps> = ({
                       {entry.roi > 0 ? '+' : ''}{entry.roi.toFixed(1)}%
                     </span>
                   </div>
-                  <div className="h-1.5 bg-ink-3/60 rounded-full overflow-hidden">
+                  <div className="h-1.5 bg-canvas-2 rounded-full overflow-hidden">
                     <div
                       className={`h-full rounded-full ${positive ? 'bg-forest' : 'bg-rose-700'}`}
                       style={{ width: `${width}%` }}

--- a/src/components/bets/ShareLinkModal.tsx
+++ b/src/components/bets/ShareLinkModal.tsx
@@ -130,7 +130,7 @@ export const ShareLinkModal: React.FC<ShareLinkModalProps> = ({
                 <Badge
                   key={i}
                   variant="secondary"
-                  className="bg-ink-3 border-line text-ink text-xs"
+                  className="bg-canvas-2 border-line text-ink text-xs"
                 >
                   {chip.label}
                 </Badge>
@@ -148,7 +148,7 @@ export const ShareLinkModal: React.FC<ShareLinkModalProps> = ({
             <div className="flex gap-2">
               <Popover open={isDateFromOpen} onOpenChange={setIsDateFromOpen} modal>
                 <PopoverTrigger asChild>
-                  <Button variant="outline" className="flex-1 h-10 bg-canvas border-line text-ink rounded-md hover:bg-ink-3/40 hover:text-ink text-xs justify-start py-1.5">
+                  <Button variant="outline" className="flex-1 h-10 bg-canvas border-line text-ink rounded-md hover:bg-canvas-2 hover:text-ink text-xs justify-start py-1.5">
                     <CalendarIcon className="mr-2 h-3.5 w-3.5 text-forest" />
                     {localDateFrom
                       ? format(new Date(localDateFrom + 'T12:00:00'), 'dd/MM/yyyy')
@@ -167,11 +167,11 @@ export const ShareLinkModal: React.FC<ShareLinkModalProps> = ({
                     className="bg-white"
                     classNames={{
                       caption_label: 'text-sm font-semibold text-ink',
-                      nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                      nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                       head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                      day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                      day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                       day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                      day_today: 'bg-ink-3 text-ink font-semibold',
+                      day_today: 'bg-canvas-2 text-ink font-semibold',
                       day_outside: 'text-ink-2 opacity-40',
                       day_disabled: 'text-ink-2 opacity-30',
                     }}
@@ -181,7 +181,7 @@ export const ShareLinkModal: React.FC<ShareLinkModalProps> = ({
 
               <Popover open={isDateToOpen} onOpenChange={setIsDateToOpen} modal>
                 <PopoverTrigger asChild>
-                  <Button variant="outline" className="flex-1 h-10 bg-canvas border-line text-ink rounded-md hover:bg-ink-3/40 hover:text-ink text-xs justify-start py-1.5">
+                  <Button variant="outline" className="flex-1 h-10 bg-canvas border-line text-ink rounded-md hover:bg-canvas-2 hover:text-ink text-xs justify-start py-1.5">
                     <CalendarIcon className="mr-2 h-3.5 w-3.5 text-forest" />
                     {localDateTo
                       ? format(new Date(localDateTo + 'T12:00:00'), 'dd/MM/yyyy')
@@ -200,11 +200,11 @@ export const ShareLinkModal: React.FC<ShareLinkModalProps> = ({
                     className="bg-white"
                     classNames={{
                       caption_label: 'text-sm font-semibold text-ink',
-                      nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                      nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                       head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                      day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                      day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                       day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                      day_today: 'bg-ink-3 text-ink font-semibold',
+                      day_today: 'bg-canvas-2 text-ink font-semibold',
                       day_outside: 'text-ink-2 opacity-40',
                       day_disabled: 'text-ink-2 opacity-30',
                     }}

--- a/src/components/bets/TagSelector.tsx
+++ b/src/components/bets/TagSelector.tsx
@@ -285,7 +285,7 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
                   <div className="space-y-1 max-h-40 overflow-y-auto">
                     {availableTags.map(tag => (
                       <div key={tag.id} className="space-y-1">
-                        <div className="flex items-center justify-between p-1 hover:bg-ink-3/40 rounded-md group">
+                        <div className="flex items-center justify-between p-1 hover:bg-canvas-2 rounded-md group">
                           <div className="flex-1 flex items-center gap-2 min-w-0">
                             <button
                               type="button"

--- a/src/components/dashboard/AIPeriodModal.tsx
+++ b/src/components/dashboard/AIPeriodModal.tsx
@@ -270,7 +270,7 @@ export const AIPeriodModal: React.FC<AIPeriodModalProps> = ({
               <button
                 type="button"
                 onClick={() => onOpenChange(false)}
-                className="h-10 px-4 rounded-md border border-line text-[12px] font-bold text-ink-2 hover:text-ink hover:bg-ink-3/40 transition-colors flex-1"
+                className="h-10 px-4 rounded-md border border-line text-[12px] font-bold text-ink-2 hover:text-ink hover:bg-canvas-2 transition-colors flex-1"
               >
                 Cancelar
               </button>

--- a/src/components/dashboard/BigHeatmap.tsx
+++ b/src/components/dashboard/BigHeatmap.tsx
@@ -174,7 +174,7 @@ export const BigHeatmap: React.FC<BigHeatmapProps> = ({
               } ${
                 hideEmpty
                   ? 'bg-forest-tint text-forest border border-forest/30'
-                  : 'bg-white text-ink-2 border border-line hover:bg-ink-3/40'
+                  : 'bg-white text-ink-2 border border-line hover:bg-canvas-2'
               }`}
               title={hideEmpty ? `${hiddenCount} ${hiddenCount === 1 ? 'linha/coluna oculta' : 'linhas/colunas ocultas'}. Clique para mostrar todas.` : 'Esconder linhas e colunas vazias'}
               aria-pressed={hideEmpty}
@@ -198,7 +198,7 @@ export const BigHeatmap: React.FC<BigHeatmapProps> = ({
                     } ${
                       metric === m
                         ? 'bg-forest text-white'
-                        : 'bg-white text-ink-2 border border-line hover:bg-ink-3/40'
+                        : 'bg-white text-ink-2 border border-line hover:bg-canvas-2'
                     }`}
                   >
                     {label}

--- a/src/components/dashboard/CalendarHeatmap.tsx
+++ b/src/components/dashboard/CalendarHeatmap.tsx
@@ -14,8 +14,8 @@ const WINDOW_DAYS = 91; // ~13 semanas (~3 meses)
 const STEP_DAYS = 28; // navegação: ~1 mês por click
 
 const intensityClass = (n: number, maxN: number): string => {
-  if (n === 0) return 'bg-ink-3/60';
-  if (maxN <= 0) return 'bg-ink-3/60';
+  if (n === 0) return 'bg-canvas-2';
+  if (maxN <= 0) return 'bg-canvas-2';
   const ratio = n / maxN;
   if (ratio <= 0.25) return 'bg-forest/30';
   if (ratio <= 0.5) return 'bg-forest/55';
@@ -84,7 +84,7 @@ export const CalendarHeatmap: React.FC<CalendarHeatmapProps> = ({ bets }) => {
               type="button"
               onClick={goBack}
               disabled={!canGoBack}
-              className="w-9 h-9 grid place-items-center rounded text-ink-2 hover:text-ink hover:bg-ink-3/60 disabled:opacity-30 disabled:cursor-not-allowed transition-colors shrink-0"
+              className="w-9 h-9 grid place-items-center rounded text-ink-2 hover:text-ink hover:bg-canvas-2 disabled:opacity-30 disabled:cursor-not-allowed transition-colors shrink-0"
               aria-label="Mês anterior"
             >
               <ChevronLeft className="w-3.5 h-3.5" />
@@ -110,7 +110,7 @@ export const CalendarHeatmap: React.FC<CalendarHeatmapProps> = ({ bets }) => {
               type="button"
               onClick={goForward}
               disabled={!canGoForward}
-              className="w-9 h-9 grid place-items-center rounded text-ink-2 hover:text-ink hover:bg-ink-3/60 disabled:opacity-30 disabled:cursor-not-allowed transition-colors shrink-0"
+              className="w-9 h-9 grid place-items-center rounded text-ink-2 hover:text-ink hover:bg-canvas-2 disabled:opacity-30 disabled:cursor-not-allowed transition-colors shrink-0"
               aria-label="Mês seguinte"
             >
               <ChevronRight className="w-3.5 h-3.5" />
@@ -211,7 +211,7 @@ export const CalendarHeatmap: React.FC<CalendarHeatmapProps> = ({ bets }) => {
         <div className="flex items-center gap-1.5 text-ink-2">
           <span>Menos</span>
           <div className="flex" style={{ gap: 2 }}>
-            <div className="rounded bg-ink-3/60" style={{ width: 10, height: 10 }} />
+            <div className="rounded bg-canvas-2" style={{ width: 10, height: 10 }} />
             <div className="rounded bg-forest/30" style={{ width: 10, height: 10 }} />
             <div className="rounded bg-forest/55" style={{ width: 10, height: 10 }} />
             <div className="rounded bg-forest/80" style={{ width: 10, height: 10 }} />

--- a/src/components/dashboard/DrillDown.tsx
+++ b/src/components/dashboard/DrillDown.tsx
@@ -87,7 +87,7 @@ export const DrillDown: React.FC<DrillDownProps> = ({
           <div className="text-[9px] uppercase tracking-[0.14em] text-ink-2 font-bold">Reds</div>
           <div className="text-[14px] font-bold tabular text-rose-700 leading-none mt-1">{stats.lost}</div>
         </div>
-        <div className="bg-ink-3/40 rounded-lg p-2 border border-line/60">
+        <div className="bg-canvas-2 rounded-lg p-2 border border-line/60">
           <div className="text-[9px] uppercase tracking-[0.14em] text-ink-2 font-bold">Outras</div>
           <div className="text-[14px] font-bold tabular text-ink leading-none mt-1">{stats.other}</div>
         </div>
@@ -163,7 +163,7 @@ export const DrillDown: React.FC<DrillDownProps> = ({
           <button
             type="button"
             onClick={onUpgrade}
-            className="w-full h-9 rounded-md bg-ink-3/60 border border-line text-[11px] font-bold text-ink-2 hover:bg-ink-3 hover:text-ink transition-colors flex items-center justify-center gap-1.5"
+            className="w-full h-9 rounded-md bg-canvas-2 border border-line text-[11px] font-bold text-ink-2 hover:bg-canvas-2 hover:text-ink transition-colors flex items-center justify-center gap-1.5"
           >
             <Sparkles className="w-3 h-3" />
             Análise dessa fatia · Disponível no Pro
@@ -173,7 +173,7 @@ export const DrillDown: React.FC<DrillDownProps> = ({
           <button
             type="button"
             onClick={onViewAllBets}
-            className="w-full h-9 rounded-md border border-line bg-white text-[12px] font-bold text-ink hover:bg-ink-3/40 transition-colors flex items-center justify-center gap-1.5"
+            className="w-full h-9 rounded-md border border-line bg-white text-[12px] font-bold text-ink hover:bg-canvas-2 transition-colors flex items-center justify-center gap-1.5"
           >
             {stats.n === 1 ? 'Ver a aposta' : `Ver todas as ${stats.n} apostas`}
             <ArrowRight className="w-3.5 h-3.5" />

--- a/src/components/dashboard/OddsHistogram.tsx
+++ b/src/components/dashboard/OddsHistogram.tsx
@@ -58,7 +58,7 @@ export const OddsHistogram: React.FC<OddsHistogramProps> = ({
             className={`shrink-0 h-7 px-2.5 text-[11px] font-medium rounded-md inline-flex items-center gap-1 transition-colors ${
               hideEmpty
                 ? 'bg-forest-tint text-forest border border-forest/30'
-                : 'bg-white text-ink-2 border border-line hover:bg-ink-3/40'
+                : 'bg-white text-ink-2 border border-line hover:bg-canvas-2'
             }`}
             aria-pressed={hideEmpty}
             title={hideEmpty ? 'Mostrar todas as faixas (inclusive vazias)' : 'Esconder faixas sem dados'}
@@ -89,7 +89,7 @@ export const OddsHistogram: React.FC<OddsHistogramProps> = ({
               <div className="w-full h-32 flex items-end">
                 <div
                   className={`w-full rounded-t transition-all ${
-                    isEmpty ? 'bg-ink-3/40' : isPositive ? 'bg-forest' : 'bg-rose-700'
+                    isEmpty ? 'bg-canvas-2' : isPositive ? 'bg-forest' : 'bg-rose-700'
                   }`}
                   style={{ height: `${height}%` }}
                   title={

--- a/src/components/dashboard/SliceAnalysisModal.tsx
+++ b/src/components/dashboard/SliceAnalysisModal.tsx
@@ -72,7 +72,7 @@ export const SliceAnalysisModal: React.FC<SliceAnalysisModalProps> = ({
               {/* Metrics row */}
               <div className="grid grid-cols-4 gap-2 mb-5">
                 {narrative.metrics.map((m, i) => (
-                  <div key={i} className="bg-ink-3/40 border border-line/60 rounded-lg p-2.5 min-w-0 overflow-hidden">
+                  <div key={i} className="bg-canvas-2 border border-line/60 rounded-lg p-2.5 min-w-0 overflow-hidden">
                     <div className="text-[9px] uppercase tracking-[0.14em] text-ink-2 font-bold truncate">
                       {m.label}
                     </div>
@@ -105,7 +105,7 @@ export const SliceAnalysisModal: React.FC<SliceAnalysisModalProps> = ({
                     return (
                       <div
                         key={i}
-                        className="flex items-start gap-2 bg-ink-3/30 border border-line/60 rounded-lg px-3 py-2"
+                        className="flex items-start gap-2 bg-canvas-2 border border-line/60 rounded-lg px-3 py-2"
                       >
                         <InsightIcon
                           name={ins.icon}
@@ -123,7 +123,7 @@ export const SliceAnalysisModal: React.FC<SliceAnalysisModalProps> = ({
                 <button
                   type="button"
                   onClick={() => onOpenChange(false)}
-                  className="h-10 px-4 rounded-md border border-line text-[12px] font-bold text-ink-2 hover:text-ink hover:bg-ink-3/40 transition-colors flex-1"
+                  className="h-10 px-4 rounded-md border border-line text-[12px] font-bold text-ink-2 hover:text-ink hover:bg-canvas-2 transition-colors flex-1"
                 >
                   Fechar
                 </button>

--- a/src/components/futebol/AgendaCalendario.tsx
+++ b/src/components/futebol/AgendaCalendario.tsx
@@ -1,0 +1,168 @@
+import { useMemo, useState } from 'react';
+import { DayPicker } from 'react-day-picker';
+import { ptBR } from 'date-fns/locale';
+import { CalendarDays, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useFutebolFixtureDays } from '@/hooks/use-futebol-data';
+import { brtToday } from '@/utils/futebol-datas';
+
+/**
+ * O calendário da agenda, na casa.
+ *
+ * Era o `<input type="date">` nativo: vinha em inglês ("August 2026", "Mo Tu We"),
+ * com o azul do sistema e os botões "Clear/Today" do Chrome, e mudava de cara a
+ * cada navegador. Aqui ele usa a paleta do rebrand, fala português e, o que o
+ * nativo nunca faria, **marca os dias que têm jogo** com o mesmo ponto da régua.
+ *
+ * A contagem do mês visível vem da mesma RPC da régua (get_futebol_fixture_days),
+ * consultada só para o intervalo aberto na tela.
+ */
+
+/** YYYY-MM-DD no fuso local. `toISOString` usa UTC e devolveria o dia anterior. */
+function iso(d: Date): string {
+  const m = `${d.getMonth() + 1}`.padStart(2, '0');
+  const dia = `${d.getDate()}`.padStart(2, '0');
+  return `${d.getFullYear()}-${m}-${dia}`;
+}
+
+function paraData(dia: string): Date {
+  const [a, m, d] = dia.split('-').map(Number);
+  return new Date(a, (m ?? 1) - 1, d ?? 1);
+}
+
+export function AgendaCalendario({
+  selectedDay,
+  onSelectDay,
+}: {
+  selectedDay: string;
+  onSelectDay: (day: string) => void;
+}) {
+  const [aberto, setAberto] = useState(false);
+  const [mes, setMes] = useState<Date>(() => paraData(selectedDay));
+  const hoje = brtToday();
+
+  // Sobra de 7 dias de cada lado porque a grade mostra o fim do mês anterior e o
+  // começo do próximo: sem isso, dia de fora nunca ganharia o ponto de "tem jogo".
+  const inicio = useMemo(() => iso(new Date(mes.getFullYear(), mes.getMonth(), 1 - 7)), [mes]);
+  const fim = useMemo(() => iso(new Date(mes.getFullYear(), mes.getMonth() + 1, 7)), [mes]);
+  // Só busca com o calendário aberto: fechado, a régua já basta.
+  const { data: dias } = useFutebolFixtureDays(aberto ? inicio : undefined, aberto ? fim : undefined);
+
+  const comJogo = useMemo(() => {
+    const s = new Set<string>();
+    (dias ?? []).forEach((d) => {
+      if (Number(d.jogos) > 0) s.add(d.day_brt);
+    });
+    return s;
+  }, [dias]);
+
+  const escolher = (d: Date | undefined) => {
+    if (!d) return;
+    setMes(d); // clicou num dia do mês vizinho: o calendário acompanha
+    onSelectDay(iso(d));
+    setAberto(false);
+  };
+
+  return (
+    <Popover
+      open={aberto}
+      onOpenChange={(v) => {
+        // Abrir sempre no mês do dia escolhido: quem andou pelas setas da régua
+        // espera achar o calendário onde ele parou, não onde estava da última vez.
+        if (v) setMes(paraData(selectedDay));
+        setAberto(v);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          className="h-7 w-7 shrink-0 grid place-items-center rounded-full transition hover:bg-canvas-2"
+          style={{ color: aberto ? 'var(--forest)' : '#6b6350' }}
+          aria-label="Escolher data"
+        >
+          <CalendarDays className="w-3.5 h-3.5" />
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        // `theme-bolao` na própria folha: o Radix porta o conteúdo pro body, fora da
+        // árvore do tema, e sem isso as variáveis (--forest, --canvas-2) chegam vazias.
+        className="theme-bolao w-auto p-0 rounded-[16px] border-0 shadow-lg"
+        style={{ background: '#fff', border: '1px solid #ded2b6' }}
+      >
+        <DayPicker
+          mode="single"
+          locale={ptBR}
+          month={mes}
+          onMonthChange={setMes}
+          selected={paraData(selectedDay)}
+          onSelect={escolher}
+          showOutsideDays
+          weekStartsOn={0}
+          modifiers={{
+            comJogo: (d) => comJogo.has(iso(d)),
+            hoje: (d) => iso(d) === hoje,
+            // Modificador próprio porque o `classNames` customizado tira a classe
+            // padrão do dia selecionado, e o ponto precisa clarear em cima do verde.
+            escolhido: (d) => iso(d) === selectedDay,
+          }}
+          // O `locale` cuida dos nomes de mês e dia; os rótulos das setas ficariam em
+          // inglês para o leitor de tela sem isto.
+          labels={{ labelPrevious: () => 'Mês anterior', labelNext: () => 'Próximo mês' }}
+          components={{
+            IconLeft: () => <ChevronLeft className="w-4 h-4" />,
+            IconRight: () => <ChevronRight className="w-4 h-4" />,
+          }}
+          className="p-3.5"
+          classNames={{
+            months: 'flex flex-col',
+            month: 'space-y-3',
+            caption: 'flex justify-center pt-0.5 relative items-center',
+            caption_label: 'text-[13px] font-bold capitalize text-ink tracking-tight',
+            nav: 'flex items-center',
+            nav_button:
+              'h-7 w-7 grid place-items-center rounded-lg text-[#6b6350] hover:bg-[var(--canvas-2)] transition',
+            nav_button_previous: 'absolute left-0',
+            nav_button_next: 'absolute right-0',
+            table: 'w-full border-collapse',
+            head_row: 'flex',
+            head_cell: 'w-9 text-[10px] uppercase tracking-[0.08em] font-bold text-[#8d8672]',
+            row: 'flex w-full mt-1',
+            cell: 'relative p-0',
+            day: 'relative h-9 w-9 rounded-[10px] text-[12.5px] font-medium text-ink tabular-nums hover:bg-[var(--canvas-2)] transition',
+            day_selected: '!bg-forest !text-canvas font-bold hover:!bg-forest',
+            day_outside: 'text-[#c4bda8]',
+            day_disabled: 'text-[#c4bda8]',
+            day_hidden: 'invisible',
+          }}
+          modifiersClassNames={{
+            comJogo: 'fut-dia-com-jogo',
+            hoje: 'fut-dia-hoje',
+            escolhido: 'fut-dia-escolhido',
+          }}
+        />
+
+        <div
+          className="flex items-center justify-between px-3.5 py-2.5"
+          style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6' }}
+        >
+          <span className="inline-flex items-center gap-1.5 text-[10.5px]" style={{ color: '#8d8672' }}>
+            <span className="w-1.5 h-1.5 rounded-full" style={{ background: 'var(--forest)' }} />
+            dia com jogo
+          </span>
+          <button
+            onClick={() => {
+              setMes(paraData(hoje));
+              onSelectDay(hoje);
+              setAberto(false);
+            }}
+            className="text-[11.5px] font-semibold text-forest hover:underline underline-offset-2"
+          >
+            Ir para hoje
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/futebol/AgendaDateStrip.tsx
+++ b/src/components/futebol/AgendaDateStrip.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { AgendaCalendario } from './AgendaCalendario';
+import { addDays, brtToday, fmtDayChip } from '@/utils/futebol-datas';
+
+/**
+ * Navegador de datas da agenda, no formato da Direção B aprovada: um pill compacto
+ * que mora NA BARRA da página, ao lado do título, em vez da faixa full-width que
+ * ocupava uma seção inteira só pra escolher dia (a crítica original: "o navegável
+ * da data está muito grande, ocupa a faixa inteira da tela").
+ *
+ * A contagem por dia (`jogosPorDia`) vem da RPC get_futebol_fixture_days. Dia sem
+ * jogo continua clicável: esconder dia vazio faz a régua "pular" e o usuário perde
+ * a noção de calendário — o ponto embaixo do dia é quem diz se tem jogo.
+ */
+
+const VISIBLE = 5; // dias no pill; ímpar pra ter um centro
+
+export function AgendaDateStrip({
+  selectedDay,
+  onSelectDay,
+  jogosPorDia,
+}: {
+  selectedDay: string;
+  onSelectDay: (day: string) => void;
+  jogosPorDia?: Map<string, number>;
+}) {
+  const hoje = brtToday();
+  const ativoRef = useRef<HTMLButtonElement | null>(null);
+
+  // Janela centrada no dia escolhido: mover um dia desloca a régua junto, então o
+  // dia selecionado nunca sai de vista.
+  const dias = useMemo(() => {
+    const meio = Math.floor(VISIBLE / 2);
+    return Array.from({ length: VISIBLE }, (_, i) => addDays(selectedDay, i - meio));
+  }, [selectedDay]);
+
+  // Em tela estreita o pill rola; sem isto ele abre com o dia escolhido fora da
+  // vista. `block: 'nearest'` pra não dar scroll vertical na página.
+  useEffect(() => {
+    ativoRef.current?.scrollIntoView({ block: 'nearest', inline: 'center' });
+  }, [selectedDay]);
+
+  return (
+    <div className="flex items-center gap-0.5 bg-white border border-line rounded-full p-1 max-w-full">
+      <button
+        onClick={() => onSelectDay(addDays(selectedDay, -1))}
+        className="h-7 w-7 shrink-0 grid place-items-center rounded-full text-ink-3 hover:bg-canvas-2 transition"
+        aria-label="Dia anterior"
+      >
+        <ChevronLeft className="w-3.5 h-3.5" />
+      </button>
+
+      <div className="flex items-center gap-0.5 overflow-x-auto no-scrollbar">
+        {dias.map((dia) => {
+          const ativo = dia === selectedDay;
+          const isHoje = dia === hoje;
+          const n = jogosPorDia?.get(dia) ?? 0;
+          const { weekday, day } = fmtDayChip(dia);
+          return (
+            <button
+              key={dia}
+              ref={ativo ? ativoRef : undefined}
+              onClick={() => onSelectDay(dia)}
+              aria-current={ativo ? 'date' : undefined}
+              className={`relative shrink-0 h-7 px-2.5 rounded-full text-[12px] font-semibold transition-colors ${
+                ativo ? 'bg-forest text-canvas' : isHoje ? 'text-forest hover:bg-canvas-2' : 'text-ink-2 hover:bg-canvas-2'
+              }`}
+            >
+              {isHoje ? 'Hoje' : `${weekday} ${day.slice(0, 2)}`}
+              {/* Ponto só quando tem jogo: a ausência informa tanto quanto a presença. */}
+              {n > 0 && (
+                <span
+                  className={`absolute bottom-[3px] left-1/2 -translate-x-1/2 w-1 h-1 rounded-full ${
+                    ativo ? 'bg-canvas/70' : 'bg-forest/60'
+                  }`}
+                  title={`${n} ${n === 1 ? 'jogo' : 'jogos'}`}
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <button
+        onClick={() => onSelectDay(addDays(selectedDay, 1))}
+        className="h-7 w-7 shrink-0 grid place-items-center rounded-full text-ink-3 hover:bg-canvas-2 transition"
+        aria-label="Próximo dia"
+      >
+        <ChevronRight className="w-3.5 h-3.5" />
+      </button>
+
+      <span className="w-px h-4 bg-line mx-0.5 shrink-0" />
+
+      {/* Pulo de volta pra hoje, só quando hoje saiu da janela visível. */}
+      {!dias.includes(hoje) && (
+        <button
+          onClick={() => onSelectDay(hoje)}
+          className="h-7 px-2.5 shrink-0 rounded-full text-[12px] font-semibold text-ink-2 hover:bg-canvas-2 transition"
+        >
+          Hoje
+        </button>
+      )}
+
+      {/* Calendário próprio para pular para qualquer data. O nativo do browser vinha
+          em inglês, com o azul do sistema, e não sabia dizer quais dias têm jogo. */}
+      <AgendaCalendario selectedDay={selectedDay} onSelectDay={onSelectDay} />
+    </div>
+  );
+}

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -460,7 +460,7 @@ export function BancadaMercados({
           e a folha ocupa a direita inteira; no celular a ordem do DOM manda, e é
           por isso que o contexto vem DEPOIS da folha: "como chegam" antes da
           análise empurrava o mercado duas telas para baixo. */}
-      <div className="min-w-0 xl:col-start-1 xl:row-start-1 xl:border-r" style={{ borderColor: '#ded2b6', background: '#fdfbf6' }}>
+      <div data-tour="fut-jogo-mercados" className="min-w-0 xl:col-start-1 xl:row-start-1 xl:border-r" style={{ borderColor: '#ded2b6', background: '#fdfbf6' }}>
         <div className="px-5 pt-4 pb-3.5" style={{ borderBottom: '1px solid #f1e9d6' }}>
           <div className="text-[10px] uppercase tracking-[0.18em] font-bold" style={{ color: '#8d8672' }}>
             Os 5 mercados
@@ -538,7 +538,7 @@ export function BancadaMercados({
       </div>
 
       {/* A folha do mercado aberto. */}
-      <div className="min-w-0 xl:col-start-2 xl:row-start-1 xl:row-span-2">
+      <div data-tour="fut-jogo-folha" className="min-w-0 xl:col-start-2 xl:row-start-1 xl:row-span-2">
         <div className="relative overflow-hidden px-6 md:px-8 py-6" style={{ background: 'linear-gradient(135deg,#0a3d2e,#08321f 60%,#051f12)' }}>
           <div
             className="absolute pointer-events-none"
@@ -611,7 +611,7 @@ export function BancadaMercados({
 
           {/* A régua de paradas mora no hero: trocar a parada troca o que precisa ser
               verdade, e o Score muda junto. */}
-          <div className="relative mt-5 pt-4 flex items-center gap-3.5 flex-wrap" style={{ borderTop: '1px solid rgba(255,255,255,.15)' }}>
+          <div data-tour="fut-jogo-regua" className="relative mt-5 pt-4 flex items-center gap-3.5 flex-wrap" style={{ borderTop: '1px solid rgba(255,255,255,.15)' }}>
             <span className="text-[9.5px] uppercase tracking-[0.14em] shrink-0" style={{ color: 'rgba(255,255,255,.45)' }}>
               {ehLinha ? 'Linha' : 'Saída'}
             </span>
@@ -714,7 +714,7 @@ export function BancadaMercados({
         )}
 
         {/* Sub-abas em forma de pasta: A favor · Contra. */}
-        <div className="px-6 md:px-8 pt-4 flex items-center gap-2" style={{ borderBottom: '1px solid #f1e9d6' }}>
+        <div data-tour="fut-jogo-premissas" className="px-6 md:px-8 pt-4 flex items-center gap-2" style={{ borderBottom: '1px solid #f1e9d6' }}>
           {(
             [
               ['favor', 'A favor', favorVisivel.length],

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -1,0 +1,856 @@
+import { useMemo, useState, useEffect, useRef } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Blur } from '@/components/futebol/FutebolGate';
+import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
+import {
+  useFutebolFixturePremissas,
+  useFutebolFixtureNumeros,
+  useFutebolFixtureHistorico,
+  useFutebolFixtureInjuries,
+} from '@/hooks/use-futebol-data';
+import type { FutebolFixturePremissas, FutebolFixtureValueRow } from '@/services/futebol-data.service';
+import {
+  MERCADOS,
+  PORTA_PREMISSAS,
+  PREMISSAS_OCULTAS,
+  contaQueValem,
+  contextoDoMercado,
+  melhorCandidato,
+  outcomeLabel,
+  pesoForte,
+  premissaDe,
+  premissasDaSaida,
+  type MercadoInfo,
+  type Premissa,
+} from '@/utils/futebol-premissas';
+import { evidenciaDe, ladoDaSaida } from '@/utils/futebol-evidencias';
+import { evidenciaDoHistorico } from '@/utils/futebol-historico';
+import { MotivosJogoPorJogo } from './MotivosJogoPorJogo';
+import { valueDoCandidato, resumoDosMercados, REGUA_SCORE } from '@/utils/futebol-leitura';
+import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
+import { isFinished } from '@/utils/futebol-datas';
+import type { MatchupTendencies } from '@/utils/futebol-tendencias';
+import type { JogoInfo } from './JogoResumo';
+
+/**
+ * Aba MERCADOS — a "bancada" do Protótipo 1b: um mercado por vez, com a régua de
+ * linhas (gols e handicap) ou as saídas (1X2, ambos marcam, dupla chance), os dois
+ * lados comparados, o veredito em uma frase, e as premissas com peso em PALAVRA.
+ *
+ * As apagadas vêm em três grupos que nunca se misturam (a distinção é do
+ * protótipo, e é a mais honesta que já tivemos aqui):
+ *   · não aconteceu neste jogo        (peso > 0, só não bateu)
+ *   · não conta neste mercado         (peso 0 — o preço já cobra)
+ *   · não avaliada                    (mercado sem calibragem: BTTS e dupla chance)
+ *
+ * Score/odd/chance/edge são REAIS (get_futebol_fixture_value) e só existem com
+ * odds coletadas. Sem odds, a bancada vive das premissas e diz "sem preço ainda".
+ */
+
+const TIPO_LINHA = new Set(['goals_over_under', 'asian_handicap']);
+
+/** Linha em pt-BR. Sinal só no handicap: "+2,5 gols" não existe. */
+function fmtLinha(v: number, comSinal: boolean): string {
+  return `${comSinal && v > 0 ? '+' : ''}${String(v).replace('.', ',')}`;
+}
+
+/**
+ * A régua de linhas: arrastar a bolinha, clicar na trilha ou usar as setas.
+ *
+ * Era uma fileira de pills com as 5 linhas mais centrais, e o mart cota 21 no
+ * mercado de gols e 19 no handicap: as outras 16 simplesmente não existiam na tela.
+ * As paradas ficam em intervalos iguais (não proporcionais ao valor), porque o que
+ * se escolhe aqui é uma cotação da lista, não uma posição numa reta contínua.
+ */
+function ReguaLinhas({
+  paradas,
+  valor,
+  onEscolher,
+  rotulo,
+  destaque,
+  forca,
+}: {
+  paradas: number[];
+  valor: number | null;
+  onEscolher: (v: number) => void;
+  rotulo: (v: number) => string;
+  /** A linha da melhor leitura, marcada em âmbar. */
+  destaque: number | null;
+  /**
+   * Quantas premissas sustentam cada linha, no lado escolhido. A parada mostrava a
+   * liquidação (verde/rosa) do jogo encerrado, e isso não tinha relação nenhuma com
+   * a força da leitura naquela linha, que é o que a régua deveria dizer.
+   */
+  forca: Map<number, number>;
+}) {
+  const trilha = useRef<HTMLDivElement | null>(null);
+  const [arrastando, setArrastando] = useState(false);
+  const i = valor != null ? paradas.findIndex((p) => Math.abs(p - valor) < 0.001) : -1;
+  const idx = i < 0 ? 0 : i;
+  const pos = paradas.length > 1 ? (idx / (paradas.length - 1)) * 100 : 0;
+
+  const escolherPorX = (clientX: number) => {
+    const el = trilha.current;
+    if (!el || paradas.length < 2) return;
+    const r = el.getBoundingClientRect();
+    const t = Math.min(1, Math.max(0, (clientX - r.left) / r.width));
+    onEscolher(paradas[Math.round(t * (paradas.length - 1))]);
+  };
+
+  return (
+    <div className="flex-1 min-w-[220px]">
+      <div
+        ref={trilha}
+        role="slider"
+        tabIndex={0}
+        aria-label="Linha"
+        aria-valuemin={paradas[0]}
+        aria-valuemax={paradas[paradas.length - 1]}
+        aria-valuenow={valor ?? undefined}
+        aria-valuetext={valor != null ? rotulo(valor) : undefined}
+        className="relative h-8 cursor-pointer select-none touch-none"
+        onPointerDown={(e) => {
+          (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+          setArrastando(true);
+          escolherPorX(e.clientX);
+        }}
+        onPointerMove={(e) => arrastando && escolherPorX(e.clientX)}
+        onPointerUp={() => setArrastando(false)}
+        onPointerCancel={() => setArrastando(false)}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
+            e.preventDefault();
+            onEscolher(paradas[Math.max(0, idx - 1)]);
+          }
+          if (e.key === 'ArrowRight' || e.key === 'ArrowUp') {
+            e.preventDefault();
+            onEscolher(paradas[Math.min(paradas.length - 1, idx + 1)]);
+          }
+        }}
+      >
+        <div className="absolute left-0 right-0 top-[13px] h-1.5 rounded-full" style={{ background: 'rgba(255,255,255,.14)' }} />
+        <div className="absolute left-0 top-[13px] h-1.5 rounded-full" style={{ width: `${pos}%`, background: '#fbbf24' }} />
+
+        {paradas.map((p, k) => {
+          const left = `${(k / (paradas.length - 1)) * 100}%`;
+          const n = forca.get(p) ?? 0;
+          const ehDestaque = destaque != null && Math.abs(p - destaque) < 0.001;
+          // Ponto maior e mais claro onde a linha tem mais premissas a favor; âmbar
+          // na linha da melhor leitura.
+          const tam = n >= PORTA_PREMISSAS ? 6 : n > 0 ? 4 : 3;
+          return (
+            <span
+              key={p}
+              className="absolute rounded-full pointer-events-none"
+              title={`${rotulo(p)} · ${n} ${n === 1 ? 'premissa' : 'premissas'} a favor`}
+              style={{
+                left,
+                top: 16 - (tam - 3) / 2,
+                width: tam,
+                height: tam,
+                transform: 'translateX(-50%)',
+                background: ehDestaque ? '#fbbf24' : `rgba(255,255,255,${n >= PORTA_PREMISSAS ? 0.85 : n > 0 ? 0.5 : 0.28})`,
+              }}
+            />
+          );
+        })}
+
+        <span
+          className="absolute top-[7px] w-[18px] h-[18px] rounded-full pointer-events-none"
+          style={{
+            left: `${pos}%`,
+            transform: 'translateX(-50%)',
+            background: '#fff',
+            border: '3px solid #fbbf24',
+            boxShadow: '0 2px 8px rgba(0,0,0,.35)',
+          }}
+        />
+      </div>
+      <div className="flex justify-between text-[9.5px] tabular-nums" style={{ color: 'rgba(255,255,255,.4)' }}>
+        <span>{rotulo(paradas[0])}</span>
+        <span>{rotulo(paradas[paradas.length - 1])}</span>
+      </div>
+    </div>
+  );
+}
+
+function SeloRes({ r }: { r: BetResult }) {
+  const b = resultBadge(r);
+  const c =
+    b.tone === 'won'
+      ? { bg: '#dcefe2', fg: '#0a3d2e', dot: '#2f7d50' }
+      : b.tone === 'push'
+        ? { bg: '#eef0eb', fg: '#5a625a', dot: '#8a8f86' }
+        : { bg: '#fbe3e8', fg: '#be123c', dot: '#be123c' };
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 px-2.5 h-6 rounded-full text-[10.5px] font-bold tracking-[0.06em]"
+      style={{ background: c.bg, color: c.fg }}
+    >
+      <span className="w-1.5 h-1.5 rounded-full" style={{ background: c.dot }} />
+      {b.label}
+    </span>
+  );
+}
+
+export function BancadaMercados({
+  jogo,
+  valueRows,
+  tendencies,
+  locked,
+  mercadoAtivo,
+  onMercado,
+}: {
+  jogo: JogoInfo;
+  valueRows: FutebolFixtureValueRow[] | null | undefined;
+  tendencies?: MatchupTendencies | null;
+  locked: boolean;
+  mercadoAtivo: string;
+  onMercado: (slug: string) => void;
+}) {
+  const { data: rows, isLoading } = useFutebolFixturePremissas(jogo.fixtureId);
+  const { data: numeros } = useFutebolFixtureNumeros(jogo.fixtureId);
+  const { data: historico } = useFutebolFixtureHistorico(jogo.fixtureId);
+  const { data: injuries } = useFutebolFixtureInjuries(jogo.fixtureId);
+
+  const fim = isFinished(jogo.statusShort);
+  const placar = fim ? { home: jogo.goalsHome, away: jogo.goalsAway } : null;
+  const mercado: MercadoInfo = MERCADOS.find((m) => m.slug === mercadoAtivo) ?? MERCADOS[0];
+  const ehLinha = TIPO_LINHA.has(mercado.slug);
+  const ehAH = mercado.slug === 'asian_handicap';
+
+  const resumos = useMemo(() => resumoDosMercados(rows, valueRows), [rows, valueRows]);
+
+  const doMercado = useMemo(
+    () => (rows ?? []).filter((r) => r.market === mercado.slug).filter((r) => !(mercado.slug === 'asian_handicap' && r.line_value === 0)),
+    [rows, mercado.slug],
+  );
+
+  const melhor = useMemo(() => melhorCandidato(rows ?? [], mercado.slug), [rows, mercado.slug]);
+
+  // TODAS as linhas cotadas do mercado, em ordem. Com pills a tela mostrava as 5
+  // mais centrais e as outras 16 não existiam; na régua arrastável cabem todas.
+  const paradas = useMemo(() => {
+    if (!ehLinha) return [] as number[];
+    return [...new Set(doMercado.map((r) => r.line_value).filter((v): v is number => v != null))].sort((a, b) => a - b);
+  }, [doMercado, ehLinha]);
+
+  const [linha, setLinha] = useState<number | null>(null);
+  const [saida, setSaida] = useState<string | null>(null);
+  useEffect(() => {
+    setLinha(melhor?.line_value != null && paradas.includes(melhor.line_value) ? melhor.line_value : paradas[Math.floor(paradas.length / 2)] ?? null);
+    setSaida(melhor?.outcome ?? null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mercado.slug, rows]);
+
+  // Os lados da parada atual.
+  const [ladoA, ladoB] = useMemo((): [FutebolFixturePremissas | null, FutebolFixturePremissas | null] => {
+    if (ehLinha) {
+      const [oa, ob] = mercado.slug === 'goals_over_under' ? ['Under', 'Over'] : ['Home', 'Away'];
+      const at = (o: string) => doMercado.find((r) => r.outcome === o && r.line_value != null && Math.abs((r.line_value ?? 0) - (linha ?? NaN)) < 0.001) ?? null;
+      return [at(oa), at(ob)];
+    }
+    const sel = doMercado.find((r) => r.outcome === saida) ?? melhor;
+    return [sel ?? null, null];
+  }, [ehLinha, doMercado, linha, saida, melhor, mercado.slug]);
+
+  // Principal = o lado analisado. Começa no que tem mais contexto e o usuário troca
+  // clicando no outro card: é assim que ele vê as premissas do outro lado, em vez de
+  // uma lista de espelhos ("defesas frágeis" contra "defesas firmes") que se
+  // contradiziam na mesma tela.
+  const nA = ladoA ? contaQueValem(mercado.slug, ladoA.acesas) : 0;
+  const nB = ladoB ? contaQueValem(mercado.slug, ladoB.acesas) : 0;
+  const [ladoSel, setLadoSel] = useState<'a' | 'b' | null>(null);
+  useEffect(() => setLadoSel(null), [mercado.slug, linha, saida]);
+  // Sub-abas da folha: a favor e contra, as duas jogo a jogo (é onde mora a auditoria).
+  const [abaMotivo, setAbaMotivo] = useState<'favor' | 'contra'>('favor');
+  const principal = ladoSel === 'a' ? ladoA : ladoSel === 'b' ? ladoB : ladoB && nB > nA ? ladoB : ladoA;
+
+  const valA = ladoA ? valueDoCandidato(valueRows, mercado.slug, ladoA.outcome, ladoA.line_value) : null;
+  const valB = ladoB ? valueDoCandidato(valueRows, mercado.slug, ladoB.outcome, ladoB.line_value) : null;
+  const valPrincipal = principal === ladoB ? valB : valA;
+
+
+  const labelDe = (c: FutebolFixturePremissas | null) =>
+    c ? outcomeLabel(mercado.slug, c.outcome, jogo.home, jogo.away, c.line_value) : '';
+
+  // Favor / apagadas do lado principal. Só as premissas DAQUELE lado: as do outro
+  // medem o mesmo número ao contrário ("defesas frágeis" × "defesas firmes"), então
+  // listá-las aqui como "não aconteceu" fazia a tela se contradizer.
+  const visiveis = principal
+    ? premissasDaSaida(mercado, principal.outcome, principal.line_value, principal.acesas)
+    : mercado.premissas.filter((p) => !PREMISSAS_OCULTAS.has(p.slug));
+  const acesasSet = new Set(principal?.acesas ?? []);
+  const favor = visiveis.filter((p) => acesasSet.has(p.slug)).sort((a, b) => (b.peso ?? 0) - (a.peso ?? 0));
+  const apagadas = visiveis.filter((p) => !acesasSet.has(p.slug)).sort((a, b) => (b.peso ?? 0) - (a.peso ?? 0));
+  const penAtivas = (principal?.penalidades ?? [])
+    .filter((s) => !PREMISSAS_OCULTAS.has(s))
+    .map((s) => premissaDe(mercado.slug, s))
+    .filter((p): p is Premissa => p != null);
+
+  const semCalibragem = mercado.teto == null;
+  const ctx = contextoDoMercado(favor.filter(pesoForte).length, semCalibragem);
+
+  const ladoPrincipal = principal ? ladoDaSaida(mercado.slug, principal.outcome) : null;
+  const nPrincipal = principal ? contaQueValem(mercado.slug, principal.acesas) : 0;
+  const ate = numeros?.[0]?.ate ?? null;
+
+  // "Como chegam": as barras espelhadas casa × fora, agora dentro da coluna dos
+  // mercados. A barra da posição usa o valor do OUTRO lado, porque na tabela menor
+  // é melhor.
+  const barras = useMemo(() => {
+    const casa = numeros?.find((x) => x.side === 'home');
+    const fora = numeros?.find((x) => x.side === 'away');
+    if (!casa || !fora) return [];
+    const d1 = (v: number) => v.toFixed(1).replace('.', ',');
+    const linhas: { l: string; a: string; b: string; va: number; vb: number }[] = [];
+    if (casa.gf_total != null && fora.gf_total != null)
+      linhas.push({ l: 'Gols marcados', a: d1(casa.gf_total), b: d1(fora.gf_total), va: casa.gf_total, vb: fora.gf_total });
+    if (casa.ga_total != null && fora.ga_total != null)
+      linhas.push({ l: 'Gols sofridos', a: d1(casa.ga_total), b: d1(fora.ga_total), va: fora.ga_total, vb: casa.ga_total });
+    if (casa.posicao != null && fora.posicao != null)
+      linhas.push({ l: 'Posição', a: `${casa.posicao}º`, b: `${fora.posicao}º`, va: fora.posicao, vb: casa.posicao });
+    if (casa.clean_sheets != null && fora.clean_sheets != null)
+      linhas.push({ l: 'Sem sofrer gol', a: String(casa.clean_sheets), b: String(fora.clean_sheets), va: casa.clean_sheets, vb: fora.clean_sheets });
+    return linhas.map((x) => {
+      const tot = x.va + x.vb || 1;
+      return { ...x, wa: `${Math.round((x.va / tot) * 100)}%`, wb: `${Math.round((x.vb / tot) * 100)}%` };
+    });
+  }, [numeros]);
+
+  // O número da premissa: temporada (094) e, para o que ela não cobre, calculado dos
+  // jogos do histórico (095) — é o que dá número às premissas de chance de gol.
+  const evDe = (slug: string, acesa = true) =>
+    evidenciaDe(slug, numeros, ladoPrincipal, acesa, linha) ??
+    evidenciaDoHistorico(slug, historico, ladoPrincipal, linha);
+
+  // Só o que não aconteceu E conta para o Score. Premissa apagada de peso 0 sai da
+  // tela: ela não aconteceu e nem contaria, então nomeá-la só criava dúvida sobre
+  // ser verdade ou não.
+  const naoAconteceu = apagadas.filter((p) => p.peso == null || p.peso > 0);
+
+  // Premissa acesa que não soma no Score E não tem número também sai: era a linha
+  // "jogo de ritmo alto · não conta · sem número para conferir", que só levantava a
+  // pergunta "de onde veio isso?" sem ter resposta na tela. O critério mora nos
+  // modelos dbt, não aqui.
+  const favorVisivel = favor.filter((p) => p.peso !== 0 || evDe(p.slug) != null);
+
+  // Contras: os do backend (quando há preço) + penalidades ativas.
+  //
+  // A penalidade de desfalque aparecia como título solto, sem dizer QUEM está fora.
+  // Aqui ela puxa a lista de desfalques do lado certo; quando a lista ainda não
+  // saiu, a tela diz isso em vez de deixar a linha muda.
+  const contras = useMemo(() => {
+    const out: { t: string; sub?: string }[] = [];
+    (valPrincipal?.contras ?? []).forEach((t) => out.push({ t }));
+    (valPrincipal?.avisos ?? []).forEach((t) => out.push({ t }));
+
+    const idDoLado = ladoPrincipal === 'away' ? jogo.awayId : jogo.homeId;
+    const idDoAdv = ladoPrincipal === 'away' ? jogo.homeId : jogo.awayId;
+    const nomes = (teamId: number | undefined) =>
+      (injuries ?? [])
+        .filter((i) => teamId != null && i.team_id === teamId)
+        .slice(0, 4)
+        .map((i) => i.player_name)
+        .join(', ');
+
+    penAtivas.forEach((p) => {
+      let sub = p.motivo;
+      if (p.slug === 'desfalque_proprio' || p.slug === 'desfalque_adversario') {
+        const lista = nomes(p.slug === 'desfalque_proprio' ? idDoLado : idDoAdv);
+        sub = lista
+          ? `Fora: ${lista}.`
+          : 'A lista de desfalques deste jogo ainda não saiu: ela entra junto com a escalação provável, perto do jogo.';
+      }
+      out.push({ t: `Penalidade: ${p.label.toLowerCase()}`, sub });
+    });
+    return out;
+  }, [valPrincipal, penAtivas, injuries, ladoPrincipal, jogo.homeId, jogo.awayId]);
+
+  // O veredito em uma frase, sem inventar número.
+  const veredito = useMemo(() => {
+    const lbl = labelDe(principal);
+    if (fim) {
+      const r = placar && principal ? settleFutebol(mercado.slug, principal.outcome, principal.line_value, placar.home, placar.away) : null;
+      return r ? `O mapa apontava ${lbl}: ${resultBadge(r).label.toLowerCase()}.` : `Jogo encerrado.`;
+    }
+    if (valPrincipal) {
+      if (valPrincipal.score >= 60) return `O jogo e o preço concordam: ${lbl} é onde este jogo paga.`;
+      if (valPrincipal.score >= REGUA_SCORE) return `${lbl} passa a régua, em faixa média: leitura razoável e algum valor.`;
+      return `Abaixo da régua de ${REGUA_SCORE}: ${lbl} entra como consulta, não como aposta.`;
+    }
+    const n = principal ? contaQueValem(mercado.slug, principal.acesas) : 0;
+    if (n >= PORTA_PREMISSAS) return `O jogo aponta para ${lbl}, mas falta o preço: as odds entram perto do jogo.`;
+    return `O jogo não sustenta esta saída.`;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [principal, valPrincipal, fim, mercado.slug, placar]);
+
+  // Distribuição de gols: só no mercado de gols, cortada pela linha selecionada.
+  const dist = useMemo(() => {
+    if (mercado.slug !== 'goals_over_under' || !tendencies?.lambdas || linha == null) return null;
+    const lambda = tendencies.lambdas.lh + tendencies.lambdas.la;
+    const fact = (n: number) => { let r = 1; for (let i = 2; i <= n; i++) r *= i; return r; };
+    const pois = (k: number) => (Math.exp(-lambda) * Math.pow(lambda, k)) / fact(k);
+    const bars = [0, 1, 2, 3].map((k) => ({ k: String(k), kn: k, p: pois(k) }));
+    bars.push({ k: '4+', kn: 4, p: Math.max(0, 1 - bars.reduce((s, b) => s + b.p, 0)) });
+    const max = Math.max(...bars.map((b) => b.p), 0.001);
+    return {
+      bars: bars.map((b) => ({ ...b, h: `${(b.p / max) * 100}%`, pct: `${Math.round(b.p * 100)}%`, menos: b.kn < linha })),
+      divisor: `${((Math.floor(linha) + 1) / bars.length) * 100}%`,
+      lambda: lambda.toFixed(1).replace('.', ','),
+    };
+  }, [mercado.slug, tendencies, linha]);
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-4">
+        <Skeleton className="h-16 w-full bg-canvas-2 rounded-rebrand-md" />
+        <Skeleton className="h-96 w-full rounded-[24px]" style={{ background: 'var(--canvas-2)' }} />
+      </div>
+    );
+  }
+
+  const pickAtual = labelDe(principal);
+
+  /**
+   * Quantas premissas sustentam cada linha, no lado escolhido. É o que a régua
+   * mostra nas paradas: onde a leitura se sustenta e onde ela some.
+   */
+  const forcaPorLinha = new Map<number, number>();
+  if (ehLinha && principal) {
+    paradas.forEach((p) => {
+      const r = doMercado.find(
+        (x) => x.outcome === principal.outcome && x.line_value != null && Math.abs(x.line_value - p) < 0.001,
+      );
+      forcaPorLinha.set(p, r ? contaQueValem(mercado.slug, r.acesas) : 0);
+    });
+  }
+
+  /** As saídas fixas do 1X2, ambos marcam e dupla chance (mercado sem régua). */
+  const paradasUI = ehLinha
+    ? []
+    : doMercado.map((o) => {
+        const val = valueDoCandidato(valueRows, mercado.slug, o.outcome, o.line_value);
+        const n = contaQueValem(mercado.slug, o.acesas);
+        return {
+          chave: o.outcome,
+          rotulo: outcomeLabel(mercado.slug, o.outcome, jogo.home, jogo.away, o.line_value),
+          ativa: o.outcome === (saida ?? melhor?.outcome),
+          passa: val ? val.score >= REGUA_SCORE : n >= PORTA_PREMISSAS,
+          res: placar ? settleFutebol(mercado.slug, o.outcome, o.line_value, placar.home, placar.away) : null,
+          escolher: () => setSaida(o.outcome),
+        };
+      });
+
+  const resPrincipal =
+    placar && principal
+      ? settleFutebol(mercado.slug, principal.outcome, principal.line_value, placar.home, placar.away)
+      : null;
+
+  return (
+    <div
+      className="grid xl:grid-cols-[300px_1fr] xl:grid-rows-[auto_1fr] bg-white rounded-[24px] overflow-hidden"
+      style={{ border: '1px solid #ded2b6' }}
+      data-tour="fut-jogo-mapa"
+    >
+      {/* A coluna dos 5 mercados fica FIXA: clicar em qualquer um troca a folha da
+          direita sem sair da página. Antes eram abas no topo, e a comparação entre
+          mercados sumia assim que você entrava em um.
+          No desktop, mercados e contexto ocupam a coluna da esquerda (linhas 1 e 2)
+          e a folha ocupa a direita inteira; no celular a ordem do DOM manda, e é
+          por isso que o contexto vem DEPOIS da folha: "como chegam" antes da
+          análise empurrava o mercado duas telas para baixo. */}
+      <div className="min-w-0 xl:col-start-1 xl:row-start-1 xl:border-r" style={{ borderColor: '#ded2b6', background: '#fdfbf6' }}>
+        <div className="px-5 pt-4 pb-3.5" style={{ borderBottom: '1px solid #f1e9d6' }}>
+          <div className="text-[10px] uppercase tracking-[0.18em] font-bold" style={{ color: '#8d8672' }}>
+            Os 5 mercados
+          </div>
+          <div className="mt-1 text-[11.5px] leading-relaxed" style={{ color: '#6b6350' }}>
+            {resumos.some((r) => r.value)
+              ? `${resumos.filter((r) => r.passa).length} de ${resumos.length} passam a régua de ${REGUA_SCORE}. A barra é o Score; o tracinho é a régua.`
+              : `Sem preço ainda: a barra conta as premissas e o tracinho é a porta de ${PORTA_PREMISSAS}.`}
+          </div>
+        </div>
+
+        {/* No mobile os 5 mercados rolam na horizontal: empilhados, empurravam a
+            folha do mercado cinco cards para baixo. */}
+        <div className="p-3.5 flex gap-1.5 overflow-x-auto no-scrollbar xl:flex-col xl:overflow-visible">
+          {resumos.map((r) => {
+            const on = r.mercado.slug === mercado.slug;
+            const temScore = r.value != null;
+            const s = temScore ? r.value!.score : r.nValem;
+            const larg = temScore ? `${s}%` : `${Math.min(100, (r.nValem / Math.max(r.totalQueValem, 1)) * 100)}%`;
+            const regua = temScore ? `${REGUA_SCORE}%` : `${(PORTA_PREMISSAS / Math.max(r.totalQueValem, 1)) * 100}%`;
+            const cor = on ? '#fbbf24' : r.passa ? (temScore && s >= 60 ? '#0a3d2e' : '#d4a017') : '#c4bda8';
+            const pick = outcomeLabel(r.mercado.slug, r.candidato.outcome, jogo.home, jogo.away, r.candidato.line_value);
+            return (
+              <button
+                key={r.mercado.slug}
+                onClick={() => onMercado(r.mercado.slug)}
+                className="text-left w-[210px] shrink-0 xl:w-full p-3.5 rounded-[14px] cursor-pointer transition"
+                style={{
+                  background: on ? '#0a3d2e' : r.passa ? '#fff' : '#fdfbf6',
+                  border: `1px ${r.passa || on ? 'solid' : 'dashed'} ${on ? '#0a3d2e' : r.passa ? '#ded2b6' : '#e5d9bd'}`,
+                }}
+              >
+                <div className="flex items-baseline justify-between gap-2">
+                  <span
+                    className="text-[13px] truncate"
+                    style={{ color: on ? '#fff' : r.passa ? '#1a1d1a' : '#6b6350', fontWeight: r.passa ? 600 : 500 }}
+                  >
+                    {r.mercado.label}
+                  </span>
+                  <span
+                    className="tabular-nums text-[18px] font-bold shrink-0"
+                    style={{ color: on ? '#fbbf24' : r.passa ? (temScore && s >= 60 ? '#0a3d2e' : '#b8870f') : '#8d8672' }}
+                  >
+                    <Blur active={locked && temScore}>{String(s)}</Blur>
+                  </span>
+                </div>
+                <div className="mt-1 text-[11.5px] truncate" style={{ color: on ? 'rgba(255,255,255,.6)' : '#8d8672' }}>
+                  {pick}
+                  {temScore ? (
+                    <>
+                      {' · '}
+                      <Blur active={locked}>{`${Math.round(r.value!.prob_justa_fechamento * 100)}%`}</Blur>
+                      {' · '}
+                      <Blur active={locked}>{r.value!.best_odd.toFixed(2)}</Blur>
+                    </>
+                  ) : (
+                    ' · sem preço'
+                  )}
+                </div>
+                <div
+                  className="relative mt-2.5 h-1.5 rounded-full"
+                  style={{ background: on ? 'rgba(255,255,255,.16)' : '#f1e9d6' }}
+                >
+                  <div className="absolute left-0 top-0 bottom-0 rounded-full" style={{ width: larg, background: cor }} />
+                  <div
+                    className="absolute -top-[3px] -bottom-[3px] w-0"
+                    style={{ left: regua, borderLeft: `1px dashed ${on ? 'rgba(255,255,255,.6)' : '#8d8672'}` }}
+                  />
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+      </div>
+
+      {/* A folha do mercado aberto. */}
+      <div className="min-w-0 xl:col-start-2 xl:row-start-1 xl:row-span-2">
+        <div className="relative overflow-hidden px-6 md:px-8 py-6" style={{ background: 'linear-gradient(135deg,#0a3d2e,#08321f 60%,#051f12)' }}>
+          <div
+            className="absolute pointer-events-none"
+            style={{ right: -40, top: -90, width: 300, height: 300, borderRadius: 999, background: 'radial-gradient(circle,rgba(251,191,36,.24),transparent 68%)' }}
+          />
+          {/* Arrastar a régua troca pick, selo e veredito ao mesmo tempo. Sem altura
+              reservada, o bloco inteiro saltava a cada parada: o selo Green/Red
+              empurrava o título, e o veredito ia de uma para duas linhas. O selo
+              subiu para a linha do rótulo, que tem altura fixa, e o pick e o
+              veredito ganharam altura mínima. */}
+          <div className="relative flex items-end justify-between gap-7 flex-wrap">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2.5 h-6">
+                <span className="text-[10px] uppercase tracking-[0.16em]" style={{ color: 'rgba(255,255,255,.45)' }}>
+                  Mercado aberto · {mercado.label}
+                </span>
+                {resPrincipal && <SeloRes r={resPrincipal} />}
+              </div>
+              <div className="mt-1.5 text-[28px] md:text-[34px] font-semibold leading-tight tracking-[-0.035em] text-white min-h-[42px] md:min-h-[46px]">
+                {pickAtual || '—'}
+              </div>
+              <div
+                className="mt-2 text-[13.5px] leading-relaxed max-w-[560px] min-h-[42px]"
+                style={{ color: 'rgba(255,255,255,.78)' }}
+              >
+                {veredito}
+              </div>
+            </div>
+
+            {/* Sem `shrink-0`: com quatro colunas fixas, a linha estourava a largura
+                no celular e a página inteira ganhava rolagem lateral. */}
+            <div className="flex items-end gap-4 md:gap-6 flex-wrap">
+              <div className="min-w-[58px]">
+                <div className="text-[9px] uppercase tracking-[0.14em]" style={{ color: 'rgba(255,255,255,.45)' }}>Chance</div>
+                <div className="tabular-nums text-[22px] font-semibold leading-none mt-1 text-white">
+                  {valPrincipal ? <Blur active={locked}>{`${Math.round(valPrincipal.prob_justa_fechamento * 100)}%`}</Blur> : '—'}
+                </div>
+              </div>
+              <div className="min-w-[52px]">
+                <div className="text-[9px] uppercase tracking-[0.14em]" style={{ color: 'rgba(255,255,255,.45)' }}>Odd</div>
+                <div className="tabular-nums text-[22px] font-semibold leading-none mt-1 text-white">
+                  {valPrincipal ? <Blur active={locked}>{valPrincipal.best_odd.toFixed(2)}</Blur> : '—'}
+                </div>
+              </div>
+              <div className="min-w-[76px]">
+                <div className="text-[9px] uppercase tracking-[0.14em]" style={{ color: 'rgba(255,255,255,.45)' }}>Vantagem</div>
+                <div
+                  className="tabular-nums text-[22px] font-semibold leading-none mt-1"
+                  style={{ color: valPrincipal && valPrincipal.edge > 0 ? '#8ee6b0' : 'rgba(255,255,255,.55)' }}
+                >
+                  {valPrincipal ? (
+                    <Blur active={locked}>{`${valPrincipal.edge >= 0 ? '+' : '−'}${Math.abs(valPrincipal.edge * 100).toFixed(1).replace('.', ',')}%`}</Blur>
+                  ) : (
+                    '—'
+                  )}
+                </div>
+              </div>
+              <div className="text-center pl-6 min-w-[128px]" style={{ borderLeft: '1px solid rgba(255,255,255,.15)' }}>
+                <div className="tabular-nums text-[44px] font-bold leading-none tracking-[-0.04em]" style={{ color: '#fbbf24' }}>
+                  {valPrincipal ? <Blur active={locked}>{String(valPrincipal.score)}</Blur> : nPrincipal}
+                </div>
+                <div className="mt-1.5 text-[9.5px] uppercase tracking-[0.12em]" style={{ color: 'rgba(255,255,255,.5)' }}>
+                  {valPrincipal
+                    ? `Score · ${valPrincipal.score >= 60 ? 'faixa alta' : valPrincipal.score >= REGUA_SCORE ? 'faixa média' : 'abaixo da régua'}`
+                    : 'premissas a favor'}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* A régua de paradas mora no hero: trocar a parada troca o que precisa ser
+              verdade, e o Score muda junto. */}
+          <div className="relative mt-5 pt-4 flex items-center gap-3.5 flex-wrap" style={{ borderTop: '1px solid rgba(255,255,255,.15)' }}>
+            <span className="text-[9.5px] uppercase tracking-[0.14em] shrink-0" style={{ color: 'rgba(255,255,255,.45)' }}>
+              {ehLinha ? 'Linha' : 'Saída'}
+            </span>
+
+            {/* O lado da linha é um toggle, não um link: na régua você escolhe QUAL
+                linha, aqui de que lado dela está a aposta. Só existe onde o mercado
+                tem dois lados na mesma linha (gols e handicap). */}
+            {ehLinha && ladoA && ladoB && (
+              <div className="flex p-[3px] rounded-full shrink-0" style={{ background: 'rgba(255,255,255,.08)' }}>
+                {([['a', ladoA], ['b', ladoB]] as const).map(([k, l]) => {
+                  const on = principal === l;
+                  return (
+                    <button
+                      key={k}
+                      onClick={() => setLadoSel(k)}
+                      className="h-6 px-3 rounded-full border-0 cursor-pointer truncate max-w-[110px]"
+                      style={{
+                        background: on ? '#fff' : 'transparent',
+                        color: on ? '#0a3d2e' : 'rgba(255,255,255,.72)',
+                        font: `${on ? 700 : 500} 11.5px Inter,sans-serif`,
+                      }}
+                    >
+                      {mercado.slug === 'goals_over_under'
+                        ? l.outcome === 'Under'
+                          ? 'Menos'
+                          : 'Mais'
+                        : l.outcome === 'Home'
+                          ? jogo.home
+                          : jogo.away}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
+            {ehLinha && paradas.length > 1 ? (
+              <>
+                {/* O número antes da trilha: com ele depois, no celular a régua
+                    quebrava a linha e o valor ficava sozinho, solto embaixo. */}
+                <span className="tabular-nums text-[22px] font-bold leading-none shrink-0 min-w-[58px]" style={{ color: '#fbbf24' }}>
+                  {linha != null ? fmtLinha(linha, ehAH) : '—'}
+                </span>
+                <ReguaLinhas
+                  paradas={paradas}
+                  valor={linha}
+                  onEscolher={setLinha}
+                  rotulo={(v) => fmtLinha(v, ehAH)}
+                  destaque={melhor?.line_value ?? null}
+                  forca={forcaPorLinha}
+                />
+              </>
+            ) : (
+              <div className="flex-1 min-w-0 flex gap-1.5 flex-wrap">
+                {paradasUI.map((p) => (
+                  <button
+                    key={p.chave}
+                    onClick={p.escolher}
+                    className="h-7 px-3 rounded-full inline-flex items-center gap-1.5 cursor-pointer border-0 whitespace-nowrap tabular-nums"
+                    style={{
+                      background: p.ativa ? '#fbbf24' : 'rgba(255,255,255,.08)',
+                      color: p.ativa ? '#1a1d1a' : 'rgba(255,255,255,.72)',
+                      font: `${p.ativa ? 700 : 500} 12px Inter,sans-serif`,
+                      opacity: p.passa || p.ativa ? 1 : 0.5,
+                    }}
+                  >
+                    {p.rotulo}
+                    {p.res && (
+                      <span
+                        className="w-1.5 h-1.5 rounded-full"
+                        style={{ background: isHit(p.res) ? '#2f7d50' : p.res === 'push' ? '#8a8f86' : '#be123c' }}
+                      />
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+            {valPrincipal && !fim && !locked && (
+              <RegistrarApostaCTA
+                draft={{
+                  homeName: jogo.home,
+                  awayName: jogo.away,
+                  competition: jogo.competition,
+                  kickoffUtc: jogo.kickoffUtc,
+                  market: valPrincipal.market,
+                  outcome: valPrincipal.outcome,
+                  lineValue: valPrincipal.line_value,
+                  bestOdd: valPrincipal.best_odd,
+                }}
+                variant="ambar"
+                rotulo={`Registrar ${pickAtual}`}
+              />
+            )}
+          </div>
+        </div>
+
+        {mercado.aviso && (
+          <div className="px-6 md:px-8 py-3 text-[12px] leading-relaxed" style={{ background: '#fef7df', borderBottom: '1px solid #fde68a', color: '#5a3c00' }}>
+            {mercado.aviso}
+          </div>
+        )}
+
+        {/* Sub-abas em forma de pasta: A favor · Contra. */}
+        <div className="px-6 md:px-8 pt-4 flex items-center gap-2" style={{ borderBottom: '1px solid #f1e9d6' }}>
+          {(
+            [
+              ['favor', 'A favor', favorVisivel.length],
+              ['contra', 'Contra', naoAconteceu.length + contras.length],
+            ] as const
+          ).map(([k, rot, n]) => {
+            const on = abaMotivo === k;
+            return (
+              <button
+                key={k}
+                onClick={() => setAbaMotivo(k)}
+                className="h-[34px] px-3.5 -mb-px inline-flex items-center gap-1.5 cursor-pointer text-[12.5px] font-semibold"
+                style={{
+                  borderRadius: '9px 9px 0 0',
+                  color: on ? '#0a3d2e' : '#5a625a',
+                  background: on ? '#fff' : 'transparent',
+                  // Lados separados de propósito: misturar `border` com
+                  // `borderBottom` faz o React avisar de conflito de shorthand.
+                  borderStyle: 'solid',
+                  borderColor: on ? '#ded2b6' : 'transparent',
+                  borderTopWidth: 1,
+                  borderLeftWidth: 1,
+                  borderRightWidth: 1,
+                  borderBottomWidth: 0,
+                }}
+              >
+                {rot}
+                <span className="tabular-nums text-[11px] font-bold" style={{ color: on ? '#0a3d2e' : '#8d8672' }}>
+                  {n}
+                </span>
+              </button>
+            );
+          })}
+          <span className="ml-auto pb-2 text-[11.5px] hidden md:block" style={{ color: '#8d8672' }}>
+            {ctx.label}
+          </span>
+        </div>
+
+        {abaMotivo === 'favor' ? (
+          <MotivosJogoPorJogo
+            premissas={favorVisivel}
+            modo="favor"
+            historico={historico}
+            numeros={numeros}
+            lado={ladoPrincipal}
+            linha={linha}
+            saidaLabel={pickAtual}
+          />
+        ) : (
+          <MotivosJogoPorJogo
+            premissas={naoAconteceu}
+            modo="contra"
+            contras={contras}
+            historico={historico}
+            numeros={numeros}
+            lado={ladoPrincipal}
+            linha={linha}
+            saidaLabel={pickAtual}
+          />
+        )}
+
+        <div className="px-6 md:px-8 py-3.5 text-[11px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#8d8672' }}>
+          {ehLinha
+            ? 'Cada parada da régua tem o seu conjunto de premissas: trocar a linha muda o que precisa ser verdade.'
+            : 'Cada saída do mercado tem o seu conjunto de premissas.'}{' '}
+          {ate ? `Números da temporada até ${ate}.` : ''}
+        </div>
+      </div>
+
+      {/* Contexto do confronto: no desktop desce na coluna da esquerda, embaixo
+          dos mercados; no celular vem DEPOIS da folha, senão "como chegam"
+          empurrava a análise duas telas para baixo. */}
+      <div className="min-w-0 xl:col-start-1 xl:row-start-2 xl:border-r" style={{ borderColor: '#ded2b6', background: '#fdfbf6' }}>
+          {barras.length > 0 && (
+            <div className="px-5 py-4" style={{ borderTop: '1px solid #f1e9d6' }}>
+              <div className="text-[10px] uppercase tracking-[0.16em] font-bold mb-3" style={{ color: '#8d8672' }}>
+                Como chegam
+              </div>
+              <div className="flex flex-col gap-3.5">
+                {barras.map((x) => (
+                  <div key={x.l}>
+                    <div className="flex justify-between items-baseline mb-1.5 tabular-nums">
+                      <span className="text-[13px] font-semibold" style={{ color: '#0a3d2e' }}>{x.a}</span>
+                      <span className="text-[10.5px] font-medium" style={{ color: '#8d8672' }}>{x.l}</span>
+                      <span className="text-[13px] font-semibold" style={{ color: '#6b6350' }}>{x.b}</span>
+                    </div>
+                    <div className="flex gap-[3px] h-1.5">
+                      <div className="flex-1 flex justify-end overflow-hidden" style={{ background: '#f1e9d6', borderRadius: '999px 0 0 999px' }}>
+                        <div style={{ width: x.wa, background: '#0a3d2e' }} />
+                      </div>
+                      <div className="flex-1 overflow-hidden" style={{ background: '#f1e9d6', borderRadius: '0 999px 999px 0' }}>
+                        <div style={{ width: x.wb, height: '100%', background: '#c4bda8' }} />
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {dist && (
+            <div className="px-5 py-4" style={{ borderTop: '1px solid #f1e9d6' }}>
+              <div className="text-[10px] uppercase tracking-[0.16em] font-bold" style={{ color: '#8d8672' }}>
+                Onde a linha corta
+              </div>
+              <p className="text-[11px] leading-relaxed mt-1 mb-3" style={{ color: '#6b6350' }}>
+                Quantos gols o modelo espera, e de que lado da linha cada cenário cai.
+              </p>
+              <div className="relative pb-1">
+                <div className="flex items-end gap-1.5 h-[84px]">
+                  {dist.bars.map((b) => (
+                    <div key={b.k} className="flex-1 flex flex-col items-center justify-end h-full">
+                      <span className="tabular-nums text-[9.5px] font-semibold mb-1" style={{ color: b.menos ? '#0a3d2e' : '#8d8672' }}>
+                        {b.pct}
+                      </span>
+                      <div className="w-full flex items-end flex-1 min-h-0">
+                        <div className="w-full rounded-t" style={{ height: b.h, background: b.menos ? '#0a3d2e' : '#c9cec6' }} />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="flex gap-1.5 mt-1.5">
+                  {dist.bars.map((b) => (
+                    <span key={b.k} className="flex-1 text-center tabular-nums text-[10px] font-semibold" style={{ color: b.menos ? '#0a3d2e' : '#8d8672' }}>
+                      {b.k}
+                    </span>
+                  ))}
+                </div>
+                <div className="absolute -top-1 bottom-4 w-0 opacity-35" style={{ left: dist.divisor, borderLeft: '2px dashed #1a1d1a' }} />
+              </div>
+              <p className="text-[10.5px] leading-relaxed mt-2" style={{ color: '#8d8672' }}>
+                Média esperada de {dist.lambda} gols.
+              </p>
+            </div>
+          )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/futebol/ChaveamentoBracket.tsx
+++ b/src/components/futebol/ChaveamentoBracket.tsx
@@ -1,0 +1,623 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Maximize2, Minus, Plus, RotateCcw, X } from 'lucide-react';
+import { Crest } from './Crest';
+import { ehMataMata, rodadaLonga } from '@/utils/futebol-rodadas';
+import { isFinished } from '@/utils/futebol-datas';
+import { competitionLabel } from '@/utils/futebol-competitions';
+import type { FutebolFixture } from '@/services/futebol-data.service';
+
+/**
+ * O chaveamento da copa: uma coluna por fase, afunilando até a final.
+ *
+ * Mora na coluna da direita, na mesma largura da classificação e dos artilheiros,
+ * e não na largura da tela: a chave inteira ali dentro fica pequena, então o card
+ * se arrasta com o mouse e tem um "expandir" que abre num pop-up com zoom e
+ * arrasto, já enquadrada. Foi a correção pedida depois das duas primeiras
+ * versões (lista empilhada, depois chave ocupando a página inteira).
+ *
+ * De onde sai cada coisa (tudo de fact_fixtures, sem tabela nova):
+ *  - Ida e volta viram UM confronto: os jogos da fase são agrupados pelo par de
+ *    times. O número ao lado do time é o agregado dos jogos já encerrados.
+ *  - Quem passou sai da FASE SEGUINTE: se o time aparece lá, ele passou. É o
+ *    único jeito honesto, porque o placar do mart é o dos 90 minutos e não conta
+ *    pênalti. Sem a fase seguinte coletada, o agregado decide, e agregado
+ *    empatado fica sem vencedor em vez de chutar um.
+ *  - As fases que ainda não aconteceram entram como "a definir", SEM ligar com
+ *    quem vem de onde: quem enfrenta quem na fase seguinte depende de sorteio ou
+ *    de regra da competição, e isso o dado não diz. Desenhar a linha seria
+ *    inventar.
+ */
+
+/** O formato de cada competição, em uma linha. Só o que é estável e checável. */
+const FORMATOS: Record<string, string> = {
+  copa_do_brasil: 'mata-mata em ida e volta, com final em dois jogos',
+  libertadores: '8 grupos, 2 passam por grupo, mata-mata em ida e volta e final única',
+  sudamericana: '8 grupos, mata-mata em ida e volta e final única',
+  champions_league: 'fase de liga, playoff, mata-mata em ida e volta e final única',
+  copa_mundo: 'grupos e mata-mata em jogo único',
+};
+
+type Lado = { id: number; nome: string; gols: number };
+type Confronto = {
+  chave: string;
+  a: Lado;
+  b: Lado;
+  jogos: FutebolFixture[];
+  encerrado: boolean;
+  classificado: number | null;
+};
+type Coluna = { chave: string; titulo: string; confrontos: Confronto[]; vagas: number };
+
+/** Nome da fase pelo número de confrontos, pras fases que ainda não existem. */
+function tituloPorVagas(n: number): string {
+  if (n <= 1) return 'Final';
+  if (n === 2) return 'Semifinal';
+  if (n === 4) return 'Quartas de final';
+  if (n === 8) return 'Oitavas de final';
+  if (n === 16) return '16 avos de final';
+  if (n === 32) return '32 avos de final';
+  return `${n} confrontos`;
+}
+
+function montaConfrontos(jogos: FutebolFixture[], idsDaProxima: Set<number>): Confronto[] {
+  const mapa = new Map<string, Confronto>();
+
+  jogos.forEach((f) => {
+    const chave = [f.home_team_id, f.away_team_id].sort((x, y) => x - y).join('-');
+    let c = mapa.get(chave);
+    if (!c) {
+      c = {
+        chave,
+        a: { id: f.home_team_id, nome: f.home_team_name, gols: 0 },
+        b: { id: f.away_team_id, nome: f.away_team_name, gols: 0 },
+        jogos: [],
+        encerrado: true,
+        classificado: null,
+      };
+      mapa.set(chave, c);
+    }
+    c.jogos.push(f);
+    const fim = isFinished(f.status_short);
+    if (!fim) c.encerrado = false;
+    if (fim && f.goals_home != null && f.goals_away != null) {
+      const casaEhA = f.home_team_id === c.a.id;
+      c.a.gols += casaEhA ? f.goals_home : f.goals_away;
+      c.b.gols += casaEhA ? f.goals_away : f.goals_home;
+    }
+  });
+
+  const lista = [...mapa.values()];
+  lista.forEach((c) => {
+    if (idsDaProxima.has(c.a.id)) c.classificado = c.a.id;
+    else if (idsDaProxima.has(c.b.id)) c.classificado = c.b.id;
+    else if (c.encerrado && c.a.gols !== c.b.gols) c.classificado = c.a.gols > c.b.gols ? c.a.id : c.b.id;
+    c.jogos.sort((x, y) => (x.kickoff_utc ?? '').localeCompare(y.kickoff_utc ?? ''));
+  });
+  return lista.sort((x, y) => (x.jogos[0]?.kickoff_utc ?? '').localeCompare(y.jogos[0]?.kickoff_utc ?? ''));
+}
+
+function LadoDoConfronto({ lado, c }: { lado: Lado; c: Confronto }) {
+  const decidido = c.classificado != null;
+  const passou = decidido && c.classificado === lado.id;
+  const temPlacar = c.jogos.some((j) => isFinished(j.status_short));
+
+  return (
+    <div
+      className="px-1.5 py-1 flex items-center gap-1.5 min-w-0"
+      style={{ background: passou ? 'rgba(10,61,46,.07)' : undefined }}
+    >
+      <Crest name={lado.nome} id={lado.id} size={15} />
+      <span
+        className={`flex-1 min-w-0 truncate text-[11px] ${passou ? 'font-bold' : 'font-medium'}`}
+        style={{ color: passou ? '#0a3d2e' : decidido ? '#a8a292' : '#1a1d1a' }}
+      >
+        {lado.nome}
+      </span>
+      {temPlacar && (
+        <span
+          className={`shrink-0 text-[11px] tabular-nums ${passou ? 'font-bold' : 'font-semibold'}`}
+          style={{ color: passou ? '#0a3d2e' : decidido ? '#a8a292' : '#1a1d1a' }}
+        >
+          {lado.gols}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function CardConfronto({ c, onJogo }: { c: Confronto; onJogo: (id: number) => void }) {
+  const ultimo = c.jogos[c.jogos.length - 1];
+  return (
+    <button
+      onClick={() => ultimo && onJogo(ultimo.fixture_id)}
+      className="w-full text-left rounded-rebrand-sm overflow-hidden bg-white hover:shadow-sm transition"
+      style={{ border: '1px solid #ded2b6' }}
+      title={c.jogos.length > 1 ? 'ida e volta somadas' : undefined}
+    >
+      <LadoDoConfronto lado={c.a} c={c} />
+      <div style={{ height: 1, background: '#f1e9d6' }} />
+      <LadoDoConfronto lado={c.b} c={c} />
+    </button>
+  );
+}
+
+function CardVago() {
+  return (
+    <div className="rounded-rebrand-sm overflow-hidden" style={{ border: '1px dashed #e5d9bd', background: '#fdfbf6' }}>
+      {[0, 1].map((i) => (
+        <div
+          key={i}
+          className="px-1.5 py-1 flex items-center gap-1.5"
+          style={{ borderTop: i ? '1px solid #f1e9d6' : undefined }}
+        >
+          <span className="w-[15px] h-[15px] rounded-full shrink-0" style={{ background: '#f1e9d6' }} />
+          <span className="text-[10.5px]" style={{ color: '#c4bda8' }}>
+            a definir
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Arrastar o conteúdo com o mouse, como num mapa. A barra de rolagem continua
+ * lá, mas ninguém procura barra de rolagem dentro de um card: a mão pega o
+ * branco e puxa. O clique no confronto continua funcionando porque só vira
+ * arrasto depois de 4px, e o clique seguinte a um arrasto é engolido.
+ */
+function useArrastarParaRolar() {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const est = useRef({ ativo: false, x: 0, y: 0, sx: 0, sy: 0, moveu: false });
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    const el = ref.current;
+    if (!el || e.button !== 0) return;
+    est.current = { ativo: true, x: e.clientX, y: e.clientY, sx: el.scrollLeft, sy: el.scrollTop, moveu: false };
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    const el = ref.current;
+    const s = est.current;
+    if (!el || !s.ativo) return;
+    const dx = e.clientX - s.x;
+    const dy = e.clientY - s.y;
+    if (!s.moveu && Math.abs(dx) + Math.abs(dy) < 4) return;
+    s.moveu = true;
+    el.scrollLeft = s.sx - dx;
+    el.scrollTop = s.sy - dy;
+  };
+  const encerrar = () => {
+    est.current.ativo = false;
+  };
+  const onClickCapture = (e: React.MouseEvent) => {
+    if (est.current.moveu) {
+      e.preventDefault();
+      e.stopPropagation();
+      est.current.moveu = false;
+    }
+  };
+
+  return {
+    ref,
+    handlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: encerrar,
+      onPointerLeave: encerrar,
+      onClickCapture,
+    },
+  };
+}
+
+/** A chave em si. Mesma marcação no card e na tela cheia; muda só a largura. */
+function Chave({
+  colunas,
+  onJogo,
+  largura,
+}: {
+  colunas: Coluna[];
+  onJogo: (id: number) => void;
+  largura: number;
+}) {
+  return (
+    <div className="flex gap-2.5 min-w-max items-stretch">
+      {colunas.map((col) => {
+        const vagos = col.confrontos.length ? 0 : col.vagas;
+        return (
+          <div key={col.chave} className="shrink-0 flex flex-col" style={{ width: largura }}>
+            <div
+              className="text-[9px] uppercase tracking-[0.12em] font-bold text-center pb-1.5"
+              style={{ color: col.confrontos.length ? '#0a3d2e' : '#c4bda8' }}
+            >
+              {col.titulo}
+            </div>
+            <div className="flex-1 flex flex-col justify-around gap-1.5">
+              {col.confrontos.map((c) => (
+                <CardConfronto key={c.chave} c={c} onJogo={onJogo} />
+              ))}
+              {Array.from({ length: vagos }).map((_, i) => (
+                <CardVago key={i} />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const MIN_ESCALA = 0.5;
+const MAX_ESCALA = 2.2;
+
+/** Pop-up com zoom e arrasto, pra chave grande caber no olho. */
+function ChaveExpandida({
+  colunas,
+  onJogo,
+  onFechar,
+  titulo,
+}: {
+  colunas: Coluna[];
+  onJogo: (id: number) => void;
+  onFechar: () => void;
+  titulo: string;
+}) {
+  const [escala, setEscala] = useState(1);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const arrasto = useRef<{ x: number; y: number; px: number; py: number; moveu: boolean } | null>(null);
+  const palco = useRef<HTMLDivElement | null>(null);
+  const conteudo = useRef<HTMLDivElement | null>(null);
+  // Dedos na tela: com dois, o gesto vira pinça (o celular não tem roda do mouse).
+  const dedos = useRef(new Map<number, { x: number; y: number }>());
+  const pinca = useRef<{ dist: number; escala: number; px: number; py: number; cx: number; cy: number } | null>(null);
+
+  /** Abre com a chave inteira enquadrada e centrada, em vez de 100% no canto. */
+  const enquadrar = useCallback(() => {
+    const p = palco.current;
+    const c = conteudo.current;
+    if (!p || !c) return;
+    const cw = c.scrollWidth;
+    const ch = c.scrollHeight;
+    if (!cw || !ch) return;
+    const porLargura = p.clientWidth / cw;
+    const porAltura = p.clientHeight / ch;
+    // Em tela larga cabe a chave inteira. Em celular, caber tudo na largura
+    // deixaria o nome dos times com 4px: aí vale mais enquadrar pela ALTURA, num
+    // tamanho legível, e a pessoa arrasta para o lado (ou dá pinça).
+    const nova =
+      porLargura < 0.7
+        ? Math.min(1, Math.max(0.75, porAltura))
+        : Math.min(MAX_ESCALA, Math.max(MIN_ESCALA, Math.min(porLargura, porAltura)));
+    setEscala(nova);
+    // Centraliza no eixo em que sobra espaço e encosta no canto no eixo em que
+    // falta: no celular a chave não cabe nem no zoom mínimo, e centrar cortava o
+    // começo dela (o nome do primeiro time saía da tela).
+    setPos({
+      x: cw * nova <= p.clientWidth ? (p.clientWidth - cw * nova) / 2 : 0,
+      y: ch * nova <= p.clientHeight ? (p.clientHeight - ch * nova) / 2 : 0,
+    });
+  }, []);
+
+  useEffect(() => {
+    // rAF pra medir depois que o pop-up já tem tamanho.
+    const id = requestAnimationFrame(enquadrar);
+    return () => cancelAnimationFrame(id);
+  }, [enquadrar]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onFechar();
+      if (e.key === '+' || e.key === '=') setEscala((s) => Math.min(MAX_ESCALA, s + 0.15));
+      if (e.key === '-') setEscala((s) => Math.max(MIN_ESCALA, s - 0.15));
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onFechar]);
+
+  // Roda do mouse dá zoom, e o ponto embaixo do cursor fica parado: sem isso a
+  // chave foge da tela ao aproximar. O listener é nativo com passive:false
+  // porque o onWheel do React não deixa cancelar a rolagem da página.
+  useEffect(() => {
+    const el = palco.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault();
+      const caixa = el.getBoundingClientRect();
+      const cx = e.clientX - caixa.left;
+      const cy = e.clientY - caixa.top;
+      setEscala((atual) => {
+        const nova = Math.min(MAX_ESCALA, Math.max(MIN_ESCALA, atual * (1 - e.deltaY * 0.0015)));
+        setPos((p) => ({
+          x: cx - ((cx - p.x) * nova) / atual,
+          y: cy - ((cy - p.y) * nova) / atual,
+        }));
+        return nova;
+      });
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, []);
+
+  const zoom = (delta: number) => setEscala((s) => Math.min(MAX_ESCALA, Math.max(MIN_ESCALA, s + delta)));
+
+  return (
+    // `theme-bolao` fica no PAINEL, não aqui: a classe pinta fundo (`--canvas`) no
+    // próprio elemento, e no container de tela cheia isso virava uma parede areia
+    // que escondia o site inteiro em vez de deixá-lo aparecer atrás.
+    <div
+      className="fixed inset-0 z-50 grid place-items-center p-4"
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget) onFechar();
+      }}
+    >
+      {/* Escurece de leve e desfoca: o fundo continua sendo o site, não uma parede cinza. */}
+      <div className="absolute inset-0" style={{ background: 'rgba(26,29,26,.14)', backdropFilter: 'blur(2px)' }} />
+
+      <div
+        className="theme-bolao relative flex flex-col rounded-rebrand-lg overflow-hidden shadow-xl"
+        style={{
+          background: '#f8f4ea',
+          border: '1px solid #ded2b6',
+          width: 'min(1080px, 94vw)',
+          height: 'min(720px, 86vh)',
+        }}
+      >
+      <div
+        className="shrink-0 px-4 py-2.5 flex items-center gap-3"
+        style={{ background: '#f4eddc', borderBottom: '1px solid #ded2b6' }}
+      >
+        <span className="text-[12.5px] font-bold text-ink truncate">{titulo}</span>
+        <span className="hidden md:block text-[11px]" style={{ color: '#8d8672' }}>
+          arraste para mover, role para aproximar
+        </span>
+
+        <div className="ml-auto flex items-center gap-1.5">
+          <button
+            onClick={() => zoom(-0.15)}
+            className="w-8 h-8 grid place-items-center rounded-rebrand-sm bg-white"
+            style={{ border: '1px solid #ded2b6', color: '#6b6350' }}
+            aria-label="Afastar"
+          >
+            <Minus className="w-4 h-4" />
+          </button>
+          <span className="w-12 text-center text-[11.5px] tabular-nums" style={{ color: '#6b6350' }}>
+            {Math.round(escala * 100)}%
+          </span>
+          <button
+            onClick={() => zoom(0.15)}
+            className="w-8 h-8 grid place-items-center rounded-rebrand-sm bg-white"
+            style={{ border: '1px solid #ded2b6', color: '#6b6350' }}
+            aria-label="Aproximar"
+          >
+            <Plus className="w-4 h-4" />
+          </button>
+          <button
+            onClick={enquadrar}
+            className="w-8 h-8 grid place-items-center rounded-rebrand-sm bg-white"
+            style={{ border: '1px solid #ded2b6', color: '#6b6350' }}
+            aria-label="Enquadrar a chave inteira"
+          >
+            <RotateCcw className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={onFechar}
+            className="h-8 px-3 rounded-rebrand-sm bg-forest text-canvas text-[12px] font-semibold inline-flex items-center gap-1.5"
+          >
+            <X className="w-3.5 h-3.5" />
+            Fechar
+          </button>
+        </div>
+      </div>
+
+      <div
+        ref={palco}
+        data-chave-palco
+        className="flex-1 overflow-hidden cursor-grab active:cursor-grabbing"
+        onPointerDown={(e) => {
+          dedos.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+          if (dedos.current.size === 2) {
+            // Começou uma pinça: guarda a distância e o meio dos dois dedos.
+            const [d1, d2] = [...dedos.current.values()];
+            pinca.current = {
+              dist: Math.hypot(d1.x - d2.x, d1.y - d2.y),
+              escala,
+              px: pos.x,
+              py: pos.y,
+              cx: (d1.x + d2.x) / 2,
+              cy: (d1.y + d2.y) / 2,
+            };
+            arrasto.current = null;
+          } else if (dedos.current.size === 1) {
+            arrasto.current = { x: e.clientX, y: e.clientY, px: pos.x, py: pos.y, moveu: false };
+          }
+        }}
+        onPointerMove={(e) => {
+          if (dedos.current.has(e.pointerId)) dedos.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+          const p = pinca.current;
+          if (p && dedos.current.size >= 2) {
+            const [d1, d2] = [...dedos.current.values()];
+            const dist = Math.hypot(d1.x - d2.x, d1.y - d2.y);
+            if (!dist || !p.dist) return;
+            const nova = Math.min(MAX_ESCALA, Math.max(MIN_ESCALA, (p.escala * dist) / p.dist));
+            const caixa = palco.current?.getBoundingClientRect();
+            const cx = p.cx - (caixa?.left ?? 0);
+            const cy = p.cy - (caixa?.top ?? 0);
+            setEscala(nova);
+            setPos({
+              x: cx - ((cx - p.px) * nova) / p.escala,
+              y: cy - ((cy - p.py) * nova) / p.escala,
+            });
+            return;
+          }
+
+          const a = arrasto.current;
+          if (!a) return;
+          const dx = e.clientX - a.x;
+          const dy = e.clientY - a.y;
+          if (!a.moveu && Math.abs(dx) + Math.abs(dy) < 4) return;
+          a.moveu = true;
+          setPos({ x: a.px + dx, y: a.py + dy });
+        }}
+        onPointerUp={(e) => {
+          dedos.current.delete(e.pointerId);
+          if (dedos.current.size < 2) pinca.current = null;
+          if (dedos.current.size === 0) arrasto.current = null;
+        }}
+        onPointerCancel={(e) => {
+          dedos.current.delete(e.pointerId);
+          pinca.current = null;
+          arrasto.current = null;
+        }}
+        onPointerLeave={(e) => {
+          dedos.current.delete(e.pointerId);
+          if (dedos.current.size < 2) pinca.current = null;
+          if (dedos.current.size === 0) arrasto.current = null;
+        }}
+        // Sem isto o navegador rouba o gesto: no celular, arrastar dentro do
+        // pop-up rolava a página atrás dele.
+        style={{ touchAction: 'none' }}
+        // Arrastar não pode virar clique no confronto embaixo do cursor.
+        onClickCapture={(e) => {
+          if (arrasto.current?.moveu) {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        }}
+      >
+        <div
+          ref={conteudo}
+          className="p-6 origin-top-left w-max"
+          style={{ transform: `translate(${pos.x}px, ${pos.y}px) scale(${escala})` }}
+        >
+          <Chave colunas={colunas} onJogo={onJogo} largura={190} />
+        </div>
+      </div>
+      </div>
+    </div>
+  );
+}
+
+export function ChaveamentoBracket({
+  fixtures,
+  rounds,
+  idxSelecionado,
+  competition,
+  onJogo,
+}: {
+  fixtures: FutebolFixture[];
+  rounds: string[];
+  idxSelecionado: number;
+  competition: string;
+  onJogo: (fixtureId: number) => void;
+}) {
+  const [expandido, setExpandido] = useState(false);
+  const puxar = useArrastarParaRolar();
+
+  const colunas = useMemo<Coluna[]>(() => {
+    const mata = rounds.map((r, i) => ({ round: r, i })).filter((x) => ehMataMata(x.round));
+    if (!mata.length) return [];
+
+    const coluna = ({ round, i }: { round: string; i: number }): Coluna => {
+      const jogos = fixtures.filter((f) => f.round === round);
+      const proxima = rounds[i + 1];
+      const idsDaProxima = new Set<number>();
+      if (proxima) {
+        fixtures
+          .filter((f) => f.round === proxima)
+          .forEach((f) => {
+            idsDaProxima.add(f.home_team_id);
+            idsDaProxima.add(f.away_team_id);
+          });
+      }
+      const confrontos = montaConfrontos(jogos, idsDaProxima);
+      return { chave: round, titulo: rodadaLonga(round), confrontos, vagas: confrontos.length };
+    };
+
+    // Da fase aberta pra frente; na fase de grupos, o mata-mata inteiro.
+    const posicao = mata.findIndex((x) => x.i >= idxSelecionado);
+    const daqui = posicao < 0 ? mata : mata.slice(posicao);
+    const reais: Coluna[] = daqui.map(coluna);
+
+    // Uma fase antes, mas só quando ela REALMENTE alimenta esta: quem está nas
+    // quartas quer ver de onde veio cada classificado. Na Libertadores a fase
+    // anterior às oitavas na lista é a pré-fase, que desemboca nos grupos e tem
+    // 4 confrontos contra 8 das oitavas: encaixar ali inverteria o funil.
+    if (posicao > 0 && reais[0]?.confrontos.length) {
+      const anterior = coluna(mata[posicao - 1]);
+      if (anterior.confrontos.length === reais[0].confrontos.length * 2) reais.unshift(anterior);
+    }
+
+    // O caminho até a final, mesmo antes do sorteio: cada fase seguinte tem
+    // metade dos confrontos da anterior.
+    const ultima = reais[reais.length - 1];
+    const futuras: Coluna[] = [];
+    let vagas = ultima ? Math.floor(ultima.vagas / 2) : 0;
+    while (vagas >= 1) {
+      futuras.push({ chave: `vagas-${vagas}`, titulo: tituloPorVagas(vagas), confrontos: [], vagas });
+      if (vagas === 1) break;
+      vagas = Math.floor(vagas / 2);
+    }
+
+    return [...reais, ...futuras];
+  }, [fixtures, rounds, idxSelecionado]);
+
+  if (!colunas.length) return null;
+
+  const temConfronto = colunas.some((c) => c.confrontos.length);
+  const titulo = `Chaveamento · ${competitionLabel(competition)}`;
+  const formato = FORMATOS[competition];
+
+  return (
+    <>
+      <div className="bg-white rounded-rebrand-lg overflow-hidden" style={{ border: '1px solid #ded2b6' }}>
+        <div
+          className="px-4 py-2.5 flex items-center justify-between gap-2"
+          style={{ background: '#f4eddc', borderBottom: '1px solid #ded2b6' }}
+        >
+          <span className="text-[10.5px] uppercase tracking-[0.16em] font-bold" style={{ color: '#6b6350' }}>
+            Chaveamento
+          </span>
+          {temConfronto && (
+            <button
+              onClick={() => setExpandido(true)}
+              className="text-[11px] font-semibold text-forest inline-flex items-center gap-1"
+            >
+              expandir
+              <Maximize2 className="w-3 h-3" />
+            </button>
+          )}
+        </div>
+
+        {!temConfronto ? (
+          <div className="px-6 py-9 text-center">
+            <div className="text-[14px] font-semibold text-ink">Chaveamento ainda não definido</div>
+            <div className="mt-1.5 text-[12.5px] leading-relaxed" style={{ color: '#8d8672' }}>
+              Os confrontos aparecem quando o sorteio das fases entrar na coleta.
+            </div>
+          </div>
+        ) : (
+          <>
+            <div
+              ref={puxar.ref}
+              {...puxar.handlers}
+              className="p-3 overflow-auto minimal-scrollbar max-h-[460px] cursor-grab active:cursor-grabbing select-none"
+            >
+              <Chave colunas={colunas} onJogo={onJogo} largura={158} />
+            </div>
+            <div
+              className="px-4 py-2 text-[10.5px] leading-relaxed"
+              style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#8d8672' }}
+            >
+              O número é o agregado de ida e volta.{formato ? ` Formato: ${formato}.` : ''} Quem enfrenta quem nas
+              fases seguintes depende do sorteio, então elas ficam como "a definir" até sair.
+            </div>
+          </>
+        )}
+      </div>
+
+      {expandido && (
+        <ChaveExpandida colunas={colunas} onJogo={onJogo} onFechar={() => setExpandido(false)} titulo={titulo} />
+      )}
+    </>
+  );
+}

--- a/src/components/futebol/Crest.tsx
+++ b/src/components/futebol/Crest.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { getFutebolTeamLogoUrl, crestInitials } from '@/utils/futebol-logos';
+
+/**
+ * Escudo do time, com fallback pra sigla quando não há mirror do logo.
+ *
+ * Estava copiado em 6 telas do futebol. Aqui é a versão única pras telas que a
+ * agenda toca; as outras seguem com a cópia local até alguém passar por elas
+ * (troca mecânica, mas fora do escopo desta mudança).
+ */
+export function Crest({ name, id, size = 24 }: { name: string; id: number; size?: number }) {
+  const [err, setErr] = useState(false);
+  const logo = getFutebolTeamLogoUrl(id);
+  if (logo && !err) {
+    return (
+      <img
+        src={logo}
+        alt={name}
+        onError={() => setErr(true)}
+        style={{ width: size, height: size }}
+        className="object-contain shrink-0"
+        loading="lazy"
+      />
+    );
+  }
+  return (
+    <div
+      style={{ width: size, height: size }}
+      className="rounded-full bg-canvas-2 border border-line grid place-items-center text-[8px] font-bold text-ink-2 shrink-0"
+    >
+      {crestInitials(name)}
+    </div>
+  );
+}

--- a/src/components/futebol/FaixaPartida.tsx
+++ b/src/components/futebol/FaixaPartida.tsx
@@ -1,0 +1,224 @@
+import { useMemo } from 'react';
+import { MapPin } from 'lucide-react';
+import { Blur } from '@/components/futebol/FutebolGate';
+import { Crest } from '@/components/futebol/Crest';
+import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
+import { useFutebolFixturePremissas } from '@/hooks/use-futebol-data';
+import type { FutebolFixtureValueRow, FutebolFormResult } from '@/services/futebol-data.service';
+import { melhorLeitura, resumoDosMercados, REGUA_SCORE } from '@/utils/futebol-leitura';
+import { outcomeLabel, contaQueValem, PORTA_PREMISSAS } from '@/utils/futebol-premissas';
+import { isFinished } from '@/utils/futebol-datas';
+import type { JogoInfo } from './JogoResumo';
+
+/**
+ * A faixa da partida: o jogo e a melhor leitura na MESMA faixa forest, colada no
+ * cabeçalho (protótipo "Futebol Jogo", direção B).
+ *
+ * O que mudou de ideia em relação ao que existia: o card branco do confronto e o
+ * hero da leitura eram dois blocos concorrendo pela mesma atenção no topo. Aqui o
+ * jogo fica à esquerda, a leitura à direita, o Score é a única coisa em âmbar e o
+ * botão de registrar mora ao lado dele.
+ */
+
+const RES_PT: Record<string, 'V' | 'E' | 'D'> = { W: 'V', D: 'E', L: 'D' };
+const COR_RES: Record<'V' | 'E' | 'D', string> = { V: '#2f7d50', E: 'rgba(255,255,255,.16)', D: '#b8341c' };
+
+function Forma({ form, alinhar }: { form: FutebolFormResult[]; alinhar?: 'fim' }) {
+  if (!form.length) return null;
+  return (
+    <div className={`flex gap-[3px] mt-1.5 ${alinhar === 'fim' ? 'justify-end' : ''}`}>
+      {form.slice(0, 5).map((g, i) => {
+        const r = RES_PT[g.result] ?? 'E';
+        return (
+          <span
+            key={`${g.fixture_id}-${i}`}
+            className="w-4 h-4 rounded-[3px] grid place-items-center text-[8.5px] font-bold text-white"
+            style={{ background: COR_RES[r], color: r === 'E' ? 'rgba(255,255,255,.75)' : '#fff' }}
+            title={`${g.opponent}: ${g.goals_for} a ${g.goals_against}`}
+          >
+            {r}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export function FaixaPartida({
+  jogo,
+  valueRows,
+  locked,
+  rodada,
+  estadio,
+  quando,
+  formHome,
+  formAway,
+  homeTeamId,
+  awayTeamId,
+  onAbrirMercado,
+}: {
+  jogo: JogoInfo;
+  valueRows: FutebolFixtureValueRow[] | null | undefined;
+  locked: boolean;
+  rodada: string;
+  estadio: string | null;
+  /** "sáb 18:30" já formatado pela página. */
+  quando: string;
+  formHome: FutebolFormResult[];
+  formAway: FutebolFormResult[];
+  homeTeamId: number;
+  awayTeamId: number;
+  onAbrirMercado: (slug: string) => void;
+}) {
+  const { data: rows } = useFutebolFixturePremissas(jogo.fixtureId);
+  const resumos = useMemo(() => resumoDosMercados(rows, valueRows), [rows, valueRows]);
+  const top = useMemo(() => melhorLeitura(resumos), [resumos]);
+  const fim = isFinished(jogo.statusShort);
+
+  const pick = top
+    ? outcomeLabel(top.mercado.slug, top.candidato.outcome, jogo.home, jogo.away, top.candidato.line_value)
+    : null;
+  const v = top?.value ?? null;
+  const nValem = top ? contaQueValem(top.mercado.slug, top.candidato.acesas) : 0;
+
+  const dia = (
+    <div className="text-center px-1 shrink-0">
+      {fim ? (
+        <div className="tabular-nums text-[22px] md:text-[26px] font-bold leading-none text-white">
+          {jogo.goalsHome ?? '-'} <span className="text-white/40">:</span> {jogo.goalsAway ?? '-'}
+        </div>
+      ) : (
+        <div className="tabular-nums text-[15px] md:text-[17px] font-bold leading-none text-white whitespace-nowrap">{quando}</div>
+      )}
+      <div className="mt-1.5 text-[9px] md:text-[9.5px] uppercase tracking-[0.1em] text-white/45">
+        {fim ? 'Encerrado' : 'Não começou'}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="relative overflow-hidden rounded-rebrand-xl" style={{ background: 'linear-gradient(135deg,#0a3d2e,#08321f 55%,#051f12)' }}>
+      <div
+        className="absolute pointer-events-none"
+        style={{ right: 180, top: -140, width: 420, height: 420, borderRadius: 999, background: 'radial-gradient(circle,rgba(251,191,36,.22),transparent 68%)' }}
+      />
+      <div className="relative grid xl:grid-cols-[1fr_1px_470px] gap-6 xl:gap-8 items-center p-5 md:p-6">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-[0.16em] text-white/45 flex items-center gap-1.5 flex-wrap">
+            <span>{rodada}</span>
+            {estadio && (
+              <>
+                <span>·</span>
+                <MapPin className="w-3 h-3" />
+                <span className="truncate">{estadio}</span>
+              </>
+            )}
+          </div>
+
+          {/* Mandante · placar · visitante numa grade de três colunas. Em `flex-wrap`
+              o visitante caía para a linha de baixo e o placar ficava colado no
+              mandante, parecendo o placar dele. */}
+          <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2 md:gap-4 mt-3">
+            <div className="flex items-center gap-2 md:gap-2.5 min-w-0">
+              <span className="w-9 h-9 md:w-[42px] md:h-[42px] rounded-full bg-white/10 grid place-items-center shrink-0">
+                <Crest name={jogo.home} id={homeTeamId} size={26} />
+              </span>
+              <div className="min-w-0">
+                <div className="text-[15px] md:text-[18px] font-semibold leading-tight text-white truncate">{jogo.home}</div>
+                <Forma form={formHome} />
+              </div>
+            </div>
+            {dia}
+            <div className="flex items-center gap-2 md:gap-2.5 min-w-0 justify-end">
+              <div className="min-w-0 text-right">
+                <div className="text-[15px] md:text-[18px] font-semibold leading-tight text-white truncate">{jogo.away}</div>
+                <Forma form={formAway} alinhar="fim" />
+              </div>
+              <span className="w-9 h-9 md:w-[42px] md:h-[42px] rounded-full bg-white/10 grid place-items-center shrink-0">
+                <Crest name={jogo.away} id={awayTeamId} size={26} />
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="hidden xl:block h-[76px] w-px bg-white/15" />
+
+        {/* A melhor leitura, na mesma faixa. Sem preço coletado, o número grande é
+            quantas premissas sustentam, que é o que existe para afirmar. */}
+        <button
+          type="button"
+          onClick={() => top && onAbrirMercado(top.mercado.slug)}
+          className="flex items-center gap-5 text-left bg-transparent border-0 p-0 cursor-pointer min-w-0"
+        >
+          <div className="flex-1 min-w-0">
+            <div className="text-[10px] uppercase tracking-[0.16em] text-white/45">Melhor leitura do jogo</div>
+            {/* Sem truncate: "Mais de 1,75 g…" escondia justamente a linha da
+                leitura. Aqui ela quebra em duas linhas. */}
+            <div className="mt-1.5 text-[19px] md:text-[24px] font-semibold leading-tight tracking-[-0.025em] text-white">
+              {pick ?? 'Sem leitura ainda'}
+            </div>
+            {v ? (
+              <div className="flex gap-5 mt-2.5">
+                <div>
+                  <div className="text-[9px] uppercase tracking-[0.14em] text-white/45">Chance</div>
+                  <div className="tabular-nums text-[16px] font-semibold text-white mt-0.5">
+                    <Blur active={locked}>{Math.round(v.prob_justa_fechamento * 100)}%</Blur>
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[9px] uppercase tracking-[0.14em] text-white/45">Odd</div>
+                  <div className="tabular-nums text-[16px] font-semibold text-white mt-0.5">
+                    <Blur active={locked}>{v.best_odd.toFixed(2)}</Blur>
+                  </div>
+                </div>
+                <div>
+                  <div className="text-[9px] uppercase tracking-[0.14em] text-white/45">Vantagem</div>
+                  <div
+                    className="tabular-nums text-[16px] font-semibold mt-0.5"
+                    style={{ color: v.edge > 0 ? '#8ee6b0' : 'rgba(255,255,255,.55)' }}
+                  >
+                    <Blur active={locked}>{`${v.edge >= 0 ? '+' : '−'}${Math.abs(v.edge * 100).toFixed(1).replace('.', ',')}%`}</Blur>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="text-[12px] text-white/55 mt-2.5 leading-relaxed">
+                {top ? `${nValem} de ${top.totalQueValem} premissas a favor` : 'Sem premissas suficientes'} · as odds entram
+                perto do jogo
+              </div>
+            )}
+          </div>
+
+          <div className="text-center shrink-0">
+            <div className="tabular-nums font-bold leading-none tracking-[-0.04em] text-[44px]" style={{ color: '#fbbf24' }}>
+              {v ? <Blur active={locked}>{String(v.score)}</Blur> : nValem}
+            </div>
+            <div className="mt-1.5 text-[9.5px] uppercase tracking-[0.12em] text-white/50">
+              {v ? `Score · ${v.score >= 60 ? 'faixa alta' : v.score >= REGUA_SCORE ? 'faixa média' : 'abaixo da régua'}` : 'premissas a favor'}
+            </div>
+            {v && !fim && !locked && top && (
+              <div className="mt-2.5 flex justify-center">
+                <RegistrarApostaCTA
+                  draft={{
+                    homeName: jogo.home,
+                    awayName: jogo.away,
+                    competition: jogo.competition,
+                    kickoffUtc: jogo.kickoffUtc,
+                    market: v.market,
+                    outcome: v.outcome,
+                    lineValue: v.line_value,
+                    bestOdd: v.best_odd,
+                  }}
+                  variant="ambar"
+                />
+              </div>
+            )}
+            {!v && top && nValem >= PORTA_PREMISSAS && !fim && (
+              <div className="mt-2 text-[10px] text-white/45 max-w-[130px] mx-auto leading-snug">sem preço coletado</div>
+            )}
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/futebol/FixtureRow.tsx
+++ b/src/components/futebol/FixtureRow.tsx
@@ -1,0 +1,141 @@
+import { Crest } from './Crest';
+import { fmtTime, isFinished, isLive } from '@/utils/futebol-datas';
+import { chancePct, marketShort, pickLabel } from '@/utils/futebol-score';
+import { REGUA_SCORE } from '@/utils/futebol-leitura';
+import { settleFutebol, isHit } from '@/utils/futebol-settlement';
+import type { FutebolFixture, FutebolValueBoardRow } from '@/services/futebol-data.service';
+
+/**
+ * Uma linha de jogo na lista.
+ *
+ * Times EMPILHADOS (casa em cima, fora embaixo), não lado a lado. A versão lado a
+ * lado dava dois nomes truncados a ~100px em tela de 375px, e "A. × R." não é jogo
+ * nenhum. Empilhado, o nome ganha a largura inteira da linha e cabe em qualquer
+ * viewport. É também o formato do SofaScore, inclusive no desktop.
+ *
+ * A LEITURA vive na própria linha (protótipo "Futebol Jogos"): mercado, pick, odd,
+ * chance e o Score em selo. É o que deixa varrer o dia inteiro sem clicar em nada,
+ * e sobra para o painel só a pergunta "por quê".
+ *
+ * Em jogo encerrado o vencedor fica em destaque e o perdedor recua, pra varredura
+ * ficar mais rápida do que ler dois placares.
+ */
+export function FixtureRow({
+  fixture,
+  best,
+  selected = false,
+  onClick,
+}: {
+  fixture: FutebolFixture;
+  best: FutebolValueBoardRow | null;
+  selected?: boolean;
+  onClick: () => void;
+}) {
+  const fim = isFinished(fixture.status_short);
+  const live = isLive(fixture.status_short);
+  const temPlacar = fim || live;
+  const gh = fixture.goals_home;
+  const ga = fixture.goals_away;
+  const casaVenceu = fim && gh != null && ga != null && gh > ga;
+  const foraVenceu = fim && gh != null && ga != null && ga > gh;
+
+  const nomeCls = (venceu: boolean, perdeu: boolean) =>
+    `truncate flex-1 min-w-0 text-[13px] tracking-tight ${
+      venceu ? 'font-bold text-ink' : perdeu ? 'font-medium text-ink-3' : 'font-semibold text-ink'
+    }`;
+  const golCls = (venceu: boolean, perdeu: boolean) =>
+    `w-5 shrink-0 text-right text-[13px] tabular-nums ${
+      venceu ? 'font-bold text-ink' : perdeu ? 'font-medium text-ink-3' : 'font-semibold text-ink'
+    }`;
+
+  const alto = !!best && best.score >= 60;
+  const chance = best ? chancePct(best.prob_justa_fechamento) : null;
+
+  // Jogo encerrado não precisa mais do Score, que é uma previsão: o que importa
+  // ali é se a leitura bateu. O selo vira ✓ ou ✕ pelo placar.
+  const liquidacao =
+    fim && best ? settleFutebol(best.market, best.outcome, best.line_value, gh, ga) : null;
+  const bateu = liquidacao != null ? isHit(liquidacao) : null;
+
+  return (
+    <button
+      onClick={onClick}
+      aria-current={selected ? 'true' : undefined}
+      className="w-full text-left px-3 sm:px-4 py-2.5 flex items-center gap-2.5 sm:gap-3.5 transition"
+      style={{
+        borderTop: '1px solid #f1e9d6',
+        background: selected ? '#fbfdfb' : undefined,
+        boxShadow: selected ? 'inset 3px 0 0 #0a3d2e' : undefined,
+      }}
+    >
+      <div className="w-10 sm:w-11 shrink-0 text-center">
+        {live ? (
+          <span className="text-[9px] uppercase tracking-[0.1em] font-bold text-status-danger">Ao vivo</span>
+        ) : fim ? (
+          <span className="text-[9px] uppercase tracking-[0.1em] font-bold" style={{ color: '#8d8672' }}>Fim</span>
+        ) : (
+          <span className="text-[12.5px] font-semibold tabular-nums text-ink">{fmtTime(fixture.kickoff_utc) || '—'}</span>
+        )}
+      </div>
+
+      <div className="flex-1 min-w-0 flex flex-col gap-1">
+        <div className="flex items-center gap-2 min-w-0">
+          <Crest name={fixture.home_team_name} id={fixture.home_team_id} size={20} />
+          <span className={nomeCls(casaVenceu, foraVenceu)}>{fixture.home_team_name}</span>
+          {temPlacar && <span className={golCls(casaVenceu, foraVenceu)}>{gh ?? 0}</span>}
+        </div>
+        <div className="flex items-center gap-2 min-w-0">
+          <Crest name={fixture.away_team_name} id={fixture.away_team_id} size={20} />
+          <span className={nomeCls(foraVenceu, casaVenceu)}>{fixture.away_team_name}</span>
+          {temPlacar && <span className={golCls(foraVenceu, casaVenceu)}>{ga ?? 0}</span>}
+        </div>
+      </div>
+
+      {/* A leitura da linha. No celular cabe o pick e a odd; o rótulo do mercado e a
+          chance ficam para o desktop. Sem odds coletadas não existe pick, e a linha
+          diz isso em cinza em vez de inventar um. */}
+      <div className="w-[96px] sm:w-[160px] shrink-0 text-right min-w-0">
+        <span className="hidden sm:block text-[9px] uppercase tracking-[0.14em] font-semibold" style={{ color: '#8d8672' }}>
+          {best ? marketShort(best.market) : fim ? 'sem leitura' : 'sem leitura ainda'}
+        </span>
+        {best ? (
+          <>
+            <span className="block sm:mt-0.5 text-[11.5px] sm:text-[12.5px] font-semibold text-ink truncate">
+              {pickLabel(best.market, best.outcome, best.line_value, fixture.home_team_name, fixture.away_team_name)}
+            </span>
+            <span className="block mt-px text-[10.5px] sm:text-[11px] tabular-nums truncate" style={{ color: '#8d8672' }}>
+              odd {best.best_odd.toFixed(2)}
+              {chance != null ? <span className="hidden sm:inline">{` · ${chance}% chance`}</span> : null}
+            </span>
+          </>
+        ) : (
+          <span className="block sm:mt-0.5 text-[10.5px] sm:text-[11px] truncate" style={{ color: '#8d8672' }}>
+            <span className="sm:hidden">sem leitura</span>
+            {/* Em jogo encerrado não faz sentido prometer que as odds entram. */}
+            <span className="hidden sm:inline">{fim ? 'não teve odds coletadas' : 'odds entram perto do jogo'}</span>
+          </span>
+        )}
+      </div>
+
+      <div
+        className="shrink-0 grid place-items-center tabular-nums font-bold w-8 h-8 sm:w-[38px] sm:h-[38px] text-[13px] sm:text-[14px]"
+        style={
+          !best
+            ? { borderRadius: 11, background: '#fdfbf6', border: '1px dashed #e5d9bd', color: '#c4bda8' }
+            : bateu != null
+              ? bateu
+                ? { borderRadius: 11, background: '#dcefe2', border: '1px solid #a9d4bb', color: '#0a3d2e' }
+                : { borderRadius: 11, background: '#fbe3e8', border: '1px solid #f0c2cc', color: '#be123c' }
+              : alto
+                ? { borderRadius: 11, background: '#0a3d2e', color: '#fff' }
+                : best.score >= REGUA_SCORE
+                  ? { borderRadius: 11, background: '#fdf3d9', border: '1px solid #eccf85', color: '#b8870f' }
+                  : { borderRadius: 11, background: '#f4eddc', color: '#8d8672' }
+        }
+        title={bateu != null ? (bateu ? 'a leitura bateu' : 'a leitura não bateu') : undefined}
+      >
+        {!best ? '—' : bateu != null ? (bateu ? '✓' : '✕') : best.score}
+      </div>
+    </button>
+  );
+}

--- a/src/components/futebol/GruposFase.tsx
+++ b/src/components/futebol/GruposFase.tsx
@@ -1,0 +1,145 @@
+import { useMemo } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Crest } from './Crest';
+import type { FutebolStandingRow } from '@/services/futebol-data.service';
+
+/**
+ * As tabelas da fase de grupos, uma por grupo.
+ *
+ * Enquanto a copa está nos grupos, a pergunta não é "quem enfrenta quem na
+ * final", é "como está o meu grupo". A chave só passa a valer quando o
+ * mata-mata começa; antes disso ela é um monte de "a definir".
+ *
+ * O grupo vem de fact_standings_snapshot.group_name (migration 096). São 8
+ * grupos na Libertadores e na Sul-Americana e 12 na Copa do Mundo, então a
+ * lista rola dentro do próprio card, sem empurrar o resto da página.
+ */
+
+/** 'Group A' → 'Grupo A'. Nome de liga (sem grupo de verdade) passa direto. */
+function nomeDoGrupo(g: string): string {
+  const m = g.match(/^group\s+(.+)$/i);
+  return m ? `Grupo ${m[1].toUpperCase()}` : g;
+}
+
+export function GruposFase({
+  rows,
+  loading,
+  onTeam,
+  /** Quantos passam de fase. Só pinta a barra verde, não inventa critério. */
+  classificados = 2,
+}: {
+  rows?: FutebolStandingRow[];
+  loading: boolean;
+  onTeam: (id: number) => void;
+  classificados?: number;
+}) {
+  const grupos = useMemo(() => {
+    const m = new Map<string, FutebolStandingRow[]>();
+    (rows ?? []).forEach((r) => {
+      const g = r.group_name ?? '—';
+      if (!m.has(g)) m.set(g, []);
+      m.get(g)!.push(r);
+    });
+    return [...m.entries()]
+      .map(([g, linhas]) => ({ grupo: g, linhas: [...linhas].sort((a, b) => a.rank - b.rank) }))
+      .sort((a, b) => a.grupo.localeCompare(b.grupo));
+  }, [rows]);
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-rebrand-lg overflow-hidden p-4 space-y-2" style={{ border: '1px solid #ded2b6' }}>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-full bg-canvas-2 rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!grupos.length) {
+    return (
+      <div className="bg-white rounded-rebrand-lg px-6 py-9 text-center" style={{ border: '1px dashed #ded2b6' }}>
+        <div className="text-[14px] font-semibold text-ink">Grupos ainda não coletados</div>
+        <div className="mt-1.5 text-[12.5px] leading-relaxed" style={{ color: '#8d8672' }}>
+          Entram assim que a competição passar pela coleta.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-rebrand-lg overflow-hidden" style={{ border: '1px solid #ded2b6' }}>
+      <div
+        className="px-4 py-2.5 flex items-center justify-between gap-2"
+        style={{ background: '#f4eddc', borderBottom: '1px solid #ded2b6' }}
+      >
+        <span className="text-[10.5px] uppercase tracking-[0.16em] font-bold" style={{ color: '#6b6350' }}>
+          Fase de grupos
+        </span>
+        <span className="text-[10.5px]" style={{ color: '#8d8672' }}>
+          {grupos.length} grupos
+        </span>
+      </div>
+
+      <div className="max-h-[560px] overflow-y-auto minimal-scrollbar">
+        {grupos.map(({ grupo, linhas }, iG) => (
+          <div key={grupo}>
+            <div
+              className="px-4 py-1.5 flex items-center justify-between"
+              style={{
+                background: '#f8f4ea',
+                borderTop: iG === 0 ? 'none' : '1px solid #f1e9d6',
+                borderBottom: '1px solid #f1e9d6',
+              }}
+            >
+              <span className="text-[9px] uppercase tracking-[0.12em] font-bold" style={{ color: '#0a3d2e' }}>
+                {nomeDoGrupo(grupo)}
+              </span>
+              <span className="text-[9px] uppercase tracking-[0.1em]" style={{ color: '#8d8672' }}>
+                J · SG · Pts
+              </span>
+            </div>
+
+            {linhas.map((r) => {
+              const passa = r.rank <= classificados;
+              const sg = r.goals_diff > 0 ? `+${r.goals_diff}` : r.goals_diff < 0 ? `−${Math.abs(r.goals_diff)}` : '0';
+              return (
+                <button
+                  key={r.team_id}
+                  onClick={() => onTeam(r.team_id)}
+                  className="w-full text-left px-4 py-1.5 grid grid-cols-[22px_1fr_22px_30px_30px] gap-2 items-center hover:bg-canvas-2 transition"
+                  style={{ borderTop: '1px solid #f1e9d6' }}
+                >
+                  <span className="flex items-center gap-1">
+                    <span
+                      className="w-[3px] h-3.5 rounded-full shrink-0"
+                      style={{ background: passa ? '#0a3d2e' : 'transparent' }}
+                    />
+                    <span className="text-[11px] font-semibold tabular-nums" style={{ color: '#6b6350' }}>
+                      {r.rank}
+                    </span>
+                  </span>
+                  <span className="flex items-center gap-2 min-w-0">
+                    <Crest name={r.team_name} id={r.team_id} size={18} />
+                    <span className={`truncate text-[11.5px] ${passa ? 'font-bold text-ink' : 'font-medium text-ink'}`}>
+                      {r.team_name}
+                    </span>
+                  </span>
+                  <span className="text-center text-[11px] tabular-nums" style={{ color: '#6b6350' }}>
+                    {r.played}
+                  </span>
+                  <span
+                    className="text-center text-[11px] tabular-nums"
+                    style={{ color: r.goals_diff > 0 ? '#0a3d2e' : r.goals_diff < 0 ? '#be123c' : '#6b6350' }}
+                  >
+                    {sg}
+                  </span>
+                  <span className="text-center text-[12.5px] font-bold tabular-nums text-ink">{r.points}</span>
+                </button>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/futebol/JogoResumo.tsx
+++ b/src/components/futebol/JogoResumo.tsx
@@ -1,0 +1,450 @@
+import { useMemo } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Blur } from '@/components/futebol/FutebolGate';
+import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
+import { useFutebolFixturePremissas, useFutebolFixtureNumeros } from '@/hooks/use-futebol-data';
+import type {
+  FutebolFixtureValueRow,
+  FutebolInjury,
+} from '@/services/futebol-data.service';
+import {
+  contextoDoMercado,
+  outcomeLabel,
+  pesoForte,
+  premissaDe,
+} from '@/utils/futebol-premissas';
+import { evidenciaDe, ladoDaSaida, manchete } from '@/utils/futebol-evidencias';
+import { melhorLeitura, resumoDosMercados, REGUA_SCORE, type MercadoResumo } from '@/utils/futebol-leitura';
+import { fmtDayShort, isFinished } from '@/utils/futebol-datas';
+import { settleFutebol, resultBadge, isHit } from '@/utils/futebol-settlement';
+import { faixaWord } from '@/utils/futebol-score';
+
+/**
+ * Aba RESUMO da tela de jogo (Protótipo 1b do Claude Design):
+ * esquerda = a leitura em manchete, os 5 mercados em linhas e o "como chegam";
+ * direita = o hero da melhor leitura, desfalques e o disclaimer.
+ *
+ * Adaptação honesta do protótipo: Score/odd/chance só aparecem quando existem
+ * odds coletadas (T−24h). Sem odds, as linhas mostram o contexto (premissas), que
+ * é o que dá para afirmar — o mesmo padrão "sem preço" que o protótipo usa no BTTS.
+ */
+
+export interface JogoInfo {
+  fixtureId: number;
+  /** Ids dos times: escudo e filtro de desfalques por lado. */
+  homeId?: number;
+  awayId?: number;
+  home: string;
+  away: string;
+  competition: string;
+  season: number;
+  kickoffUtc: string | null;
+  statusShort: string | null;
+  goalsHome: number | null;
+  goalsAway: number | null;
+}
+
+function scoreBadge(r: MercadoResumo): { texto: string; cls: string; style?: React.CSSProperties } {
+  if (r.value) {
+    const s = r.value.score;
+    if (s >= 60) return { texto: String(s), cls: 'bg-forest text-canvas border-forest' };
+    if (s >= REGUA_SCORE)
+      return { texto: String(s), cls: '', style: { background: 'rgba(212,160,23,.15)', color: '#b8870f', border: '1px solid rgba(212,160,23,.4)' } };
+    return { texto: String(s), cls: 'bg-canvas-2 text-ink-3 border-line' };
+  }
+  return r.passa
+    ? { texto: `${r.nValem}✓`, cls: 'bg-forest/10 text-forest border-forest/30' }
+    : { texto: `${r.nValem}✓`, cls: 'bg-canvas-2 text-ink-3 border-line' };
+}
+
+/** Hero "Melhor leitura do jogo" — o gradiente de assinatura do DS. */
+export function HeroLeitura({
+  top,
+  jogo,
+  locked,
+  compacto = false,
+  retro,
+}: {
+  top: MercadoResumo | null;
+  jogo: JogoInfo;
+  locked: boolean;
+  compacto?: boolean;
+  retro?: string | null;
+}) {
+  const { data: numeros } = useFutebolFixtureNumeros(jogo.fixtureId);
+  if (!top) return null;
+  const lado = ladoDaSaida(top.mercado.slug, top.candidato.outcome);
+  const pick = outcomeLabel(top.mercado.slug, top.candidato.outcome, jogo.home, jogo.away, top.candidato.line_value);
+
+  // Os porquês: a evidência das acesas de maior peso, no máximo 3.
+  const porques = top.candidato.acesas
+    .map((s) => premissaDe(top.mercado.slug, s))
+    .filter((p): p is NonNullable<typeof p> => p != null)
+    .sort((a, b) => (b.peso ?? 0) - (a.peso ?? 0))
+    .slice(0, 3)
+    .map((p) => {
+      const ev = evidenciaDe(p.slug, numeros, lado);
+      return ev ? `${p.label}: ${ev.texto.charAt(0).toLowerCase()}${ev.texto.slice(1)}.` : `${p.label}.`;
+    });
+
+  const fim = isFinished(jogo.statusShort);
+  const res = fim ? settleFutebol(top.mercado.slug, top.candidato.outcome, top.candidato.line_value, jogo.goalsHome, jogo.goalsAway) : null;
+
+  return (
+    <div
+      className={`rounded-rebrand-xl text-white relative overflow-hidden ${compacto ? 'p-5' : 'p-6'}`}
+      style={{ background: 'linear-gradient(135deg,#0a3d2e,#08321f 60%,#051f12)' }}
+    >
+      <div
+        className="absolute rounded-full pointer-events-none"
+        style={{ right: -50, top: -60, width: 220, height: 220, background: 'radial-gradient(circle,rgba(251,191,36,.26),transparent 68%)' }}
+      />
+      <div className="relative">
+        <div className="text-[10px] uppercase tracking-[0.16em] font-semibold text-white/50">Melhor leitura do jogo</div>
+        <div className={`font-semibold tracking-[-0.02em] mt-2 leading-[1.25] ${compacto ? 'text-[21px]' : 'text-[23px]'}`}>{pick}</div>
+        <div className="text-[12px] text-white/50 mt-1">{top.mercado.label}</div>
+
+        <div className="flex items-baseline gap-2 mt-4">
+          {top.value ? (
+            <>
+              <span className="tabular-nums font-bold leading-none text-[44px]" style={{ color: '#fbbf24' }}>
+                {top.value.score}
+              </span>
+              <span className="text-[12px] text-white/45">/100 · faixa {faixaWord(top.value.faixa)}</span>
+            </>
+          ) : (
+            <>
+              <span className="tabular-nums font-bold leading-none text-[44px]" style={{ color: '#fbbf24' }}>
+                {top.nValem}
+              </span>
+              <span className="text-[12px] text-white/45">de {top.totalQueValem} premissas a favor · sem preço ainda</span>
+            </>
+          )}
+        </div>
+
+        {top.value && (
+          <div className="grid grid-cols-2 gap-3.5 mt-4">
+            <div>
+              <div className="text-[9px] uppercase tracking-[0.14em] font-semibold text-white/50">Chance</div>
+              <div className="tabular-nums text-[18px] font-semibold mt-1">
+                <Blur active={locked}>{Math.round(top.value.prob_justa_fechamento * 100)}%</Blur>
+              </div>
+            </div>
+            <div>
+              <div className="text-[9px] uppercase tracking-[0.14em] font-semibold text-white/50">Odd</div>
+              <div className="tabular-nums text-[18px] font-semibold mt-1">
+                <Blur active={locked}>{top.value.best_odd.toFixed(2)}</Blur>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {(retro || res) && (
+          <div className="mt-4 pt-3.5 border-t border-white/15 text-[12px] leading-relaxed text-white/75">
+            {retro}
+            {res && (
+              <span
+                className="ml-2 px-2 h-5 inline-flex items-center rounded-full text-[10px] font-bold uppercase tracking-[0.06em]"
+                style={{
+                  background: isHit(res) ? 'rgba(220,239,226,.2)' : res === 'push' ? 'rgba(255,255,255,.12)' : 'rgba(251,227,232,.18)',
+                  color: isHit(res) ? '#8ee6b0' : res === 'push' ? 'rgba(255,255,255,.7)' : '#ffb3c0',
+                }}
+              >
+                {resultBadge(res).label}
+              </span>
+            )}
+          </div>
+        )}
+
+        {!compacto && porques.length > 0 && (
+          <div className="mt-4 pt-4 border-t border-white/15 flex flex-col gap-2">
+            {porques.map((t) => (
+              <div key={t} className="flex gap-2 items-start text-[12.5px] leading-relaxed text-white/80">
+                <span className="w-[5px] h-[5px] rounded-full mt-[7px] shrink-0" style={{ background: '#fbbf24' }} />
+                <span>{t}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function JogoResumo({
+  jogo,
+  valueRows,
+  injuries,
+  locked,
+  onAbrirMercado,
+}: {
+  jogo: JogoInfo;
+  valueRows: FutebolFixtureValueRow[] | null | undefined;
+  injuries: FutebolInjury[] | null | undefined;
+  locked: boolean;
+  onAbrirMercado: (slug: string) => void;
+}) {
+  const { data: rows, isLoading } = useFutebolFixturePremissas(jogo.fixtureId);
+  const { data: numeros } = useFutebolFixtureNumeros(jogo.fixtureId);
+
+  const resumos = useMemo(() => resumoDosMercados(rows, valueRows), [rows, valueRows]);
+  const top = useMemo(() => melhorLeitura(resumos), [resumos]);
+  const fim = isFinished(jogo.statusShort);
+  const placar = useMemo(
+    () => (fim ? { home: jogo.goalsHome, away: jogo.goalsAway } : null),
+    [fim, jogo.goalsHome, jogo.goalsAway],
+  );
+
+  // A manchete: a evidência mais pesada do melhor mercado, em frase grande.
+  const leitura = useMemo(() => {
+    if (!top) return null;
+    const lado = ladoDaSaida(top.mercado.slug, top.candidato.outcome);
+    const acesasPorPeso = top.candidato.acesas
+      .map((s) => premissaDe(top.mercado.slug, s))
+      .filter((p): p is NonNullable<typeof p> => p != null)
+      .sort((a, b) => (b.peso ?? 0) - (a.peso ?? 0))
+      .map((p) => p.slug);
+    return manchete(top.candidato.acesas, acesasPorPeso, numeros, lado);
+  }, [top, numeros]);
+
+  const chips = useMemo(() => {
+    const out: string[] = [];
+    if (top) {
+      const fortes = top.candidato.acesas
+        .map((s) => premissaDe(top.mercado.slug, s))
+        .filter((p): p is NonNullable<typeof p> => p != null)
+        .filter(pesoForte).length;
+      const semCal = top.mercado.teto == null;
+      const ctx = contextoDoMercado(fortes, semCal);
+      out.push(`${top.nValem} ${top.nValem === 1 ? 'premissa' : 'premissas'} a favor · ${ctx.label.toLowerCase()}`);
+    }
+    const amostra = Math.min(...(numeros ?? []).map((x) => x.jogos ?? Infinity));
+    if (Number.isFinite(amostra) && amostra < 5) out.push(`amostra curta: ${amostra} jogos na competição`);
+    const fora = (injuries ?? []).length;
+    if (fora > 0) out.push(`${fora} ${fora === 1 ? 'desfalque' : 'desfalques'} no radar`);
+    return out;
+  }, [top, numeros, injuries]);
+
+  // Retro do encerrado: dos que passavam, quantos bateram.
+  const retro = useMemo(() => {
+    if (!placar || !resumos.length) return null;
+    const apontados = resumos.filter((r) => r.passa);
+    const liq = apontados
+      .map((r) => settleFutebol(r.mercado.slug, r.candidato.outcome, r.candidato.line_value, placar.home, placar.away))
+      .filter((x): x is NonNullable<typeof x> => x != null);
+    if (!liq.length) return null;
+    const hits = liq.filter(isHit).length;
+    return `O mapa apontava ${liq.length} ${liq.length === 1 ? 'mercado' : 'mercados'} · ${hits} ${hits === 1 ? 'bateu' : 'bateram'}`;
+  }, [placar, resumos]);
+
+  // "Como chegam": as 4 barras espelhadas do protótipo, casa × fora.
+  const barras = useMemo(() => {
+    const casa = numeros?.find((x) => x.side === 'home');
+    const fora = numeros?.find((x) => x.side === 'away');
+    if (!casa || !fora) return [];
+    const d1 = (v: number) => v.toFixed(1).replace('.', ',');
+    const linhas: { l: string; a: string; b: string; va: number; vb: number }[] = [];
+    if (casa.gf_total != null && fora.gf_total != null)
+      linhas.push({ l: 'Gols marcados por jogo', a: d1(casa.gf_total), b: d1(fora.gf_total), va: casa.gf_total, vb: fora.gf_total });
+    if (casa.ga_total != null && fora.ga_total != null)
+      linhas.push({ l: 'Gols sofridos por jogo', a: d1(casa.ga_total), b: d1(fora.ga_total), va: casa.ga_total, vb: fora.ga_total });
+    if (casa.posicao != null && fora.posicao != null)
+      // Posição: menor é melhor, então a barra usa o valor do OUTRO lado.
+      linhas.push({ l: 'Posição na tabela', a: `${casa.posicao}º`, b: `${fora.posicao}º`, va: fora.posicao, vb: casa.posicao });
+    if (casa.clean_sheets != null && fora.clean_sheets != null)
+      linhas.push({ l: 'Jogos sem sofrer gol', a: String(casa.clean_sheets), b: String(fora.clean_sheets), va: casa.clean_sheets, vb: fora.clean_sheets });
+    return linhas.map((x) => {
+      const tot = x.va + x.vb || 1;
+      return { ...x, wa: `${Math.round((x.va / tot) * 100)}%`, wb: `${Math.round((x.vb / tot) * 100)}%` };
+    });
+  }, [numeros]);
+  const ate = numeros?.[0]?.ate ?? null;
+  const temValor = (valueRows?.length ?? 0) > 0;
+
+  const foraDaRegua = resumos.filter((r) => !r.passa).map((r) => r.mercado.label.toLowerCase());
+  const juntar = (arr: string[]) => (arr.length <= 1 ? arr[0] ?? '' : `${arr.slice(0, -1).join(', ')} e ${arr[arr.length - 1]}`);
+  const nota = fim && retro
+    ? retro
+    : !temValor
+      ? 'Sem preço coletado ainda: as odds entram perto do jogo, e com elas o Score fecha.'
+      : foraDaRegua.length
+        ? `${juntar(foraDaRegua)} ${foraDaRegua.length === 1 ? 'fica' : 'ficam'} abaixo da régua de ${REGUA_SCORE}, ${foraDaRegua.length === 1 ? 'entra' : 'entram'} como consulta.`
+        : `Os cinco mercados passam a régua de ${REGUA_SCORE} neste jogo.`;
+
+  if (isLoading) {
+    return (
+      <div className="grid gap-4">
+        <Skeleton className="h-40 w-full bg-canvas-2 rounded-rebrand-xl" />
+        <Skeleton className="h-72 w-full bg-canvas-2 rounded-rebrand-xl" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid xl:grid-cols-[1fr_340px] gap-5 items-start">
+      <div className="min-w-0 flex flex-col gap-5">
+        {/* A leitura do jogo, em manchete. */}
+        <div className="bg-white border border-line rounded-rebrand-xl p-6 md:p-7">
+          <div className="text-[10px] uppercase tracking-[0.18em] font-bold text-ink-3">A leitura do jogo</div>
+          <p
+            className="mt-3 text-[22px] md:text-[28px] leading-[1.28] font-semibold tracking-[-0.025em] text-ink max-w-[620px]"
+            style={{ textWrap: 'pretty' }}
+          >
+            {leitura?.texto ?? 'Sem premissas suficientes para uma leitura neste jogo.'}
+          </p>
+          {chips.length > 0 && (
+            <div className="flex gap-2 mt-4 flex-wrap">
+              {chips.map((c) => (
+                <span
+                  key={c}
+                  className="inline-flex items-center gap-1.5 h-[30px] px-3 rounded-full bg-canvas-2 text-[11.5px] font-semibold text-ink-2"
+                >
+                  <span className="w-1.5 h-1.5 rounded-full bg-forest" />
+                  {c}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Os 5 mercados, uma linha cada. Clique abre a bancada. */}
+        <div className="bg-white border border-line rounded-rebrand-xl overflow-hidden">
+          <div className="px-6 py-4 border-b border-line flex items-baseline justify-between gap-3">
+            <span className="text-[10.5px] uppercase tracking-[0.18em] font-bold text-ink-2">Os 5 mercados</span>
+            <span className="text-[11.5px] text-ink-3">clique para abrir a bancada</span>
+          </div>
+          {resumos.map((r) => {
+            const pick = outcomeLabel(r.mercado.slug, r.candidato.outcome, jogo.home, jogo.away, r.candidato.line_value);
+            const badge = scoreBadge(r);
+            const res = placar
+              ? settleFutebol(r.mercado.slug, r.candidato.outcome, r.candidato.line_value, placar.home, placar.away)
+              : null;
+            return (
+              <button
+                key={r.mercado.slug}
+                onClick={() => onAbrirMercado(r.mercado.slug)}
+                className={`w-full text-left border-b border-line/60 last:border-b-0 px-6 py-3.5 grid grid-cols-[96px_1fr_auto_auto] gap-4 items-center hover:bg-canvas transition ${r.passa ? '' : 'opacity-60'}`}
+              >
+                <span className="text-[10px] uppercase tracking-[0.14em] font-semibold text-ink-3">{r.mercado.label}</span>
+                <span className="min-w-0">
+                  <span className="block text-[14.5px] font-semibold text-ink truncate">
+                    {pick}
+                    {res && (
+                      <span
+                        className="ml-2 px-1.5 h-[18px] inline-flex items-center rounded text-[9px] font-bold uppercase tracking-[0.06em] align-middle"
+                        style={
+                          isHit(res)
+                            ? { background: '#dcefe2', color: '#0a3d2e' }
+                            : res === 'push'
+                              ? { background: '#eef0eb', color: '#5a625a' }
+                              : { background: '#fbe3e8', color: '#be123c' }
+                        }
+                      >
+                        {resultBadge(res).label}
+                      </span>
+                    )}
+                  </span>
+                  <span className="block text-[11.5px] text-ink-3 mt-0.5 truncate">
+                    {r.value
+                      ? `${Math.round(r.value.prob_justa_fechamento * 100)}% de chance · odd ${r.value.best_odd.toFixed(2)}`
+                      : `${r.nValem} de ${r.totalQueValem} premissas a favor`}
+                  </span>
+                </span>
+                {r.value ? (
+                  <span
+                    className="tabular-nums text-[13px] font-semibold hidden md:block"
+                    style={{ color: r.value.edge > 0 ? 'var(--forest)' : 'var(--ink-3)' }}
+                  >
+                    <Blur active={locked}>{`${r.value.edge >= 0 ? '+' : '−'}${Math.abs(r.value.edge * 100).toFixed(1).replace('.', ',')}%`}</Blur>
+                  </span>
+                ) : (
+                  <span className="hidden md:block" />
+                )}
+                <span
+                  className={`tabular-nums w-[42px] h-[42px] rounded-xl grid place-items-center text-[15px] font-bold border ${badge.cls}`}
+                  style={badge.style}
+                >
+                  {badge.texto}
+                </span>
+              </button>
+            );
+          })}
+          <div className="px-6 py-3.5 bg-canvas-2 text-[11.5px] text-ink-2">{nota}</div>
+        </div>
+
+        {/* Como chegam: barras espelhadas casa × fora, como no protótipo. A barra
+            da posição usa o valor do outro lado, porque na tabela menor é melhor. */}
+        {barras.length > 0 && (
+          <div className="bg-white border border-line rounded-rebrand-xl p-6">
+            <div className="text-[10.5px] uppercase tracking-[0.18em] font-bold text-ink-2 mb-4">Como chegam</div>
+            <div className="grid md:grid-cols-2 gap-x-8 gap-y-5">
+              {barras.map((x) => (
+                <div key={x.l}>
+                  <div className="flex justify-between items-baseline mb-1.5 tabular-nums">
+                    <span className="text-[15px] font-semibold text-forest">{x.a}</span>
+                    <span className="text-[11px] font-medium text-ink-3">{x.l}</span>
+                    <span className="text-[15px] font-semibold text-ink-2">{x.b}</span>
+                  </div>
+                  <div className="flex gap-1 h-[7px]">
+                    <div className="flex-1 bg-canvas-2 rounded-l-full flex justify-end overflow-hidden">
+                      <div className="bg-forest" style={{ width: x.wa }} />
+                    </div>
+                    <div className="flex-1 bg-canvas-2 rounded-r-full overflow-hidden">
+                      <div className="bg-ink-3" style={{ width: x.wb }} />
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="min-w-0 flex flex-col gap-4">
+        <HeroLeitura top={top} jogo={jogo} locked={locked} retro={fim ? retro : null} />
+
+        {top?.value && !fim && !locked && (
+          <div className="bg-white border border-line rounded-rebrand-xl overflow-hidden">
+            <RegistrarApostaCTA
+              draft={{
+                homeName: jogo.home,
+                awayName: jogo.away,
+                competition: jogo.competition,
+                kickoffUtc: jogo.kickoffUtc,
+                market: top.value.market,
+                outcome: top.value.outcome,
+                lineValue: top.value.line_value,
+                bestOdd: top.value.best_odd,
+              }}
+            />
+          </div>
+        )}
+
+        {(injuries?.length ?? 0) > 0 && (
+          <div className="bg-white border border-line rounded-rebrand-xl p-5">
+            <div className="text-[10.5px] uppercase tracking-[0.18em] font-bold text-ink-2 mb-2">Desfalques</div>
+            {(injuries ?? []).slice(0, 8).map((d, i) => {
+              const duvida = /quest|doubt|dúvid/i.test(d.injury_type || '');
+              return (
+                <div key={i} className="flex items-center gap-2.5 py-2 border-t border-line/60 first:border-t-0">
+                  <span className="text-[12.5px] font-semibold text-ink truncate">{d.player_name}</span>
+                  <span className="text-[11px] text-ink-3 truncate">{d.injury_reason || d.injury_type}</span>
+                  <span
+                    className="ml-auto px-1.5 h-[18px] inline-flex items-center rounded text-[9px] font-bold shrink-0"
+                    style={duvida ? { background: '#fef7df', color: '#9a6c00' } : { background: '#fde2e7', color: '#9a1f2e' }}
+                  >
+                    {duvida ? 'Dúvida' : 'Fora'}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <p className="text-[11px] leading-relaxed text-ink-3">
+          Leitura de risco, não recomendação de aposta.{ate ? ` Números da temporada até ${fmtDayShort(ate)}.` : ''}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -1,0 +1,383 @@
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRight, X, Minus } from 'lucide-react';
+import { Crest } from './Crest';
+import { RegistrarApostaCTA } from './RegistrarAposta';
+import {
+  useFutebolFixturePremissas,
+  useFutebolFixtureNumeros,
+  useFutebolFixtureInjuries,
+  useFutebolFixtureHistorico,
+} from '@/hooks/use-futebol-data';
+import { fmtDayChip, fmtTime, isFinished, isLive } from '@/utils/futebol-datas';
+import { chancePct, pickLabel } from '@/utils/futebol-score';
+import { marketShort } from '@/utils/futebol-score';
+import { contaQueValem, premissaDe, rotuloPremissa, pesoForte } from '@/utils/futebol-premissas';
+import { melhorLeitura, resumoDosMercados, REGUA_SCORE } from '@/utils/futebol-leitura';
+import { evidenciaDe, ladoDaSaida } from '@/utils/futebol-evidencias';
+import { evidenciaDoHistorico } from '@/utils/futebol-historico';
+import { settleFutebol, isHit } from '@/utils/futebol-settlement';
+import type { FutebolFixtureByDay, FutebolValueBoardRow } from '@/services/futebol-data.service';
+
+/**
+ * O painel do jogo na coluna da direita (protótipo "Futebol Jogos").
+ *
+ * Ele responde uma pergunta só: POR QUE esta leitura. A lista já mostra pick, odd e
+ * Score em cada linha, então aqui entra o motivo (as premissas com o número que as
+ * embasa), como os dois chegam, a forma e os desfalques.
+ *
+ * Sem leitura o painel NÃO esvazia: explica o motivo e mostra o contexto assim
+ * mesmo. A maioria dos jogos legitimamente não tem oportunidade, e um painel em
+ * branco lê como defeito.
+ *
+ * Três queries por jogo aberto (premissas, números e desfalques), todas leves e
+ * compartilhadas com a tela de jogo: abrir o painel aquece a análise completa. A
+ * `fixture_detail` saiu junto com o bloco de stats, que este desenho não tem mais.
+ */
+
+const RES_COR: Record<'V' | 'E' | 'D', { bg: string; fg: string }> = {
+  V: { bg: '#2f7d50', fg: '#fff' },
+  E: { bg: '#f1e9d6', fg: '#6b6350' },
+  D: { bg: '#b8341c', fg: '#fff' },
+};
+
+function Forma({ forma }: { forma: string | null | undefined }) {
+  if (!forma) return <span className="text-[11px]" style={{ color: '#8d8672' }}>—</span>;
+  const ult = forma.slice(-5).split('').map((c) => (c === 'W' ? 'V' : c === 'D' ? 'E' : 'D') as 'V' | 'E' | 'D');
+  return (
+    <span className="flex gap-[3px]">
+      {ult.map((r, i) => (
+        <span
+          key={i}
+          className="w-[17px] h-[17px] rounded grid place-items-center text-[8.5px] font-bold"
+          style={{ background: RES_COR[r].bg, color: RES_COR[r].fg }}
+        >
+          {r}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export function JogoResumoPanel({
+  fixture,
+  best,
+  onClose,
+}: {
+  fixture: FutebolFixtureByDay;
+  best: FutebolValueBoardRow | null;
+  onClose: () => void;
+}) {
+  const { data: premissas } = useFutebolFixturePremissas(fixture.fixture_id);
+  const { data: numeros } = useFutebolFixtureNumeros(fixture.fixture_id);
+  const { data: injuries } = useFutebolFixtureInjuries(fixture.fixture_id);
+  const { data: historico } = useFutebolFixtureHistorico(fixture.fixture_id);
+
+  const fim = isFinished(fixture.status_short);
+  const live = isLive(fixture.status_short);
+  const dia = fmtDayChip(fixture.day_brt);
+
+  // A leitura: com preço, a melhor do value board; sem preço, o mercado com mais
+  // premissas. É a mesma conta da tela de jogo, então os dois nunca divergem.
+  const resumos = useMemo(() => resumoDosMercados(premissas, best ? [] : null), [premissas, best]);
+  const topo = useMemo(() => melhorLeitura(resumos), [resumos]);
+
+  const mercadoLeitura = best ? best.market : topo?.mercado.slug ?? null;
+  // As premissas têm que ser as da MESMA saída do pick. Pegando só "o melhor
+  // candidato do mercado", o painel listava as premissas da linha 4,25 embaixo de um
+  // pick de 2,5 — duas leituras diferentes na mesma caixa.
+  const cand = !mercadoLeitura
+    ? null
+    : (best
+        ? (premissas ?? []).find(
+            (r) =>
+              r.market === best.market &&
+              r.outcome === best.outcome &&
+              ((r.line_value == null && best.line_value == null) ||
+                (r.line_value != null && best.line_value != null && Math.abs(r.line_value - best.line_value) < 0.011)),
+          )
+        : null) ?? resumos.find((r) => r.mercado.slug === mercadoLeitura)?.candidato ?? null;
+  const pick = best
+    ? pickLabel(best.market, best.outcome, best.line_value, fixture.home_team_name, fixture.away_team_name)
+    : topo
+      ? pickLabel(
+          topo.mercado.slug,
+          topo.candidato.outcome,
+          topo.candidato.line_value,
+          fixture.home_team_name,
+          fixture.away_team_name,
+        )
+      : null;
+
+  const temLeitura = !!best || (topo != null && topo.nValem > 0);
+  const lado = cand ? ladoDaSaida(mercadoLeitura!, cand.outcome) : null;
+  const nValem = cand && mercadoLeitura ? contaQueValem(mercadoLeitura, cand.acesas) : 0;
+
+  // Os porquês: premissas acesas que valem, com o número que as embasa.
+  const porques = (cand?.acesas ?? [])
+    .map((s) => premissaDe(mercadoLeitura!, s))
+    .filter((p): p is NonNullable<typeof p> => p != null && (p.peso == null || p.peso > 0))
+    .sort((a, b) => (b.peso ?? 0) - (a.peso ?? 0))
+    .slice(0, 4)
+    .map((p) => ({
+      p,
+      ev:
+        evidenciaDe(p.slug, numeros, lado, true, cand?.line_value ?? null) ??
+        evidenciaDoHistorico(p.slug, historico, lado, cand?.line_value ?? null),
+    }));
+
+  // O que pesou contra: as premissas do lado que NÃO aconteceram.
+  const contra = topo && cand && mercadoLeitura
+    ? (() => {
+        const acesas = new Set(cand.acesas);
+        const faltou = topo.mercado.premissas
+          .filter((p) => !acesas.has(p.slug) && p.peso != null && p.peso > 0)
+          .slice(0, 2)
+          .map((p) => rotuloPremissa(p, lado, true).toLowerCase());
+        return faltou.length ? `${faltou.length} ${faltou.length === 1 ? 'pesou' : 'pesaram'} contra: ${faltou.join(' e ')}.` : null;
+      })()
+    : null;
+
+  const casa = numeros?.find((n) => n.side === 'home');
+  const fora = numeros?.find((n) => n.side === 'away');
+  const d1 = (v: number | null | undefined) => (v == null ? '—' : v.toFixed(1).replace('.', ','));
+  const chegam = casa && fora
+    ? [
+        { label: 'Gols marcados', a: casa.gf_total, b: fora.gf_total, maiorEhCasa: true },
+        { label: 'Gols sofridos', a: casa.ga_total, b: fora.ga_total, maiorEhCasa: false },
+        { label: 'Sem sofrer gol', a: casa.clean_sheets, b: fora.clean_sheets, maiorEhCasa: true },
+      ].filter((x) => x.a != null && x.b != null)
+    : [];
+
+  const desfalques = (teamId: number) =>
+    (injuries ?? [])
+      .filter((i) => i.team_id === teamId)
+      .slice(0, 2)
+      .map((i) => i.player_name)
+      .join(', ') || '—';
+
+  const desfecho =
+    fim && cand && mercadoLeitura
+      ? settleFutebol(mercadoLeitura, cand.outcome, cand.line_value, fixture.goals_home, fixture.goals_away)
+      : null;
+
+  const chance = best ? chancePct(best.prob_justa_fechamento) : null;
+
+  return (
+    <div className="bg-white rounded-[20px] overflow-hidden" style={{ border: '1px solid #ded2b6' }}>
+      <div
+        className="px-4 py-2.5 flex items-center gap-2.5"
+        style={{ background: 'var(--canvas-2)', borderBottom: '1px solid #ded2b6' }}
+      >
+        <Crest name={fixture.home_team_name} id={fixture.home_team_id} size={20} />
+        <span className="text-[13.5px] font-semibold tracking-tight text-ink truncate">
+          {fixture.home_team_name} × {fixture.away_team_name}
+        </span>
+        <Crest name={fixture.away_team_name} id={fixture.away_team_id} size={20} />
+        <span className="text-[11px] truncate" style={{ color: '#8d8672' }}>
+          {fim || live
+            ? `${live ? 'ao vivo' : 'encerrado'} · ${fixture.goals_home ?? 0} × ${fixture.goals_away ?? 0}`
+            : `${dia.weekday} ${dia.day} ${fmtTime(fixture.kickoff_utc) ?? ''}`}
+        </span>
+        <button
+          onClick={onClose}
+          className="ml-auto w-6 h-6 shrink-0 grid place-items-center rounded-md transition hover:bg-white"
+          style={{ color: '#8d8672' }}
+          aria-label="Fechar resumo"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {temLeitura && pick && (
+        <div className="relative overflow-hidden px-5 py-5" style={{ background: 'linear-gradient(135deg,#0a3d2e,#08321f 60%,#051f12)' }}>
+          <div
+            className="absolute pointer-events-none"
+            style={{ right: -50, top: -70, width: 230, height: 230, borderRadius: 999, background: 'radial-gradient(circle,rgba(251,191,36,.24),transparent 68%)' }}
+          />
+          <div className="relative flex items-end justify-between gap-5">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2 h-[17px]">
+                <span className="text-[9.5px] uppercase tracking-[0.16em]" style={{ color: 'rgba(255,255,255,.45)' }}>
+                  Melhor leitura · {marketShort(mercadoLeitura!)}
+                </span>
+                {desfecho && (
+                  <span
+                    className="inline-flex items-center h-[17px] px-1.5 rounded text-[9px] font-bold uppercase tracking-[0.08em]"
+                    style={
+                      isHit(desfecho)
+                        ? { background: 'rgba(142,230,176,.18)', color: '#8ee6b0' }
+                        : { background: 'rgba(255,255,255,.12)', color: 'rgba(255,255,255,.7)' }
+                    }
+                  >
+                    {isHit(desfecho) ? 'bateu' : desfecho === 'push' ? 'anulada' : 'não bateu'}
+                  </span>
+                )}
+              </div>
+              <div className="mt-1.5 text-[22px] font-semibold leading-tight tracking-[-0.025em] text-white">{pick}</div>
+              {best ? (
+                <div className="flex gap-4 mt-2.5">
+                  <div>
+                    <div className="text-[8.5px] uppercase tracking-[0.14em]" style={{ color: 'rgba(255,255,255,.45)' }}>Chance</div>
+                    <div className="tabular-nums text-[15px] font-semibold text-white mt-0.5">{chance}%</div>
+                  </div>
+                  <div>
+                    <div className="text-[8.5px] uppercase tracking-[0.14em]" style={{ color: 'rgba(255,255,255,.45)' }}>Odd</div>
+                    <div className="tabular-nums text-[15px] font-semibold text-white mt-0.5">{best.best_odd.toFixed(2)}</div>
+                  </div>
+                  <div>
+                    <div className="text-[8.5px] uppercase tracking-[0.14em]" style={{ color: 'rgba(255,255,255,.45)' }}>Vantagem</div>
+                    <div className="tabular-nums text-[15px] font-semibold mt-0.5" style={{ color: best.edge > 0 ? '#8ee6b0' : 'rgba(255,255,255,.55)' }}>
+                      {`${best.edge >= 0 ? '+' : '−'}${Math.abs(best.edge * 100).toFixed(1).replace('.', ',')}%`}
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-[12px] mt-2.5" style={{ color: 'rgba(255,255,255,.55)' }}>
+                  sem preço coletado ainda · as odds entram perto do jogo
+                </div>
+              )}
+            </div>
+            <div className="text-center shrink-0">
+              <div className="tabular-nums text-[40px] font-bold leading-none tracking-[-0.04em]" style={{ color: '#fbbf24' }}>
+                {best ? best.score : nValem}
+              </div>
+              <div className="mt-1 text-[9px] uppercase tracking-[0.12em]" style={{ color: 'rgba(255,255,255,.5)' }}>
+                {best ? `Score · ${best.score >= 60 ? 'faixa alta' : best.score >= REGUA_SCORE ? 'faixa média' : 'abaixo da régua'}` : 'premissas a favor'}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="p-4">
+        {temLeitura ? (
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.16em] font-bold" style={{ color: '#8d8672' }}>
+              Por que · {nValem} {nValem === 1 ? 'premissa a favor' : 'premissas a favor'}
+            </div>
+            <div className="mt-2.5 flex flex-col gap-2.5">
+              {porques.map(({ p, ev }) => (
+                <div key={p.slug} className="flex gap-2.5 items-start">
+                  <span
+                    className="shrink-0 mt-0.5 h-[18px] px-1.5 rounded inline-flex items-center text-[9px] font-bold uppercase tracking-[0.08em]"
+                    style={pesoForte(p) ? { background: '#dcefe2', color: '#0a3d2e' } : { background: '#eae2cf', color: '#8d8672' }}
+                  >
+                    {pesoForte(p) ? 'Forte' : 'Médio'}
+                  </span>
+                  <span className="flex-1 min-w-0 text-[12.5px] leading-relaxed" style={{ color: '#3f463d' }}>
+                    <b className="font-semibold">{rotuloPremissa(p, lado)}.</b>
+                    {ev ? ` ${ev.texto}.` : ''}
+                  </span>
+                </div>
+              ))}
+            </div>
+            {contra && (
+              <div
+                className="mt-3.5 px-3.5 py-2.5 rounded-xl flex gap-2.5 items-start"
+                style={{ background: 'var(--canvas-2)', border: '1px solid #e5d9bd' }}
+              >
+                <Minus className="w-3.5 h-3.5 shrink-0 mt-0.5" style={{ color: '#b8870f' }} strokeWidth={3} />
+                <span className="text-[12px] leading-relaxed" style={{ color: '#6b6350' }}>{contra}</span>
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="px-4 py-3.5 rounded-[14px]" style={{ background: 'var(--canvas-2)', border: '1px solid #e5d9bd' }}>
+            <div className="text-[12.5px] font-semibold text-ink">Sem leitura para este jogo</div>
+            <p className="mt-1 text-[12.5px] leading-relaxed" style={{ color: '#6b6350' }}>
+              {premissas?.length
+                ? 'Nenhuma premissa passou a porta de 2 em nenhum mercado.'
+                : 'As premissas deste jogo ainda não foram calculadas.'}
+            </p>
+            <p className="mt-2 text-[11.5px] leading-relaxed" style={{ color: '#8d8672' }}>
+              Isso não é defeito: a maioria dos jogos legitimamente não tem oportunidade. O contexto abaixo continua
+              valendo.
+            </p>
+          </div>
+        )}
+
+        {chegam.length > 0 && (
+          <div className="mt-4 pt-3.5" style={{ borderTop: '1px solid #f1e9d6' }}>
+            <div className="flex items-baseline justify-between">
+              <span className="text-[10px] uppercase tracking-[0.16em] font-bold" style={{ color: '#8d8672' }}>
+                Como chegam
+              </span>
+              <span className="text-[10.5px] truncate max-w-[60%]" style={{ color: '#8d8672' }}>
+                {fixture.home_team_name} · {fixture.away_team_name}
+              </span>
+            </div>
+            <div className="mt-2.5 flex flex-col gap-3">
+              {chegam.map((c) => {
+                const tot = (c.a ?? 0) + (c.b ?? 0) || 1;
+                const wa = `${Math.round(((c.a ?? 0) / tot) * 100)}%`;
+                const wb = `${Math.round(((c.b ?? 0) / tot) * 100)}%`;
+                const inteiro = c.label === 'Sem sofrer gol';
+                return (
+                  <div key={c.label}>
+                    <div className="flex justify-between items-baseline mb-1 tabular-nums">
+                      <span className="text-[14px] font-semibold" style={{ color: '#0a3d2e' }}>
+                        {inteiro ? c.a : d1(c.a)}
+                      </span>
+                      <span className="text-[10.5px] font-medium" style={{ color: '#8d8672' }}>{c.label}</span>
+                      <span className="text-[14px] font-semibold" style={{ color: '#6b6350' }}>
+                        {inteiro ? c.b : d1(c.b)}
+                      </span>
+                    </div>
+                    <div className="flex gap-[3px] h-1.5">
+                      <div className="flex-1 flex justify-end overflow-hidden" style={{ background: '#f1e9d6', borderRadius: '999px 0 0 999px' }}>
+                        <div style={{ width: wa, background: '#0a3d2e' }} />
+                      </div>
+                      <div className="flex-1 overflow-hidden" style={{ background: '#f1e9d6', borderRadius: '0 999px 999px 0' }}>
+                        <div style={{ width: wb, height: '100%', background: '#c4bda8' }} />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="mt-3 pt-3 flex items-center gap-2.5" style={{ borderTop: '1px solid #f1e9d6' }}>
+              <span className="text-[10.5px] font-medium shrink-0" style={{ color: '#8d8672' }}>Forma</span>
+              <Forma forma={casa?.forma} />
+              <span className="ml-auto">
+                <Forma forma={fora?.forma} />
+              </span>
+            </div>
+
+            <div className="mt-3 pt-3 flex items-center gap-2.5" style={{ borderTop: '1px solid #f1e9d6' }}>
+              <span className="text-[10.5px] font-medium shrink-0" style={{ color: '#8d8672' }}>Desfalques</span>
+              <span className="text-[12px] truncate" style={{ color: '#3f463d' }}>{desfalques(fixture.home_team_id)}</span>
+              <span className="ml-auto text-[12px] truncate" style={{ color: '#3f463d' }}>{desfalques(fixture.away_team_id)}</span>
+            </div>
+          </div>
+        )}
+
+        <div className="mt-4 flex gap-2">
+          <Link
+            to={`/futebol/jogo/${fixture.fixture_id}`}
+            className="flex-1 h-10 rounded-[10px] bg-forest text-canvas text-[13px] font-semibold inline-flex items-center justify-center gap-1.5 hover:bg-forest-2 transition"
+          >
+            {temLeitura ? 'Ver a análise dos 5 mercados' : 'Ver a análise completa'} <ArrowRight className="w-4 h-4" />
+          </Link>
+          {best && !fim && (
+            <RegistrarApostaCTA
+              draft={{
+                homeName: fixture.home_team_name,
+                awayName: fixture.away_team_name,
+                competition: fixture.competition,
+                kickoffUtc: fixture.kickoff_utc,
+                market: best.market,
+                outcome: best.outcome,
+                lineValue: best.line_value,
+                bestOdd: best.best_odd,
+              }}
+              variant="ambar"
+              rotulo="Registrar"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -17,7 +17,12 @@ import { melhorLeitura, resumoDosMercados, REGUA_SCORE } from '@/utils/futebol-l
 import { evidenciaDe, ladoDaSaida } from '@/utils/futebol-evidencias';
 import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 import { settleFutebol, isHit } from '@/utils/futebol-settlement';
-import type { FutebolFixtureByDay, FutebolValueBoardRow } from '@/services/futebol-data.service';
+import type {
+  FutebolFixtureByDay,
+  FutebolFixtureNumeros,
+  FutebolFixturePremissas,
+  FutebolValueBoardRow,
+} from '@/services/futebol-data.service';
 
 /**
  * O painel do jogo na coluna da direita (protótipo "Futebol Jogos").
@@ -63,13 +68,22 @@ export function JogoResumoPanel({
   fixture,
   best,
   onClose,
+  demo,
 }: {
   fixture: FutebolFixtureByDay;
   best: FutebolValueBoardRow | null;
   onClose: () => void;
+  /**
+   * Premissas e números de exemplo, usados só enquanto o tour roda. O jogo do
+   * tour é fictício, então buscar no banco devolvia vazio e o passo do porquê
+   * abria um painel sem porquê nenhum.
+   */
+  demo?: { premissas: FutebolFixturePremissas[]; numeros: FutebolFixtureNumeros[] };
 }) {
-  const { data: premissas } = useFutebolFixturePremissas(fixture.fixture_id);
-  const { data: numeros } = useFutebolFixtureNumeros(fixture.fixture_id);
+  const { data: premissasReais } = useFutebolFixturePremissas(demo ? undefined : fixture.fixture_id);
+  const { data: numerosReais } = useFutebolFixtureNumeros(demo ? undefined : fixture.fixture_id);
+  const premissas = demo?.premissas ?? premissasReais;
+  const numeros = demo?.numeros ?? numerosReais;
   const { data: injuries } = useFutebolFixtureInjuries(fixture.fixture_id);
   const { data: historico } = useFutebolFixtureHistorico(fixture.fixture_id);
 

--- a/src/components/futebol/LigaCrest.tsx
+++ b/src/components/futebol/LigaCrest.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { Trophy } from 'lucide-react';
+import { getFutebolLeagueLogoUrl } from '@/utils/futebol-logos';
+
+/**
+ * Brasão do campeonato, com o troféu como plano B.
+ *
+ * Mesma lógica do Crest dos times: a imagem vem do nosso Storage, nunca da
+ * api-sports direto (o navegador leva bloqueio de hotlink lá). Quem popula o
+ * bucket é a edge function mirror-futebol-league-logos, que também é onde entra
+ * liga nova. Sem arquivo, o <img> 404 e a tela mostra o troféu.
+ *
+ * Copa do Mundo cai sempre no troféu: a api-sports não tem brasão dela, devolve
+ * um escudo cinza de "sem imagem", então ela ficou fora do espelho de propósito.
+ */
+export function LigaCrest({ slug, size = 20 }: { slug: string; size?: number }) {
+  const [falhou, setFalhou] = useState(false);
+  const url = getFutebolLeagueLogoUrl(slug);
+
+  if (!url || falhou) return <Trophy className="text-ink-2" style={{ width: size, height: size }} />;
+
+  return (
+    <img
+      src={url}
+      alt=""
+      width={size}
+      height={size}
+      loading="lazy"
+      onError={() => setFalhou(true)}
+      className="object-contain"
+      style={{ width: size, height: size }}
+    />
+  );
+}

--- a/src/components/futebol/MapaPremissas.tsx
+++ b/src/components/futebol/MapaPremissas.tsx
@@ -1,0 +1,605 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Check, ChevronDown, Minus } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useFutebolFixturePremissas, useFutebolFixtureNumeros } from '@/hooks/use-futebol-data';
+import type { FutebolFixturePremissas, FutebolFixtureNumeros } from '@/services/futebol-data.service';
+import {
+  MERCADOS,
+  PREMISSAS_OCULTAS,
+  PORTA_PREMISSAS,
+  contaQueValem,
+  melhorCandidato,
+  outcomeLabel,
+  premissaDe,
+  type MercadoInfo,
+  type Premissa,
+} from '@/utils/futebol-premissas';
+import {
+  evidenciaDe,
+  ladoDaSaida,
+  tilesDe,
+  manchete,
+  type Evidencia,
+  type Tile as TileT,
+} from '@/utils/futebol-evidencias';
+import { fmtDayShort } from '@/utils/futebol-datas';
+import type { MatchupTendencies } from '@/utils/futebol-tendencias';
+import { settleFutebol, resultBadge, isHit } from '@/utils/futebol-settlement';
+
+/** O placar do jogo encerrado, para liquidar cada mercado do mapa. */
+export interface PlacarFinal {
+  home: number | null;
+  away: number | null;
+}
+
+/**
+ * Distribuição de gols (Poisson sobre λ total). Transplantado do antigo card
+ * "Nosso modelo de gols": era a peça reaproveitável dele, e agora vive onde ela
+ * fala do assunto, a aba de Gols.
+ */
+function GoalDistChart({ lh, la }: { lh: number; la: number }) {
+  const lambda = lh + la;
+  const fact = (n: number) => { let r = 1; for (let i = 2; i <= n; i++) r *= i; return r; };
+  const pois = (k: number) => (Math.exp(-lambda) * Math.pow(lambda, k)) / fact(k);
+  const bars = [0, 1, 2, 3].map((k) => ({ k: String(k), p: pois(k) }));
+  const acc = bars.reduce((s, b) => s + b.p, 0);
+  bars.push({ k: '4+', p: Math.max(0, 1 - acc) });
+  const max = Math.max(...bars.map((b) => b.p), 0.001);
+  return (
+    <div>
+      <div className="flex items-end gap-2 h-20">
+        {bars.map((b) => (
+          <div key={b.k} className="flex-1 flex flex-col items-center justify-end h-full gap-1">
+            <span className="text-[9px] text-ink-3 tabular-nums">{Math.round(b.p * 100)}%</span>
+            <div className="w-full bg-forest/80 rounded-t" style={{ height: `${(b.p / max) * 100}%` }} />
+            <span className="text-[10px] text-ink-2 font-semibold">{b.k}</span>
+          </div>
+        ))}
+      </div>
+      <p className="text-[10px] text-ink-3 mt-1.5 text-center">
+        chance de cada total de gols · esperado {lambda.toFixed(1).replace('.', ',')}
+      </p>
+    </div>
+  );
+}
+
+function SeloResultado({ market, outcome, line, placar }: { market: string; outcome: string; line: number | null; placar: PlacarFinal }) {
+  const r = settleFutebol(market, outcome, line, placar.home, placar.away);
+  if (!r) return null;
+  const b = resultBadge(r);
+  const cls =
+    b.tone === 'won'
+      ? 'bg-forest/10 text-forest'
+      : b.tone === 'lost'
+        ? ''
+        : 'bg-canvas-2 text-ink-2';
+  return (
+    <span
+      className={`px-1.5 h-5 inline-flex items-center rounded text-[9px] font-bold uppercase tracking-[0.1em] ${cls}`}
+      style={b.tone === 'lost' ? { background: '#fde2e7', color: '#9a1f2e' } : undefined}
+    >
+      {b.label}
+    </span>
+  );
+}
+
+/**
+ * O mapa de premissas do jogo.
+ *
+ * Substitui "a aposta e o preço" como conteúdo principal: a revisão da metodologia
+ * (docs/premissas-recalibragem.md) trocou a porta de publicação de preço para
+ * contexto, então o pick é consequência e o contexto é o conteúdo.
+ *
+ * Duas coisas guiaram esta versão, as duas vindas da revisão de UI:
+ *
+ * 1. CADA PREMISSA MOSTRA O NÚMERO. Check e peso não são análise: "em boa fase" sem
+ *    o dado é adjetivo. Cada premissa acesa vem com a frase que a sustenta, e as
+ *    apagadas também, pra dar pra ver se faltou pouco ou muito.
+ * 2. UM MERCADO POR VEZ. A versão anterior empilhava 5 mercados abertos, cada um com
+ *    duas colunas de até 13 itens. Virou aba: o usuário lê um mercado inteiro sem
+ *    rolar, e troca quando quiser.
+ */
+
+// `melhorCandidato` mudou pra utils/futebol-premissas: o painel da agenda também
+// resume o jogo por ele.
+
+/**
+ * Stat tile do design system (components/patterns/StatMetric): label 9px em caixa
+ * alta com tracking 0.16em, valor semibold com tracking negativo, sub 10px. Célula
+ * de uma linha separada por borda à esquerda.
+ */
+function Tile({ t, primeiro }: { t: TileT; primeiro: boolean }) {
+  return (
+    <div className={`px-4 py-3 min-w-0 ${primeiro ? '' : 'border-l border-line'}`}>
+      <div className="text-[9px] uppercase tracking-[0.16em] font-semibold text-ink-2 truncate">{t.label}</div>
+      <div
+        className={`text-[22px] font-semibold tracking-[-0.02em] leading-none mt-1.5 tabular-nums ${
+          t.forte ? 'text-forest' : 'text-ink'
+        }`}
+      >
+        {t.valor}
+      </div>
+      {t.sub && <div className="text-[10px] text-ink-3 mt-1.5 truncate">{t.sub}</div>}
+    </div>
+  );
+}
+
+/**
+ * Meter da porta de publicação. O trilho é um tom mais claro da MESMA cor do
+ * preenchimento, não cinza neutro, pra o estado ser legível na barra inteira.
+ */
+function MeterPorta({ n, total, passa }: { n: number; total: number; passa: boolean }) {
+  const pct = total > 0 ? Math.min(100, Math.round((n / total) * 100)) : 0;
+  return (
+    <div className="shrink-0 w-[132px]">
+      <div className="flex items-baseline gap-1.5 justify-end">
+        <span className={`text-[30px] font-semibold leading-none tabular-nums ${passa ? 'text-forest' : 'text-ink-3'}`}>
+          {n}
+        </span>
+        <span className="text-[13px] text-ink-3">de {total}</span>
+      </div>
+      <div className="mt-2 h-1.5 rounded-full overflow-hidden" style={{ background: 'rgba(10,61,46,0.12)' }}>
+        <div
+          className={`h-full rounded-full ${passa ? 'bg-forest' : 'bg-ink-3'}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div
+        className={`text-[9px] uppercase tracking-[0.14em] font-bold mt-1.5 text-right ${
+          passa ? 'text-forest' : 'text-ink-3'
+        }`}
+      >
+        {passa ? 'entra no board' : `precisa de ${PORTA_PREMISSAS}`}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A premissa em uma linha. O número saiu daqui e subiu para os tiles: repetir a
+ * mesma métrica em cada linha era o que deixava a tela pesada. Aqui fica o fato
+ * ("aconteceu ou não") e a frase curta que o sustenta.
+ */
+function LinhaPremissa({
+  p,
+  acesa,
+  evidencia,
+}: {
+  p: Premissa;
+  acesa: boolean;
+  evidencia: Evidencia | null;
+}) {
+  const semValor = p.peso === 0;
+  return (
+    <div className="py-2.5 border-t border-line/60 first:border-t-0">
+      <div className="flex items-start gap-2.5">
+        <span className="mt-[3px] shrink-0">
+          {acesa ? (
+            <Check className={`w-3.5 h-3.5 ${semValor ? 'text-ink-3' : 'text-forest'}`} strokeWidth={3} />
+          ) : (
+            <span className="block w-3.5 h-3.5 rounded-full border-[1.5px] border-line-2" />
+          )}
+        </span>
+        <span className="flex-1 min-w-0">
+          <span className="flex items-center gap-2 flex-wrap">
+            <span className={`text-[13px] leading-snug ${acesa ? 'font-semibold text-ink' : 'text-ink-3'}`}>
+              {p.label}
+            </span>
+            {semValor && acesa && (
+              <span
+                className="text-[9px] uppercase tracking-[0.1em] font-bold text-ink-3 bg-canvas-2 px-1.5 py-0.5 rounded"
+                title={p.motivo}
+              >
+                já na odd
+              </span>
+            )}
+          </span>
+          {evidencia && (
+            <span className={`block text-[11.5px] leading-snug mt-0.5 ${acesa ? 'text-ink-2' : 'text-ink-3'}`}>
+              {evidencia.texto}
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function PainelMercado({
+  mercado,
+  rows,
+  numeros,
+  home,
+  away,
+  tendencies,
+  placar,
+}: {
+  mercado: MercadoInfo;
+  rows: FutebolFixturePremissas[];
+  numeros: FutebolFixtureNumeros[] | undefined;
+  home: string;
+  away: string;
+  tendencies?: MatchupTendencies | null;
+  placar?: PlacarFinal | null;
+}) {
+  const candidatos = useMemo(
+    () =>
+      rows
+        .filter((r) => r.market === mercado.slug)
+        .filter((r) => !(mercado.slug === 'asian_handicap' && r.line_value === 0)),
+    [rows, mercado.slug],
+  );
+  const melhor = useMemo(() => melhorCandidato(rows, mercado.slug), [rows, mercado.slug]);
+  const chave = (r: FutebolFixturePremissas) => `${r.outcome}|${r.line_value ?? ''}`;
+
+  const [escolhido, setEscolhido] = useState<string | null>(null);
+  const [verOutras, setVerOutras] = useState(false);
+  const [verApagadas, setVerApagadas] = useState(false);
+  // Trocar de mercado zera a escolha, senão a saída de um vaza no outro.
+  useEffect(() => {
+    setEscolhido(null);
+    setVerOutras(false);
+    setVerApagadas(false);
+  }, [mercado.slug]);
+
+  const atual = candidatos.find((r) => chave(r) === escolhido) ?? melhor;
+  if (!atual) {
+    return (
+      <div className="bg-white border border-line rounded-rebrand-md p-6 text-center text-sm text-ink-3">
+        Sem premissas calculadas para este mercado.
+      </div>
+    );
+  }
+
+  const lado = ladoDaSaida(mercado.slug, atual.outcome);
+  const acesasSet = new Set(atual.acesas);
+  const visiveis = mercado.premissas.filter((p) => !PREMISSAS_OCULTAS.has(p.slug));
+  const totalQueValem = visiveis.filter((p) => p.peso == null || p.peso > 0).length;
+  const nValem = contaQueValem(mercado.slug, atual.acesas);
+  const passa = nValem >= PORTA_PREMISSAS;
+
+  const ordena = (a: Premissa, b: Premissa) => (b.peso ?? 0) - (a.peso ?? 0);
+  const acesas = visiveis.filter((p) => acesasSet.has(p.slug)).sort(ordena);
+  const apagadas = visiveis.filter((p) => !acesasSet.has(p.slug)).sort(ordena);
+
+  const penAtivas = (atual.penalidades ?? [])
+    .filter((s) => !PREMISSAS_OCULTAS.has(s))
+    .map((s) => premissaDe(mercado.slug, s))
+    .filter(Boolean) as Premissa[];
+
+  const tiles = tilesDe(mercado.slug, numeros, lado);
+  const frase = manchete(
+    atual.acesas,
+    acesas.map((p) => p.slug),
+    numeros,
+    lado,
+  );
+
+  return (
+    <div className="bg-white border border-line rounded-rebrand-md overflow-hidden">
+      {/* Manchete + meter. Espelha o "Por quê" da /futebol: uma frase grande que diz
+          o caso, e o número da porta ao lado. */}
+      <div className="px-5 pt-5 pb-4 flex items-start justify-between gap-5">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-[10px] uppercase tracking-[0.18em] font-semibold text-ink-3">
+              {outcomeLabel(mercado.slug, atual.outcome, home, away, atual.line_value)}
+            </span>
+            {/* Jogo encerrado: o que o mapa apontava, liquidado contra o placar. */}
+            {placar && (
+              <SeloResultado market={mercado.slug} outcome={atual.outcome} line={atual.line_value} placar={placar} />
+            )}
+          </div>
+          <p
+            className="text-[17px] md:text-[18px] leading-[1.4] font-medium tracking-tight text-ink mt-2"
+            style={{ textWrap: 'pretty' }}
+          >
+            {frase?.texto ?? 'Nenhuma premissa a favor desta saída.'}
+          </p>
+        </div>
+        <MeterPorta n={nValem} total={totalQueValem} passa={passa} />
+      </div>
+
+      {/* KPI row: os números do confronto, uma vez só, em vez de repetidos linha a linha. */}
+      {tiles.length > 0 && (
+        <div
+          className="grid border-y border-line bg-white"
+          style={{ gridTemplateColumns: `repeat(${tiles.length}, minmax(0, 1fr))` }}
+        >
+          {tiles.map((t, i) => (
+            <Tile key={t.label} t={t} primeiro={i === 0} />
+          ))}
+        </div>
+      )}
+
+      <div className="px-5 py-3 flex items-start justify-between gap-3 border-b border-line bg-canvas-2">
+        <div className="min-w-0">
+          <div className="text-[10px] uppercase tracking-[0.16em] font-bold text-ink-2">O que pesou</div>
+        </div>
+        {candidatos.length > 1 && (
+          <button
+            onClick={() => setVerOutras((v) => !v)}
+            className="shrink-0 h-8 px-3 rounded-rebrand-sm border border-line bg-white text-[11.5px] font-semibold text-ink hover:bg-canvas-2 transition inline-flex items-center gap-1"
+          >
+            Outras saídas
+            <ChevronDown className={`w-3.5 h-3.5 transition-transform ${verOutras ? 'rotate-180' : ''}`} />
+          </button>
+        )}
+      </div>
+
+      {/* Trocar de saída fica ESCONDIDO por padrão: eram 8 chips de handicap
+          competindo com o conteúdo. */}
+      {verOutras && candidatos.length > 1 && (
+        <div className="px-5 py-3 border-b border-line/60 flex gap-1.5 flex-wrap">
+          {candidatos.map((r) => {
+            const k = chave(r);
+            const ativo = chave(atual) === k;
+            const n = contaQueValem(mercado.slug, r.acesas);
+            // Jogo encerrado: cada saída ganha o ponto do que aconteceu.
+            const res = placar ? settleFutebol(mercado.slug, r.outcome, r.line_value, placar.home, placar.away) : null;
+            return (
+              <button
+                key={k}
+                onClick={() => {
+                  setEscolhido(k);
+                  setVerOutras(false);
+                }}
+                className={`px-2.5 h-7 rounded-rebrand-sm text-[11px] font-semibold border transition inline-flex items-center gap-1.5 ${
+                  ativo ? 'bg-forest text-canvas border-forest' : 'bg-white text-ink-2 border-line hover:bg-canvas-2'
+                }`}
+              >
+                {res && (
+                  <span
+                    className="w-1.5 h-1.5 rounded-full shrink-0"
+                    title={resultBadge(res).label}
+                    style={{
+                      background: isHit(res) ? 'var(--forest)' : res === 'push' ? 'var(--ink-3)' : '#be123c',
+                    }}
+                  />
+                )}
+                {outcomeLabel(mercado.slug, r.outcome, home, away, r.line_value)}
+                {n > 0 && <span className={ativo ? 'text-canvas/70' : 'text-forest'}> · {n}</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {mercado.aviso && (
+        <div className="px-5 py-2.5 bg-canvas-2 border-b border-line/60 text-[11.5px] text-ink-2">
+          {mercado.aviso}
+        </div>
+      )}
+
+      <div className="px-5 py-1">
+        {acesas.length === 0 ? (
+          <div className="py-6 text-center text-[13px] text-ink-2">
+            Nenhuma premissa a favor desta saída.
+          </div>
+        ) : (
+          acesas.map((p) => (
+            <LinhaPremissa
+              key={p.slug}
+              p={p}
+              acesa
+              // A premissa que virou manchete não repete a frase logo abaixo dela.
+              evidencia={p.slug === frase?.slug ? null : evidenciaDe(p.slug, numeros, lado)}
+            />
+          ))
+        )}
+      </div>
+
+      {penAtivas.length > 0 && (
+        <div className="px-5 pb-3">
+          {penAtivas.map((p) => (
+            <div key={p.slug} className="flex items-start gap-2.5 py-2.5 border-t border-line/60">
+              <Minus className="w-4 h-4 text-status-danger shrink-0 mt-0.5" strokeWidth={3} />
+              <span className="flex-1 min-w-0">
+                <span className="text-[13px] font-semibold text-ink leading-snug">{p.label}</span>
+                {p.motivo && <span className="block text-[10.5px] text-ink-3 leading-snug mt-0.5">{p.motivo}</span>}
+              </span>
+              {p.peso != null && p.peso !== 0 && (
+                <span className="shrink-0 text-[12px] tabular-nums font-bold text-status-danger">{p.peso}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Única sobra do antigo "Nosso modelo de gols": a distribuição de placares,
+          que não repete nada dito acima. As leituras textuais do modelo ("Vitória do
+          X · 57%") saíram — diziam o mesmo que o cabeçalho do mercado, com outra
+          régua, e duas réguas para a mesma frase confundem. */}
+      {mercado.slug === 'goals_over_under' && tendencies?.lambdas && (
+        <div className="px-5 py-3 border-t border-line bg-canvas-2/50">
+          <GoalDistChart lh={tendencies.lambdas.lh} la={tendencies.lambdas.la} />
+        </div>
+      )}
+
+      {apagadas.length > 0 && (
+        <div className="border-t border-line">
+          <button
+            onClick={() => setVerApagadas((v) => !v)}
+            className="w-full px-5 py-3 flex items-center justify-between gap-2 text-left hover:bg-canvas-2 transition"
+          >
+            <span className="text-[12px] font-semibold text-ink-2">
+              {apagadas.length} {apagadas.length === 1 ? 'premissa não bateu' : 'premissas não bateram'}
+            </span>
+            <ChevronDown className={`w-4 h-4 text-ink-3 transition-transform ${verApagadas ? 'rotate-180' : ''}`} />
+          </button>
+          {verApagadas && (
+            <div className="px-5 pb-2 bg-canvas-2/40">
+              {apagadas.map((p) => (
+                <LinhaPremissa
+                  key={p.slug}
+                  p={p}
+                  acesa={false}
+                  // acesa=false: numa premissa apagada o número nunca é suprimido,
+                  // porque é ele que explica o porquê de não ter batido.
+                  evidencia={evidenciaDe(p.slug, numeros, lado, false)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function MapaPremissas({
+  fixtureId,
+  home,
+  away,
+  tendencies,
+  placar,
+}: {
+  fixtureId: number | undefined;
+  home: string;
+  away: string;
+  /** Estimativa Poisson do confronto; renderiza como referência dentro de cada mercado. */
+  tendencies?: MatchupTendencies | null;
+  /** Placar final. Presente = jogo encerrado, e o mapa liquida cada mercado. */
+  placar?: PlacarFinal | null;
+}) {
+  const { data: rows, isLoading, isError } = useFutebolFixturePremissas(fixtureId);
+  const { data: numeros } = useFutebolFixtureNumeros(fixtureId);
+  const [aba, setAba] = useState<string>(MERCADOS[0].slug);
+
+  const contagem = useMemo(() => {
+    const m = new Map<string, number>();
+    MERCADOS.forEach((mk) => {
+      const melhor = rows ? melhorCandidato(rows, mk.slug) : null;
+      m.set(mk.slug, melhor ? contaQueValem(mk.slug, melhor.acesas) : 0);
+    });
+    return m;
+  }, [rows]);
+
+  // Abre no mercado com mais contexto, que é onde a aposta tende a estar.
+  useEffect(() => {
+    if (!rows?.length) return;
+    const melhorAba = [...contagem.entries()].sort((a, b) => b[1] - a[1])[0];
+    if (melhorAba) setAba(melhorAba[0]);
+  }, [rows, contagem]);
+
+  const passam = [...contagem.values()].filter((n) => n >= PORTA_PREMISSAS).length;
+
+  // Jogo encerrado: dos mercados que o mapa apontava (passavam a porta), quantos
+  // bateram de fato. É a resposta do usuário na tela: "mostrar se ocorreu ou não".
+  const retro = useMemo(() => {
+    if (!placar || !rows?.length) return null;
+    const apontados = MERCADOS
+      .map((m) => ({ slug: m.slug, c: melhorCandidato(rows, m.slug) }))
+      .filter((x): x is { slug: string; c: FutebolFixturePremissas } =>
+        x.c != null && contaQueValem(x.slug, x.c.acesas) >= PORTA_PREMISSAS,
+      );
+    const liquidados = apontados
+      .map((x) => settleFutebol(x.slug, x.c.outcome, x.c.line_value, placar.home, placar.away))
+      .filter((r): r is NonNullable<typeof r> => r != null);
+    if (!liquidados.length) return null;
+    return { total: liquidados.length, hits: liquidados.filter(isHit).length };
+  }, [placar, rows]);
+
+  const ate = numeros?.[0]?.ate ?? null;
+  // Copa do Brasil no mata-mata tem 2 jogos de amostra por time, e com 2 jogos as
+  // premissas acendem para qualquer lado (caso real: "defesas frágeis" no Over e
+  // "defesas firmes" no Under, no mesmo jogo, ambas com pontuação cheia). O aviso
+  // não conserta o dado, mas avisa o usuário do tamanho do chão que ele pisa.
+  const menorAmostra = Math.min(...(numeros ?? []).map((x) => x.jogos ?? Infinity));
+  const amostraCurta = Number.isFinite(menorAmostra) && menorAmostra < 5;
+  const mercado = MERCADOS.find((m) => m.slug === aba) ?? MERCADOS[0];
+
+  if (isError) return null;
+
+  return (
+    <section>
+      <div className="flex items-end justify-between gap-3 mb-3 flex-wrap">
+        <div>
+          <h2 className="text-[11px] uppercase tracking-[0.2em] font-bold text-ink-3">Mapa de premissas</h2>
+          <p className="text-[13px] text-ink-2 mt-1">
+            {isLoading
+              ? 'Verificando as premissas do jogo…'
+              : retro
+                ? `O mapa apontava ${retro.total} ${retro.total === 1 ? 'mercado' : 'mercados'} · ${retro.hits} ${retro.hits === 1 ? 'bateu' : 'bateram'}`
+                : passam > 0
+                  ? `${passam} de ${MERCADOS.length} mercados com contexto para aposta`
+                  : 'Nenhum mercado com contexto suficiente neste jogo'}
+          </p>
+        </div>
+        {/* A data do dado, declarada. O snapshot da temporada não é de hoje. */}
+        {ate && <span className="text-[10.5px] text-ink-3">Números da temporada até {fmtDayShort(ate)}</span>}
+      </div>
+
+      {amostraCurta && !isLoading && (
+        <div
+          className="mb-3 rounded-rebrand-sm px-3 py-2 text-[11.5px] leading-snug"
+          style={{ background: '#fef7df', border: '1px solid #fde68a', color: '#5a3c00' }}
+        >
+          <span className="font-semibold" style={{ color: '#9a6c00' }}>
+            Amostra curta ·{' '}
+          </span>
+          Cada time tem só {menorAmostra} {menorAmostra === 1 ? 'jogo' : 'jogos'} nesta competição. Com tão pouco
+          jogo, as premissas acendem fácil e dizem pouco.
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="grid gap-3">
+          <Skeleton className="h-10 w-full bg-canvas-2 rounded-rebrand-md" />
+          <Skeleton className="h-64 w-full bg-canvas-2 rounded-rebrand-md" />
+        </div>
+      ) : !rows?.length ? (
+        <div className="bg-white border border-line rounded-rebrand-md p-6 text-center text-sm text-ink-3">
+          Este jogo ainda não tem premissas calculadas.
+        </div>
+      ) : (
+        <>
+          {/* Um mercado por vez. Os 5 continuam visíveis, como abas. */}
+          <div className="flex gap-1.5 overflow-x-auto no-scrollbar mb-3">
+            {MERCADOS.map((m) => {
+              const n = contagem.get(m.slug) ?? 0;
+              const ativo = m.slug === aba;
+              return (
+                <button
+                  key={m.slug}
+                  onClick={() => setAba(m.slug)}
+                  className={`shrink-0 h-9 px-3.5 rounded-rebrand-sm text-[12px] font-semibold border transition inline-flex items-center gap-1.5 ${
+                    ativo ? 'bg-forest text-canvas border-forest' : 'bg-white text-ink border-line hover:bg-canvas-2'
+                  }`}
+                >
+                  {m.label}
+                  <span
+                    className={`text-[10px] tabular-nums font-bold px-1.5 rounded ${
+                      ativo
+                        ? 'bg-white/15 text-canvas'
+                        : n >= PORTA_PREMISSAS
+                          ? 'bg-forest/10 text-forest'
+                          : 'bg-canvas-2 text-ink-3'
+                    }`}
+                  >
+                    {n}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <PainelMercado
+            mercado={mercado}
+            rows={rows}
+            numeros={numeros}
+            home={home}
+            away={away}
+            tendencies={tendencies}
+            placar={placar}
+          />
+        </>
+      )}
+
+      <p className="text-[10.5px] text-ink-3 mt-3 leading-relaxed">
+        A aposta entra no board quando o jogo tem {PORTA_PREMISSAS} premissas ou mais a favor. O preço entra depois,
+        só para checar que não estamos pagando abaixo do justo.
+      </p>
+    </section>
+  );
+}

--- a/src/components/futebol/MotivosJogoPorJogo.tsx
+++ b/src/components/futebol/MotivosJogoPorJogo.tsx
@@ -1,0 +1,552 @@
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronRight, X } from 'lucide-react';
+import type { FutebolFixtureHistorico, FutebolFixtureNumeros } from '@/services/futebol-data.service';
+import { pesoPalavra, pesoForte, rotuloPremissa, type Premissa } from '@/utils/futebol-premissas';
+import { evidenciaDe, type Evidencia } from '@/utils/futebol-evidencias';
+import { evidenciaDoHistorico, storyDaPremissa, type SerieHistorico, type Story } from '@/utils/futebol-historico';
+import { Crest } from './Crest';
+
+/**
+ * As abas "A favor" e "Contra": cada premissa com os jogos que produziram a média.
+ *
+ * O gráfico é UM só para os dois times, com escala compartilhada. Duas caixas
+ * separadas, como estava antes, deixavam cada time com a sua própria escala, e aí
+ * barra alta de um valia menos que barra baixa do outro. Aqui a altura compara.
+ *
+ * O que cada elemento existe para responder:
+ *   rótulo em cima da barra → quanto foi naquele jogo
+ *   escudo embaixo         → contra quem foi
+ *   linha tracejada âmbar  → a média, que é o número que a premissa usa
+ *   rótulo na ponta da linha → qual é essa média, sem precisar medir no olho
+ */
+
+const d1 = (v: number) => v.toFixed(1).replace('.', ',');
+/**
+ * A linha sai como está cotada: 1,75 é 1,75, não 1,8. Arredondar para uma casa
+ * dizia "linha 1,8" numa aposta que é de 1,75.
+ */
+const fmtLinhaExata = (v: number) => String(v).replace('.', ',');
+const dia = (iso: string) => {
+  const [, m, d] = iso.split('-');
+  return `${d}/${m}`;
+};
+
+/** Gol é inteiro, gol esperado é decimal. */
+const rotuloValor = (v: number | null, metrica: SerieHistorico['metrica']) => {
+  if (v == null) return '';
+  return metrica === 'xg' ? d1(v) : String(Math.round(v));
+};
+
+/**
+ * A cor da barra diz o que o jogo significa PARA A SAÍDA ESCOLHIDA, não só "acima ou
+ * abaixo da média": num "mais de 2,5" o jogo de 4 gols joga a favor, num "menos de
+ * 2,5" o mesmo jogo joga contra. Quem separa os times é a posição (bloco da esquerda
+ * e da direita, com o nome em cima), então a cor fica livre para o significado.
+ */
+const COR_FAVOR = '#0a3d2e';
+const COR_CONTRA = '#c9cec6';
+
+const COR_RES: Record<'V' | 'E' | 'D', { bg: string; fg: string }> = {
+  V: { bg: '#dcefe2', fg: '#0a3d2e' },
+  E: { bg: '#eef0eb', fg: '#5a625a' },
+  D: { bg: '#fbe3e8', fg: '#be123c' },
+};
+
+/** Sequência de resultados: um quadro por jogo, com placar, escudo e adversário. */
+function SerieResultados({ s }: { s: SerieHistorico }) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {s.jogos.map((j) => {
+        const c = COR_RES[j.resultado];
+        return (
+          <div
+            key={`${j.ordem}-${j.data}`}
+            className="rounded-lg px-2 py-1.5"
+            style={{ background: c.bg }}
+            title={`${dia(j.data)} · ${j.emCasa ? 'em casa' : 'fora'} contra ${j.adversario}`}
+          >
+            <div className="tabular-nums text-[12.5px] font-bold leading-none text-center" style={{ color: c.fg }}>
+              {j.placar}
+            </div>
+            <div className="flex items-center gap-1 mt-1.5">
+              <Crest name={j.adversario} id={j.adversarioId} size={13} />
+              <span className="text-[9.5px] truncate max-w-[58px]" style={{ color: c.fg, opacity: 0.8 }}>
+                {j.adversario}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Amostra de 1 ou 2 jogos não vira gráfico: barra sozinha ocupando a largura toda
+ * parecia bloco de cor e não informava nada. Vira o valor escrito.
+ */
+function SerieMiuda({ s }: { s: SerieHistorico }) {
+  const rotulo = (v: number | null) => {
+    if (v == null) return '—';
+    if (s.metrica === 'xg') return `${d1(v)} de gol esperado`;
+    const n = Math.round(v);
+    if (s.metrica === 'ga') return `${n} ${n === 1 ? 'gol sofrido' : 'gols sofridos'}`;
+    if (s.metrica === 'gf') return `${n} ${n === 1 ? 'gol marcado' : 'gols marcados'}`;
+    return `${n} ${n === 1 ? 'gol no jogo' : 'gols no jogo'}`;
+  };
+  return (
+    <div className="flex flex-wrap gap-2">
+      {s.jogos.map((j) => (
+        <div key={`${j.ordem}-${j.data}`} className="rounded-lg px-2.5 py-1.5 bg-canvas-2">
+          <div className="tabular-nums text-[13px] font-bold text-ink leading-none">{rotulo(j.valor)}</div>
+          <div className="flex items-center gap-1 mt-1.5">
+            <Crest name={j.adversario} id={j.adversarioId} size={13} />
+            <span className="text-[9.5px] text-ink-3">
+              {j.placar} contra {j.adversario} · {dia(j.data)}
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const PLOT = 96;
+const TOPO_ROTULO = 16;
+
+/** Um bloco do gráfico unificado: as barras de um time, na escala comum. */
+function BlocoSerie({
+  s,
+  teto,
+  comRotulo,
+  referencia,
+}: {
+  s: SerieHistorico;
+  teto: number;
+  comRotulo: boolean;
+  referencia?: Story['referencia'];
+}) {
+  const y = (v: number) => (v / teto) * (PLOT - TOPO_ROTULO);
+  return (
+    <div className="min-w-0" style={{ flexGrow: s.jogos.length, flexBasis: 0 }}>
+      {/* O escudo e o nome ficam em cima do PRÓPRIO gráfico: na legenda longe dele
+          não dava para saber qual metade era de quem. */}
+      <div className="flex items-center gap-1.5 mb-2 min-w-0">
+        <Crest name={s.teamName} id={s.teamId} size={16} />
+        <span className="text-[11.5px] font-semibold text-ink truncate">{s.titulo}</span>
+        <span className="text-[10.5px] text-ink-3 shrink-0">{s.sub}</span>
+      </div>
+      <div className="relative" style={{ height: PLOT }}>
+        <div className="absolute inset-0 flex items-end gap-[3px]">
+          {s.jogos.map((j) => (
+            <div
+              key={`${j.ordem}-${j.data}`}
+              className="flex-1 min-w-[6px] max-w-[44px] flex flex-col items-center justify-end"
+              title={`${dia(j.data)} · ${j.emCasa ? 'em casa' : 'fora'} contra ${j.adversario} · ${j.placar}${
+                j.valor != null ? ` · ${rotuloValor(j.valor, s.metrica)}` : ' · sem dado'
+              }`}
+            >
+              {comRotulo && (
+                <span className="tabular-nums text-[9.5px] font-semibold leading-none mb-1" style={{ color: 'var(--ink-2)' }}>
+                  {j.valor == null ? '·' : rotuloValor(j.valor, s.metrica)}
+                </span>
+              )}
+              <div
+                className="w-full rounded-t-[3px]"
+                style={{
+                  height: j.valor == null ? 3 : Math.max(3, y(j.valor)),
+                  background: j.valor == null ? '#e3e6e0' : j.favorece ? COR_FAVOR : COR_CONTRA,
+                }}
+              />
+            </div>
+          ))}
+        </div>
+        {referencia && (
+          <div
+            className="absolute left-0 right-0 border-t border-dashed pointer-events-none"
+            style={{ borderColor: 'var(--ink-3)', bottom: y(referencia.valor) }}
+          />
+        )}
+        {s.media != null && (
+          <>
+            <div
+              className="absolute left-0 right-0 border-t-2 border-dashed pointer-events-none"
+              style={{ borderColor: '#d4a017', bottom: y(s.media) }}
+            />
+            <span
+              className="absolute right-0 tabular-nums text-[9.5px] font-bold px-1 rounded bg-white/90 pointer-events-none"
+              style={{ color: '#b8870f', bottom: y(s.media) + 2 }}
+            >
+              média {d1(s.media)}
+            </span>
+          </>
+        )}
+      </div>
+      {/* Contra quem foi cada jogo. */}
+      <div className="flex items-start gap-[3px] mt-1.5">
+        {s.jogos.map((j) => (
+          <div key={`c-${j.ordem}-${j.data}`} className="flex-1 min-w-[6px] max-w-[44px] flex justify-center">
+            <Crest name={j.adversario} id={j.adversarioId} size={comRotulo ? 15 : 11} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** O gráfico dos dois times em uma caixa, escala compartilhada. */
+function GraficoUnificado({ story }: { story: Story }) {
+  const numericas = story.series.filter((s) => s.metrica !== 'resultado');
+  const todosValores = numericas.flatMap((s) => s.jogos.map((j) => j.valor)).filter((v): v is number => v != null);
+  const teto = Math.max(...todosValores, story.referencia?.valor ?? 0, 1);
+  const total = numericas.reduce((n, s) => n + s.jogos.length, 0);
+  // Rótulo de dados em cima de cada barra. Gol é 1 caractere e cabe quase sempre; o
+  // gol esperado tem decimal e só cabe até a temporada inteira dos dois times.
+  const comRotulo = total <= 24 || numericas.every((s) => s.metrica !== 'xg');
+
+  // A barra por jogo compara com a MÉDIA (é o que a barra tem para comparar), e o
+  // consolidado compara com a LINHA. Dizer "joga a favor" nas duas fazia as duas se
+  // contradizerem quando a linha ficava longe da média, então aqui a legenda diz
+  // exatamente o que a cor mede.
+  const quer = story.series[0]?.direcao === 'maior';
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-3 flex-wrap justify-end">
+        <span className="flex items-center gap-1.5">
+          <span className="w-2.5 h-2.5 rounded-sm" style={{ background: COR_FAVOR }} />
+          <span className="text-[10.5px] text-ink-2">{quer ? 'acima da média' : 'abaixo da média'}, o lado que a premissa quer</span>
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="w-2.5 h-2.5 rounded-sm" style={{ background: COR_CONTRA }} />
+          <span className="text-[10.5px] text-ink-3">{quer ? 'abaixo' : 'acima'}</span>
+        </span>
+      </div>
+      {/* Lado a lado no desktop, empilhado no celular: em 343px os dois blocos
+          deixavam barras de 10px. A escala segue compartilhada nos dois casos. */}
+      <div className="flex flex-col md:flex-row items-stretch md:items-start gap-4 md:gap-3">
+        {numericas.map((s, i) => (
+          <div
+            key={s.chave}
+            className={`flex min-w-0 ${i > 0 ? 'pt-4 border-t md:pt-0 md:pl-3 md:border-t-0 md:border-l border-line' : ''}`}
+            style={{ flexGrow: s.jogos.length, flexBasis: 0 }}
+          >
+            <BlocoSerie s={s} teto={teto} comRotulo={comRotulo} referencia={story.referencia} />
+          </div>
+        ))}
+      </div>
+      {story.referencia && (
+        <div className="text-[10px] text-ink-3 mt-2">Linha tracejada cinza: {story.referencia.label}.</div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * O fechamento: o número dos dois times somado, contra a linha escolhida. Responde
+ * "por que essa premissa joga a favor DESTA saída", que o gráfico de cada time
+ * separado não responde.
+ */
+function Consolidado({ c, saidaLabel, modo }: { c: NonNullable<Story['consolidado']>; saidaLabel: string; modo: 'favor' | 'contra' }) {
+  const teto = Math.max(c.valor, c.linha) * 1.25;
+  const pct = (v: number) => `${Math.min(100, (v / teto) * 100)}%`;
+  const cor = c.favorece ? 'var(--forest)' : 'var(--ink-3)';
+  return (
+    <div className="rounded-xl bg-canvas-2 p-4">
+      <div className="flex items-end justify-between gap-4 flex-wrap">
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.14em] font-semibold text-ink-3">Somando os dois times</div>
+          <div className="flex items-baseline gap-2 mt-1">
+            <span className="tabular-nums text-[30px] font-semibold leading-none" style={{ color: cor }}>
+              {d1(c.valor)}
+            </span>
+            <span className="text-[12px] text-ink-2">{c.unidade}</span>
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[10px] uppercase tracking-[0.14em] font-semibold text-ink-3">Linha escolhida</div>
+          <div className="tabular-nums text-[20px] font-semibold leading-none mt-1.5 text-ink">{fmtLinhaExata(c.linha)}</div>
+        </div>
+      </div>
+      {/* A marca da linha fica POR CIMA do preenchimento, com contorno branco: dentro
+          da barra cheia, um tracinho âmbar sem contorno desaparecia. */}
+      <div className="relative mt-5 pt-4">
+        <span
+          className="absolute top-0 -translate-x-1/2 text-[9.5px] font-bold tabular-nums whitespace-nowrap"
+          style={{ left: pct(c.linha), color: '#b8870f' }}
+        >
+          linha {fmtLinhaExata(c.linha)}
+        </span>
+        <div className="relative h-3.5 rounded-full bg-white">
+          <div className="absolute left-0 top-0 bottom-0 rounded-full" style={{ width: pct(c.valor), background: cor }} />
+          <div
+            className="absolute -top-1 -bottom-1 w-[3px] rounded-full"
+            style={{ left: pct(c.linha), background: '#b8870f', boxShadow: '0 0 0 1.5px #fff' }}
+          />
+        </div>
+      </div>
+      {/* Na aba Contra a premissa NÃO acendeu, então o consolidado não pode dizer
+          "joga a favor" só porque o número passa da linha: o critério do modelo é
+          mais exigente que a linha, e é isso que a frase precisa contar. */}
+      <div className="text-[11.5px] leading-relaxed text-ink-2 mt-2.5">
+        {modo === 'favor'
+          ? c.favorece
+            ? `Fica ${c.direcao === 'maior' ? 'acima' : 'abaixo'} da linha de ${fmtLinhaExata(c.linha)}, e é por isso que esta premissa joga a favor de ${saidaLabel}.`
+            : `Fica ${c.direcao === 'maior' ? 'abaixo' : 'acima'} da linha de ${fmtLinhaExata(c.linha)}: por este número, a premissa não sustenta ${saidaLabel}.`
+          : c.favorece
+            ? `Fica ${c.direcao === 'maior' ? 'acima' : 'abaixo'} da linha de ${fmtLinhaExata(c.linha)}, mas a premissa não acendeu: o critério do modelo é mais exigente do que a linha.`
+            : `Fica ${c.direcao === 'maior' ? 'abaixo' : 'acima'} da linha de ${fmtLinhaExata(c.linha)}, e é por isso que esta premissa não aconteceu.`}
+      </div>
+    </div>
+  );
+}
+/** O painel que abre dentro da linha: consolidado, gráficos e como ler. */
+function PainelPremissa({ story, saidaLabel, modo }: { story: Story; saidaLabel: string; modo: 'favor' | 'contra' }) {
+  const soMiudas = story.series.every((s) => s.metrica !== 'resultado' && s.jogos.length <= 2);
+  return (
+    <div className="px-4 pb-4 pt-3.5" style={{ borderTop: '1px solid #f1e9d6' }}>
+      {story.consolidado && (
+        <div className="mb-4">
+          <Consolidado c={story.consolidado} saidaLabel={saidaLabel} modo={modo} />
+        </div>
+      )}
+
+      {story.series[0].metrica === 'resultado' ? (
+        <div className="flex flex-col gap-4">
+          {story.series.map((s) => (
+            <div key={s.chave}>
+              <div className="flex items-center gap-1.5 mb-2">
+                <Crest name={s.teamName} id={s.teamId} size={16} />
+                <span className="text-[12px] font-semibold text-ink">{s.titulo}</span>
+                <span className="text-[10.5px] ml-auto" style={{ color: '#8d8672' }}>{s.sub}</span>
+              </div>
+              <SerieResultados s={s} />
+            </div>
+          ))}
+        </div>
+      ) : soMiudas ? (
+        <div className="flex flex-col gap-4">
+          {story.series.map((s) => (
+            <div key={s.chave}>
+              <div className="flex items-center gap-1.5 mb-2">
+                <Crest name={s.teamName} id={s.teamId} size={16} />
+                <span className="text-[12px] font-semibold text-ink">{s.titulo}</span>
+                <span className="text-[10.5px] ml-auto" style={{ color: '#8d8672' }}>{s.sub}</span>
+              </div>
+              <SerieMiuda s={s} />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <GraficoUnificado story={story} />
+      )}
+
+      <div className="text-[11px] leading-relaxed mt-3" style={{ color: '#8d8672' }}>
+        {soMiudas ? 'Amostra curta na competição: em vez de gráfico, o valor de cada jogo.' : story.comoLer}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A premissa como LINHA: peso à esquerda, nome no meio, "ver os jogos" e a seta à
+ * direita. A barra inteira é clicável e o gráfico abre embaixo, na mesma linha.
+ */
+function LinhaPremissa({
+  p,
+  modo,
+  lado,
+  ev,
+  story,
+  aberta,
+  onAlternar,
+  saidaLabel,
+}: {
+  p: Premissa;
+  modo: 'favor' | 'contra';
+  lado: 'home' | 'away' | null;
+  ev: Evidencia | null;
+  story: Story | null;
+  aberta: boolean;
+  onAlternar: () => void;
+  saidaLabel: string;
+}) {
+  const forte = pesoForte(p);
+  const podeAbrir = story != null;
+  return (
+    <div
+      className="rounded-[14px] overflow-hidden bg-white"
+      style={{ border: `1px solid ${aberta ? '#0a3d2e' : '#ded2b6'}` }}
+    >
+      <button
+        type="button"
+        onClick={podeAbrir ? onAlternar : undefined}
+        className="w-full flex items-center gap-3 px-4 py-3 text-left border-0"
+        style={{
+          background: aberta ? '#0a3d2e' : '#f4eddc',
+          borderBottom: `1px solid ${aberta ? '#0a3d2e' : '#ded2b6'}`,
+          cursor: podeAbrir ? 'pointer' : 'default',
+        }}
+      >
+        {modo === 'contra' && (
+          <X className="w-3.5 h-3.5 shrink-0" style={{ color: aberta ? '#fbbf24' : '#c58b96' }} strokeWidth={3} />
+        )}
+        <span
+          className="shrink-0 inline-flex items-center h-5 px-1.5 rounded-[5px] text-[9.5px] font-bold uppercase tracking-[0.08em]"
+          style={
+            aberta
+              ? { background: 'rgba(251,191,36,.18)', color: '#fbbf24' }
+              : forte
+                ? { background: '#dcefe2', color: '#0a3d2e' }
+                : { background: '#eae2cf', color: '#8d8672' }
+          }
+        >
+          {pesoPalavra(p)}
+        </span>
+        <span className="flex-1 min-w-0 text-[13.5px] font-semibold" style={{ color: aberta ? '#fff' : '#1a1d1a' }}>
+          {rotuloPremissa(p, lado, modo === 'contra')}
+        </span>
+        {podeAbrir ? (
+          <span className="shrink-0 inline-flex items-center gap-1.5 text-[11.5px] font-semibold" style={{ color: aberta ? '#fbbf24' : '#0a3d2e' }}>
+            {aberta ? 'fechar' : 'ver os jogos'}
+            <ChevronRight className="w-3.5 h-3.5 transition-transform" style={{ transform: `rotate(${aberta ? 90 : 0}deg)` }} />
+          </span>
+        ) : (
+          <span className="shrink-0 text-[11px]" style={{ color: aberta ? 'rgba(255,255,255,.5)' : '#8d8672' }}>
+            sem jogo a jogo
+          </span>
+        )}
+      </button>
+
+      {ev && (
+        <div className="px-4 py-3 text-[12.5px] leading-relaxed" style={{ color: '#5a625a' }}>
+          {ev.texto}
+        </div>
+      )}
+
+      {aberta && story && <PainelPremissa story={story} saidaLabel={saidaLabel} modo={modo} />}
+    </div>
+  );
+}
+
+export function MotivosJogoPorJogo({
+  premissas,
+  modo,
+  contras,
+  historico,
+  numeros,
+  lado,
+  linha,
+  saidaLabel,
+}: {
+  premissas: Premissa[];
+  modo: 'favor' | 'contra';
+  /** Só no modo contra: o que o preço e as penalidades pesam. */
+  contras?: { t: string; sub?: string }[];
+  historico: FutebolFixtureHistorico[] | undefined;
+  numeros: FutebolFixtureNumeros[] | undefined;
+  lado: 'home' | 'away' | null;
+  linha: number | null;
+  /** A saída analisada, para o fechamento dizer a favor de quê. */
+  saidaLabel: string;
+}) {
+  const acesa = modo === 'favor';
+  const itens = useMemo(
+    () =>
+      premissas.map((p) => ({
+        p,
+        ev: evidenciaDe(p.slug, numeros, lado, acesa, linha) ?? evidenciaDoHistorico(p.slug, historico, lado, linha),
+        story: storyDaPremissa(p.slug, historico, lado, linha),
+      })),
+    [premissas, numeros, historico, lado, linha, acesa],
+  );
+
+  // Abre a primeira que tem gráfico: chegar numa lista toda fechada esconde o que a
+  // aba veio mostrar.
+  const primeira = itens.find((x) => x.story != null)?.p.slug ?? null;
+  const [aberta, setAberta] = useState<string | null>(primeira);
+  const chave = itens.map((x) => x.p.slug).join('|');
+  useEffect(() => setAberta(primeira), [chave, primeira]);
+
+  if (!historico) {
+    return <div className="p-6 md:p-8 text-[13px]" style={{ color: '#8d8672' }}>Carregando os jogos anteriores.</div>;
+  }
+
+  return (
+    <div className="p-5 md:p-7">
+      <div className="flex items-center justify-between gap-4 mb-3.5 flex-wrap">
+        <div className="text-[12.5px]" style={{ color: '#8d8672' }}>
+          {modo === 'favor'
+            ? itens.length > 0
+              ? `${itens.length} ${itens.length === 1 ? 'premissa sustenta' : 'premissas sustentam'} ${saidaLabel.toLowerCase()}. Clique numa linha para ver os jogos que produziram o número.`
+              : 'Nenhuma premissa a favor desta saída.'
+            : itens.length > 0 || (contras?.length ?? 0) > 0
+              ? 'O que o jogo e o preço colocam contra esta saída.'
+              : 'Nada pesando contra esta saída: todas as premissas que valem aconteceram.'}
+        </div>
+        {itens.some((x) => x.story != null) && (
+          <div className="flex items-center gap-4">
+            <span className="inline-flex items-center gap-1.5">
+              <span className="w-2.5 h-2.5 rounded-sm" style={{ background: COR_FAVOR }} />
+              <span className="text-[10.5px]" style={{ color: '#5a625a' }}>o lado que a premissa quer</span>
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="w-2.5 h-2.5 rounded-sm" style={{ background: COR_CONTRA }} />
+              <span className="text-[10.5px]" style={{ color: '#8d8672' }}>o lado contrário</span>
+            </span>
+          </div>
+        )}
+      </div>
+
+      {modo === 'contra' && (contras?.length ?? 0) > 0 && (
+        <div className="flex flex-col gap-2.5 mb-2.5">
+          {contras!.map((c, i) => (
+            <div
+              key={i}
+              className="flex gap-3 items-start p-4 rounded-[14px]"
+              style={{ border: '1px solid #ded2b6', background: '#fdfbf6' }}
+            >
+              <span
+                className="shrink-0 w-[22px] h-[22px] rounded-md grid place-items-center text-[13px] font-bold"
+                style={{ background: '#fdf3d9', color: '#b8870f' }}
+              >
+                −
+              </span>
+              <div>
+                <div className="text-[13px] font-semibold leading-snug text-ink">{c.t}</div>
+                {c.sub && <div className="text-[12px] leading-relaxed mt-0.5" style={{ color: '#8d8672' }}>{c.sub}</div>}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2.5">
+        {itens.map(({ p, ev, story }) => (
+          <LinhaPremissa
+            key={p.slug}
+            p={p}
+            modo={modo}
+            lado={lado}
+            ev={ev}
+            story={story}
+            aberta={aberta === p.slug}
+            onAlternar={() => setAberta(aberta === p.slug ? null : p.slug)}
+            saidaLabel={saidaLabel}
+          />
+        ))}
+      </div>
+
+      {itens.some((x) => x.story == null) && (
+        <div className="text-[11.5px] leading-relaxed mt-4 pt-4" style={{ borderTop: '1px solid #f1e9d6', color: '#8d8672' }}>
+          Sem jogo a jogo:{' '}
+          {itens
+            .filter((x) => x.story == null)
+            .map((x) => rotuloPremissa(x.p, lado, modo === 'contra').toLowerCase())
+            .join('; ')}
+          . Aqui o sinal não vem de gol marcado ou sofrido, vem da tabela, do histórico entre os dois ou da escalação.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/futebol/RegistrarAposta.tsx
+++ b/src/components/futebol/RegistrarAposta.tsx
@@ -178,12 +178,32 @@ export function RegistrarApostaModal({
  * - 'text': linha discreta (estilo bolão) — usada FORA da área clicável da linha/card
  *   da Oportunidades, pra não disparar a navegação e só abrir o modal.
  */
-export function RegistrarApostaCTA({ draft, variant = 'footer' }: { draft: FutebolBetDraft; variant?: 'footer' | 'text' }) {
+export function RegistrarApostaCTA({
+  draft,
+  variant = 'footer',
+  rotulo,
+}: {
+  draft: FutebolBetDraft;
+  /** `ambar` é o botão sólido da faixa da partida e da folha do mercado. */
+  variant?: 'footer' | 'text' | 'ambar';
+  rotulo?: string;
+}) {
   const [open, setOpen] = useState(false);
   const trigger = (e: React.MouseEvent) => { e.stopPropagation(); e.preventDefault(); setOpen(true); };
 
   return (
     <>
+      {variant === 'ambar' && (
+        <button
+          type="button"
+          onClick={trigger}
+          className="inline-flex items-center justify-center h-9 px-4 rounded-[9px] text-[12.5px] font-bold whitespace-nowrap transition hover:brightness-95"
+          style={{ background: '#fbbf24', color: '#1a1d1a' }}
+        >
+          {rotulo ?? 'Registrar aposta'}
+        </button>
+      )}
+
       {variant === 'footer' && (
         <div className="flex items-center flex-wrap gap-x-3 gap-y-2 px-5 md:px-6 py-3 border-t border-line" style={{ background: 'var(--canvas-2)' }}>
           <span className="text-[13px] font-semibold text-ink">Apostou nessa oportunidade?</span>

--- a/src/components/futebol/ReguaRodadas.tsx
+++ b/src/components/futebol/ReguaRodadas.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { rodadaCurta } from '@/utils/futebol-rodadas';
+
+/**
+ * A régua de rodadas do campeonato.
+ *
+ * No lugar do stepper de "‹ Rodada 22 ›", que só dizia onde você está e obrigava
+ * a clicar 15 vezes pra chegar na rodada 7. Aqui a temporada inteira está à
+ * mostra: primeira, última, uma janela em volta da atual e "…" no meio do
+ * caminho. Rodada passada fica areia (já jogou), futura fica branca com borda,
+ * a atual fica verde com o ponto âmbar.
+ *
+ * Em mata-mata a mesma régua serve pras fases, e aí não tem janela nem "…":
+ * são poucas, cabem todas (protótipo "Futebol Campeonato").
+ */
+
+const JANELA = 3; // rodadas de cada lado da atual, no desktop
+
+export function ReguaRodadas({
+  rounds,
+  idx,
+  onIdx,
+  jogosNaRodada,
+  porPontos,
+}: {
+  rounds: string[];
+  idx: number;
+  onIdx: (i: number) => void;
+  jogosNaRodada: number;
+  porPontos: boolean;
+}) {
+  const ativoRef = useRef<HTMLButtonElement | null>(null);
+  const trilhaRef = useRef<HTMLDivElement | null>(null);
+
+  /** Índices visíveis, com marcador de corte onde a sequência pula. */
+  const paradas = useMemo(() => {
+    const total = rounds.length;
+    if (!total) return [] as Array<{ tipo: 'corte'; chave: string } | { tipo: 'rodada'; i: number }>;
+
+    const set = new Set<number>();
+    if (porPontos && total > JANELA * 2 + 3) {
+      set.add(0);
+      set.add(total - 1);
+      for (let i = idx - JANELA; i <= idx + JANELA; i++) if (i >= 0 && i < total) set.add(i);
+    } else {
+      for (let i = 0; i < total; i++) set.add(i);
+    }
+
+    const ordenados = [...set].sort((a, b) => a - b);
+    const saida: Array<{ tipo: 'corte'; chave: string } | { tipo: 'rodada'; i: number }> = [];
+    let anterior: number | null = null;
+    ordenados.forEach((i) => {
+      if (anterior != null && i - anterior > 1) saida.push({ tipo: 'corte', chave: `c${i}` });
+      saida.push({ tipo: 'rodada', i });
+      anterior = i;
+    });
+    return saida;
+  }, [rounds.length, idx, porPontos]);
+
+  // Em tela estreita a régua rola, e sem isto ela abre no começo da temporada: no
+  // celular a Libertadores mostrava "Pré 1" com as oitavas fora da vista. Mexo no
+  // scrollLeft da trilha em vez de usar scrollIntoView, que também rolava a
+  // PÁGINA e não reagia quando a lista de fases chegava depois do primeiro
+  // desenho. O rAF é pra medir com a régua já do tamanho final.
+  useEffect(() => {
+    const centralizar = () => {
+      const trilha = trilhaRef.current;
+      const ativo = ativoRef.current;
+      if (!trilha || !ativo) return;
+      trilha.scrollLeft = ativo.offsetLeft - (trilha.clientWidth - ativo.clientWidth) / 2;
+    };
+    const raf = requestAnimationFrame(centralizar);
+    // Segunda tentativa: em carregamento de página inteira a fonte e os escudos
+    // chegam depois e mudam a largura dos chips, e a régua voltava pro começo.
+    const tarde = setTimeout(centralizar, 350);
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(tarde);
+    };
+  }, [idx, rounds.length]);
+
+  if (!rounds.length) return null;
+
+  const jogadas = idx; // tudo que vem antes da rodada aberta já aconteceu
+
+  return (
+    <div
+      className="bg-white rounded-rebrand-lg px-3 py-2 flex items-center gap-2 min-w-0"
+      style={{ border: '1px solid #ded2b6' }}
+    >
+      <span
+        className="hidden sm:block shrink-0 text-[9.5px] uppercase tracking-[0.14em] font-bold pr-1"
+        style={{ color: '#8d8672' }}
+      >
+        {porPontos ? 'Rodada' : 'Fase'}
+      </span>
+
+      <button
+        onClick={() => onIdx(Math.max(0, idx - 1))}
+        disabled={idx <= 0}
+        className="shrink-0 w-7 h-7 grid place-items-center rounded-rebrand-sm transition disabled:opacity-30 hover:bg-canvas-2"
+        style={{ color: '#8d8672', background: '#f8f4ea' }}
+        aria-label="Rodada anterior"
+      >
+        <ChevronLeft className="w-4 h-4" />
+      </button>
+
+      <div ref={trilhaRef} className="flex items-center gap-1.5 overflow-x-auto no-scrollbar min-w-0">
+        {paradas.map((p) =>
+          p.tipo === 'corte' ? (
+            <span key={p.chave} className="shrink-0 text-[12px] px-0.5" style={{ color: '#c4bda8' }}>
+              …
+            </span>
+          ) : (
+            <button
+              key={rounds[p.i]}
+              ref={p.i === idx ? ativoRef : undefined}
+              onClick={() => onIdx(p.i)}
+              aria-current={p.i === idx ? 'true' : undefined}
+              className="shrink-0 h-7 rounded-rebrand-sm inline-flex items-center gap-1.5 tabular-nums transition"
+              style={
+                p.i === idx
+                  ? { padding: '0 13px', background: '#0a3d2e', color: '#fff', font: '700 12.5px Inter, sans-serif' }
+                  : p.i < idx
+                    ? { padding: '0 10px', background: '#f1e9d6', color: '#8d8672', font: '600 12px Inter, sans-serif' }
+                    : {
+                        padding: '0 10px',
+                        background: '#fff',
+                        border: '1px solid #ded2b6',
+                        color: '#3f463d',
+                        font: '600 12px Inter, sans-serif',
+                      }
+              }
+            >
+              {rodadaCurta(rounds[p.i])}
+              {p.i === idx && (
+                <span className="w-[5px] h-[5px] rounded-full" style={{ background: '#fbbf24' }} />
+              )}
+            </button>
+          ),
+        )}
+      </div>
+
+      <button
+        onClick={() => onIdx(Math.min(rounds.length - 1, idx + 1))}
+        disabled={idx >= rounds.length - 1}
+        className="shrink-0 w-7 h-7 grid place-items-center rounded-rebrand-sm transition disabled:opacity-30 hover:bg-canvas-2"
+        style={{ color: '#8d8672', background: '#f8f4ea' }}
+        aria-label="Próxima rodada"
+      >
+        <ChevronRight className="w-4 h-4" />
+      </button>
+
+      <span className="hidden lg:block ml-auto shrink-0 text-[11px]" style={{ color: '#8d8672' }}>
+        {porPontos
+          ? `${jogadas} ${jogadas === 1 ? 'rodada jogada' : 'rodadas jogadas'} · ${jogosNaRodada} ${jogosNaRodada === 1 ? 'jogo' : 'jogos'} nesta`
+          : `${rounds.length} fases · ${jogosNaRodada} ${jogosNaRodada === 1 ? 'jogo' : 'jogos'} nesta`}
+      </span>
+    </div>
+  );
+}

--- a/src/components/futebol/ScorersCard.tsx
+++ b/src/components/futebol/ScorersCard.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getFutebolPlayerPhotoUrl, crestInitials } from '@/utils/futebol-logos';
+import type { FutebolLeaders } from '@/services/futebol-data.service';
+
+/**
+ * Artilheiros do campeonato: top 6 na tela, os 12 a um clique.
+ *
+ * Era top 8 com um "ver todos" que abria modal. O modal saiu junto com o da
+ * classificação: pra uma lista de 12 linhas ele cobria a tela inteira e obrigava
+ * a fechar pra continuar lendo o resto (protótipo "Futebol Campeonato").
+ *
+ * Sem coluna de jogos: `get_futebol_leaders` devolve nome, time e gols, e não
+ * quantos jogos o cara fez. O protótipo mostrava essa coluna; preferi não
+ * inventar número a botar um traço em toda linha.
+ */
+
+const TOPO = 6;
+const TOTAL = 12;
+
+function PlayerAvatar({ id, name, size = 26 }: { id: number; name: string; size?: number }) {
+  const [err, setErr] = useState(false);
+  const url = getFutebolPlayerPhotoUrl(id);
+  if (url && !err) {
+    return (
+      <img
+        src={url}
+        alt=""
+        onError={() => setErr(true)}
+        style={{ width: size, height: size }}
+        className="rounded-full object-cover bg-canvas-2 shrink-0"
+        loading="lazy"
+      />
+    );
+  }
+  return (
+    <div
+      style={{ width: size, height: size }}
+      className="rounded-full bg-canvas-2 border border-line grid place-items-center text-[8px] font-bold text-ink-2 shrink-0"
+    >
+      {crestInitials(name)}
+    </div>
+  );
+}
+
+export function ScorersCard({
+  leaders,
+  loading,
+  vazio,
+}: {
+  leaders?: FutebolLeaders;
+  loading: boolean;
+  vazio?: { titulo: string; texto: string };
+}) {
+  const [tudo, setTudo] = useState(false);
+  const todos = leaders?.scorers ?? [];
+  const lista = todos.slice(0, tudo ? TOTAL : TOPO);
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-rebrand-lg overflow-hidden p-4 space-y-2" style={{ border: '1px solid #ded2b6' }}>
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-7 w-full bg-canvas-2 rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!todos.length) {
+    return (
+      <div className="bg-white rounded-rebrand-lg px-6 py-9 text-center" style={{ border: '1px dashed #ded2b6' }}>
+        <div className="text-[14px] font-semibold text-ink">{vazio?.titulo ?? 'Artilheiros não disponíveis'}</div>
+        <div className="mt-1.5 text-[12.5px] leading-relaxed" style={{ color: '#8d8672' }}>
+          {vazio?.texto ?? 'Entram assim que a competição passar pela coleta.'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-rebrand-lg overflow-hidden" style={{ border: '1px solid #ded2b6' }}>
+      <div
+        className="px-4 py-2.5 flex items-center justify-between gap-2"
+        style={{ background: '#f4eddc', borderBottom: '1px solid #ded2b6' }}
+      >
+        <span className="text-[10.5px] uppercase tracking-[0.16em] font-bold" style={{ color: '#6b6350' }}>
+          Artilheiros
+        </span>
+        {todos.length > TOPO && (
+          <button
+            onClick={() => setTudo((v) => !v)}
+            className="text-[11px] font-semibold text-forest inline-flex items-center gap-1"
+          >
+            {tudo ? `ver só o top ${TOPO}` : `ver os ${Math.min(TOTAL, todos.length)}`}
+            <ChevronDown className={`w-3 h-3 transition-transform ${tudo ? 'rotate-180' : ''}`} />
+          </button>
+        )}
+      </div>
+
+      {lista.map((s, i) => (
+        <div
+          key={s.player_id}
+          className="px-4 py-2 flex items-center gap-2.5"
+          style={{ borderTop: i === 0 ? 'none' : '1px solid #f1e9d6' }}
+        >
+          <span className="w-4 text-[11.5px] font-semibold tabular-nums" style={{ color: '#8d8672' }}>
+            {i + 1}
+          </span>
+          <PlayerAvatar id={s.player_id} name={s.player_name} />
+          <span className="flex-1 min-w-0">
+            <span className="block text-[12.5px] font-semibold text-ink truncate">{s.player_name}</span>
+            <span className="block text-[10.5px] truncate" style={{ color: '#8d8672' }}>
+              {s.team_name}
+            </span>
+          </span>
+          <span className="text-[14px] font-bold tabular-nums text-forest">{s.goals}</span>
+          <span className="text-[10px]" style={{ color: '#8d8672' }}>
+            gols
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/futebol/StandingsTable.tsx
+++ b/src/components/futebol/StandingsTable.tsx
@@ -1,0 +1,226 @@
+import { useMemo, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Crest } from './Crest';
+import type { FutebolStandingRow } from '@/services/futebol-data.service';
+
+/**
+ * A classificação, em blocos por zona.
+ *
+ * Antes eram as 9 primeiras linhas com um "tabela completa" que abria modal. Duas
+ * perdas nisso: o rebaixamento, que é metade do interesse de quem acompanha, só
+ * existia dentro do modal; e a zona só aparecia como uma barrinha colorida sem
+ * legenda. Aqui as pontas ficam sempre à vista (classificação e rebaixamento) e o
+ * miolo, que é onde ninguém olha, abre e fecha (protótipo "Futebol Campeonato").
+ *
+ * Os blocos NÃO são fixos em G4/G6/Z4: eles saem do `rank_description` oficial da
+ * API, que muda por liga e por temporada. No Brasileirão dá Libertadores (1-5),
+ * Sul-Americana (6-11), miolo e rebaixamento; na Premier daria Champions e
+ * Europa. Liga sem descrição vira um bloco só, sem inventar zona.
+ */
+
+const GRID = 'grid grid-cols-[26px_1fr_24px_24px_24px_24px_34px_38px] gap-1.5 items-center';
+const GRID_M = 'grid grid-cols-[22px_1fr_24px_32px_34px] gap-2 items-center';
+
+/** Traduz a descrição oficial da API para o rótulo curto que vai na tela. */
+function rotuloZona(desc: string): { texto: string; cor: string } {
+  const d = desc.toLowerCase();
+  if (d.includes('relegation')) return { texto: 'Rebaixamento', cor: '#be123c' };
+  if (d.includes('libertadores')) {
+    return d.includes('qualification')
+      ? { texto: 'Pré-Libertadores', cor: '#2f7d50' }
+      : { texto: 'Libertadores', cor: '#0a3d2e' };
+  }
+  if (d.includes('sudamericana')) return { texto: 'Sul-Americana', cor: '#1a5fb4' };
+  if (d.includes('champions league')) return { texto: 'Champions League', cor: '#0a3d2e' };
+  if (d.includes('europa league')) return { texto: 'Europa League', cor: '#2f7d50' };
+  if (d.includes('conference')) return { texto: 'Conference League', cor: '#1a5fb4' };
+  if (d.includes('promotion')) return { texto: 'Acesso', cor: '#0a3d2e' };
+  return { texto: desc, cor: '#6b6350' };
+}
+
+type Bloco = { chave: string; zona: { texto: string; cor: string } | null; linhas: FutebolStandingRow[] };
+
+/** Quebra a tabela em faixas seguidas de mesma descrição. */
+function blocos(rows: FutebolStandingRow[]): Bloco[] {
+  const out: Bloco[] = [];
+  rows.forEach((r) => {
+    const desc = r.rank_description ?? '';
+    const ultimo = out[out.length - 1];
+    if (ultimo && (ultimo.linhas[0].rank_description ?? '') === desc) {
+      ultimo.linhas.push(r);
+      return;
+    }
+    // Chave pelo time, não pelo rank: em copa com grupos o rank repete (1 a 4 em
+    // cada grupo) e dois blocos acabavam com a mesma chave.
+    out.push({ chave: `${desc}-${r.team_id}`, zona: desc ? rotuloZona(desc) : null, linhas: [r] });
+  });
+  return out;
+}
+
+function Linha({
+  r,
+  onTeam,
+  cor,
+  compacto,
+}: {
+  r: FutebolStandingRow;
+  onTeam: (id: number) => void;
+  cor: string | null;
+  compacto: boolean;
+}) {
+  const sgTexto = r.goals_diff > 0 ? `+${r.goals_diff}` : r.goals_diff < 0 ? `−${Math.abs(r.goals_diff)}` : '0';
+  const sgCor = r.goals_diff > 0 ? '#0a3d2e' : r.goals_diff < 0 ? '#be123c' : '#6b6350';
+  const num = 'text-center text-[11.5px] tabular-nums';
+
+  return (
+    <button
+      onClick={() => onTeam(r.team_id)}
+      className={`w-full text-left px-3 sm:px-4 py-2 hover:bg-canvas-2 transition ${compacto ? GRID_M : GRID}`}
+      style={{ borderTop: '1px solid #f1e9d6' }}
+    >
+      <span className="flex items-center gap-1">
+        <span
+          className="w-[3px] h-4 rounded-full shrink-0"
+          style={{ background: cor ?? 'transparent' }}
+        />
+        <span className="text-[11.5px] font-semibold tabular-nums" style={{ color: '#6b6350' }}>
+          {r.rank}
+        </span>
+      </span>
+      <span className="flex items-center gap-2 min-w-0">
+        <Crest name={r.team_name} id={r.team_id} size={20} />
+        <span className="text-[12px] font-semibold text-ink truncate">{r.team_name}</span>
+      </span>
+      <span className={num} style={{ color: '#6b6350' }}>{r.played}</span>
+      {!compacto && <span className={num} style={{ color: '#6b6350' }}>{r.wins}</span>}
+      {!compacto && <span className={num} style={{ color: '#6b6350' }}>{r.draws}</span>}
+      {!compacto && <span className={num} style={{ color: '#6b6350' }}>{r.loses}</span>}
+      <span className={num} style={{ color: sgCor }}>{sgTexto}</span>
+      <span className="text-center text-[13.5px] font-bold tabular-nums text-ink">{r.points}</span>
+    </button>
+  );
+}
+
+export function StandingsTable({
+  rows,
+  loading,
+  onTeam,
+  compacto = false,
+  legenda,
+  vazio,
+}: {
+  rows?: FutebolStandingRow[];
+  loading: boolean;
+  onTeam: (id: number) => void;
+  /** Mobile: esconde V, E e D, que não cabem em 390px. */
+  compacto?: boolean;
+  /** Texto do canto direito do cabeçalho, ex.: "após 22 rodadas". */
+  legenda?: string;
+  /** O que dizer quando a competição não tem tabela. */
+  vazio?: { titulo: string; texto: string };
+}) {
+  const [miolo, setMiolo] = useState(false);
+  const grupos = useMemo(() => blocos(rows ?? []), [rows]);
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-rebrand-lg overflow-hidden p-4 space-y-2" style={{ border: '1px solid #ded2b6' }}>
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-8 w-full bg-canvas-2 rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!rows?.length) {
+    return (
+      <div
+        className="bg-white rounded-rebrand-lg px-6 py-9 text-center"
+        style={{ border: '1px dashed #ded2b6' }}
+      >
+        <div className="text-[14px] font-semibold text-ink">
+          {vazio?.titulo ?? 'Classificação não disponível'}
+        </div>
+        <div className="mt-1.5 text-[12.5px] leading-relaxed" style={{ color: '#8d8672' }}>
+          {vazio?.texto ?? 'Entra assim que a competição passar pela coleta.'}
+        </div>
+      </div>
+    );
+  }
+
+  // O miolo é o bloco sem zona no meio da tabela: é o que ninguém abre. Só vale
+  // esconder quando ele é grande, senão a linha de "mostrar" custa mais que as
+  // linhas que ela economiza.
+  const iMiolo = grupos.findIndex((g, i) => !g.zona && i > 0 && i < grupos.length - 1 && g.linhas.length >= 4);
+
+  return (
+    <div className="bg-white rounded-rebrand-lg overflow-hidden" style={{ border: '1px solid #ded2b6' }}>
+      <div
+        className="px-4 py-2.5 flex items-center justify-between gap-2"
+        style={{ background: '#f4eddc', borderBottom: '1px solid #ded2b6' }}
+      >
+        <span className="text-[10.5px] uppercase tracking-[0.16em] font-bold" style={{ color: '#6b6350' }}>
+          Classificação
+        </span>
+        {legenda && <span className="text-[10.5px]" style={{ color: '#8d8672' }}>{legenda}</span>}
+      </div>
+
+      <div
+        className={`px-3 sm:px-4 py-2 text-[9.5px] uppercase tracking-[0.12em] font-bold ${compacto ? GRID_M : GRID}`}
+        style={{ background: '#fdfbf6', borderBottom: '1px solid #f1e9d6', color: '#8d8672' }}
+      >
+        <span>#</span>
+        <span>Time</span>
+        <span className="text-center">J</span>
+        {!compacto && <span className="text-center">V</span>}
+        {!compacto && <span className="text-center">E</span>}
+        {!compacto && <span className="text-center">D</span>}
+        <span className="text-center">SG</span>
+        <span className="text-center">Pts</span>
+      </div>
+
+      {grupos.map((g, i) => {
+        const escondido = i === iMiolo && !miolo;
+        return (
+          <div key={g.chave}>
+            {g.zona ? (
+              <div
+                className="px-3 sm:px-4 py-1.5 flex items-center gap-1.5"
+                style={{ background: '#f8f4ea', borderTop: '1px solid #f1e9d6', borderBottom: '1px solid #f1e9d6' }}
+              >
+                <span className="w-[3px] h-2.5 rounded-full" style={{ background: g.zona.cor }} />
+                <span
+                  className="text-[9px] uppercase tracking-[0.12em] font-bold"
+                  style={{ color: g.zona.cor }}
+                >
+                  {g.zona.texto} · {g.linhas.length === 1 ? `${g.linhas[0].rank}º` : `${g.linhas[0].rank}º ao ${g.linhas[g.linhas.length - 1].rank}º`}
+                </span>
+              </div>
+            ) : i === iMiolo ? (
+              <button
+                onClick={() => setMiolo((v) => !v)}
+                className="w-full px-3 sm:px-4 py-2.5 flex items-center gap-2 text-left"
+                style={{ background: '#fdfbf6', borderTop: '1px solid #f1e9d6', borderBottom: '1px solid #f1e9d6' }}
+              >
+                <span className="text-[11.5px] font-semibold" style={{ color: '#6b6350' }}>
+                  {g.linhas[0].rank}º ao {g.linhas[g.linhas.length - 1].rank}º · {g.linhas.length} times
+                </span>
+                <span className="flex-1 h-px" style={{ background: '#f1e9d6' }} />
+                <span className="text-[11px] font-semibold text-forest inline-flex items-center gap-1">
+                  {miolo ? 'ocultar' : 'mostrar'}
+                  <ChevronDown className={`w-3 h-3 transition-transform ${miolo ? 'rotate-180' : ''}`} />
+                </span>
+              </button>
+            ) : null}
+
+            {!escondido &&
+              g.linhas.map((r) => (
+                <Linha key={r.team_id} r={r} onTeam={onTeam} cor={g.zona?.cor ?? null} compacto={compacto} />
+              ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/nba-home/NBAHotOppCard.tsx
+++ b/src/components/nba-home/NBAHotOppCard.tsx
@@ -103,7 +103,7 @@ export const NBAHotOppCard: React.FC<NBAHotOppCardProps> = ({ opp, onClick, href
       </div>
 
       <div className="flex items-center gap-1.5 mt-3 flex-wrap">
-        <span className="px-2 h-6 inline-flex items-center rounded text-[11px] font-semibold bg-ink-3 text-ink">{statShort}</span>
+        <span className="px-2 h-6 inline-flex items-center rounded text-[11px] font-semibold bg-canvas-2 text-ink">{statShort}</span>
         <span className="px-2 h-6 inline-flex items-center rounded text-[11px] font-semibold bg-amber-50 text-amber-700 border border-amber-200">
           {filterChip}
         </span>

--- a/src/components/onboarding/demo/futebol.ts
+++ b/src/components/onboarding/demo/futebol.ts
@@ -1,4 +1,5 @@
-import type { FutebolValueBoardRow, FutebolFixture, FutebolStandingRow, FutebolLeaders, FutebolTeamProfile, FutebolTeamSeason, FutebolFixtureDetail, FutebolFixtureValueRow } from '@/services/futebol-data.service';
+import type { FutebolValueBoardRow, FutebolFixture, FutebolFixtureByDay, FutebolStandingRow, FutebolLeaders, FutebolTeamProfile, FutebolTeamSeason, FutebolFixtureDetail, FutebolFixtureValueRow } from '@/services/futebol-data.service';
+import { fmtTime, addDays } from '@/utils/futebol-datas';
 
 // Dados de EXEMPLO (fictícios) pro onboarding guiado — usados só enquanto o tour
 // roda, pra a tela nunca ficar vazia. Nada aqui é real. Times/valores ilustrativos.
@@ -94,6 +95,35 @@ export const demoFutebolFixtures: FutebolFixture[] = [
   fx({ fixture_id: 9004, home_team_id: 120, away_team_id: 124, home_team_name: 'Botafogo', away_team_name: 'Fluminense', kickoff_utc: '2025-08-11T00:00:00Z' }),
   fx({ fixture_id: 9005, home_team_id: 135, away_team_id: 118, home_team_name: 'Cruzeiro', away_team_name: 'Bahia', kickoff_utc: '2025-08-10T19:00:00Z' }),
 ];
+
+/**
+ * Agenda de exemplo pro tour da /futebol/jogos (que virou agenda por dia).
+ *
+ * Reaproveita os mesmos jogos e fixture_ids do board, mas remapeados pro dia que a
+ * régua está mostrando: o tour roda em qualquer data, e lista de um dia com jogo de
+ * outro dia é exatamente o tipo de incoerência que a agenda veio corrigir.
+ *
+ * Mantém a HORA de Brasília original de cada jogo e reconstrói o kickoff em UTC.
+ * BRT é UTC−3 fixo (o Brasil não tem horário de verão desde 2019), então somar 3
+ * basta; se passar da meia-noite, o kickoff cai no dia UTC seguinte, e nesse caso o
+ * `day_brt` continua sendo o dia pedido, que é o certo.
+ */
+export function makeDemoAgenda(dayKey: string): FutebolFixtureByDay[] {
+  return demoFutebolFixtures.map((f) => {
+    const [hh, mm] = (fmtTime(f.kickoff_utc) || '21:30').split(':').map(Number);
+    const utcHour = hh + 3;
+    const diaUtc = utcHour >= 24 ? addDays(dayKey, 1) : dayKey;
+    const hora = String(utcHour % 24).padStart(2, '0');
+    return {
+      ...f,
+      kickoff_utc: `${diaUtc}T${hora}:${String(mm).padStart(2, '0')}:00`,
+      date_utc: diaUtc,
+      competition: 'brasileirao',
+      season: 2026,
+      day_brt: dayKey,
+    };
+  });
+}
 
 // Classificação de exemplo (topo da tabela) — usada em /futebol/jogos e /futebol/time.
 const st = (

--- a/src/components/onboarding/demo/futebol.ts
+++ b/src/components/onboarding/demo/futebol.ts
@@ -1,4 +1,4 @@
-import type { FutebolValueBoardRow, FutebolFixture, FutebolFixtureByDay, FutebolStandingRow, FutebolLeaders, FutebolTeamProfile, FutebolTeamSeason, FutebolFixtureDetail, FutebolFixtureValueRow } from '@/services/futebol-data.service';
+import type { FutebolFixturePremissas, FutebolFixtureNumeros, FutebolValueBoardRow, FutebolFixture, FutebolFixtureByDay, FutebolStandingRow, FutebolLeaders, FutebolTeamProfile, FutebolTeamSeason, FutebolFixtureDetail, FutebolFixtureValueRow } from '@/services/futebol-data.service';
 import { fmtTime, addDays } from '@/utils/futebol-datas';
 
 // Dados de EXEMPLO (fictícios) pro onboarding guiado — usados só enquanto o tour
@@ -253,3 +253,46 @@ export const demoFutebolLeaders: FutebolLeaders = {
   ],
   cards: [],
 };
+
+/**
+ * Premissas e números de exemplo para o painel da agenda durante o tour.
+ *
+ * O tour troca a lista por jogos de exemplo, e o painel da direita ia buscar
+ * premissas do fixture 9001 no banco: não existe, então o passo "o porquê, do
+ * lado" abria um painel sem porquê nenhum ("0 premissas a favor", sem "como
+ * chegam", sem forma). Aqui o exemplo fica completo, com o mesmo formato das
+ * RPCs 093 e 094.
+ */
+export const demoFutebolPremissas: FutebolFixturePremissas[] = [
+  {
+    market: 'match_winner',
+    outcome: 'Home',
+    line_value: null,
+    pts_premissas: 46,
+    penalidades_pts: 6,
+    acesas: ['forma', 'mando', 'superioridade_tabela'],
+    apagadas: ['forca_mismatch', 'h2h_favoravel'],
+    penalidades: [],
+  },
+];
+
+/** Os números que embasam as premissas de exemplo (formato da RPC 094). */
+export const demoFutebolNumeros: FutebolFixtureNumeros[] = [
+  {
+    side: 'home', team_id: 121, team_name: 'Palmeiras',
+    posicao: 1, pontos: 48, zona: 'Libertadores', jogos: 22, jogos_casa: 11, jogos_fora: 11,
+    v_casa: 8, e_casa: 2, d_casa: 1, v_fora: 6, e_fora: 4, d_fora: 1,
+    gf_casa: 2.1, ga_casa: 0.8, gf_fora: 1.5, ga_fora: 1.0,
+    gf_total: 1.8, ga_total: 0.9, clean_sheets: 9, sem_marcar: 2,
+    // `forma` no formato da API: W vitória, D empate, L derrota.
+    forma: 'WWDWW', h2h_jogos: 6, h2h_vitorias: 3, h2h_empates: 2, ate: '2026-08-13',
+  },
+  {
+    side: 'away', team_id: 127, team_name: 'Flamengo',
+    posicao: 2, pontos: 42, zona: 'Libertadores', jogos: 21, jogos_casa: 11, jogos_fora: 10,
+    v_casa: 7, e_casa: 3, d_casa: 1, v_fora: 5, e_fora: 2, d_fora: 3,
+    gf_casa: 2.0, ga_casa: 0.9, gf_fora: 1.4, ga_fora: 1.3, 
+    gf_total: 1.7, ga_total: 1.1, clean_sheets: 7, sem_marcar: 3,
+    forma: 'WLWWD', h2h_jogos: 6, h2h_vitorias: 1, h2h_empates: 2, ate: '2026-08-13',
+  },
+];

--- a/src/components/onboarding/demo/futebol.ts
+++ b/src/components/onboarding/demo/futebol.ts
@@ -133,6 +133,8 @@ const st = (
   team_id, team_name, rank, points, played: wins + draws + loses,
   wins, draws, loses, goals_for: gf, goals_against: ga, goals_diff: gf - ga,
   rank_description: zone,
+  // Em pontos corridos a API repete o nome da liga no lugar do grupo (096).
+  group_name: 'Serie A',
 });
 
 export const demoFutebolStandings: FutebolStandingRow[] = [

--- a/src/components/onboarding/tours.tsx
+++ b/src/components/onboarding/tours.tsx
@@ -239,14 +239,17 @@ export function makeFutebolJogoSteps({
     });
   }
 
+  // O passo do "Nosso modelo de gols" saiu junto com o card no pré-jogo: o modelo
+  // contava a história do mapa com um sinal que a recalibragem rebaixou. O `hasModel`
+  // agora significa "a página tem o mapa de premissas" (jogo futuro).
   if (hasModel) {
     steps.push({
-      id: 'fut-jogo-modelo',
-      target: '[data-tour="fut-jogo-modelo"]',
+      id: 'fut-jogo-mapa',
+      target: '[data-tour="fut-jogo-mapa"]',
       placement: 'top',
-      title: 'Nosso modelo de gols',
+      title: 'O mapa de premissas',
       content:
-        'A partir das médias da temporada, o modelo estima os gols esperados de cada time e a chance de cada mercado.',
+        'O coração da análise: o que sustenta cada mercado deste jogo, com o número por trás de cada premissa e quantas faltam pra virar aposta.',
     });
   }
 
@@ -277,57 +280,91 @@ export function makeFutebolJogoSteps({
 
 export const FUT_JOGOS_TOUR_ID = 'futebol-jogos';
 
-// Tela /futebol/jogos — visão geral do campeonato (rodadas, tabela,
-// artilheiros). O stepper de rodada é condicional (depende de rodadas
-// carregadas).
-export function makeFutebolJogosSteps({ hasRounds }: { hasRounds: boolean }): Step[] {
+// Tela /futebol/jogos — agenda por dia, todas as ligas juntas. O passo do painel
+// só existe no desktop, porque em telas menores o clique navega pra tela do jogo
+// e o alvo não está montado.
+export function makeFutebolJogosSteps({ hasPanel }: { hasPanel: boolean }): Step[] {
   const steps: Step[] = [
     {
       id: 'fut-jogos-intro',
       target: 'body',
       placement: 'center',
-      title: 'O campeonato inteiro',
+      title: 'Os jogos do dia',
       content:
-        'Aqui é a visão geral do campeonato: rodadas, tabela e artilheiros num lugar só.',
+        'Aqui ficam os jogos de todos os campeonatos, dia por dia. É a resposta pra "o que tem hoje".',
     },
     {
-      id: 'fut-jogos-header',
-      target: '[data-tour="fut-jogos-header"]',
+      id: 'fut-jogos-datas',
+      target: '[data-tour="fut-jogos-datas"]',
       placement: 'bottom',
-      title: 'Competição e temporada',
+      title: 'Escolha o dia',
       content:
-        'Escolha a competição (Brasileirão, Série B, Copa) e a temporada aqui em cima.',
+        'Use as setas pra andar pelos dias, ou o calendário pra pular pra qualquer data. O pontinho embaixo do dia avisa que tem jogo.',
+    },
+    {
+      id: 'fut-jogos-lista',
+      target: '[data-tour="fut-jogos-lista"]',
+      placement: 'top',
+      title: 'Os jogos, por campeonato',
+      content:
+        'Dentro do dia, os jogos vêm separados por campeonato e na ordem do horário. A etiqueta na direita aparece quando aquele jogo tem oportunidade de valor.',
+    },
+  ];
+
+  if (hasPanel) {
+    steps.push({
+      id: 'fut-jogos-painel',
+      target: '[data-tour="fut-jogos-painel"]',
+      placement: 'left',
+      title: 'O resumo do lado',
+      content:
+        'Clique num jogo e o resumo abre aqui, sem sair da lista. Pra ver tudo (escalação, tendências, odds), é o botão "ver análise completa".',
+    });
+  }
+
+  return steps;
+}
+
+export const FUT_CAMPEONATO_TOUR_ID = 'futebol-campeonato';
+
+// Tela /futebol/campeonato/:slug — o que saiu da agenda: rodada, tabela e
+// artilheiros, que são conceitos por liga.
+export function makeFutebolCampeonatoSteps({ hasRounds }: { hasRounds: boolean }): Step[] {
+  const steps: Step[] = [
+    {
+      id: 'fut-camp-intro',
+      target: 'body',
+      placement: 'center',
+      title: 'O campeonato inteiro',
+      content: 'Aqui é a visão de um campeonato: rodadas, tabela e artilheiros num lugar só.',
+    },
+    {
+      id: 'fut-camp-header',
+      target: '[data-tour="fut-camp-header"]',
+      placement: 'bottom',
+      title: 'Campeonato e temporada',
+      content: 'Troque de campeonato ou de temporada aqui em cima.',
     },
   ];
 
   if (hasRounds) {
     steps.push({
-      id: 'fut-jogos-rodada',
-      target: '[data-tour="fut-jogos-rodada"]',
+      id: 'fut-camp-rodada',
+      target: '[data-tour="fut-camp-rodada"]',
       placement: 'bottom',
       title: 'Navegue pelas rodadas',
       content: 'Use as setas pra ir de uma rodada pra outra e ver os jogos de cada uma.',
     });
   }
 
-  steps.push(
-    {
-      id: 'fut-jogos-lista',
-      target: '[data-tour="fut-jogos-lista"]',
-      placement: 'top',
-      title: 'Os jogos da rodada',
-      content:
-        'Os jogos agrupados por dia. A etiqueta na direita mostra a faixa de valor de cada jogo. Toque pra abrir a análise completa.',
-    },
-    {
-      id: 'fut-jogos-tabela',
-      target: '[data-tour="fut-jogos-tabela"]',
-      placement: 'top',
-      title: 'Tabela e artilheiros',
-      content:
-        'Pra acompanhar a temporada: a classificação e os artilheiros, com a tabela e a lista completas a um toque.',
-    },
-  );
+  steps.push({
+    id: 'fut-camp-tabela',
+    target: '[data-tour="fut-camp-tabela"]',
+    placement: 'top',
+    title: 'Tabela e artilheiros',
+    content:
+      'Pra acompanhar a temporada: a classificação e os artilheiros, com a tabela e a lista completas a um toque.',
+  });
 
   return steps;
 }

--- a/src/components/onboarding/tours.tsx
+++ b/src/components/onboarding/tours.tsx
@@ -197,26 +197,37 @@ export function makeFutebolOportunidadesSteps({
 
 export const FUT_JOGO_TOUR_ID = 'futebol-jogo';
 
-// Tela /futebol/jogo/:id — análise completa da partida. Várias seções são
-// condicionais (só existem em jogo com valor / com dados descritivos), daí o
-// builder com flags. Mostrado uma vez (não por jogo).
+/**
+ * Tela /futebol/jogo/:id — a leitura da partida.
+ *
+ * Refeito para a página em abas e para a bancada de mercados. O tour antigo
+ * apontava para o card "o que olhar neste jogo", para o modelo de gols e para o
+ * bloco de contexto, três alvos que deixaram de existir no redesenho, e por isso
+ * estava desligado (as três flags iam `false` e sobrava só a introdução).
+ *
+ * Régua e premissas são condicionais porque dependem do mercado aberto: 1X2 e
+ * ambos marcam não têm linha para arrastar, e jogo sem coleta não tem premissa
+ * nenhuma para mostrar.
+ */
 export function makeFutebolJogoSteps({
-  hasValue,
-  hasModel,
-  hasContext,
+  hasRegua,
+  hasPremissas,
+  ladoALado,
 }: {
-  hasValue: boolean;
-  hasModel: boolean;
-  hasContext: boolean;
+  hasRegua: boolean;
+  hasPremissas: boolean;
+  /** Bancada em duas colunas (a partir de 1280px). Empilhada, o balão ao lado
+   *  não cabe: a folha do mercado é mais alta que a tela. */
+  ladoALado: boolean;
 }): Step[] {
   const steps: Step[] = [
     {
       id: 'fut-jogo-intro',
       target: 'body',
       placement: 'center',
-      title: 'A análise do jogo',
+      title: 'A leitura do jogo',
       content:
-        'Esta é a análise completa de uma partida. Tudo que a gente reuniu pra você decidir com base em dado.',
+        'Esta tela responde uma pergunta só: o que os números deste jogo sustentam. A aposta vem depois disso, não antes.',
     },
     {
       id: 'fut-jogo-header',
@@ -224,54 +235,53 @@ export function makeFutebolJogoSteps({
       placement: 'bottom',
       title: 'O confronto',
       content:
-        'Os dois times, a forma recente (os últimos resultados) e onde e quando o jogo acontece. Toque num escudo pra abrir o perfil do time.',
+        'Os dois times, como cada um vem chegando, e à direita a melhor leitura da partida com o Score dela.',
+    },
+    {
+      id: 'fut-jogo-abas',
+      target: '[data-tour="fut-jogo-abas"]',
+      placement: 'bottom',
+      title: 'Duas abas',
+      content:
+        'Leitura e mercados é onde a análise mora. Times é o retrato dos dois: campanha, forma e confrontos diretos.',
+    },
+    {
+      id: 'fut-jogo-mercados',
+      target: '[data-tour="fut-jogo-mercados"]',
+      placement: ladoALado ? 'right' : 'bottom',
+      title: 'Os cinco mercados, sempre à vista',
+      content:
+        'Gols, resultado, handicap, ambos marcam e dupla chance ficam sempre à mão, em coluna no computador e numa fileira que rola no celular. A barra é o Score de cada um, e o tracinho é a régua que separa o que vale olhar.',
+    },
+    {
+      id: 'fut-jogo-folha',
+      target: '[data-tour="fut-jogo-folha"]',
+      placement: ladoALado ? 'left' : 'center',
+      title: 'A folha do mercado',
+      content:
+        'Clique num mercado e ele abre aqui: a aposta, a chance, a odd, a vantagem sobre o preço e o veredito em uma frase.',
     },
   ];
 
-  if (hasValue) {
+  if (hasRegua) {
     steps.push({
-      id: 'fut-jogo-oque-olhar',
-      target: '[data-tour="fut-jogo-oque-olhar"]',
-      placement: 'top',
-      title: 'O que olhar neste jogo',
+      id: 'fut-jogo-regua',
+      target: '[data-tour="fut-jogo-regua"]',
+      placement: 'bottom',
+      title: 'Arraste a linha',
       content:
-        'O resumo da partida: a aposta de maior valor, o porquê dela, os pontos de atenção e o Score de confiabilidade num só lugar.',
+        'Nos gols e no handicap dá para arrastar a bolinha e ver a leitura mudar em cada linha. As bolinhas maiores são as linhas que mais premissas sustentam.',
     });
   }
 
-  // O passo do "Nosso modelo de gols" saiu junto com o card no pré-jogo: o modelo
-  // contava a história do mapa com um sinal que a recalibragem rebaixou. O `hasModel`
-  // agora significa "a página tem o mapa de premissas" (jogo futuro).
-  if (hasModel) {
+  if (hasPremissas) {
     steps.push({
-      id: 'fut-jogo-mapa',
-      target: '[data-tour="fut-jogo-mapa"]',
+      id: 'fut-jogo-premissas',
+      target: '[data-tour="fut-jogo-premissas"]',
       placement: 'top',
-      title: 'O mapa de premissas',
+      title: 'A favor e contra',
       content:
-        'O coração da análise: o que sustenta cada mercado deste jogo, com o número por trás de cada premissa e quantas faltam pra virar aposta.',
-    });
-  }
-
-  if (hasValue) {
-    steps.push({
-      id: 'fut-jogo-mercados',
-      target: '[data-tour="fut-jogo-mercados"]',
-      placement: 'top',
-      title: 'Explorar mercados',
-      content:
-        'Quer ir além do resumo? Aqui estão todos os mercados e opções, com chance, odd e valor lado a lado.',
-    });
-  }
-
-  if (hasContext) {
-    steps.push({
-      id: 'fut-jogo-contexto',
-      target: '[data-tour="fut-jogo-contexto"]',
-      placement: 'top',
-      title: 'O contexto pra fechar',
-      content:
-        'E pra completar a leitura: escalação provável, desfalques, confrontos diretos e as estatísticas da temporada.',
+        'Aqui está o porquê: o que sustenta a leitura, o que faltou acontecer e, em cada premissa, o "ver os jogos" abre o gráfico dos jogos que produziram aquele número.',
     });
   }
 
@@ -305,9 +315,9 @@ export function makeFutebolJogosSteps({ hasPanel }: { hasPanel: boolean }): Step
       id: 'fut-jogos-lista',
       target: '[data-tour="fut-jogos-lista"]',
       placement: 'top',
-      title: 'Os jogos, por campeonato',
+      title: 'A leitura na própria linha',
       content:
-        'Dentro do dia, os jogos vêm separados por campeonato e na ordem do horário. A etiqueta na direita aparece quando aquele jogo tem oportunidade de valor.',
+        'Os jogos vêm separados por campeonato, e cada campeonato recolhe. Na linha: o mercado, a aposta, a odd e o selo do Score. Jogo encerrado troca o Score por certo ou errado, dizendo se a leitura bateu.',
     },
   ];
 
@@ -316,9 +326,9 @@ export function makeFutebolJogosSteps({ hasPanel }: { hasPanel: boolean }): Step
       id: 'fut-jogos-painel',
       target: '[data-tour="fut-jogos-painel"]',
       placement: 'left',
-      title: 'O resumo do lado',
+      title: 'O porquê, do lado',
       content:
-        'Clique num jogo e o resumo abre aqui, sem sair da lista. Pra ver tudo (escalação, tendências, odds), é o botão "ver análise completa".',
+        'Clique num jogo e o resumo abre aqui, sem sair da lista: o que sustenta a leitura, o que pesa contra e como os dois times chegam. Pra ver tudo, é o botão de análise completa.',
     });
   }
 
@@ -327,23 +337,38 @@ export function makeFutebolJogosSteps({ hasPanel }: { hasPanel: boolean }): Step
 
 export const FUT_CAMPEONATO_TOUR_ID = 'futebol-campeonato';
 
-// Tela /futebol/campeonato/:slug — o que saiu da agenda: rodada, tabela e
-// artilheiros, que são conceitos por liga.
-export function makeFutebolCampeonatoSteps({ hasRounds }: { hasRounds: boolean }): Step[] {
+/**
+ * Tela /futebol/campeonato/:slug — o campeonato inteiro.
+ *
+ * O último passo muda de assunto conforme a competição: liga tem tabela, copa
+ * tem chaveamento. Falar em "classificação" numa copa seria descrever uma tela
+ * que a pessoa não está vendo.
+ */
+export function makeFutebolCampeonatoSteps({
+  hasRounds,
+  ehCopa,
+  isMobile,
+}: {
+  hasRounds: boolean;
+  ehCopa: boolean;
+  /** No celular a tabela/chave vive dentro de abas, e o alvo do desktop não existe. */
+  isMobile: boolean;
+}): Step[] {
   const steps: Step[] = [
     {
       id: 'fut-camp-intro',
       target: 'body',
       placement: 'center',
       title: 'O campeonato inteiro',
-      content: 'Aqui é a visão de um campeonato: rodadas, tabela e artilheiros num lugar só.',
+      content: 'Aqui é a visão de uma competição: rodada a rodada, com os números da temporada.',
     },
     {
       id: 'fut-camp-header',
       target: '[data-tour="fut-camp-header"]',
       placement: 'bottom',
-      title: 'Campeonato e temporada',
-      content: 'Troque de campeonato ou de temporada aqui em cima.',
+      title: 'Competição e números',
+      content:
+        'Troque de campeonato ou de temporada aqui em cima. Embaixo ficam os números da temporada: média de gols, quanto passa de 2,5, quanto o mandante ganha e em quantos jogos os dois lados marcam.',
     },
   ];
 
@@ -352,18 +377,30 @@ export function makeFutebolCampeonatoSteps({ hasRounds }: { hasRounds: boolean }
       id: 'fut-camp-rodada',
       target: '[data-tour="fut-camp-rodada"]',
       placement: 'bottom',
-      title: 'Navegue pelas rodadas',
-      content: 'Use as setas pra ir de uma rodada pra outra e ver os jogos de cada uma.',
+      title: ehCopa ? 'A régua de fases' : 'A régua de rodadas',
+      content: ehCopa
+        ? 'Todas as fases numa linha, da primeira até a final: clique em qualquer uma pra ver os jogos dela. As de areia já passaram, a verde é a que está aberta.'
+        : 'A temporada inteira numa linha: clique em qualquer rodada pra ver os jogos dela. As de areia já passaram, a verde é a que está aberta.',
     });
   }
 
+  // O alvo muda por viewport: no desktop é a coluna da direita, no celular é a
+  // barra de abas (a coluna existe no DOM mas fica escondida, e apontar pra ela
+  // deixava o último passo no vazio).
   steps.push({
     id: 'fut-camp-tabela',
-    target: '[data-tour="fut-camp-tabela"]',
-    placement: 'top',
-    title: 'Tabela e artilheiros',
-    content:
-      'Pra acompanhar a temporada: a classificação e os artilheiros, com a tabela e a lista completas a um toque.',
+    target: isMobile ? '[data-tour="fut-camp-abas"]' : '[data-tour="fut-camp-tabela"]',
+    placement: isMobile ? 'bottom' : 'top',
+    title: isMobile
+      ? (ehCopa ? 'Fase, chave e artilheiros' : 'Rodada, tabela e artilheiros')
+      : (ehCopa ? 'A chave e os artilheiros' : 'A tabela e os artilheiros'),
+    content: isMobile
+      ? (ehCopa
+          ? 'Nestas abas você troca entre os jogos da fase, a chave da competição (ou a tabela dos grupos, quando ela está na fase de grupos) e os artilheiros.'
+          : 'Nestas abas você troca entre os jogos da rodada, a classificação separada por zona e os artilheiros.')
+      : (ehCopa
+          ? 'Copa não tem tabela de pontos, tem chave: os confrontos fase a fase até a final, com ida e volta somadas. Na fase de grupos, este mesmo espaço mostra a tabela de cada grupo.'
+          : 'A classificação vem separada por zona, com o miolo recolhido pra caber na tela, e logo abaixo os artilheiros.'),
   });
 
   return steps;

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -27,9 +27,10 @@ export const config = {
     enableRealTimeUpdates: import.meta.env.VITE_ENABLE_REAL_TIME_UPDATES === 'true',
     enableDataExport: import.meta.env.VITE_ENABLE_DATA_EXPORT === 'true',
     enableAnalytics: import.meta.env.VITE_ENABLE_ANALYTICS === 'true',
-    // Cross-sell da Plataforma Futebol — ligado por padrão; kill switch via
-    // VITE_CROSSSELL_FUTEBOL=off (sem deploy de código).
-    enableCrossSellFutebol: import.meta.env.VITE_CROSSSELL_FUTEBOL !== 'off',
+    // Cross-sell da Plataforma Futebol — campanha do bolão da Copa, encerrada.
+    // Desligado por padrão; religa via VITE_CROSSSELL_FUTEBOL=on (sem deploy de
+    // código). O preview por ?crosssell na URL continua funcionando pra demo.
+    enableCrossSellFutebol: import.meta.env.VITE_CROSSSELL_FUTEBOL === 'on',
   },
   
   data: {

--- a/src/hooks/use-crosssell-futebol.ts
+++ b/src/hooks/use-crosssell-futebol.ts
@@ -8,7 +8,7 @@ import { canUseCrossSellFutebol } from '@/config/environment';
  * Regra de exibição:
  *  - 1x por dia (chave datada em localStorage), site-wide;
  *  - respeita opt-out permanente ("não mostrar de novo");
- *  - kill switch via env (VITE_CROSSSELL_FUTEBOL=off).
+ *  - desligado por padrão (campanha encerrada); religa com VITE_CROSSSELL_FUTEBOL=on.
  *
  * O gate de rota/usuário fica no CrossSellManager; aqui só cuidamos da
  * regra de frequência + persistência + eventos de analytics.

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -6,6 +6,12 @@ import {
   type FutebolAccess,
   type Competition,
   type FutebolFixture,
+  type FutebolFixtureByDay,
+  type FutebolFixtureDay,
+  type FutebolFixturePremissas,
+  type FutebolFixtureNumeros,
+  type FutebolFixtureHistorico,
+  type FutebolCompetitionInfo,
   type FutebolFixtureDetail,
   type FutebolFixtureExtras,
   type FutebolH2HMeeting,
@@ -46,6 +52,88 @@ export function useFutebolFixtures(competition: Competition, season: number, rou
     queryFn: () => futebolDataService.getFixtures(competition, season, round),
     staleTime: 5 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/**
+ * Agenda de UM dia (BRT) em todas as ligas. É o caminho novo da /futebol/jogos.
+ * Prefira este ao useFutebolFixturesMulti quando a pergunta é "o que tem no dia X":
+ * uma chamada de ~16 KB no pior dia, contra ~850 KB das 8 chamadas por liga.
+ * `day` é chave `YYYY-MM-DD` (use brtToday()/addDays de utils/futebol-datas).
+ */
+export function useFutebolFixturesByDay(day: string | null | undefined, competitions?: string[] | null) {
+  return useQuery<FutebolFixtureByDay[]>({
+    queryKey: ['futebol', 'fixtures-by-day', day, competitions ?? 'all'],
+    queryFn: () => futebolDataService.getFixturesByDay(day as string, competitions),
+    enabled: !!day,
+    staleTime: 2 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/** Dias com jogo no intervalo, pra régua de datas saber onde tem jogo e quantos. */
+export function useFutebolFixtureDays(from: string | null | undefined, to: string | null | undefined) {
+  return useQuery<FutebolFixtureDay[]>({
+    queryKey: ['futebol', 'fixture-days', from, to],
+    queryFn: () => futebolDataService.getFixtureDays(from as string, to as string),
+    enabled: !!from && !!to,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/**
+ * Mapa de premissas do jogo (acesas e apagadas), nos 5 mercados. É o conteúdo
+ * analítico que existe mesmo sem odd coletada, então não depende de preço.
+ */
+export function useFutebolFixturePremissas(fixtureId: number | undefined) {
+  return useQuery<FutebolFixturePremissas[]>({
+    queryKey: ['futebol', 'fixture-premissas', fixtureId],
+    queryFn: () => futebolDataService.getFixturePremissas(fixtureId as number),
+    enabled: !!fixtureId,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/** Números de temporada dos dois times, para embasar cada premissa com o dado real. */
+export function useFutebolFixtureNumeros(fixtureId: number | undefined) {
+  return useQuery<FutebolFixtureNumeros[]>({
+    queryKey: ['futebol', 'fixture-numeros', fixtureId],
+    queryFn: () => futebolDataService.getFixtureNumeros(fixtureId as number),
+    enabled: !!fixtureId,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/** Jogo a jogo dos dois times: é o que sustenta o gráfico embaixo de cada premissa. */
+export function useFutebolFixtureHistorico(fixtureId: number | undefined) {
+  return useQuery<FutebolFixtureHistorico[]>({
+    queryKey: ['futebol', 'fixture-historico', fixtureId],
+    queryFn: () => futebolDataService.getFixtureHistorico(fixtureId as number),
+    enabled: !!fixtureId,
+    staleTime: 10 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/**
+ * Competições e temporadas que existem no mart. Cache longo: muda quando o Mateus
+ * sobe liga nova, não a cada minuto.
+ */
+export function useFutebolCompetitions() {
+  return useQuery<FutebolCompetitionInfo[]>({
+    queryKey: ['futebol', 'competitions'],
+    queryFn: () => futebolDataService.getCompetitions(),
+    staleTime: 30 * 60 * 1000,
+    gcTime: 60 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 }

--- a/src/index.css
+++ b/src/index.css
@@ -448,10 +448,36 @@ All colors MUST be HSL.
    fundo pra hierarquia).
    ============================================================================ */
 
+/* Calendário da agenda de futebol: o ponto do dia com jogo e o anel de hoje. Vivem
+   aqui porque o react-day-picker aplica as classes no <button> do dia, e o
+   pseudo-elemento é o único jeito de marcar sem mexer no conteúdo. */
+.fut-dia-com-jogo::after {
+  content: '';
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 4px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(10, 61, 46, 0.55);
+}
+.fut-dia-escolhido.fut-dia-com-jogo::after {
+  background: rgba(255, 255, 255, 0.75);
+}
+.fut-dia-hoje:not(.fut-dia-escolhido) {
+  box-shadow: inset 0 0 0 1.5px #d4a017;
+  color: #b8870f;
+}
+
 .theme-bolao {
   /* Brand */
-  --canvas: #f6f7f5;
-  --canvas-2: #eef0eb;
+  /* O chão da página é bege, não branco-acinzentado: com --canvas quase branco, o
+     card branco em cima dele sumia. O conteúdo continua branco; o bege é o chão e o
+     rótulo (cabeçalho de card). Decisão do protótipo "Futebol Jogo", vale para
+     todas as telas do tema. */
+  --canvas: #f8f4ea;
+  --canvas-2: #f1e9d6;
   --ink: #1a1d1a;
   --ink-2: #4a4f48;
   --ink-3: #8a8f86;

--- a/src/index.css
+++ b/src/index.css
@@ -481,8 +481,11 @@ All colors MUST be HSL.
   --ink: #1a1d1a;
   --ink-2: #4a4f48;
   --ink-3: #8a8f86;
-  --line: #e3e6e0;
-  --line-2: #d4d8d0;
+  /* Linha areia: a borda do card precisa conversar com o chão bege. O cinza
+     esverdeado antigo virava um contorno frio em cima do areia, e as telas de
+     futebol acabaram cravando #ded2b6 no arquivo pra fugir dele. Agora é token. */
+  --line: #ded2b6;
+  --line-2: #cbbb92;
   --forest: #0a3d2e;
   --forest-2: #0f5238;
   --amber: #d4a017;

--- a/src/pages/Analise360Detail.tsx
+++ b/src/pages/Analise360Detail.tsx
@@ -140,10 +140,10 @@ function gapBarColor(pct: number): string {
 }
 
 function scoreColor(score: number | null): string {
-  if (score == null) return 'bg-ink-3 text-ink-2';
+  if (score == null) return 'bg-canvas-2 text-ink-2';
   if (score >= 75) return 'bg-emerald-100 text-emerald-700';
   if (score >= 60) return 'bg-amber-100 text-amber-700';
-  return 'bg-ink-3 text-ink-2';
+  return 'bg-canvas-2 text-ink-2';
 }
 
 function getSatelliteRing(pct: number): string {
@@ -201,7 +201,7 @@ function PlayerPhoto({
   }[size];
 
   return (
-    <div className={`${sizeClass} rounded-full overflow-hidden bg-ink-3 border border-line shrink-0 flex items-center justify-center ${ringClass ?? ''}`}>
+    <div className={`${sizeClass} rounded-full overflow-hidden bg-canvas-2 border border-line shrink-0 flex items-center justify-center ${ringClass ?? ''}`}>
       <img
         src={getPlayerPhotoUrl(name, teamAbbr)}
         alt={name}
@@ -331,7 +331,7 @@ function MandalaView({
                     ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
                     : pct < -3
                     ? 'bg-status-danger/10 text-status-danger border border-status-danger/20'
-                    : 'bg-ink-3 text-ink-2 border border-line'
+                    : 'bg-canvas-2 text-ink-2 border border-line'
                 }`}>
                   {isPos ? '+' : ''}{pct.toFixed(0)}%
                 </span>
@@ -503,7 +503,7 @@ function MobileChain({
                     ? 'bg-emerald-50 text-emerald-700 border border-emerald-200'
                     : pct < -3
                     ? 'bg-status-danger/10 text-status-danger border border-status-danger/20'
-                    : 'bg-ink-3 text-ink-2 border border-line'
+                    : 'bg-canvas-2 text-ink-2 border border-line'
                 }`}>
                   {isPos ? '+' : ''}{pct.toFixed(0)}%
                 </span>
@@ -779,7 +779,7 @@ export default function Analise360Detail() {
         <title>{triggerInfo ? `${triggerInfo.triggerName} · Análise 360°` : 'Análise 360°'} — Smart Betting</title>
       </Helmet>
 
-      <div className="theme-rebrand min-h-screen bg-canvas text-ink">
+      <div className="theme-bolao min-h-screen bg-canvas text-ink">
         <AnalyticsNav variant="rebrand" showBack backTo="/analise-360" />
         <OnboardingTour tourId={ANALISE360_DETAIL_TOUR_ID} steps={nbaAnalise360DetailSteps} run={a360Tour.run} onFinish={a360Tour.finish} />
 

--- a/src/pages/Analise360List.tsx
+++ b/src/pages/Analise360List.tsx
@@ -109,7 +109,7 @@ function PlayerPhoto({ name, teamAbbr, size = 'md' }: { name: string; teamAbbr: 
   const sizeClass = size === 'lg' ? 'w-12 h-12' : size === 'md' ? 'w-10 h-10' : 'w-8 h-8';
   const textClass = size === 'lg' ? 'text-sm' : size === 'md' ? 'text-[11px]' : 'text-[9px]';
   return (
-    <div className={`${sizeClass} rounded-full overflow-hidden bg-ink-3 border border-line shrink-0 flex items-center justify-center`}>
+    <div className={`${sizeClass} rounded-full overflow-hidden bg-canvas-2 border border-line shrink-0 flex items-center justify-center`}>
       <img
         src={getPlayerPhotoUrl(name, teamAbbr)}
         alt={name}
@@ -151,7 +151,7 @@ function FilterPill({
       className={`px-2.5 py-1 text-[11px] font-medium rounded-md border transition-colors ${
         active
           ? PILL_ACTIVE_CLS[tone]
-          : 'text-ink-2 border-transparent hover:text-ink hover:bg-ink-3/60'
+          : 'text-ink-2 border-transparent hover:text-ink hover:bg-canvas-2'
       }`}
     >
       {children}
@@ -355,7 +355,7 @@ export default function Analise360List() {
         <title>Análise 360° — Smart Betting</title>
       </Helmet>
 
-      <div className="theme-rebrand min-h-screen bg-canvas text-ink">
+      <div className="theme-bolao min-h-screen bg-canvas text-ink">
         <AnalyticsNav variant="rebrand" showBack backTo="/home-nba" />
         <OnboardingTour tourId={ANALISE360_LIST_TOUR_ID} steps={a360ListSteps} run={a360ListTour.run} onFinish={a360ListTour.finish} />
 

--- a/src/pages/Bankroll.tsx
+++ b/src/pages/Bankroll.tsx
@@ -141,7 +141,7 @@ export default function Bankroll() {
 
   if (authLoading || isLoading) {
     return (
-      <div className="theme-rebrand min-h-screen bg-canvas text-ink flex items-center justify-center">
+      <div className="theme-bolao min-h-screen bg-canvas text-ink flex items-center justify-center">
         <div className="text-ink-2 text-[13px]">Carregando...</div>
       </div>
     );
@@ -200,7 +200,7 @@ export default function Bankroll() {
   };
 
   return (
-    <div className="theme-rebrand w-full min-h-screen bg-canvas text-ink">
+    <div className="theme-bolao w-full min-h-screen bg-canvas text-ink">
       <AnalyticsNav variant="rebrand" showBack />
       <OnboardingTour tourId={BANKROLL_TOUR_ID} steps={bankrollSteps} run={bankrollTour.run} onFinish={bankrollTour.finish} />
 
@@ -223,7 +223,7 @@ export default function Bankroll() {
                 setMovementDate('');
                 setMovementModalOpen(true);
               }}
-              className="h-9 px-3 inline-flex items-center gap-2 text-[13px] font-medium text-ink-2 hover:text-ink border border-line bg-white hover:bg-ink-3/40 rounded-md transition-colors"
+              className="h-9 px-3 inline-flex items-center gap-2 text-[13px] font-medium text-ink-2 hover:text-ink border border-line bg-white hover:bg-canvas-2 rounded-md transition-colors"
             >
               <ArrowUpCircle className="w-4 h-4" />
               <span>Resgate</span>
@@ -410,11 +410,11 @@ export default function Bankroll() {
                     className="bg-white"
                     classNames={{
                       caption_label: 'text-sm font-semibold text-ink',
-                      nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                      nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                       head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                      day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                      day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                       day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                      day_today: 'bg-ink-3 text-ink font-semibold',
+                      day_today: 'bg-canvas-2 text-ink font-semibold',
                       day_outside: 'text-ink-2 opacity-40',
                       day_disabled: 'text-ink-2 opacity-30',
                     }}
@@ -457,7 +457,7 @@ export default function Bankroll() {
           <AlertDialogFooter>
             <AlertDialogCancel
               disabled={deleteConfirming}
-              className="h-9 px-4 text-[13px] font-medium text-ink-2 hover:text-ink border-line bg-white hover:bg-ink-3/40"
+              className="h-9 px-4 text-[13px] font-medium text-ink-2 hover:text-ink border-line bg-white hover:bg-canvas-2"
             >
               Cancelar
             </AlertDialogCancel>

--- a/src/pages/Bets.tsx
+++ b/src/pages/Bets.tsx
@@ -284,10 +284,10 @@ const BetRow = React.memo(function BetRow({
     bet.status === 'half_lost' ? 'text-status-danger bg-status-danger/15 border-status-danger/30' :
     bet.status === 'pending' ? 'text-status-warning bg-status-warning/10 border-status-warning/20' :
     bet.status === 'cashout' ? 'text-forest bg-forest-tint border-forest/20' :
-    'text-ink-2 bg-ink-3 border-line';
+    'text-ink-2 bg-canvas-2 border-line';
 
   return (
-    <tr className="border-b border-line hover:bg-ink-3/30 transition-colors">
+    <tr className="border-b border-line hover:bg-canvas-2 transition-colors">
       <td className="py-2 px-1.5 w-8">
         <input
           type="checkbox"
@@ -401,7 +401,7 @@ const BetRow = React.memo(function BetRow({
                     <TrendingDown className="w-4 h-4 text-status-danger opacity-70" />
                     <span>1/2 Red</span>
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => updateBetStatus(bet.id, 'void')} className="flex items-center gap-2 cursor-pointer focus:bg-ink-3/60">
+                  <DropdownMenuItem onClick={() => updateBetStatus(bet.id, 'void')} className="flex items-center gap-2 cursor-pointer focus:bg-canvas-2">
                     <X className="w-4 h-4 text-ink-2" />
                     <span>Anulada</span>
                   </DropdownMenuItem>
@@ -420,7 +420,7 @@ const BetRow = React.memo(function BetRow({
           <button
             type="button"
             onClick={() => openEditModal(bet)}
-            className="h-7 w-7 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-ink-3/60 rounded transition-colors shrink-0"
+            className="h-7 w-7 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-canvas-2 rounded transition-colors shrink-0"
             title="Editar"
           >
             <Edit className="w-4 h-4" />
@@ -474,7 +474,7 @@ const BetCard = React.memo(function BetCard({
     bet.status === 'half_lost' ? 'text-status-danger bg-status-danger/15 border-status-danger/30' :
     bet.status === 'pending' ? 'text-status-warning bg-status-warning/10 border-status-warning/20' :
     bet.status === 'cashout' ? 'text-forest bg-forest-tint border-forest/20' :
-    'text-ink-2 bg-ink-3 border-line';
+    'text-ink-2 bg-canvas-2 border-line';
 
   return (
     <div className="bg-white border border-line-2 p-4 rounded-lg space-y-3 shadow-[0_1px_3px_rgba(0,0,0,0.04)]">
@@ -596,7 +596,7 @@ const BetCard = React.memo(function BetCard({
                   <TrendingDown className="w-4 h-4 text-status-danger opacity-70" />
                   <span>1/2 Red</span>
                 </DropdownMenuItem>
-                <DropdownMenuItem onClick={() => updateBetStatus(bet.id, 'void')} className="flex items-center gap-2 cursor-pointer focus:bg-ink-3/60">
+                <DropdownMenuItem onClick={() => updateBetStatus(bet.id, 'void')} className="flex items-center gap-2 cursor-pointer focus:bg-canvas-2">
                   <X className="w-4 h-4 text-ink-2" />
                   <span>Anulada</span>
                 </DropdownMenuItem>
@@ -611,7 +611,7 @@ const BetCard = React.memo(function BetCard({
               <DollarSign className="w-4 h-4 text-forest shrink-0" />
               <span className="text-xs font-semibold text-forest uppercase tracking-[0.04em]">Cashout</span>
             </button>
-            <button type="button" onClick={() => openEditModal(bet)} className="h-9 w-9 rounded-md bg-white border border-line text-ink-2 hover:text-ink hover:bg-ink-3/60 transition-colors flex items-center justify-center" title="Editar">
+            <button type="button" onClick={() => openEditModal(bet)} className="h-9 w-9 rounded-md bg-white border border-line text-ink-2 hover:text-ink hover:bg-canvas-2 transition-colors flex items-center justify-center" title="Editar">
               <Edit className="w-4 h-4" />
             </button>
             <button type="button" onClick={() => deleteBet(bet.id)} className="h-9 w-9 rounded-md bg-white border border-line text-ink-2 hover:text-status-danger hover:bg-status-danger/10 hover:border-status-danger/30 transition-colors flex items-center justify-center" title="Excluir">
@@ -623,7 +623,7 @@ const BetCard = React.memo(function BetCard({
             <button
               type="button"
               onClick={() => openEditModal(bet)}
-              className="flex-1 h-10 rounded-md bg-white border border-line text-ink-2 hover:text-ink hover:bg-ink-3/60 transition-colors flex items-center justify-center gap-2"
+              className="flex-1 h-10 rounded-md bg-white border border-line text-ink-2 hover:text-ink hover:bg-canvas-2 transition-colors flex items-center justify-center gap-2"
               title="Editar"
             >
               <Edit className="w-4 h-4" />
@@ -2092,7 +2092,7 @@ export default function Bets() {
     if (value === 'lost' || value === 'half_lost') return 'bg-status-danger/10 text-status-danger border-status-danger/30';
     if (value === 'pending') return 'bg-status-warning/10 text-status-warning border-status-warning/30';
     if (value === 'cashout') return 'bg-forest-tint text-forest border-forest/30';
-    return 'bg-ink-3 text-ink-2 border-line';
+    return 'bg-canvas-2 text-ink-2 border-line';
   };
 
   // Conta total de filtros ativos no botão "Mais filtros" / "Filtros"
@@ -2136,7 +2136,7 @@ export default function Bets() {
         {/* Período — segmented control + popover de calendário em "Personalizado" */}
         <div>
           <label className="text-[10px] uppercase tracking-[0.12em] text-ink-2 font-semibold">Período</label>
-          <div className="mt-2 grid grid-cols-3 gap-1 p-1 bg-ink-3/60 rounded-md text-[11px] font-medium">
+          <div className="mt-2 grid grid-cols-3 gap-1 p-1 bg-canvas-2 rounded-md text-[11px] font-medium">
             {([
               { k: '7d', l: '7d' },
               { k: '30d', l: '30d' },
@@ -2208,11 +2208,11 @@ export default function Bets() {
                   numberOfMonths={2}
                   classNames={{
                     caption_label: 'text-sm font-semibold text-ink',
-                    nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                    nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                     head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                    day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                    day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                     day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                    day_today: 'bg-ink-3 text-ink font-semibold',
+                    day_today: 'bg-canvas-2 text-ink font-semibold',
                     day_outside: 'text-ink-2 opacity-40',
                     day_disabled: 'text-ink-2 opacity-30',
                     day_range_middle: 'aria-selected:bg-forest-tint aria-selected:text-forest aria-selected:rounded-none',
@@ -2462,7 +2462,7 @@ export default function Bets() {
   }
 
   return (
-    <div className="theme-rebrand w-full min-h-screen bg-canvas text-ink">
+    <div className="theme-bolao w-full min-h-screen bg-canvas text-ink">
       <AnalyticsNav variant="rebrand" showBack />
       <OnboardingTour tourId={BETINHO_TOUR_ID} steps={betinhoSteps} run={betinhoTour.run} onFinish={betinhoTour.finish} />
 
@@ -2478,7 +2478,7 @@ export default function Bets() {
           </div>
           <div className="flex flex-wrap items-center gap-2">
             {/* Toggle R$ / u */}
-            <div className="h-9 inline-flex items-center p-0.5 bg-ink-3 border border-line rounded-md">
+            <div className="h-9 inline-flex items-center p-0.5 bg-canvas-2 border border-line rounded-md">
               <button
                 type="button"
                 onClick={() => setShowUnitsView(false)}
@@ -2510,7 +2510,7 @@ export default function Bets() {
             <button
               type="button"
               onClick={() => setUnitConfigOpen(true)}
-              className="h-9 px-2 md:px-2.5 inline-flex items-center gap-1.5 text-[11px] text-ink-2 hover:text-ink border border-line bg-white hover:bg-ink-3/40 rounded-md transition-colors"
+              className="h-9 px-2 md:px-2.5 inline-flex items-center gap-1.5 text-[11px] text-ink-2 hover:text-ink border border-line bg-white hover:bg-canvas-2 rounded-md transition-colors"
               title={isConfigured() && config.unit_value ? `1u = ${formatCurrency(config.unit_value)}` : 'Configurar unidade'}
             >
               {isConfigured() && config.unit_value ? (
@@ -2531,7 +2531,7 @@ export default function Bets() {
             <button
               type="button"
               onClick={handleExportCsv}
-              className="h-9 px-2 md:px-3 inline-flex items-center gap-2 text-[13px] font-medium text-ink-2 hover:text-ink border border-line bg-white hover:bg-ink-3/40 rounded-md transition-colors"
+              className="h-9 px-2 md:px-3 inline-flex items-center gap-2 text-[13px] font-medium text-ink-2 hover:text-ink border border-line bg-white hover:bg-canvas-2 rounded-md transition-colors"
               title="Exportar CSV"
               aria-label="Exportar CSV"
             >
@@ -2543,7 +2543,7 @@ export default function Bets() {
             <button
               type="button"
               onClick={() => setIsShareModalOpen(true)}
-              className="h-9 px-2 md:px-3 inline-flex items-center gap-2 text-[13px] font-medium text-ink-2 hover:text-ink border border-line bg-white hover:bg-ink-3/40 rounded-md transition-colors"
+              className="h-9 px-2 md:px-3 inline-flex items-center gap-2 text-[13px] font-medium text-ink-2 hover:text-ink border border-line bg-white hover:bg-canvas-2 rounded-md transition-colors"
               title="Compartilhar"
             >
               <Share2 className="w-4 h-4" />
@@ -2961,11 +2961,11 @@ export default function Bets() {
                 numberOfMonths={1}
                 classNames={{
                   caption_label: 'text-sm font-semibold text-ink',
-                  nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                  nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                   head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                  day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                  day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                   day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                  day_today: 'bg-ink-3 text-ink font-semibold',
+                  day_today: 'bg-canvas-2 text-ink font-semibold',
                   day_outside: 'text-ink-2 opacity-40',
                   day_disabled: 'text-ink-2 opacity-30',
                   day_range_middle: 'aria-selected:bg-forest-tint aria-selected:text-forest aria-selected:rounded-none',
@@ -3019,7 +3019,7 @@ export default function Bets() {
         <div className="hidden md:block bg-white border border-line rounded-lg p-3 mb-4">
           <div className="flex flex-wrap items-center gap-2">
               {/* Search */}
-              <div className="flex items-center gap-2 px-2.5 h-9 bg-ink-3/40 border border-line rounded-md w-[200px]">
+              <div className="flex items-center gap-2 px-2.5 h-9 bg-canvas-2 border border-line rounded-md w-[200px]">
                 <Search className="w-4 h-4 text-ink-2 shrink-0" />
                 <input
                   type="text"
@@ -3097,7 +3097,7 @@ export default function Bets() {
                 <PopoverTrigger asChild>
                   <button
                     type="button"
-                    className="h-9 px-3 inline-flex items-center gap-2 text-[12px] text-ink-2 border border-line bg-white hover:bg-ink-3/40 rounded-md transition-colors font-medium"
+                    className="h-9 px-3 inline-flex items-center gap-2 text-[12px] text-ink-2 border border-line bg-white hover:bg-canvas-2 rounded-md transition-colors font-medium"
                   >
                     <span className="font-semibold uppercase tracking-[0.08em] text-[10px] text-ink-2">PERÍODO</span>
                     {(() => {
@@ -3164,11 +3164,11 @@ export default function Bets() {
                     initialFocus
                     classNames={{
                       caption_label: 'text-sm font-semibold text-ink',
-                      nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                      nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                       head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                      day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                      day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                       day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                      day_today: 'bg-ink-3 text-ink font-semibold',
+                      day_today: 'bg-canvas-2 text-ink font-semibold',
                       day_outside: 'text-ink-2 opacity-40',
                       day_disabled: 'text-ink-2 opacity-30',
                       day_range_middle: 'aria-selected:bg-forest-tint aria-selected:text-forest aria-selected:rounded-none',
@@ -3201,7 +3201,7 @@ export default function Bets() {
                     className={`h-9 px-3 inline-flex items-center gap-2 text-[12px] font-semibold border rounded-md transition-colors ${
                       advancedFiltersTotal > 0
                         ? 'text-forest border-forest/30 bg-forest-tint hover:bg-forest-tint/80'
-                        : 'text-ink-2 border-line bg-white hover:bg-ink-3/40 hover:text-ink'
+                        : 'text-ink-2 border-line bg-white hover:bg-canvas-2 hover:text-ink'
                     }`}
                   >
                     <Filter className="w-3.5 h-3.5" />
@@ -3242,7 +3242,7 @@ export default function Bets() {
             <button
               type="button"
               onClick={fetchBets}
-              className="h-8 w-8 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-ink-3/40 rounded-md transition-colors"
+              className="h-8 w-8 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-canvas-2 rounded-md transition-colors"
               title="Atualizar"
             >
               <RefreshCw className={`w-3.5 h-3.5 shrink-0 ${isLoading ? 'animate-spin' : ''}`} />
@@ -3252,7 +3252,7 @@ export default function Bets() {
           {isLoading ? (
             <div className="space-y-2 p-5">
               {[...Array(5)].map((_, i) => (
-                <Skeleton key={i} className="h-10 w-full bg-ink-3" />
+                <Skeleton key={i} className="h-10 w-full bg-canvas-2" />
               ))}
             </div>
           ) : filteredBets.length === 0 ? (
@@ -3266,7 +3266,7 @@ export default function Bets() {
               {/* Desktop Table View */}
               <div className="hidden md:block overflow-x-auto">
                 <table className="w-full text-[12px] min-w-[960px] table-auto">
-                  <thead className="bg-ink-3/40">
+                  <thead className="bg-canvas-2">
                     <tr>
                       <th className="py-2.5 px-1.5 w-8 text-left">
                         <input
@@ -3314,7 +3314,7 @@ export default function Bets() {
                     onClick={() => handlePageChange(currentPage - 1)}
                     disabled={currentPage === 1}
                     aria-label="Página anterior"
-                    className="h-8 w-8 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-ink-3/40 rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                    className="h-8 w-8 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-canvas-2 rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                   >
                     <ChevronLeft className="w-4 h-4" />
                   </button>
@@ -3342,7 +3342,7 @@ export default function Bets() {
                           className={`h-8 w-8 inline-flex items-center justify-center text-[12px] rounded-md font-medium transition-colors ${
                             p === currentPage
                               ? 'bg-forest text-white'
-                              : 'text-ink-2 hover:text-ink hover:bg-ink-3/40'
+                              : 'text-ink-2 hover:text-ink hover:bg-canvas-2'
                           }`}
                         >
                           {p}
@@ -3355,7 +3355,7 @@ export default function Bets() {
                     onClick={() => handlePageChange(currentPage + 1)}
                     disabled={currentPage === totalPages}
                     aria-label="Próxima página"
-                    className="h-8 w-8 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-ink-3/40 rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                    className="h-8 w-8 inline-flex items-center justify-center text-ink-2 hover:text-ink hover:bg-canvas-2 rounded-md transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                   >
                     <ChevronRight className="w-4 h-4" />
                   </button>
@@ -3477,7 +3477,7 @@ export default function Bets() {
                       <TrendingDown className="w-4 h-4 opacity-70" /> ½ Red
                     </button>
                     <button type="button" onClick={() => bulkUpdateStatus('void')}
-                      className="h-11 text-[12px] font-semibold border border-line text-ink-2 bg-white hover:bg-ink-3/40 rounded-md transition-colors flex items-center justify-center gap-2">
+                      className="h-11 text-[12px] font-semibold border border-line text-ink-2 bg-white hover:bg-canvas-2 rounded-md transition-colors flex items-center justify-center gap-2">
                       <X className="w-4 h-4" /> Anulada
                     </button>
                     <button type="button" onClick={bulkDelete}
@@ -3492,7 +3492,7 @@ export default function Bets() {
                         {userTags.map(tag => (
                           <button key={tag.id} type="button"
                             onClick={() => bulkAddTag(tag)}
-                            className="h-8 px-3 text-[11px] border border-line bg-white text-ink hover:bg-ink-3/40 rounded-md transition-colors flex items-center gap-1.5">
+                            className="h-8 px-3 text-[11px] border border-line bg-white text-ink hover:bg-canvas-2 rounded-md transition-colors flex items-center gap-1.5">
                             <span className="w-2 h-2 rounded-full" style={{ backgroundColor: tag.color }} />
                             {tag.name}
                           </button>
@@ -3509,7 +3509,7 @@ export default function Bets() {
               <Popover>
                 <PopoverTrigger asChild>
                   <button type="button"
-                    className="h-8 px-3 text-[11px] font-semibold border border-line text-ink-2 bg-white hover:bg-ink-3/40 hover:text-ink rounded-md transition-colors flex items-center gap-1.5">
+                    className="h-8 px-3 text-[11px] font-semibold border border-line text-ink-2 bg-white hover:bg-canvas-2 hover:text-ink rounded-md transition-colors flex items-center gap-1.5">
                     <Plus className="w-3.5 h-3.5" /> TAG
                   </button>
                 </PopoverTrigger>
@@ -3520,7 +3520,7 @@ export default function Bets() {
                     userTags.map(tag => (
                       <button key={tag.id} type="button"
                         onClick={() => bulkAddTag(tag)}
-                        className="w-full text-left px-2 py-1.5 text-[11px] text-ink hover:bg-ink-3/40 rounded flex items-center gap-2 transition-colors">
+                        className="w-full text-left px-2 py-1.5 text-[11px] text-ink hover:bg-canvas-2 rounded flex items-center gap-2 transition-colors">
                         <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: tag.color }} />
                         {tag.name}
                       </button>
@@ -3545,7 +3545,7 @@ export default function Bets() {
                 <TrendingDown className="w-3.5 h-3.5 opacity-70" /> ½ Red
               </button>
               <button type="button" onClick={() => bulkUpdateStatus('void')}
-                className="h-8 px-3 text-[11px] font-semibold border border-line text-ink-2 bg-white hover:bg-ink-3/40 hover:text-ink rounded-md transition-colors flex items-center gap-1.5">
+                className="h-8 px-3 text-[11px] font-semibold border border-line text-ink-2 bg-white hover:bg-canvas-2 hover:text-ink rounded-md transition-colors flex items-center gap-1.5">
                 <X className="w-3.5 h-3.5" /> Anulada
               </button>
               <button type="button" onClick={bulkDelete}
@@ -3640,7 +3640,7 @@ export default function Bets() {
                 <Button
                   onClick={() => setCashoutModal({ isOpen: false, bet: null, cashoutAmount: '', cashoutOdds: '' })}
                   variant="ghost"
-                  className="h-10 px-4 text-[13px] font-medium text-ink-2 hover:bg-ink-3/40 hover:text-ink"
+                  className="h-10 px-4 text-[13px] font-medium text-ink-2 hover:bg-canvas-2 hover:text-ink"
                 >
                   Cancelar
                 </Button>
@@ -3693,7 +3693,7 @@ export default function Bets() {
               <Button
                 onClick={() => setCapitalModal(prev => ({ ...prev, isOpen: false }))}
                 variant="outline"
-                className="flex-1 h-10 border-line bg-white hover:bg-ink-3/40 text-ink-2 hover:text-ink"
+                className="flex-1 h-10 border-line bg-white hover:bg-canvas-2 text-ink-2 hover:text-ink"
               >
                 Cancelar
               </Button>
@@ -3851,8 +3851,8 @@ export default function Bets() {
                               setIsSportQueryTouched(false);
                               setSportHighlightIndex(-1);
                             }}
-                            className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                              index === sportHighlightIndex ? 'bg-ink-3/40' : ''
+                            className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-canvas-2 ${
+                              index === sportHighlightIndex ? 'bg-canvas-2' : ''
                             }`}
                           >
                             {sport}
@@ -3974,8 +3974,8 @@ export default function Bets() {
                               setIsLeagueQueryTouched(false);
                               setLeagueHighlightIndex(-1);
                             }}
-                            className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                              index === leagueHighlightIndex ? 'bg-ink-3/40' : ''
+                            className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-canvas-2 ${
+                              index === leagueHighlightIndex ? 'bg-canvas-2' : ''
                             }`}
                           >
                             {league}
@@ -4093,8 +4093,8 @@ export default function Bets() {
                               setIsBettingMarketQueryTouched(false);
                               setBettingMarketHighlightIndex(-1);
                             }}
-                            className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-ink-3/40 ${
-                              index === bettingMarketHighlightIndex ? 'bg-ink-3/40' : ''
+                            className={`w-full text-left px-3 py-2 text-sm text-ink hover:bg-canvas-2 ${
+                              index === bettingMarketHighlightIndex ? 'bg-canvas-2' : ''
                             }`}
                           >
                             {market}
@@ -4198,7 +4198,7 @@ export default function Bets() {
                   <PopoverTrigger asChild>
                     <Button
                       variant="outline"
-                      className="w-full justify-start text-left font-normal h-10 bg-canvas border-line text-ink rounded-md hover:bg-ink-3/40 hover:text-ink"
+                      className="w-full justify-start text-left font-normal h-10 bg-canvas border-line text-ink rounded-md hover:bg-canvas-2 hover:text-ink"
                     >
                       <CalendarIcon className="mr-2 h-4 w-4 text-forest" />
                       {(() => {
@@ -4225,11 +4225,11 @@ export default function Bets() {
                       className="bg-white"
                       classNames={{
                         caption_label: 'text-sm font-semibold text-ink',
-                        nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                        nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                         head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                        day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                        day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                         day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                        day_today: 'bg-ink-3 text-ink font-semibold',
+                        day_today: 'bg-canvas-2 text-ink font-semibold',
                         day_outside: 'text-ink-2 opacity-40',
                         day_disabled: 'text-ink-2 opacity-30',
                       }}
@@ -4263,7 +4263,7 @@ export default function Bets() {
                 <Button
                   onClick={() => setEditModal(prev => ({ ...prev, isOpen: false }))}
                   variant="outline"
-                  className="flex-1 h-10 border-line bg-white hover:bg-ink-3/40 text-ink-2 hover:text-ink"
+                  className="flex-1 h-10 border-line bg-white hover:bg-canvas-2 text-ink-2 hover:text-ink"
                 >
                   Cancelar
                 </Button>
@@ -4324,7 +4324,7 @@ export default function Bets() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter className="mt-4">
-            <AlertDialogCancel className="h-10 px-4 text-[13px] font-medium text-ink-2 hover:text-ink border-line bg-white hover:bg-ink-3/40">
+            <AlertDialogCancel className="h-10 px-4 text-[13px] font-medium text-ink-2 hover:text-ink border-line bg-white hover:bg-canvas-2">
               Cancelar
             </AlertDialogCancel>
             <AlertDialogAction

--- a/src/pages/BettingDashboard.tsx
+++ b/src/pages/BettingDashboard.tsx
@@ -285,7 +285,7 @@ export default function BettingDashboard() {
 
   if (authLoading) {
     return (
-      <div className="theme-rebrand min-h-screen bg-canvas flex items-center justify-center">
+      <div className="theme-bolao min-h-screen bg-canvas flex items-center justify-center">
         <div className="animate-spin rounded-full h-12 w-12 border-2 border-forest border-t-transparent" />
       </div>
     );
@@ -293,7 +293,7 @@ export default function BettingDashboard() {
 
   if (!user) {
     return (
-      <div className="theme-rebrand min-h-screen bg-canvas text-ink flex items-center justify-center">
+      <div className="theme-bolao min-h-screen bg-canvas text-ink flex items-center justify-center">
         <div className="text-center">
           <AlertCircle className="h-12 w-12 mx-auto mb-4 text-status-danger" />
           <p className="text-[14px] text-ink-2">Por favor, faça login para ver o painel.</p>
@@ -303,7 +303,7 @@ export default function BettingDashboard() {
   }
 
   return (
-    <div className="theme-rebrand w-full min-h-screen bg-canvas text-ink">
+    <div className="theme-bolao w-full min-h-screen bg-canvas text-ink">
       <AnalyticsNav variant="rebrand" showBack />
       <OnboardingTour tourId={BETINHO_DASH_TOUR_ID} steps={dashSteps} run={dashTour.run} onFinish={dashTour.finish} />
 
@@ -331,7 +331,7 @@ export default function BettingDashboard() {
               </span>
             ) : (
               <span
-                className="h-7 px-2.5 inline-flex items-center rounded text-[10px] font-bold uppercase tracking-[0.14em] bg-ink-3 text-ink-2 border border-line"
+                className="h-7 px-2.5 inline-flex items-center rounded text-[10px] font-bold uppercase tracking-[0.14em] bg-canvas-2 text-ink-2 border border-line"
                 role="status"
                 aria-label="Plano Free"
                 title="Plano Free"
@@ -341,7 +341,7 @@ export default function BettingDashboard() {
             )}
 
             {/* Toggle R$ / u */}
-            <div className="h-9 inline-flex items-center p-0.5 bg-ink-3 border border-line rounded-md">
+            <div className="h-9 inline-flex items-center p-0.5 bg-canvas-2 border border-line rounded-md">
               <button
                 type="button"
                 onClick={() => setShowUnitsView(false)}
@@ -373,7 +373,7 @@ export default function BettingDashboard() {
             <button
               type="button"
               onClick={() => setUnitConfigOpen(true)}
-              className="h-9 px-2 md:px-2.5 inline-flex items-center gap-1.5 text-[11px] text-ink-2 hover:text-ink border border-line bg-white hover:bg-ink-3/40 rounded-md transition-colors"
+              className="h-9 px-2 md:px-2.5 inline-flex items-center gap-1.5 text-[11px] text-ink-2 hover:text-ink border border-line bg-white hover:bg-canvas-2 rounded-md transition-colors"
               title={isConfigured() && config?.unit_value ? `1u = ${formatCurrency(config.unit_value)}` : 'Configurar unidade'}
             >
               {isConfigured() && config?.unit_value ? (
@@ -393,7 +393,7 @@ export default function BettingDashboard() {
             <button
               type="button"
               onClick={() => exportBetsToCSV(currentBets, formatValue)}
-              className="h-9 px-2 md:px-3 inline-flex items-center gap-2 text-[13px] font-medium text-ink-2 hover:text-ink border border-line bg-white hover:bg-ink-3/40 rounded-md transition-colors"
+              className="h-9 px-2 md:px-3 inline-flex items-center gap-2 text-[13px] font-medium text-ink-2 hover:text-ink border border-line bg-white hover:bg-canvas-2 rounded-md transition-colors"
               title="Exportar CSV"
               aria-label="Exportar CSV"
             >
@@ -413,7 +413,7 @@ export default function BettingDashboard() {
                   <SelectItem
                     key={opt.value}
                     value={opt.value}
-                    className="text-ink text-[13px] focus:bg-ink-3/60 focus:text-ink"
+                    className="text-ink text-[13px] focus:bg-canvas-2 focus:text-ink"
                   >
                     {opt.label}
                   </SelectItem>
@@ -427,7 +427,7 @@ export default function BettingDashboard() {
                   <PopoverTrigger asChild>
                     <button
                       type="button"
-                      className="h-9 px-3 inline-flex items-center gap-2 text-[13px] bg-white border border-line text-ink hover:bg-ink-3/40 rounded-md w-full sm:w-[150px]"
+                      className="h-9 px-3 inline-flex items-center gap-2 text-[13px] bg-white border border-line text-ink hover:bg-canvas-2 rounded-md w-full sm:w-[150px]"
                     >
                       <CalendarIcon className="w-3.5 h-3.5 text-forest" />
                       <span className={customFrom ? 'tabular' : 'text-ink-2'}>
@@ -449,11 +449,11 @@ export default function BettingDashboard() {
                       className="bg-white"
                       classNames={{
                         caption_label: 'text-sm font-bold text-ink',
-                        nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                        nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                         head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                        day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                        day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                         day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                        day_today: 'bg-ink-3 text-ink font-bold',
+                        day_today: 'bg-canvas-2 text-ink font-bold',
                         day_outside: 'text-ink-2 opacity-40',
                         day_disabled: 'text-ink-2 opacity-30',
                       }}
@@ -464,7 +464,7 @@ export default function BettingDashboard() {
                   <PopoverTrigger asChild>
                     <button
                       type="button"
-                      className="h-9 px-3 inline-flex items-center gap-2 text-[13px] bg-white border border-line text-ink hover:bg-ink-3/40 rounded-md w-full sm:w-[150px]"
+                      className="h-9 px-3 inline-flex items-center gap-2 text-[13px] bg-white border border-line text-ink hover:bg-canvas-2 rounded-md w-full sm:w-[150px]"
                     >
                       <CalendarIcon className="w-3.5 h-3.5 text-forest" />
                       <span className={customTo ? 'tabular' : 'text-ink-2'}>
@@ -485,11 +485,11 @@ export default function BettingDashboard() {
                       className="bg-white"
                       classNames={{
                         caption_label: 'text-sm font-bold text-ink',
-                        nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-ink-3/40 hover:text-ink rounded-md inline-flex items-center justify-center',
+                        nav_button: 'h-7 w-7 bg-white border border-line text-ink-2 hover:bg-canvas-2 hover:text-ink rounded-md inline-flex items-center justify-center',
                         head_cell: 'text-ink-2 rounded-md w-9 font-medium text-[0.7rem] uppercase tracking-[0.08em]',
-                        day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-ink-3/40 rounded-md aria-selected:opacity-100',
+                        day: 'h-9 w-9 p-0 font-normal text-ink hover:bg-canvas-2 rounded-md aria-selected:opacity-100',
                         day_selected: 'bg-forest text-white hover:bg-forest hover:text-white focus:bg-forest focus:text-white',
-                        day_today: 'bg-ink-3 text-ink font-bold',
+                        day_today: 'bg-canvas-2 text-ink font-bold',
                         day_outside: 'text-ink-2 opacity-40',
                         day_disabled: 'text-ink-2 opacity-30',
                       }}
@@ -894,7 +894,7 @@ export default function BettingDashboard() {
             <button
               type="button"
               onClick={() => setExampleModalOpen(false)}
-              className="h-10 px-4 rounded-md border border-line text-[12px] font-bold text-ink-2 hover:text-ink hover:bg-ink-3/40 transition-colors flex-1"
+              className="h-10 px-4 rounded-md border border-line text-[12px] font-bold text-ink-2 hover:text-ink hover:bg-canvas-2 transition-colors flex-1"
             >
               Fechar
             </button>

--- a/src/pages/FutebolCampeonato.tsx
+++ b/src/pages/FutebolCampeonato.tsx
@@ -1,0 +1,570 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { CalendarDays, ChevronDown } from 'lucide-react';
+import AnalyticsNav from '@/components/AnalyticsNav';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { FixtureRow } from '@/components/futebol/FixtureRow';
+import { LigaCrest } from '@/components/futebol/LigaCrest';
+import { ReguaRodadas } from '@/components/futebol/ReguaRodadas';
+import { StandingsTable } from '@/components/futebol/StandingsTable';
+import { ScorersCard } from '@/components/futebol/ScorersCard';
+import {
+  useFutebolFixtures,
+  useFutebolStandings,
+  useFutebolLeaders,
+  useFutebolValueBoard,
+  useFutebolCompetitions,
+} from '@/hooks/use-futebol-data';
+import type { Competition, FutebolFixture, FutebolValueBoardRow } from '@/services/futebol-data.service';
+import { brtDayOf, fmtDayHeader, isFinished } from '@/utils/futebol-datas';
+import { groupBoardByFixture } from '@/utils/futebol-score';
+import { settleFutebol, isHit } from '@/utils/futebol-settlement';
+import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
+import { ChaveamentoBracket } from '@/components/futebol/ChaveamentoBracket';
+import { GruposFase } from '@/components/futebol/GruposFase';
+import { ehCampeonatoDePontos, ehMataMata, rodadaLonga } from '@/utils/futebol-rodadas';
+import OnboardingTour from '@/components/onboarding/OnboardingTour';
+import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
+import { FUT_CAMPEONATO_TOUR_ID, makeFutebolCampeonatoSteps } from '@/components/onboarding/tours';
+
+/**
+ * Um campeonato: rodada a rodada, classificação e artilheiros.
+ *
+ * É o que saiu da /futebol/jogos quando ela virou agenda por dia. Rodada e
+ * temporada são conceitos POR LIGA (rodada de ligas diferentes não se alinha),
+ * então o lugar deles é aqui, não numa lista multi-liga.
+ *
+ * Desenho do protótipo "Futebol Campeonato": faixa areia com o brasão e os
+ * números da temporada, régua de rodadas no lugar do stepper, e as duas colunas
+ * (jogos da rodada · tabela e artilheiros) que no celular viram três abas. Saiu
+ * a fileira de nove pills de liga, que estourava a linha, e saíram os dois
+ * modais.
+ *
+ * Campeonatos e temporadas vêm da RPC get_futebol_competitions, não de lista fixa
+ * no front. A lista fixa escondia a champions_league e as temporadas 2025 de La
+ * Liga, Premier, Libertadores e Sul-Americana.
+ */
+
+const DEFAULT_COMP = 'brasileirao';
+
+const d1 = (n: number) => n.toFixed(1).replace('.', ',');
+const pct = (n: number) => `${Math.round(n * 100)}%`;
+
+function Estatistica({ rotulo, valor, unidade }: { rotulo: string; valor: string; unidade: string }) {
+  return (
+    <div className="min-w-0">
+      <div className="text-[9.5px] uppercase tracking-[0.14em] font-bold" style={{ color: '#8d8672' }}>
+        {rotulo}
+      </div>
+      <div className="mt-0.5 flex items-baseline gap-1.5">
+        <span className="text-[18px] leading-none font-semibold tabular-nums text-ink">{valor}</span>
+        <span className="text-[11px]" style={{ color: '#8d8672' }}>
+          {unidade}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default function FutebolCampeonato() {
+  const navigate = useNavigate();
+  const { slug } = useParams<{ slug: string }>();
+  const [params, setParams] = useSearchParams();
+
+  const competition = (slug || DEFAULT_COMP) as Competition;
+  const { data: comps } = useFutebolCompetitions();
+
+  /** Temporadas que a liga realmente tem no mart, mais recente primeiro. */
+  const seasons = useMemo(() => {
+    const s = (comps ?? []).filter((c) => c.competition === competition).map((c) => Number(c.season));
+    return [...new Set(s)].sort((a, b) => b - a);
+  }, [comps, competition]);
+
+  const seasonParam = Number(params.get('s')) || null;
+  const season = seasonParam && seasons.includes(seasonParam) ? seasonParam : (seasons[0] ?? 2026);
+
+  const ligas = useMemo(() => sortCompetitions([...new Set((comps ?? []).map((c) => c.competition))]), [comps]);
+
+  const [roundIdx, setRoundIdx] = useState(0);
+  const [aba, setAba] = useState<'rodada' | 'tabela' | 'artilheiros'>('rodada');
+  const [menuLiga, setMenuLiga] = useState(false);
+
+  const { data: fixtures, isLoading, isError } = useFutebolFixtures(competition, season);
+  const { data: standings, isLoading: loadingStandings } = useFutebolStandings(competition, season, true);
+  const { data: leaders, isLoading: loadingLeaders } = useFutebolLeaders(competition, season, true);
+  const { data: board } = useFutebolValueBoard();
+
+  const bestByFixture = useMemo(() => {
+    const m = new Map<number, FutebolValueBoardRow>();
+    groupBoardByFixture(board || []).forEach((bf) => m.set(bf.fixtureId, bf.best));
+    return m;
+  }, [board]);
+
+  const rounds = useMemo(() => {
+    const seen: string[] = [];
+    (fixtures ?? []).forEach((f) => {
+      if (f.round && !seen.includes(f.round)) seen.push(f.round);
+    });
+    return seen;
+  }, [fixtures]);
+  const porPontos = useMemo(() => ehCampeonatoDePontos(rounds), [rounds]);
+
+  // Abre na rodada do PRÓXIMO jogo, não na mais próxima do relógio. A diferença
+  // aparece em copa: na quarta-feira depois das oitavas, o jogo mais próximo em
+  // horas ainda é o de ontem, e a tela abria numa fase que já acabou em vez das
+  // quartas, que é o que a pessoa foi ver. Terminada a temporada, cai na última.
+  // `Date.now()` na hora do efeito, não numa const de módulo: a versão antiga era
+  // avaliada no import e errava o dia em aba aberta de véspera.
+  useEffect(() => {
+    const list = fixtures ?? [];
+    if (!list.length || !rounds.length) return;
+    const agora = Date.now();
+    const quando = (f: FutebolFixture) => {
+      const raw = f.kickoff_utc || f.date_utc;
+      if (!raw) return NaN;
+      return new Date(raw.includes('T') ? `${raw}Z` : `${raw}T00:00:00Z`).getTime();
+    };
+
+    let alvo: string | null = null;
+    let melhor = Infinity;
+    for (const f of list) {
+      const t = quando(f);
+      if (isNaN(t) || t < agora) continue;
+      if (t < melhor) {
+        melhor = t;
+        alvo = f.round;
+      }
+    }
+    if (!alvo) {
+      let ultimo = -Infinity;
+      for (const f of list) {
+        const t = quando(f);
+        if (!isNaN(t) && t > ultimo) {
+          ultimo = t;
+          alvo = f.round;
+        }
+      }
+    }
+    const idx = rounds.indexOf(alvo as string);
+    setRoundIdx(idx >= 0 ? idx : 0);
+  }, [fixtures, rounds]);
+
+  const currentRound = rounds[roundIdx];
+
+  /** Jogos da rodada agrupados por dia BRT (não por date_utc, que é data UTC). */
+  const groups = useMemo(() => {
+    const list = (fixtures ?? []).filter((f) => f.round === currentRound);
+    const byDay = new Map<string, FutebolFixture[]>();
+    list.forEach((f) => {
+      const k = brtDayOf(f.kickoff_utc) ?? f.date_utc ?? '—';
+      if (!byDay.has(k)) byDay.set(k, []);
+      byDay.get(k)!.push(f);
+    });
+    return [...byDay.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+  }, [fixtures, currentRound]);
+
+  const jogosDaRodada = useMemo(() => groups.flatMap(([, g]) => g), [groups]);
+
+  /** Os números da temporada, calculados dos jogos que já terminaram. */
+  const estat = useMemo(() => {
+    const fim = (fixtures ?? []).filter(
+      (f) => isFinished(f.status_short) && f.goals_home != null && f.goals_away != null,
+    );
+    if (!fim.length) return null;
+    const n = fim.length;
+    const soma = (fn: (f: FutebolFixture) => boolean) => fim.filter(fn).length / n;
+    return {
+      n,
+      gols: fim.reduce((s, f) => s + (f.goals_home ?? 0) + (f.goals_away ?? 0), 0) / n,
+      over: soma((f) => (f.goals_home ?? 0) + (f.goals_away ?? 0) > 2.5),
+      mando: soma((f) => (f.goals_home ?? 0) > (f.goals_away ?? 0)),
+      btts: soma((f) => (f.goals_home ?? 0) > 0 && (f.goals_away ?? 0) > 0),
+    };
+  }, [fixtures]);
+
+  /** O resumo da rodada aberta: quantas leituras existem, ou quantas bateram. */
+  const resumoRodada = useMemo(() => {
+    const comLeitura = jogosDaRodada.filter((f) => bestByFixture.has(f.fixture_id));
+    const encerrada = jogosDaRodada.length > 0 && jogosDaRodada.every((f) => isFinished(f.status_short));
+    const rotulo = encerrada ? (porPontos ? 'Rodada encerrada' : 'Fase encerrada') : porPontos ? 'Nesta rodada' : 'Nesta fase';
+
+    if (!comLeitura.length) {
+      return {
+        rotulo,
+        valor: '—',
+        texto: jogosDaRodada.length ? `sem leitura ${porPontos ? 'nesta rodada' : 'nesta fase'}` : 'sem jogos',
+      };
+    }
+    if (encerrada) {
+      const bateram = comLeitura.filter((f) => {
+        const b = bestByFixture.get(f.fixture_id)!;
+        const r = settleFutebol(b.market, b.outcome, b.line_value, f.goals_home, f.goals_away);
+        return r != null && isHit(r);
+      }).length;
+      return { rotulo, valor: `${bateram}/${comLeitura.length}`, texto: 'leituras bateram' };
+    }
+    const melhor = comLeitura.reduce((m, f) => Math.max(m, bestByFixture.get(f.fixture_id)!.score), 0);
+    return {
+      rotulo,
+      valor: String(comLeitura.length),
+      texto: melhor ? `com leitura · melhor Score ${melhor}` : 'com leitura',
+    };
+  }, [jogosDaRodada, bestByFixture, porPontos]);
+
+  const nTimes = standings?.length ?? new Set((fixtures ?? []).map((f) => f.home_team_id)).size;
+  const ondeEstamos = currentRound
+    ? porPontos
+      ? `${rodadaLonga(currentRound).toLowerCase()} de ${rounds.length}`
+      : rodadaLonga(currentRound)
+    : null;
+  const subtitulo = [`Temporada ${season}`, nTimes ? `${nTimes} times` : null, ondeEstamos].filter(Boolean).join(' · ');
+  // No celular a linha não cabe inteira e o fim dela, que é onde está a rodada,
+  // era justamente o pedaço que sumia no "…".
+  const subtituloCurto = [String(season), ondeEstamos].filter(Boolean).join(' · ');
+
+  // Mata-mata não tem tabela; liga sem tabela é coleta que ainda não veio. A
+  // distinção importa: um é assim mesmo, o outro é pendência nossa.
+  const vazioTabela = porPontos
+    ? { titulo: 'Classificação ainda não coletada', texto: 'Entra assim que a competição passar pela coleta.' }
+    : { titulo: 'Competição de mata-mata', texto: 'Sem tabela de pontos, o que vale é o chaveamento de cada fase.' };
+  const vazioArtilheiros = { titulo: 'Artilheiros ainda não coletados', texto: 'Entram assim que a competição passar pela coleta.' };
+
+  const campTour = useOnboardingTour(FUT_CAMPEONATO_TOUR_ID, { enabled: !isLoading && !isError });
+  const campSteps = useMemo(() => makeFutebolCampeonatoSteps({ hasRounds: rounds.length > 0 }), [rounds.length]);
+
+  const goTeam = (id: number) => navigate(`/futebol/time/${id}?c=${competition}&s=${season}`);
+  const setSeason = (s: number) => setParams({ s: String(s) }, { replace: true });
+
+  const listaJogos = (
+    <div className="flex flex-col gap-4 min-w-0">
+      {isLoading ? (
+        Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} className="h-28 w-full bg-canvas-2 rounded-rebrand-lg" />
+        ))
+      ) : !jogosDaRodada.length ? (
+        <div
+          className="bg-white rounded-rebrand-lg px-8 py-11 text-center"
+          style={{ border: '1px dashed #ded2b6' }}
+        >
+          <div
+            className="w-9 h-9 mx-auto rounded-rebrand-sm grid place-items-center"
+            style={{ background: '#f8f4ea', border: '1px solid #e5d9bd', color: '#c4bda8' }}
+          >
+            <CalendarDays className="w-4 h-4" />
+          </div>
+          <div className="mt-3.5 text-[15px] font-semibold text-ink">Nenhum jogo nesta rodada</div>
+          <div className="mt-1.5 text-[12.5px] leading-relaxed max-w-[380px] mx-auto" style={{ color: '#8d8672' }}>
+            O calendário desta competição pode não ter entrado na coleta ainda.
+          </div>
+        </div>
+      ) : (
+        groups.map(([day, games]) => {
+          const comLeitura = games.filter((f) => bestByFixture.has(f.fixture_id)).length;
+          return (
+            <div key={day} className="bg-white rounded-rebrand-lg overflow-hidden" style={{ border: '1px solid #ded2b6' }}>
+              <div
+                className="px-4 py-2.5 flex items-center justify-between gap-2"
+                style={{ background: '#f4eddc', borderBottom: '1px solid #ded2b6' }}
+              >
+                <span className="text-[10.5px] uppercase tracking-[0.16em] font-bold" style={{ color: '#6b6350' }}>
+                  {fmtDayHeader(day)}
+                </span>
+                <span className="text-[10.5px]" style={{ color: '#8d8672' }}>
+                  {games.length} {games.length === 1 ? 'jogo' : 'jogos'} · {comLeitura} com leitura
+                </span>
+              </div>
+              {games.map((f) => (
+                <FixtureRow
+                  key={f.fixture_id}
+                  fixture={f}
+                  best={bestByFixture.get(f.fixture_id) ?? null}
+                  onClick={() => navigate(`/futebol/jogo/${f.fixture_id}`)}
+                />
+              ))}
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+
+  // "após N rodadas" pelo time que mais jogou: com jogo adiado, os times têm
+  // números diferentes, e o maior é o que responde "a tabela está em que altura".
+  const rodadasJogadas = (standings ?? []).reduce((m, r) => Math.max(m, r.played), 0);
+  const legendaTabela = rodadasJogadas
+    ? `após ${rodadasJogadas} ${rodadasJogadas === 1 ? 'rodada' : 'rodadas'}`
+    : undefined;
+
+  // O que vai na coluna da direita depende de onde a competição está:
+  //  - pontos corridos: a classificação, sempre;
+  //  - copa na fase de grupos: as tabelas dos grupos, que é a pergunta do
+  //    momento (a chave ali seria uma parede de "a definir");
+  //  - copa no mata-mata: a chave.
+  const temMataMata = rounds.some((r) => ehMataMata(r));
+  const naFaseDeGrupos = !porPontos && /group stage/i.test(currentRound ?? '');
+  const temGrupos = (standings ?? []).some((r) => /^group\s/i.test(r.group_name ?? ''));
+
+  const chave =
+    !porPontos && temMataMata ? (
+      <ChaveamentoBracket
+        fixtures={fixtures ?? []}
+        rounds={rounds}
+        idxSelecionado={roundIdx}
+        competition={competition}
+        onJogo={(id) => navigate(`/futebol/jogo/${id}`)}
+      />
+    ) : null;
+  const grupos = <GruposFase rows={standings} loading={loadingStandings} onTeam={goTeam} />;
+  const tabela = (
+    <StandingsTable
+      rows={standings}
+      loading={loadingStandings}
+      onTeam={goTeam}
+      legenda={legendaTabela}
+      vazio={vazioTabela}
+    />
+  );
+  const artilheiros = <ScorersCard leaders={leaders} loading={loadingLeaders} vazio={vazioArtilheiros} />;
+  const painelDireita = porPontos ? tabela : naFaseDeGrupos && temGrupos ? grupos : (chave ?? tabela);
+
+  return (
+    <div className="theme-bolao min-h-screen bg-canvas flex flex-col">
+      <AnalyticsNav variant="rebrand" showBack backTo="/futebol/campeonatos" />
+      <OnboardingTour tourId={FUT_CAMPEONATO_TOUR_ID} steps={campSteps} run={campTour.run} onFinish={campTour.finish} />
+
+      {/* Faixa do campeonato: o rótulo da página, em areia, com o brasão, os
+          números da temporada e a troca de liga. */}
+      <div data-tour="fut-camp-header" style={{ background: '#f4eddc', borderBottom: '1px solid #ded2b6' }}>
+        <div className="max-w-[1240px] w-full mx-auto px-4 md:px-6 py-3.5 md:py-4">
+          <div className="flex items-center gap-3 min-w-0">
+            <span
+              className="shrink-0 w-10 h-10 rounded-rebrand-sm grid place-items-center"
+              style={{ background: '#fff', border: '1px solid #ded2b6' }}
+            >
+              <LigaCrest slug={competition} size={26} />
+            </span>
+            <div className="min-w-0">
+              <h1 className="font-display text-[19px] md:text-[22px] font-bold tracking-tight text-ink truncate">
+                {competitionLabel(competition)}
+              </h1>
+              <div className="text-[11.5px] md:text-[12px] truncate" style={{ color: '#8d8672' }}>
+                <span className="md:hidden">{subtituloCurto}</span>
+                <span className="hidden md:inline">{subtitulo}</span>
+              </div>
+            </div>
+
+            <div className="ml-auto flex items-center gap-2 shrink-0">
+              <Popover open={menuLiga} onOpenChange={setMenuLiga}>
+                <PopoverTrigger asChild>
+                  <button
+                    className="h-8 px-3 rounded-rebrand-sm bg-white text-[12px] font-semibold text-ink inline-flex items-center gap-1.5"
+                    style={{ border: `1px solid ${menuLiga ? '#0a3d2e' : '#ded2b6'}` }}
+                  >
+                    <span className="hidden sm:inline">{competitionLabel(competition)}</span>
+                    <span className="sm:hidden">Trocar</span>
+                    <ChevronDown className="w-3.5 h-3.5" style={{ color: '#8d8672' }} />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="end"
+                  sideOffset={6}
+                  className="theme-bolao w-[250px] p-0 rounded-rebrand-lg border-0 shadow-lg overflow-hidden"
+                  style={{ background: '#fff', border: '1px solid #ded2b6' }}
+                >
+                  <div
+                    className="px-3.5 py-2 text-[9.5px] uppercase tracking-[0.14em] font-bold"
+                    style={{ background: '#fdfbf6', borderBottom: '1px solid #f1e9d6', color: '#8d8672' }}
+                  >
+                    Competição
+                  </div>
+                  <div className="max-h-[320px] overflow-y-auto minimal-scrollbar">
+                    {ligas.map((c, i) => (
+                      <button
+                        key={c}
+                        onClick={() => {
+                          setMenuLiga(false);
+                          navigate(`/futebol/campeonato/${c}`);
+                        }}
+                        className="w-full px-3.5 py-2.5 flex items-center gap-2.5 text-left"
+                        style={{
+                          background: c === competition ? '#f4eddc' : '#fff',
+                          borderTop: i === 0 ? 'none' : '1px solid #f1e9d6',
+                        }}
+                      >
+                        <LigaCrest slug={c} size={18} />
+                        <span
+                          className={`min-w-0 truncate text-[12.5px] text-ink ${c === competition ? 'font-bold' : 'font-medium'}`}
+                        >
+                          {competitionLabel(c)}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </PopoverContent>
+              </Popover>
+
+              {seasons.length > 1 ? (
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <button
+                      className="hidden sm:inline-flex h-8 px-3 rounded-rebrand-sm bg-white text-[12px] font-semibold text-ink items-center gap-1.5 tabular-nums"
+                      style={{ border: '1px solid #ded2b6' }}
+                    >
+                      {season}
+                      <ChevronDown className="w-3.5 h-3.5" style={{ color: '#8d8672' }} />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    align="end"
+                    sideOffset={6}
+                    className="theme-bolao w-[120px] p-0 rounded-rebrand-lg border-0 shadow-lg overflow-hidden"
+                    style={{ background: '#fff', border: '1px solid #ded2b6' }}
+                  >
+                    {seasons.map((s, i) => (
+                      <button
+                        key={s}
+                        onClick={() => setSeason(s)}
+                        className="w-full px-3.5 py-2.5 text-left text-[12.5px] tabular-nums text-ink"
+                        style={{
+                          background: s === season ? '#f4eddc' : '#fff',
+                          borderTop: i === 0 ? 'none' : '1px solid #f1e9d6',
+                          fontWeight: s === season ? 700 : 500,
+                        }}
+                      >
+                        {s}
+                      </button>
+                    ))}
+                  </PopoverContent>
+                </Popover>
+              ) : (
+                <span
+                  className="hidden sm:inline-flex h-8 px-3 rounded-rebrand-sm bg-white text-[12px] font-semibold text-ink items-center tabular-nums"
+                  style={{ border: '1px solid #ded2b6' }}
+                >
+                  {season}
+                </span>
+              )}
+
+              <Link
+                to="/futebol/jogos"
+                className="hidden md:inline-flex h-8 px-3 rounded-rebrand-sm bg-white text-[12px] font-semibold text-ink items-center gap-1.5 hover:bg-canvas-2 transition"
+                style={{ border: '1px solid #ded2b6' }}
+              >
+                <CalendarDays className="w-3.5 h-3.5" />
+                Jogos do dia
+              </Link>
+            </div>
+          </div>
+
+          {/* Os números da temporada. Saem dos jogos já encerrados, então numa
+              competição que ainda não começou eles simplesmente não aparecem. */}
+          {estat && (
+            <div
+              className="mt-3.5 pt-3.5 grid grid-cols-2 md:flex md:items-center gap-3 md:gap-8"
+              style={{ borderTop: '1px solid #e5d9bd' }}
+            >
+              <Estatistica rotulo="Média de gols" valor={d1(estat.gols)} unidade="por jogo" />
+              <Estatistica rotulo="Mais de 2,5" valor={pct(estat.over)} unidade="dos jogos" />
+              <Estatistica rotulo="Vitória do mandante" valor={pct(estat.mando)} unidade="na temporada" />
+              <Estatistica rotulo="Ambos marcam" valor={pct(estat.btts)} unidade="dos jogos" />
+              <div className="col-span-2 md:ml-auto md:pl-8" style={{ borderLeft: 'none' }}>
+                <div className="text-[9.5px] uppercase tracking-[0.14em] font-bold" style={{ color: '#8d8672' }}>
+                  {resumoRodada.rotulo}
+                </div>
+                <div className="mt-0.5 flex items-baseline gap-1.5">
+                  <span
+                    className="text-[18px] leading-none font-semibold tabular-nums"
+                    style={{ color: resumoRodada.valor === '—' ? '#c4bda8' : '#0a3d2e' }}
+                  >
+                    {resumoRodada.valor}
+                  </span>
+                  <span className="text-[11px]" style={{ color: '#6b6350' }}>
+                    {resumoRodada.texto}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="max-w-[1240px] w-full mx-auto px-4 md:px-6 py-4 md:py-5 flex-1 min-w-0">
+        {isError ? (
+          <div className="bg-white border border-line rounded-rebrand-md p-6 text-center text-sm text-status-danger">
+            Erro ao carregar os jogos.
+          </div>
+        ) : (
+          <>
+            {rounds.length > 0 && (
+              <div data-tour="fut-camp-rodada" className="mb-4">
+                <ReguaRodadas
+                  rounds={rounds}
+                  idx={roundIdx}
+                  onIdx={setRoundIdx}
+                  jogosNaRodada={jogosDaRodada.length}
+                  porPontos={porPontos}
+                />
+              </div>
+            )}
+
+            {/* Celular: três abas, porque tabela e artilheiros embaixo da lista de
+                jogos ficam a uma rolagem inteira de distância. */}
+            <div className="lg:hidden mb-3 inline-flex p-0.5 rounded-rebrand-sm" style={{ background: '#f1e9d6', border: '1px solid #e5d9bd' }}>
+              {(['rodada', 'tabela', 'artilheiros'] as const).map((a) => (
+                <button
+                  key={a}
+                  onClick={() => setAba(a)}
+                  className="h-7 px-3 rounded-[7px] text-[12px] capitalize transition"
+                  style={
+                    aba === a
+                      ? { background: '#fff', color: '#1a1d1a', fontWeight: 600, boxShadow: '0 1px 2px rgba(0,0,0,.06)' }
+                      : { color: '#6b6350', fontWeight: 500 }
+                  }
+                >
+                  {a === 'rodada'
+                    ? porPontos
+                      ? 'Rodada'
+                      : 'Fase'
+                    : a === 'tabela'
+                      ? porPontos
+                        ? 'Tabela'
+                        : naFaseDeGrupos && temGrupos
+                          ? 'Grupos'
+                          : 'Chave'
+                      : 'Artilheiros'}
+                </button>
+              ))}
+            </div>
+
+            <div className="hidden lg:grid grid-cols-[1.35fr_1fr] gap-5 items-start">
+              {listaJogos}
+              <div data-tour="fut-camp-tabela" className="flex flex-col gap-4 min-w-0">
+                {painelDireita}
+                {artilheiros}
+              </div>
+            </div>
+
+            <div className="lg:hidden min-w-0">
+              {aba === 'rodada' && listaJogos}
+              {aba === 'tabela' &&
+                (porPontos ? (
+                  <StandingsTable
+                    rows={standings}
+                    loading={loadingStandings}
+                    onTeam={goTeam}
+                    compacto
+                    legenda={legendaTabela}
+                    vazio={vazioTabela}
+                  />
+                ) : (
+                  painelDireita
+                ))}
+              {aba === 'artilheiros' && artilheiros}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/FutebolCampeonato.tsx
+++ b/src/pages/FutebolCampeonato.tsx
@@ -48,6 +48,26 @@ import { FUT_CAMPEONATO_TOUR_ID, makeFutebolCampeonatoSteps } from '@/components
 
 const DEFAULT_COMP = 'brasileirao';
 
+/**
+ * Duas colunas (jogos + tabela/chave) ou abas? Casado com o `lg:` do grid, e não
+ * com o breakpoint de 768px do useIsMobile: entre 768 e 1024 a tela já está em
+ * abas, e o tour apontaria para a coluna escondida.
+ */
+const COLUNAS_MQ = '(min-width: 1024px)';
+
+function useDuasColunas(): boolean {
+  const [tem, setTem] = useState<boolean>(() =>
+    typeof window !== 'undefined' ? window.matchMedia(COLUNAS_MQ).matches : true,
+  );
+  useEffect(() => {
+    const mql = window.matchMedia(COLUNAS_MQ);
+    const onChange = (e: MediaQueryListEvent) => setTem(e.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+  return tem;
+}
+
 const d1 = (n: number) => n.toFixed(1).replace('.', ',');
 const pct = (n: number) => `${Math.round(n * 100)}%`;
 
@@ -88,6 +108,7 @@ export default function FutebolCampeonato() {
 
   const [roundIdx, setRoundIdx] = useState(0);
   const [aba, setAba] = useState<'rodada' | 'tabela' | 'artilheiros'>('rodada');
+  const duasColunas = useDuasColunas();
   const [menuLiga, setMenuLiga] = useState(false);
 
   const { data: fixtures, isLoading, isError } = useFutebolFixtures(competition, season);
@@ -231,7 +252,10 @@ export default function FutebolCampeonato() {
   const vazioArtilheiros = { titulo: 'Artilheiros ainda não coletados', texto: 'Entram assim que a competição passar pela coleta.' };
 
   const campTour = useOnboardingTour(FUT_CAMPEONATO_TOUR_ID, { enabled: !isLoading && !isError });
-  const campSteps = useMemo(() => makeFutebolCampeonatoSteps({ hasRounds: rounds.length > 0 }), [rounds.length]);
+  const campSteps = useMemo(
+    () => makeFutebolCampeonatoSteps({ hasRounds: rounds.length > 0, ehCopa: !porPontos, isMobile: !duasColunas }),
+    [rounds.length, porPontos, duasColunas],
+  );
 
   const goTeam = (id: number) => navigate(`/futebol/time/${id}?c=${competition}&s=${season}`);
   const setSeason = (s: number) => setParams({ s: String(s) }, { replace: true });
@@ -510,7 +534,11 @@ export default function FutebolCampeonato() {
 
             {/* Celular: três abas, porque tabela e artilheiros embaixo da lista de
                 jogos ficam a uma rolagem inteira de distância. */}
-            <div className="lg:hidden mb-3 inline-flex p-0.5 rounded-rebrand-sm" style={{ background: '#f1e9d6', border: '1px solid #e5d9bd' }}>
+            <div
+              data-tour="fut-camp-abas"
+              className="lg:hidden mb-3 inline-flex p-0.5 rounded-rebrand-sm"
+              style={{ background: '#f1e9d6', border: '1px solid #e5d9bd' }}
+            >
               {(['rodada', 'tabela', 'artilheiros'] as const).map((a) => (
                 <button
                   key={a}

--- a/src/pages/FutebolCampeonatos.tsx
+++ b/src/pages/FutebolCampeonatos.tsx
@@ -1,0 +1,128 @@
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRight, CalendarDays } from 'lucide-react';
+import AnalyticsNav from '@/components/AnalyticsNav';
+import { LigaCrest } from '@/components/futebol/LigaCrest';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useFutebolCompetitions } from '@/hooks/use-futebol-data';
+import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
+import { brtToday, fmtDayShort, yearOf } from '@/utils/futebol-datas';
+
+/**
+ * Lista de campeonatos, ponto de entrada pra navegar por liga.
+ *
+ * Data-driven de propósito: sai da RPC get_futebol_competitions, não da lista fixa
+ * ALL_COMPETITIONS. Aquela lista tinha 8 slugs escritos na mão enquanto o mart tinha
+ * 9 competições, e a champions_league (76 jogos em 2026) não aparecia em tela nenhuma.
+ * Liga nova que o Mateus subir passa a aparecer aqui sozinha, com nome humanizado até
+ * alguém dar um rótulo bonito em utils/futebol-competitions.
+ */
+
+export default function FutebolCampeonatos() {
+  const { data: comps, isLoading, isError } = useFutebolCompetitions();
+  const hoje = brtToday();
+
+  /** Uma linha por liga, com as temporadas que ela tem e a mais recente na frente. */
+  const ligas = useMemo(() => {
+    const byComp = new Map<string, { season: number; jogos: number; primeiro: string | null; ultimo: string | null }[]>();
+    (comps ?? []).forEach((c) => {
+      const arr = byComp.get(c.competition) ?? [];
+      arr.push({ season: Number(c.season), jogos: Number(c.jogos), primeiro: c.primeiro, ultimo: c.ultimo });
+      byComp.set(c.competition, arr);
+    });
+    return sortCompetitions([...byComp.keys()]).map((slug) => {
+      const temporadas = (byComp.get(slug) ?? []).sort((a, b) => b.season - a.season);
+      return { slug, temporadas, atual: temporadas[0] };
+    });
+  }, [comps]);
+
+  return (
+    <div className="theme-bolao min-h-screen bg-canvas flex flex-col">
+      <AnalyticsNav variant="rebrand" showBack backTo="/futebol/jogos" />
+
+      <div className="bg-white border-b border-line">
+        <div className="max-w-[1480px] w-full mx-auto px-4 md:px-6 py-5 md:py-6 flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
+          <div>
+            <div className="text-[11px] uppercase tracking-[0.2em] font-bold text-ink-3">Futebol</div>
+            <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">
+              Campeonatos
+            </h1>
+            <p className="text-[13px] mt-1 text-ink-2">
+              Escolha um campeonato pra ver rodadas, classificação e artilheiros.
+            </p>
+          </div>
+          <Link
+            to="/futebol/jogos"
+            className="h-9 px-3 shrink-0 self-start sm:self-auto rounded-rebrand-sm text-xs font-semibold bg-white text-ink border border-line hover:bg-canvas-2 transition inline-flex items-center gap-1.5"
+          >
+            <CalendarDays className="w-3.5 h-3.5" />
+            Jogos do dia
+          </Link>
+        </div>
+      </div>
+
+      <div className="max-w-[1480px] w-full mx-auto px-4 md:px-6 py-6 flex-1">
+        {isError ? (
+          <div className="bg-white border border-line rounded-rebrand-md p-6 text-center text-sm text-status-danger">
+            Erro ao carregar os campeonatos.
+          </div>
+        ) : isLoading ? (
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-28 w-full bg-canvas-2 rounded-rebrand-md" />
+            ))}
+          </div>
+        ) : ligas.length === 0 ? (
+          <div className="bg-white border border-line rounded-rebrand-md p-6 text-center text-sm text-ink-3">
+            Nenhum campeonato disponível.
+          </div>
+        ) : (
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {ligas.map(({ slug, temporadas, atual }) => {
+              // "Em andamento" é só a janela de datas do mart, não status oficial.
+              const emAndamento = !!(atual?.primeiro && atual?.ultimo && atual.primeiro <= hoje && atual.ultimo >= hoje);
+              return (
+                <Link
+                  key={slug}
+                  to={`/futebol/campeonato/${slug}`}
+                  className="bg-white border border-line rounded-rebrand-md p-4 hover:bg-canvas-2 transition group"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="w-9 h-9 rounded-rebrand-sm bg-canvas-2 border border-line grid place-items-center shrink-0">
+                      <LigaCrest slug={slug} size={26} />
+                    </div>
+                    {emAndamento && (
+                      <span className="px-1.5 h-5 inline-flex items-center rounded text-[9px] font-bold uppercase tracking-[0.1em] bg-forest/10 text-forest">
+                        Em andamento
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-3 text-[15px] font-bold tracking-tight text-ink">{competitionLabel(slug)}</div>
+                  <div className="text-[12px] text-ink-2 mt-0.5">
+                    {atual ? `${atual.jogos} jogos · temporada ${atual.season}` : 'Sem jogos'}
+                  </div>
+                  {atual?.primeiro && atual?.ultimo && (
+                    <div className="text-[11px] text-ink-3 mt-0.5">
+                      {fmtDayShort(atual.primeiro)} até{' '}
+                      {/* Ano só quando a temporada atravessa o ano (La Liga vai de
+                          ago/2026 a mai/2027), senão "30 de mai" fica ambíguo. */}
+                      {fmtDayShort(atual.ultimo, yearOf(atual.primeiro) !== yearOf(atual.ultimo))}
+                    </div>
+                  )}
+                  <div className="mt-3 flex items-center justify-between gap-2">
+                    <span className="text-[11px] text-ink-3">
+                      {temporadas.length > 1 ? `${temporadas.length} temporadas` : '1 temporada'}
+                    </span>
+                    <span className="text-[11px] font-semibold text-forest inline-flex items-center gap-1 group-hover:gap-1.5 transition-all">
+                      Abrir <ArrowRight className="w-3 h-3" />
+                    </span>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -1,16 +1,17 @@
 import { useState, useMemo, type ReactNode } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { MapPin, AlertTriangle, ChevronDown, Check } from 'lucide-react';
+import { MapPin } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
+import { type JogoInfo } from '@/components/futebol/JogoResumo';
+import { FaixaPartida } from '@/components/futebol/FaixaPartida';
+import { BancadaMercados } from '@/components/futebol/BancadaMercados';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { useFutebolFixtureDetail, useFutebolFixtureExtras, useFutebolMatchupTendencies, useFutebolFixtureValue, useFutebolH2H, useFutebolFixtureInjuries, useFutebolTeamProfile, useFutebolAccess } from '@/hooks/use-futebol-data';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
 import {
-  computeMatchupTendencies, headlineMarket, STRENGTH_LABEL,
-  type MarketTendency, type Strength, type MatchupTendencies,
+  computeMatchupTendencies,
 } from '@/utils/futebol-tendencias';
 import {
   pickLabel, marketLabel, valorVerdict, fmtEdgeScore,
@@ -41,25 +42,6 @@ function injuryReason(r: string): string {
   return r;
 }
 
-function InjuryCol({ injuries, teamId, teamName }: { injuries: FutebolInjury[]; teamId: number; teamName: string }) {
-  const list = injuries.filter((i) => i.team_id === teamId);
-  return (
-    <div>
-      <p className="text-sm font-semibold text-ink mb-2">{teamName} <span className="text-ink-3 text-xs font-normal">({list.length})</span></p>
-      {list.length ? list.map((i) => {
-        const t = INJURY_TYPE[i.injury_type];
-        return (
-          <div key={i.player_id} className="flex items-center gap-2 py-1 text-sm">
-            <span className={`text-[9px] font-bold rounded px-1 py-0.5 shrink-0 ${t ? t.cls : 'bg-canvas-2 text-ink-3'}`}>{t ? t.label : i.injury_type}</span>
-            <span className="truncate text-ink">{i.player_name}</span>
-            <span className="ml-auto text-[10px] text-ink-3 truncate">{injuryReason(i.injury_reason)}</span>
-          </div>
-        );
-      }) : <p className="text-xs text-ink-3">Sem desfalques.</p>}
-    </div>
-  );
-}
-
 const SAO_PAULO_TZ = 'America/Sao_Paulo';
 
 function fmtDateTime(raw: string | null): string {
@@ -79,10 +61,21 @@ function fmtDate(raw: string | null): string {
   return new Intl.DateTimeFormat('pt-BR', { timeZone: SAO_PAULO_TZ, day: '2-digit', month: '2-digit', year: '2-digit' }).format(d);
 }
 
+// Fases de mata-mata que a API manda em inglês. pt-BR sempre, inclusive aqui.
+const FASE_PT: Record<string, string> = {
+  'round of 32': '16-avos de final',
+  'round of 16': 'Oitavas de final',
+  'quarter-finals': 'Quartas de final',
+  'semi-finals': 'Semifinal',
+  final: 'Final',
+  '3rd place final': 'Disputa de 3º lugar',
+};
+
 function prettyRound(round: string | null): string {
   if (!round) return '';
   const m = round.match(/Regular Season\s*-\s*(\d+)/i);
-  return m ? `Rodada ${m[1]}` : round;
+  if (m) return `Rodada ${m[1]}`;
+  return FASE_PT[round.trim().toLowerCase()] ?? round;
 }
 
 function crestInitials(name: string): string {
@@ -107,6 +100,9 @@ const FORM_COLORS: Record<string, string> = {
   L: 'bg-status-danger text-canvas',
 };
 
+/** W/D/L da API em português. O DS é explícito: pt-BR sempre, inclusive em micro-rótulo. */
+const RESULTADO_PT: Record<string, string> = { W: 'V', D: 'E', L: 'D' };
+
 function FormChips({ form }: { form: FutebolFormResult[] }) {
   if (!form?.length) return <span className="text-xs text-ink-3">Sem histórico</span>;
   const ordered = [...form].reverse(); // antigo → recente
@@ -115,10 +111,10 @@ function FormChips({ form }: { form: FutebolFormResult[] }) {
       {ordered.map((g) => (
         <span
           key={g.fixture_id}
-          title={`${g.side === 'home' ? 'vs' : '@'} ${g.opponent} • ${g.goals_for}-${g.goals_against}`}
+          title={`${g.side === 'home' ? 'contra' : 'fora, contra'} ${g.opponent} · ${g.goals_for} a ${g.goals_against}`}
           className={`w-5 h-5 rounded text-[10px] font-bold flex items-center justify-center ${FORM_COLORS[g.result] || ''}`}
         >
-          {g.result}
+          {RESULTADO_PT[g.result] ?? g.result}
         </span>
       ))}
     </div>
@@ -136,62 +132,9 @@ const STAT_ROWS: { key: keyof FutebolTeamStats; label: string }[] = [
   { key: 'passes_pct', label: 'Passes certos (%)' },
 ];
 
-function StatRow({ label, home, away }: { label: string; home: number | null; away: number | null }) {
-  const h = typeof home === 'number' ? home : null;
-  const a = typeof away === 'number' ? away : null;
-  const total = (h ?? 0) + (a ?? 0);
-  const hPct = total > 0 ? ((h ?? 0) / total) * 100 : 50;
-  return (
-    <div className="py-2">
-      <div className="flex items-center justify-between text-sm tabular-nums mb-1">
-        <span className="font-bold text-ink w-12">{h ?? '—'}</span>
-        <span className="text-[11px] text-ink-3 uppercase tracking-wide">{label}</span>
-        <span className="font-bold text-ink w-12 text-right">{a ?? '—'}</span>
-      </div>
-      <div className="flex h-1.5 rounded overflow-hidden bg-canvas-2">
-        <div className="bg-forest" style={{ width: `${hPct}%` }} />
-        <div className="bg-amber" style={{ width: `${100 - hPct}%` }} />
-      </div>
-    </div>
-  );
-}
-
 function RatingBadge({ value }: { value: number }) {
   const cls = value >= 7.5 ? 'bg-forest text-canvas' : value >= 6.5 ? 'bg-canvas-2 text-ink border border-line' : 'bg-status-danger/15 text-status-danger';
   return <span className={`text-[10px] font-bold tabular-nums rounded px-1 py-0.5 ${cls}`}>{value.toFixed(1)}</span>;
-}
-
-function LineupColumn({ players, side, statsById }: { players: FutebolLineupPlayer[]; side: 'home' | 'away'; statsById: Map<number, FutebolPlayerStat> }) {
-  const list = players.filter((p) => p.team_side === side);
-  const starters = list.filter((p) => p.is_starter);
-  const bench = list.filter((p) => !p.is_starter);
-  const Row = (p: FutebolLineupPlayer) => {
-    const st = p.player_id != null ? statsById.get(p.player_id) : undefined;
-    return (
-      <div key={`${p.player_id}-${p.player_slot}`} className="flex items-center gap-2 py-1 text-sm">
-        <span className="w-6 text-[11px] text-ink-3 tabular-nums text-right">{p.shirt_number ?? '–'}</span>
-        <span className="truncate text-ink">{p.player_name}</span>
-        {st?.goals ? <span className="text-[10px] font-bold text-forest">{st.goals}G</span> : null}
-        {st?.assists ? <span className="text-[10px] font-bold text-amber-2">{st.assists}A</span> : null}
-        <span className="ml-auto flex items-center gap-2">
-          {p.position && <span className="text-[10px] text-ink-3">{p.position}</span>}
-          {st?.rating != null && <RatingBadge value={st.rating} />}
-        </span>
-      </div>
-    );
-  };
-  return (
-    <div>
-      <p className="text-[10px] uppercase tracking-wide text-ink-3 mb-1">Titulares</p>
-      {starters.length ? starters.map(Row) : <p className="text-xs text-ink-3">—</p>}
-      {bench.length > 0 && (
-        <>
-          <p className="text-[10px] uppercase tracking-wide text-ink-3 mt-3 mb-1">Banco</p>
-          {bench.map(Row)}
-        </>
-      )}
-    </div>
-  );
 }
 
 const GOAL_SUFFIX: Record<string, string> = { Penalty: ' (pênalti)', 'Own Goal': ' (gol contra)' };
@@ -199,109 +142,6 @@ const GOAL_SUFFIX: Record<string, string> = { Penalty: ' (pênalti)', 'Own Goal'
 function eventMinute(e: FutebolEvent): string {
   if (e.minute == null) return '—';
   return e.minute_extra ? `${e.minute}+${e.minute_extra}'` : `${e.minute}'`;
-}
-
-function EventRow({ e }: { e: FutebolEvent }) {
-  const sideColor = e.team_side === 'home' ? 'text-forest' : 'text-amber-2';
-  const dot = e.team_side === 'home' ? 'bg-forest' : 'bg-amber';
-  let indicator: ReactNode;
-  let text: ReactNode;
-
-  if (e.event_type === 'Goal') {
-    indicator = <span className={`w-2.5 h-2.5 rounded-full ${dot}`} />;
-    text = (
-      <span className="text-ink-2">
-        <b className="text-ink">{e.player_name}</b> Gol{e.event_detail ? GOAL_SUFFIX[e.event_detail] || '' : ''}
-        {e.assist_player_name && <span className="text-ink-3"> · assist. {e.assist_player_name}</span>}
-      </span>
-    );
-  } else if (e.event_type === 'Card') {
-    const red = (e.event_detail || '').toLowerCase().includes('red');
-    indicator = <span className={`w-2 h-3 rounded-sm ${red ? 'bg-status-danger' : 'bg-amber'}`} />;
-    text = <span className="text-ink-2">{e.player_name} · {red ? 'Vermelho' : 'Amarelo'}</span>;
-  } else if (e.event_type === 'subst') {
-    indicator = <span className="text-[8px] font-bold text-ink-3">SUB</span>;
-    text = (
-      <span className="text-ink-2">
-        <span className="text-status-success">Entra {e.assist_player_name}</span>
-        <span className="text-ink-3"> · Sai {e.player_name}</span>
-      </span>
-    );
-  } else if (e.event_type === 'Var') {
-    indicator = <span className="text-[8px] font-bold text-ink-3 border border-line rounded px-1 leading-tight">VAR</span>;
-    text = <span className="text-ink-3">{e.event_detail}{e.player_name ? ` (${e.player_name})` : ''}</span>;
-  } else {
-    indicator = <span className={`w-2 h-2 rounded-full ${dot}`} />;
-    text = <span className="text-ink-2">{e.event_type} {e.player_name}</span>;
-  }
-
-  return (
-    <div className="flex items-center gap-3 py-1.5">
-      <span className={`w-9 shrink-0 text-xs tabular-nums text-right font-semibold ${sideColor}`}>{eventMinute(e)}</span>
-      <span className="w-8 shrink-0 flex items-center justify-center">{indicator}</span>
-      <span className="text-sm flex-1 min-w-0">{text}</span>
-    </div>
-  );
-}
-
-const STRENGTH_CHIP: Record<Strength, string> = {
-  alta: 'bg-forest text-canvas',
-  media: 'bg-amber text-canvas',
-  baixa: 'bg-canvas-2 text-ink-3 border border-line',
-};
-const STRENGTH_BAR: Record<Strength, string> = {
-  alta: 'bg-forest',
-  media: 'bg-amber',
-  baixa: 'bg-ink-3',
-};
-
-function TendencyRow({ m }: { m: MarketTendency }) {
-  const pct = Math.round(m.prob * 100);
-  return (
-    <div className="py-2">
-      <div className="flex items-center justify-between gap-2 mb-1">
-        <span className="text-sm text-ink font-medium truncate">{m.label}</span>
-        <span className="flex items-center gap-2 shrink-0 tabular-nums">
-          <span className="text-sm font-bold text-ink">{pct}%</span>
-          <span className="text-[10px] text-ink-3">justa {m.fairOdds.toFixed(2)}</span>
-        </span>
-      </div>
-      <div className="flex items-center gap-2">
-        <div className="flex-1 h-1.5 rounded overflow-hidden bg-canvas-2">
-          <div className={`h-full ${STRENGTH_BAR[m.strength]}`} style={{ width: `${pct}%` }} />
-        </div>
-        <span className={`text-[9px] font-bold rounded px-1 py-0.5 shrink-0 ${STRENGTH_CHIP[m.strength]}`}>{STRENGTH_LABEL[m.strength]}</span>
-      </div>
-      <p className="text-[10px] text-ink-3 mt-1">{m.reading}</p>
-    </div>
-  );
-}
-
-
-
-// Distribuição de gols do jogo (Poisson sobre λ total) — gráfico de barras vertical
-function GoalDistChart({ lh, la }: { lh: number; la: number }) {
-  const lambda = lh + la;
-  const fact = (n: number) => { let r = 1; for (let i = 2; i <= n; i++) r *= i; return r; };
-  const pois = (k: number) => (Math.exp(-lambda) * Math.pow(lambda, k)) / fact(k);
-  const bars = [0, 1, 2, 3].map((k) => ({ k: String(k), p: pois(k) }));
-  const acc = bars.reduce((s, b) => s + b.p, 0);
-  bars.push({ k: '4+', p: Math.max(0, 1 - acc) });
-  const max = Math.max(...bars.map((b) => b.p), 0.001);
-  return (
-    <div>
-      <div className="flex items-end gap-2 h-24">
-        {bars.map((b) => (
-          <div key={b.k} className="flex-1 flex flex-col items-center justify-end h-full gap-1">
-            <span className="text-[9px] text-ink-3 tabular-nums">{Math.round(b.p * 100)}%</span>
-            <div className="w-full bg-forest/80 rounded-t" style={{ height: `${(b.p / max) * 100}%` }} />
-            <span className="text-[10px] text-ink-2 font-semibold">{b.k}</span>
-          </div>
-        ))}
-      </div>
-      <p className="text-[10px] text-ink-3 mt-1.5 text-center">chance de cada placar de gols (modelo) · esperado {lambda.toFixed(1)}</p>
-    </div>
-  );
 }
 
 const CARD = 'bg-white border border-line rounded-rebrand-xl';
@@ -328,242 +168,6 @@ function ResultBadge({ r, big }: { r: BetResult; big?: boolean }) {
 }
 
 // Oportunidades mapeadas de um jogo ENCERRADO + como performaram (green/red).
-function PlayedOpportunities({ rows, homeName, awayName, goalsHome, goalsAway }: {
-  rows: FutebolFixtureValueRow[]; homeName: string; awayName: string; goalsHome: number | null; goalsAway: number | null;
-}) {
-  const valueOpps = [...rows].filter((r) => r.score >= SCORE_MEDIA).sort((a, b) => b.score - a.score);
-  if (!valueOpps.length) return null;
-
-  const settled = valueOpps.map((o) => ({ o, r: settleFutebol(o.market, o.outcome, o.line_value, goalsHome, goalsAway) }));
-  const greens = settled.filter((s) => s.r && isHit(s.r)).length;
-  const reds = settled.filter((s) => s.r === 'lost' || s.r === 'half_lost').length;
-  const voids = settled.filter((s) => s.r === 'push').length;
-
-  return (
-    <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
-      <div className="px-5 py-3.5 flex items-center justify-between gap-3 bg-canvas-2 border-b border-line">
-        <div className="min-w-0">
-          <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Oportunidades deste jogo</div>
-          <div className="text-[11px] text-ink-3 mt-0.5">{valueOpps.length} mapeada{valueOpps.length === 1 ? '' : 's'} · resultado pelo placar</div>
-        </div>
-        <div className="flex items-center gap-1.5 shrink-0">
-          {greens > 0 && <span className="inline-flex items-center h-6 px-2 rounded-full text-[11px] font-bold tabular-nums" style={{ background: '#dcefe2', color: '#0a3d2e' }}>{greens} green</span>}
-          {reds > 0 && <span className="inline-flex items-center h-6 px-2 rounded-full text-[11px] font-bold tabular-nums" style={{ background: '#fbe3e8', color: '#be123c' }}>{reds} red</span>}
-          {voids > 0 && <span className="inline-flex items-center h-6 px-2 rounded-full text-[11px] font-bold tabular-nums" style={{ background: '#eef0ec', color: '#5a625a' }}>{voids} anul.</span>}
-        </div>
-      </div>
-      <div className="divide-y divide-line">
-        {settled.map(({ o, r }) => {
-          const chance = chancePct(o.prob_justa_fechamento);
-          const spine = !r ? 'border-l-line-2'
-            : isHit(r) ? 'border-l-[#2f7d50]'
-            : r === 'push' ? 'border-l-line-2'
-            : 'border-l-[#be123c]';
-          return (
-            <div key={`${o.market}-${o.outcome}-${o.line_value}`} className={`px-5 py-3.5 flex items-center gap-3.5 border-l-4 ${spine}`}>
-              <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[15px] w-9 h-9 shrink-0 ${faixaBadgeCls(o.faixa)}`}>{o.score}</span>
-              <div className="min-w-0 flex-1">
-                <div className="text-[14px] font-semibold text-ink truncate leading-tight">{pickLabel(o.market, o.outcome, o.line_value, homeName, awayName)}</div>
-                <div className="text-[11px] text-ink-3 truncate mt-0.5">{marketLabel(o.market)}{chance != null ? ` · ${chance}% chance` : ''} · odd {o.best_odd.toFixed(2)}</div>
-              </div>
-              {r && <ResultBadge r={r} big />}
-            </div>
-          );
-        })}
-      </div>
-      <p className="px-5 py-2.5 text-[10px] text-ink-3 border-t border-line">Resultado calculado pelo placar final. Não é recomendação.</p>
-    </div>
-  );
-}
-
-function WhatToWatch({ rows, homeName, awayName, competition, kickoffUtc, locked }: { rows: FutebolFixtureValueRow[]; homeName: string; awayName: string; competition: string; kickoffUtc: string | null; locked?: boolean }) {
-  const ranked = [...rows].sort((a, b) => b.score - a.score);
-  const valueOpps = ranked.filter((r) => r.score >= SCORE_MEDIA); // todas as mapeadas (com valor)
-  const top = valueOpps[0];
-  const others = valueOpps.slice(1);
-  const note = 'Leitura de risco, não recomendação de aposta.';
-
-  if (!top) {
-    return (
-      <div className="rounded-rebrand-xl border border-line border-l-4 border-l-amber bg-white p-5">
-        <div className="text-[10px] uppercase tracking-[0.16em] font-semibold text-ink-3">O que olhar neste jogo</div>
-        <div className="text-lg font-bold text-ink mt-1.5">Sem valor claro nos mercados</div>
-        <p className="text-sm text-ink-2 mt-1">As melhores odds estão alinhadas ao risco real — nada que se destaque aqui. Os dados abaixo seguem pra você tirar sua própria conclusão.</p>
-        <p className="text-[10px] text-ink-3 mt-3">{note}</p>
-      </div>
-    );
-  }
-
-  const pick = pickLabel(top.market, top.outcome, top.line_value, homeName, awayName);
-  const verdict = valorVerdict(top.edge);
-  const porque = top.evidencias ?? [];
-  // Pontos de atenção: contras (premissas que não bateram) + avisos (penalidades)
-  const atencao = [...(top.contras ?? []), ...(top.avisos ?? [])];
-
-  const vColor = verdict.toLowerCase().includes('forte') ? 'text-forest' : 'text-amber-2';
-  const chance = chancePct(top.prob_justa_fechamento);
-
-  return (
-    <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
-      <div className="px-5 py-3 flex items-center justify-between bg-canvas-2 border-b border-line">
-        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">O que olhar neste jogo{valueOpps.length > 1 ? ` · ${valueOpps.length} oportunidades` : ''}</div>
-        <span className={`text-[11px] font-semibold ${vColor}`}>{verdict}</span>
-      </div>
-      <div className="p-5 md:p-6 grid md:grid-cols-[1fr_260px] gap-6">
-        {/* Veredito + por quê + atenção */}
-        <div>
-          <div className="flex items-center gap-2">
-            <span className="px-1.5 h-5 inline-flex items-center rounded text-[10px] font-semibold uppercase tracking-[0.08em] bg-canvas-2 text-ink-2">{marketLabel(top.market)}</span>
-            <span className={`px-1.5 h-5 inline-flex items-center rounded text-[10px] font-bold uppercase tracking-[0.1em] ${faixaBadgeCls(top.faixa)}`}>Faixa {faixaWord(top.faixa)}</span>
-          </div>
-          <div className="text-2xl md:text-[30px] font-bold tracking-tight mt-2 text-ink leading-tight"><Blur active={!!locked} strength={9}>{pick}</Blur></div>
-          {porque.length > 0 && (
-            <div className="mt-4">
-              <div className="text-[10px] uppercase tracking-[0.16em] font-bold mb-2 text-forest">Por quê</div>
-              <ul className="flex flex-col gap-1.5">
-                {porque.map((p, i) => (
-                  <li key={i} className="flex items-start gap-2 text-[13px] leading-snug text-ink-2"><span className="mt-1.5 w-1.5 h-1.5 rounded-full shrink-0 bg-forest" /><span><Blur active={!!locked}>{p}</Blur></span></li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {atencao.length > 0 && (
-            <div className="mt-4">
-              <div className="text-[10px] uppercase tracking-[0.16em] font-bold mb-2 text-amber-2">Pontos de atenção</div>
-              <ul className="flex flex-col gap-1.5">
-                {atencao.map((p, i) => (
-                  <li key={i} className="flex items-start gap-2 text-[13px] leading-snug text-ink-2"><span className="mt-1.5 w-1.5 h-1.5 rounded-full shrink-0 bg-amber" /><span>{p}</span></li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
-
-        {/* Painel de confiabilidade + 2ª opção */}
-        <div className="md:pl-6 md:border-l md:border-line flex flex-col gap-4">
-          <div className="rounded-rebrand-md p-4 text-white" style={{ background: 'linear-gradient(135deg, #0a3d2e, #08321f)' }}>
-            <div className="text-[10px] uppercase tracking-[0.16em] font-semibold text-white/50">Confiabilidade</div>
-            <div className="flex items-baseline gap-1.5 mt-1">
-              <span className="text-[44px] font-bold tabular-nums tracking-tight leading-none" style={{ color: '#fbbf24' }}>{top.score}</span>
-              <span className="text-[13px] text-white/40">/100</span>
-            </div>
-            <div className="grid grid-cols-2 gap-3 mt-4">
-              {chance != null && <div><div className="text-[9px] uppercase tracking-[0.14em] font-semibold text-white/50">Chance</div><div className="text-[18px] font-semibold tabular-nums leading-none mt-1"><Blur active={!!locked}>{chance}%</Blur></div></div>}
-              <div><div className="text-[9px] uppercase tracking-[0.14em] font-semibold text-white/50">Odd</div><div className="text-[18px] font-semibold tabular-nums leading-none mt-1"><Blur active={!!locked}>{top.best_odd.toFixed(2)}</Blur></div></div>
-            </div>
-          </div>
-          {others.length > 0 && (
-            <div className="rounded-rebrand-md p-3 bg-canvas-2 border border-line">
-              <div className="text-[9px] uppercase tracking-[0.16em] font-bold mb-2 text-ink-3">Outras oportunidades neste jogo</div>
-              <div className="flex flex-col gap-2.5">
-                {others.map((o) => {
-                  const oc = chancePct(o.prob_justa_fechamento);
-                  return (
-                    <div key={`${o.market}-${o.outcome}-${o.line_value}`} className="flex items-center justify-between gap-2">
-                      <div className="min-w-0">
-                        <div className="text-[13px] font-semibold tracking-tight text-ink truncate"><Blur active={!!locked}>{pickLabel(o.market, o.outcome, o.line_value, homeName, awayName)}</Blur></div>
-                        <div className="text-[10px] text-ink-3 truncate">{marketLabel(o.market)}<Blur active={!!locked}>{oc != null ? ` · ${oc}%` : ''} · {o.best_odd.toFixed(2)}</Blur></div>
-                      </div>
-                      <span className={`text-[11px] font-bold tabular-nums px-1.5 h-5 inline-flex items-center rounded shrink-0 ${faixaBadgeCls(o.faixa)}`}>{o.score}</span>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
-          <p className="text-[10px] text-ink-3 leading-snug">{note}</p>
-        </div>
-      </div>
-      {!locked && (
-        <RegistrarApostaCTA
-          variant="footer"
-          draft={{ homeName, awayName, competition, kickoffUtc, market: top.market, outcome: top.outcome, lineValue: top.line_value, bestOdd: top.best_odd }}
-        />
-      )}
-    </div>
-  );
-}
-
-// "Explorar mercados" — todas as opções por mercado (Chance · Odd · Valor · ★ melhor)
-function ResultExplorer({ rows, homeName, awayName, locked }: { rows: FutebolFixtureValueRow[]; homeName: string; awayName: string; locked?: boolean }) {
-  const markets = [...new Set(rows.map((r) => r.market))];
-  return (
-    <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
-      <div className="px-5 py-3 flex items-center justify-between border-b border-line">
-        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Explorar mercados</div>
-        <span className="text-[10px] text-ink-3">{markets.length} mercado{markets.length === 1 ? '' : 's'}</span>
-      </div>
-      {markets.map((mk, mi) => {
-        const list = rows.filter((r) => r.market === mk).sort((a, b) => a.outcome_order - b.outcome_order);
-        const bestScore = Math.max(...list.map((r) => r.score));
-        return (
-          <div key={mk} className={mi ? 'border-t border-line' : ''}>
-            <div className="px-5 py-2 flex items-center gap-2 bg-canvas-2">
-              <span className="text-[11px] font-semibold tracking-tight text-ink">{marketLabel(mk)}</span>
-              <span className="ml-auto grid grid-cols-[52px_52px_56px] gap-2 text-right text-[9px] uppercase tracking-[0.14em] font-bold text-ink-3">
-                <span>Chance</span><span>Odd</span><span>Valor</span>
-              </span>
-            </div>
-            {list.map((r) => {
-              const chance = chancePct(r.prob_justa_fechamento);
-              const isBest = r.score === bestScore;
-              return (
-                <div key={`${r.outcome}-${r.line_value}`} className="px-5 py-2.5 grid grid-cols-[1fr_52px_52px_56px] gap-2 items-center border-t border-line/50">
-                  <div className="flex items-center gap-2 min-w-0">
-                    {isBest && <span className="text-[10px]" style={{ color: '#fbbf24' }} title="melhor opção do mercado">★</span>}
-                    <span className={`text-[12px] font-medium tracking-tight truncate ${isBest ? 'text-ink' : 'text-ink-2'}`}>{pickLabel(r.market, r.outcome, r.line_value, homeName, awayName)}</span>
-                  </div>
-                  <div className="text-right tabular-nums text-[12px] text-ink-2">{chance != null ? `${chance}%` : '—'}</div>
-                  <div className="text-right tabular-nums text-[12px] font-semibold text-ink">{r.best_odd.toFixed(2)}</div>
-                  <div className="text-right tabular-nums text-[12px] font-semibold" style={{ color: r.edge > 0 ? 'var(--forest)' : '#9aa097' }}><Blur active={!!locked}>{r.edge > 0 ? fmtEdgeScore(r.edge) : 'sem valor'}</Blur></div>
-                </div>
-              );
-            })}
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-// "Nosso modelo de gols" — Poisson sobre médias da temporada (rebrand card)
-function ModelCard({ tendencies, head, homeName, awayName }: { tendencies: MatchupTendencies; head: MarketTendency | null; homeName: string; awayName: string }) {
-  const { lh, la } = tendencies.lambdas;
-  return (
-    <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
-      <div className="px-5 py-3 border-b border-line">
-        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Nosso modelo de gols</div>
-      </div>
-      <div className="p-5">
-        {head && <div className="text-[13px] leading-snug text-ink-2">{head.reading}</div>}
-        <div className="flex items-center gap-6 mt-4">
-          <div className="text-center"><div className="text-[28px] font-bold tabular-nums tracking-tight leading-none text-forest">{lh.toFixed(1)}</div><div className="text-[10px] mt-1 text-ink-3 max-w-[90px] truncate mx-auto">{homeName}</div></div>
-          <div className="text-[14px] text-ink-3">×</div>
-          <div className="text-center"><div className="text-[28px] font-bold tabular-nums tracking-tight leading-none text-ink-2">{la.toFixed(1)}</div><div className="text-[10px] mt-1 text-ink-3 max-w-[90px] truncate mx-auto">{awayName}</div></div>
-          <div className="text-[10px] text-ink-3 leading-tight">gols<br/>esperados</div>
-        </div>
-        <div className="mt-5"><GoalDistChart lh={lh} la={la} /></div>
-        {head && (
-          <div className="rounded-rebrand-sm bg-canvas-2 border border-line p-3 mt-4">
-            <p className="text-[9px] uppercase tracking-[0.16em] text-ink-3 mb-1 font-bold">Leitura principal · {head.group}</p>
-            <div className="flex items-end justify-between gap-2">
-              <span className="text-[15px] font-bold text-ink leading-tight">{head.label}</span>
-              <span className="text-[22px] font-extrabold text-forest tabular-nums leading-none">{Math.round(head.prob * 100)}%</span>
-            </div>
-          </div>
-        )}
-        <div className="divide-y divide-line mt-2">
-          {tendencies.markets.filter((mk) => mk.key !== head?.key).map((mk) => (
-            <TendencyRow key={mk.key} m={mk} />
-          ))}
-        </div>
-        <p className="mt-4 text-[10px] leading-snug text-ink-3">Conta baseada nas médias da temporada. Não é valor de mercado.</p>
-      </div>
-    </div>
-  );
-}
-
-// Campo (pitch) com o XI provável a partir do `grid` (linha:coluna da API)
 function Pitch({ players, side, formation }: { players: FutebolLineupPlayer[]; side: 'home' | 'away'; formation: string | null }) {
   const starters = players.filter((p) => p.team_side === side && p.is_starter && p.grid);
   if (!starters.length) {
@@ -660,7 +264,6 @@ export default function FutebolJogo() {
     if (!fixture || !tend?.home || !tend?.away) return null;
     return computeMatchupTendencies(tend.home, tend.away, fixture.home_team_name, fixture.away_team_name);
   }, [tend, fixture]);
-  const head = tendencies ? headlineMarket(tendencies.markets) : null;
   // Score vem PRONTO do backend (fact_value_opportunities). 1X2 por enquanto.
   const { data: realValueRows } = useFutebolFixtureValue(fid);
   const valueRows = isDemo ? demoFixtureValueRows : realValueRows;
@@ -697,20 +300,137 @@ export default function FutebolJogo() {
     (h2h && h2h.length) || extras?.form_home?.length || extras?.form_away?.length
   );
 
+  // Duas abas (Leitura & mercados · Times) e o mercado aberto na bancada.
+  const [aba, setAba] = useState<'mercados' | 'times'>('mercados');
+  const [mercadoAtivo, setMercadoAtivo] = useState('goals_over_under');
+  const jogoInfo: JogoInfo | null = fixture
+    ? {
+        fixtureId: fid!,
+        homeId: fixture.home_team_id,
+        awayId: fixture.away_team_id,
+        home: fixture.home_team_name,
+        away: fixture.away_team_name,
+        competition: fixture.competition,
+        season: fixture.season,
+        kickoffUtc: fixture.kickoff_utc,
+        statusShort: fixture.status_short,
+        goalsHome: fixture.goals_home,
+        goalsAway: fixture.goals_away,
+      }
+    : null;
+
   const jogoSteps = useMemo(
     () => makeFutebolJogoSteps({
-      hasValue: showValue,
-      hasModel: !!tendencies,
-      hasContext: hasDescriptive || !!homeProfile || !!awayProfile,
+      // Com a página em abas, os alvos de mapa/contexto ficam em abas ocultas na
+      // carga — o tour precisa ser refeito para navegar entre abas (pendência).
+      hasValue: false,
+      hasModel: false,
+      hasContext: false,
     }),
-    [showValue, tendencies, hasDescriptive, homeProfile, awayProfile],
+    [],
   );
+
+  // ── Cards de contexto, montados uma vez e posicionados conforme o estado ──
+  // Jogo FUTURO: h2h + estatísticas entram no trilho da direita (junto do veredito
+  // e do modelo) e a escalação fica sob o mapa — um rail de consulta contínuo, em
+  // vez de uma coluna direita que ficava VAZIA quando o jogo não tinha odd nem
+  // modelo (caso Santos × Remo). Jogo ENCERRADO: grade original lá embaixo.
+  const escalacaoCard = fixture ? (
+    <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
+      <div className="px-5 py-3 flex items-center justify-between border-b border-line">
+        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Escalação provável & desfalques</div>
+        {extras?.lineups?.length ? (
+          <span className="text-[10px] tabular-nums text-ink-3">{extras.lineups.find((l) => l.team_side === 'home')?.formation || '—'} × {extras.lineups.find((l) => l.team_side === 'away')?.formation || '—'}</span>
+        ) : null}
+      </div>
+      <div className="p-5">
+        {extras?.lineup_players?.length ? (
+          <div className="grid grid-cols-2 gap-4">
+            {(['home', 'away'] as const).map((sideKey) => {
+              const teamName = sideKey === 'home' ? fixture.home_team_name : fixture.away_team_name;
+              const teamId = sideKey === 'home' ? fixture.home_team_id : fixture.away_team_id;
+              const formation = extras!.lineups.find((l) => l.team_side === sideKey)?.formation ?? null;
+              const inj = (injuries || []).filter((x) => x.team_id === teamId);
+              return (
+                <div key={sideKey}>
+                  <div className="flex items-center gap-2 mb-2.5">
+                    <span className="text-[12px] font-semibold tracking-tight text-ink truncate">{teamName}</span>
+                    {formation && <span className="text-[10px] tabular-nums ml-auto text-ink-3">{formation}</span>}
+                  </div>
+                  <Pitch players={extras!.lineup_players} side={sideKey} formation={formation} />
+                  <div className="mt-3">
+                    <div className="text-[9px] uppercase tracking-[0.16em] font-bold mb-1.5 text-ink-3">Desfalques</div>
+                    {inj.length === 0 ? <div className="text-[11px] text-ink-3">Sem desfalques</div> : inj.map((d, i) => {
+                      const duvida = /quest|doubt|dúvid/i.test(d.injury_type || '');
+                      return (
+                        <div key={i} className={`flex items-center gap-2 py-1.5 text-[12px] ${i ? 'border-t border-line/60' : ''}`}>
+                          <span className="font-semibold tracking-tight text-ink truncate">{d.player_name}</span>
+                          <span className="text-[10px] text-ink-3 truncate">{d.injury_reason || d.injury_type}</span>
+                          <span className="px-1.5 h-4 inline-flex items-center rounded text-[9px] font-bold ml-auto shrink-0" style={duvida ? { background: '#fef7df', color: '#9a6c00' } : { background: '#fde2e7', color: '#9a1f2e' }}>{duvida ? 'Dúvida' : 'Fora'}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-sm text-ink-3 text-center py-6">Escalação provável disponível próximo ao jogo.</p>
+        )}
+      </div>
+    </div>
+  ) : null;
+
+  const h2hCard = fixture ? (
+    <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
+      <div className="px-5 py-3 border-b border-line"><div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Confrontos diretos</div></div>
+      <div className="p-5">
+        {h2hLoading ? <p className="text-xs text-ink-3">Carregando…</p> : h2h && h2h.length ? (
+          <>
+            <div className="flex items-center gap-2 mb-2">
+              <span className="text-[20px] font-semibold tabular-nums text-forest shrink-0">{h2hHomeWins}</span>
+              <div className="flex-1 h-2 rounded-full overflow-hidden flex bg-canvas-2">
+                <div style={{ width: `${h2hPct(h2hHomeWins)}%`, background: 'var(--forest)' }} />
+                <div style={{ width: `${h2hPct(h2hDraws)}%`, background: 'var(--ink-3)' }} />
+                <div style={{ width: `${h2hPct(h2hAwayWins)}%`, background: '#be123c' }} />
+              </div>
+              <span className="text-[20px] font-semibold tabular-nums shrink-0" style={{ color: '#be123c' }}>{h2hAwayWins}</span>
+            </div>
+            <p className="text-[11px] mb-2 text-ink-3">{h2hTotal} confronto{h2hTotal === 1 ? '' : 's'} · {h2hHomeWins} {fixture.home_team_name} · {h2hDraws} empate · {h2hAwayWins} {fixture.away_team_name}</p>
+            {h2h.slice(0, 6).map((m) => {
+              const win = (m.goals_home ?? 0) > (m.goals_away ?? 0) ? 'home' : (m.goals_away ?? 0) > (m.goals_home ?? 0) ? 'away' : 'draw';
+              return (
+                <div key={m.fixture_id} className="grid grid-cols-[1fr_auto_60px] gap-2 items-center py-2 text-[12px] border-t border-line/60">
+                  <span className="text-[11px] text-ink-3 truncate">{fmtDate(m.date_utc)} · {m.competition}</span>
+                  <span className="font-semibold tabular-nums text-ink">{m.goals_home} × {m.goals_away}</span>
+                  <span className="text-right text-[10px] font-bold uppercase" style={{ color: win === 'home' ? 'var(--forest)' : win === 'away' ? '#be123c' : 'var(--ink-3)' }}>{win === 'home' ? 'Casa' : win === 'away' ? 'Fora' : 'Empate'}</span>
+                </div>
+              );
+            })}
+          </>
+        ) : <p className="text-xs text-ink-3">Sem confrontos diretos no histórico.</p>}
+      </div>
+    </div>
+  ) : null;
+
+  const statsCard = fixture && (homeProfile || awayProfile) ? (
+    <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
+      <div className="px-5 py-3 flex items-center justify-between border-b border-line">
+        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Estatísticas · temporada</div>
+        <span className="text-[10px] flex items-center gap-2"><span className="text-forest font-semibold truncate max-w-[90px]">{fixture.home_team_name}</span><span className="text-ink-3 truncate max-w-[90px]">{fixture.away_team_name}</span></span>
+      </div>
+      <div className="p-5"><StatsCompare home={homeProfile} away={awayProfile} /></div>
+    </div>
+  ) : null;
 
   return (
     <div className="theme-bolao min-h-screen bg-canvas flex flex-col">
       <AnalyticsNav variant="rebrand" showBack />
       <OnboardingTour tourId={FUT_JOGO_TOUR_ID} steps={jogoSteps} run={jogoTour.run} onFinish={jogoTour.finish} />
-      <div className="max-w-6xl w-full mx-auto px-4 md:px-6 py-6 flex-1">
+      {/* 1480px pra bater com a agenda. Em max-w-6xl (1152) sobravam ~290px de ar
+          numa tela de 1440, e todo bloco esticava na mesma largura. */}
+      <div className="max-w-[1480px] w-full mx-auto px-4 md:px-6 py-6 flex-1">
         {isLoading ? (
           <div className="space-y-3">
             <Skeleton className="h-28 w-full bg-canvas-2 rounded-rebrand-md" />
@@ -724,175 +444,83 @@ export default function FutebolJogo() {
         ) : (
           <>
             {isDemo && <div className="mb-4"><DemoRibbon show /></div>}
-            {/* Header */}
-            <div data-tour="fut-jogo-header" className="bg-white border border-line border-l-4 border-l-forest rounded-rebrand-xl p-5 md:p-6">
-              <div className="flex items-center justify-center gap-2 mb-5 text-[10px] uppercase tracking-[0.16em] text-ink-3">
-                {isDemo && <DemoBadge />}<span>{prettyRound(fixture.round)}</span>
-                {fixture.venue_name && (
-                  <><span>•</span><MapPin className="w-3 h-3" /><span>{fixture.venue_name}{fixture.venue_city ? `, ${fixture.venue_city}` : ''}</span></>
-                )}
+
+            {/* Protótipo "Futebol Jogo" (Claude Design): o confronto e a melhor
+                leitura moram na MESMA faixa forest, colada no cabeçalho. Eram dois
+                blocos disputando o topo da tela. */}
+            {jogoInfo && (
+              <div data-tour="fut-jogo-header">
+                {isDemo && <div className="mb-2"><DemoBadge /></div>}
+                <FaixaPartida
+                  jogo={jogoInfo}
+                  valueRows={valueRows}
+                  locked={locked}
+                  rodada={prettyRound(fixture.round)}
+                  estadio={fixture.venue_name ? `${fixture.venue_name}${fixture.venue_city ? `, ${fixture.venue_city}` : ''}` : null}
+                  quando={fmtDateTime(fixture.kickoff_utc)}
+                  formHome={extrasLoading ? [] : extras?.form_home || []}
+                  formAway={extrasLoading ? [] : extras?.form_away || []}
+                  homeTeamId={fixture.home_team_id}
+                  awayTeamId={fixture.away_team_id}
+                  onAbrirMercado={(slug) => {
+                    setMercadoAtivo(slug);
+                    setAba('mercados');
+                  }}
+                />
               </div>
-              <div className="grid grid-cols-[1fr_auto_1fr] items-start gap-4">
-                <button
-                  onClick={() => navigate(`/futebol/time/${fixture.home_team_id}?c=${fixture.competition}&s=${fixture.season}`)}
-                  className="flex flex-col items-center gap-2 group"
-                >
-                  <Crest name={fixture.home_team_name} logo={getFutebolTeamLogoUrl(fixture.home_team_id)} />
-                  <span className="text-base font-semibold text-ink text-center group-hover:text-forest leading-tight">{fixture.home_team_name}</span>
-                  {!extrasLoading && <FormChips form={extras?.form_home || []} />}
-                </button>
-                <div className="px-2 md:px-4 text-center pt-1">
-                  {finished ? (
-                    <div className="text-4xl md:text-5xl font-extrabold text-ink tabular-nums leading-none">
-                      {fixture.goals_home ?? '-'} <span className="text-ink-3">:</span> {fixture.goals_away ?? '-'}
-                    </div>
-                  ) : (
-                    <div className="text-lg md:text-xl font-bold text-ink tabular-nums leading-none">{fmtDateTime(fixture.kickoff_utc)}</div>
-                  )}
-                  <div className="text-[10px] uppercase tracking-wide text-ink-3 mt-2">
-                    {finished ? 'Encerrado' : (fixture.status_long || 'Agendado')}
-                  </div>
-                </div>
-                <button
-                  onClick={() => navigate(`/futebol/time/${fixture.away_team_id}?c=${fixture.competition}&s=${fixture.season}`)}
-                  className="flex flex-col items-center gap-2 group"
-                >
-                  <Crest name={fixture.away_team_name} logo={getFutebolTeamLogoUrl(fixture.away_team_id)} />
-                  <span className="text-base font-semibold text-ink text-center group-hover:text-forest leading-tight">{fixture.away_team_name}</span>
-                  {!extrasLoading && <FormChips form={extras?.form_away || []} />}
-                </button>
+            )}
+
+            {!finished && showValue && <FutebolAccessBanner access={access} className="mt-5" />}
+
+            {/* Duas abas: a leitura com os 5 mercados de um lado, os times do outro.
+                O antigo "Resumo" virou a própria faixa da partida mais a coluna de
+                mercados, então deixou de ser uma aba. */}
+            <div className="mt-5 flex items-center justify-between gap-4 flex-wrap">
+              <div className="inline-flex p-[3px] rounded-[11px]" style={{ background: 'var(--canvas-2)', border: '1px solid #ded2b6' }}>
+                {(
+                  [
+                    ['mercados', 'Leitura & mercados'],
+                    ['times', 'Times'],
+                  ] as const
+                ).map(([k, label]) => (
+                  <button
+                    key={k}
+                    onClick={() => setAba(k)}
+                    className={`h-8 px-4 rounded-lg text-[13px] cursor-pointer transition border-0 ${
+                      aba === k ? 'bg-white text-ink font-semibold shadow-sm' : 'bg-transparent text-ink-2 font-medium'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
               </div>
+              <span className="text-[11.5px]" style={{ color: '#8d8672' }}>
+                Leitura de risco, não recomendação de aposta
+              </span>
             </div>
 
-            {/* Jogo ENCERRADO: oportunidades (resultado) + nosso modelo, lado a lado (~40/60) */}
-            {finished && (hasPlayed || tendencies) && (
-              <div className={`mt-5 grid gap-5 items-start ${hasPlayed && tendencies ? 'lg:grid-cols-[2fr_3fr]' : 'grid-cols-1'}`}>
-                {hasPlayed && valueRows && (
-                  <PlayedOpportunities rows={valueRows} homeName={fixture.home_team_name} awayName={fixture.away_team_name} goalsHome={fixture.goals_home} goalsAway={fixture.goals_away} />
-                )}
-                {tendencies && (
-                  <ModelCard tendencies={tendencies} head={head} homeName={fixture.home_team_name} awayName={fixture.away_team_name} />
-                )}
-              </div>
-            )}
+            <div className="mt-4">
+              {aba === 'mercados' && (
+                <BancadaMercados
+                  jogo={jogoInfo}
+                  valueRows={valueRows}
+                  tendencies={tendencies}
+                  locked={locked}
+                  mercadoAtivo={mercadoAtivo}
+                  onMercado={setMercadoAtivo}
+                />
+              )}
 
-            {/* Jogo FUTURO: acesso + veredito + nosso modelo, lado a lado */}
-            {!finished && showValue && <FutebolAccessBanner access={access} className="mt-5" />}
-            {!finished && (showValue || tendencies) && (
-              <div className={`mt-5 grid gap-5 items-start ${showValue && tendencies ? 'lg:grid-cols-[1.5fr_1fr]' : 'grid-cols-1'}`}>
-                {showValue && valueRows && (
-                  <div data-tour="fut-jogo-oque-olhar">
-                    <WhatToWatch rows={valueRows} homeName={fixture.home_team_name} awayName={fixture.away_team_name} competition={fixture.competition} kickoffUtc={fixture.kickoff_utc} locked={locked} />
+              {aba === 'times' && (
+                <div data-tour="fut-jogo-contexto" className="flex flex-col gap-5">
+                  <div className="grid lg:grid-cols-2 gap-5 items-start">
+                    {statsCard}
+                    {h2hCard}
                   </div>
-                )}
-                {tendencies && (
-                  <div data-tour="fut-jogo-modelo">
-                    <ModelCard tendencies={tendencies} head={head} homeName={fixture.home_team_name} awayName={fixture.away_team_name} />
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* Explorar mercados — largura total (só pré-jogo, é interativo pra decidir) */}
-            {showValue && valueRows && (
-              <div data-tour="fut-jogo-mercados" className="mt-5">
-                <ResultExplorer rows={valueRows} homeName={fixture.home_team_name} awayName={fixture.away_team_name} locked={locked} />
-              </div>
-            )}
-
-            {/* Contexto — escalação (pitch) + confrontos diretos + estatísticas */}
-            {(hasDescriptive || homeProfile || awayProfile) && (
-              <div data-tour="fut-jogo-contexto" className="mt-5 grid lg:grid-cols-[1.3fr_1fr] gap-5 items-start">
-                {/* Escalação provável & desfalques */}
-                <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
-                  <div className="px-5 py-3 flex items-center justify-between border-b border-line">
-                    <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Escalação provável & desfalques</div>
-                    {extras?.lineups?.length ? (
-                      <span className="text-[10px] tabular-nums text-ink-3">{extras.lineups.find((l) => l.team_side === 'home')?.formation || '—'} × {extras.lineups.find((l) => l.team_side === 'away')?.formation || '—'}</span>
-                    ) : null}
-                  </div>
-                  <div className="p-5">
-                    {extras?.lineup_players?.length ? (
-                      <div className="grid grid-cols-2 gap-4">
-                        {(['home', 'away'] as const).map((sideKey) => {
-                          const teamName = sideKey === 'home' ? fixture.home_team_name : fixture.away_team_name;
-                          const teamId = sideKey === 'home' ? fixture.home_team_id : fixture.away_team_id;
-                          const formation = extras!.lineups.find((l) => l.team_side === sideKey)?.formation ?? null;
-                          const inj = (injuries || []).filter((x) => x.team_id === teamId);
-                          return (
-                            <div key={sideKey}>
-                              <div className="flex items-center gap-2 mb-2.5">
-                                <span className="text-[12px] font-semibold tracking-tight text-ink truncate">{teamName}</span>
-                                {formation && <span className="text-[10px] tabular-nums ml-auto text-ink-3">{formation}</span>}
-                              </div>
-                              <Pitch players={extras!.lineup_players} side={sideKey} formation={formation} />
-                              <div className="mt-3">
-                                <div className="text-[9px] uppercase tracking-[0.16em] font-bold mb-1.5 text-ink-3">Desfalques</div>
-                                {inj.length === 0 ? <div className="text-[11px] text-ink-3">Sem desfalques</div> : inj.map((d, i) => {
-                                  const duvida = /quest|doubt|dúvid/i.test(d.injury_type || '');
-                                  return (
-                                    <div key={i} className={`flex items-center gap-2 py-1.5 text-[12px] ${i ? 'border-t border-line/60' : ''}`}>
-                                      <span className="font-semibold tracking-tight text-ink truncate">{d.player_name}</span>
-                                      <span className="text-[10px] text-ink-3 truncate">{d.injury_reason || d.injury_type}</span>
-                                      <span className="px-1.5 h-4 inline-flex items-center rounded text-[9px] font-bold ml-auto shrink-0" style={duvida ? { background: '#fef7df', color: '#9a6c00' } : { background: '#fde2e7', color: '#9a1f2e' }}>{duvida ? 'Dúvida' : 'Fora'}</span>
-                                    </div>
-                                  );
-                                })}
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    ) : (
-                      <p className="text-sm text-ink-3 text-center py-6">Escalação provável disponível próximo ao jogo.</p>
-                    )}
-                  </div>
+                  {escalacaoCard}
                 </div>
-
-                {/* Confrontos diretos + Estatísticas */}
-                <div className="flex flex-col gap-5">
-                  <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
-                    <div className="px-5 py-3 border-b border-line"><div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Confrontos diretos</div></div>
-                    <div className="p-5">
-                      {h2hLoading ? <p className="text-xs text-ink-3">Carregando…</p> : h2h && h2h.length ? (
-                        <>
-                          <div className="flex items-center gap-2 mb-2">
-                            <span className="text-[20px] font-semibold tabular-nums text-forest shrink-0">{h2hHomeWins}</span>
-                            <div className="flex-1 h-2 rounded-full overflow-hidden flex bg-canvas-2">
-                              <div style={{ width: `${h2hPct(h2hHomeWins)}%`, background: 'var(--forest)' }} />
-                              <div style={{ width: `${h2hPct(h2hDraws)}%`, background: 'var(--ink-3)' }} />
-                              <div style={{ width: `${h2hPct(h2hAwayWins)}%`, background: '#be123c' }} />
-                            </div>
-                            <span className="text-[20px] font-semibold tabular-nums shrink-0" style={{ color: '#be123c' }}>{h2hAwayWins}</span>
-                          </div>
-                          <p className="text-[11px] mb-2 text-ink-3">{h2hTotal} confronto{h2hTotal === 1 ? '' : 's'} · {h2hHomeWins} {fixture.home_team_name} · {h2hDraws} empate · {h2hAwayWins} {fixture.away_team_name}</p>
-                          {h2h.slice(0, 6).map((m) => {
-                            const win = (m.goals_home ?? 0) > (m.goals_away ?? 0) ? 'home' : (m.goals_away ?? 0) > (m.goals_home ?? 0) ? 'away' : 'draw';
-                            return (
-                              <div key={m.fixture_id} className="grid grid-cols-[1fr_auto_60px] gap-2 items-center py-2 text-[12px] border-t border-line/60">
-                                <span className="text-[11px] text-ink-3 truncate">{fmtDate(m.date_utc)} · {m.competition}</span>
-                                <span className="font-semibold tabular-nums text-ink">{m.goals_home} × {m.goals_away}</span>
-                                <span className="text-right text-[10px] font-bold uppercase" style={{ color: win === 'home' ? 'var(--forest)' : win === 'away' ? '#be123c' : 'var(--ink-3)' }}>{win === 'home' ? 'Casa' : win === 'away' ? 'Fora' : 'Empate'}</span>
-                              </div>
-                            );
-                          })}
-                        </>
-                      ) : <p className="text-xs text-ink-3">Sem confrontos diretos no histórico.</p>}
-                    </div>
-                  </div>
-
-                  {(homeProfile || awayProfile) && (
-                    <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
-                      <div className="px-5 py-3 flex items-center justify-between border-b border-line">
-                        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Estatísticas · temporada</div>
-                        <span className="text-[10px] flex items-center gap-2"><span className="text-forest font-semibold truncate max-w-[90px]">{fixture.home_team_name}</span><span className="text-ink-3 truncate max-w-[90px]">{fixture.away_team_name}</span></span>
-                      </div>
-                      <div className="p-5"><StatsCompare home={homeProfile} away={awayProfile} /></div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
+              )}
+            </div>
           </>
         )}
       </div>

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, type ReactNode } from 'react';
+import { useEffect, useState, useMemo, type ReactNode } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { MapPin } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
@@ -8,7 +8,7 @@ import { type JogoInfo } from '@/components/futebol/JogoResumo';
 import { FaixaPartida } from '@/components/futebol/FaixaPartida';
 import { BancadaMercados } from '@/components/futebol/BancadaMercados';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useFutebolFixtureDetail, useFutebolFixtureExtras, useFutebolMatchupTendencies, useFutebolFixtureValue, useFutebolH2H, useFutebolFixtureInjuries, useFutebolTeamProfile, useFutebolAccess } from '@/hooks/use-futebol-data';
+import { useFutebolFixtureDetail, useFutebolFixtureExtras, useFutebolMatchupTendencies, useFutebolFixtureValue, useFutebolH2H, useFutebolFixtureInjuries, useFutebolFixturePremissas, useFutebolTeamProfile, useFutebolAccess } from '@/hooks/use-futebol-data';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
 import {
   computeMatchupTendencies,
@@ -26,6 +26,26 @@ import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
 import { FUT_JOGO_TOUR_ID, makeFutebolJogoSteps } from '@/components/onboarding/tours';
 import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
 import { demoFixtureDetail, demoFixtureValueRows, demoTeamSeason, demoAwaySeason } from '@/components/onboarding/demo/futebol';
+
+/**
+ * A bancada fica lado a lado a partir de 1280px (o breakpoint `xl` do grid). O
+ * tour usa isto pra decidir se o balão cabe ao lado do alvo ou se precisa ir por
+ * cima: empilhada, a folha do mercado é mais alta que a tela.
+ */
+const BANCADA_MQ = '(min-width: 1280px)';
+
+function useBancadaLadoALado(): boolean {
+  const [lado, setLado] = useState<boolean>(() =>
+    typeof window !== 'undefined' ? window.matchMedia(BANCADA_MQ).matches : true,
+  );
+  useEffect(() => {
+    const mql = window.matchMedia(BANCADA_MQ);
+    const onChange = (e: MediaQueryListEvent) => setLado(e.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+  return lado;
+}
 
 const INJURY_TYPE: Record<string, { label: string; cls: string }> = {
   'Missing Fixture': { label: 'Fora', cls: 'bg-status-danger text-canvas' },
@@ -302,6 +322,7 @@ export default function FutebolJogo() {
 
   // Duas abas (Leitura & mercados · Times) e o mercado aberto na bancada.
   const [aba, setAba] = useState<'mercados' | 'times'>('mercados');
+  const bancadaLadoALado = useBancadaLadoALado();
   const [mercadoAtivo, setMercadoAtivo] = useState('goals_over_under');
   const jogoInfo: JogoInfo | null = fixture
     ? {
@@ -319,15 +340,18 @@ export default function FutebolJogo() {
       }
     : null;
 
+  // O tour fala do que está montado: a régua só existe nos mercados de linha, e
+  // as premissas só quando a coleta trouxe alguma para este jogo. A query é a
+  // mesma da bancada, então sai do cache do react-query, sem ida extra à rede.
+  const { data: premissasDoJogo } = useFutebolFixturePremissas(fid);
   const jogoSteps = useMemo(
-    () => makeFutebolJogoSteps({
-      // Com a página em abas, os alvos de mapa/contexto ficam em abas ocultas na
-      // carga — o tour precisa ser refeito para navegar entre abas (pendência).
-      hasValue: false,
-      hasModel: false,
-      hasContext: false,
-    }),
-    [],
+    () =>
+      makeFutebolJogoSteps({
+        hasRegua: mercadoAtivo === 'goals_over_under' || mercadoAtivo === 'asian_handicap',
+        hasPremissas: (premissasDoJogo?.length ?? 0) > 0,
+        ladoALado: bancadaLadoALado,
+      }),
+    [mercadoAtivo, premissasDoJogo, bancadaLadoALado],
   );
 
   // ── Cards de contexto, montados uma vez e posicionados conforme o estado ──
@@ -476,7 +500,11 @@ export default function FutebolJogo() {
                 O antigo "Resumo" virou a própria faixa da partida mais a coluna de
                 mercados, então deixou de ser uma aba. */}
             <div className="mt-5 flex items-center justify-between gap-4 flex-wrap">
-              <div className="inline-flex p-[3px] rounded-[11px]" style={{ background: 'var(--canvas-2)', border: '1px solid #ded2b6' }}>
+              <div
+                data-tour="fut-jogo-abas"
+                className="inline-flex p-[3px] rounded-[11px]"
+                style={{ background: 'var(--canvas-2)', border: '1px solid #ded2b6' }}
+              >
                 {(
                   [
                     ['mercados', 'Leitura & mercados'],

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -1,348 +1,338 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, ArrowRight, X } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { ArrowRight, ArrowUpRight, CalendarOff, ChevronDown } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useFutebolFixtures, useFutebolStandings, useFutebolLeaders, useFutebolValueBoard } from '@/hooks/use-futebol-data';
-import type { Competition, FutebolFixture, FutebolStandingRow, FutebolLeaders, FutebolZone, FutebolValueBoardRow } from '@/services/futebol-data.service';
-import { futebolZone, FUTEBOL_ZONE_COLOR as ZONE_COLOR, FUTEBOL_ZONE_LABEL as ZONE_LABEL } from '@/services/futebol-data.service';
-import { getFutebolTeamLogoUrl, getFutebolPlayerPhotoUrl } from '@/utils/futebol-logos';
-import { groupBoardByFixture, faixaWord, faixaBadgeCls } from '@/utils/futebol-score';
-import { competitionLabel, ALL_COMPETITIONS } from '@/utils/futebol-competitions';
+import { FixtureRow } from '@/components/futebol/FixtureRow';
+import { AgendaDateStrip } from '@/components/futebol/AgendaDateStrip';
+import { JogoResumoPanel } from '@/components/futebol/JogoResumoPanel';
+import { useFutebolFixturesByDay, useFutebolFixtureDays, useFutebolValueBoard } from '@/hooks/use-futebol-data';
+import type { FutebolFixtureByDay, FutebolValueBoardRow } from '@/services/futebol-data.service';
+import { addDays, brtToday, fmtDayHeader } from '@/utils/futebol-datas';
+import { groupBoardByFixture } from '@/utils/futebol-score';
+import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
 import { FUT_JOGOS_TOUR_ID, makeFutebolJogosSteps } from '@/components/onboarding/tours';
 import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
-import { demoFutebolBoard, demoFutebolFixtures, demoFutebolStandings, demoFutebolLeaders } from '@/components/onboarding/demo/futebol';
+import { demoFutebolBoard, makeDemoAgenda } from '@/components/onboarding/demo/futebol';
 
-const COMPETITIONS: { value: Competition; label: string }[] = ALL_COMPETITIONS.map((value) => ({
-  value,
-  label: competitionLabel(value),
-}));
-// Temporadas por competição. Brasileirão/Série B têm histórico; as demais, só 2026.
-const SEASONS_BY_COMP: Record<string, number[]> = { brasileirao: [2024, 2025, 2026], serie_b: [2024, 2025, 2026] };
-const seasonsFor = (c: string): number[] => SEASONS_BY_COMP[c] ?? [2026];
-const SAO_PAULO_TZ = 'America/Sao_Paulo';
-const TODAY = new Date();
+/**
+ * Agenda de jogos por DIA, multi-liga.
+ *
+ * Antes esta tela era campeonato → rodada → dia, o que obrigava o usuário a saber em
+ * qual competição estava o jogo antes de achar o jogo, e "Rodada 21" atravessa três
+ * datas. Agora o eixo é o dia, e a competição é só agrupamento dentro dele.
+ *
+ * O que era rodada, temporada, classificação e artilheiros mudou pra
+ * /futebol/campeonato/:slug, onde esses conceitos fazem sentido (são por liga).
+ *
+ * Dados: uma chamada get_futebol_fixtures_by_day por dia (~16 KB no pior dia do
+ * mart) no lugar das 8 chamadas de temporada inteira que o useFutebolFixturesMulti
+ * fazia (~850 KB). O dia vem em BRT do banco, então jogo de 21:30 não escorrega
+ * mais pro dia seguinte.
+ */
 
-function parseUtc(raw: string | null): Date | null {
-  if (!raw) return null;
-  const iso = raw.includes('T') ? raw : `${raw}T00:00:00`;
-  const d = new Date(/[Z]|[+-]\d{2}:?\d{2}$/.test(iso) ? iso : `${iso}Z`);
-  return isNaN(d.getTime()) ? null : d;
-}
-function fmtTime(raw: string | null): string {
-  const d = parseUtc(raw);
-  return d ? new Intl.DateTimeFormat('pt-BR', { timeZone: SAO_PAULO_TZ, hour: '2-digit', minute: '2-digit' }).format(d) : '';
-}
-function fmtDayHeader(dateUtc: string | null): string {
-  if (!dateUtc) return '—';
-  const d = new Date(`${dateUtc}T12:00:00Z`);
-  const s = new Intl.DateTimeFormat('pt-BR', { timeZone: SAO_PAULO_TZ, weekday: 'long', day: '2-digit', month: 'short' }).format(d).replace('.', '');
-  return s.charAt(0).toUpperCase() + s.slice(1);
-}
-function prettyRound(round: string | null): string {
-  if (!round) return 'Rodada';
-  const m = round.match(/Regular Season\s*-\s*(\d+)/i);
-  return m ? `Rodada ${m[1]}` : round;
-}
-function crestInitials(name: string): string {
-  return name.replace(/[^A-Za-zÀ-ÿ\s]/g, '').trim().slice(0, 3).toUpperCase() || '?';
-}
-function isFinished(status: string | null): boolean {
-  return status === 'FT' || status === 'AET' || status === 'PEN';
-}
-function Crest({ name, id, size = 24 }: { name: string; id: number; size?: number }) {
-  const [err, setErr] = useState(false);
-  const logo = getFutebolTeamLogoUrl(id);
-  if (logo && !err) return <img src={logo} alt={name} onError={() => setErr(true)} style={{ width: size, height: size }} className="object-contain shrink-0" loading="lazy" />;
-  return <div style={{ width: size, height: size }} className="rounded-full bg-canvas-2 border border-line grid place-items-center text-[8px] font-bold text-ink-2 shrink-0">{crestInitials(name)}</div>;
-}
-function Pill({ active, onClick, children }: { active: boolean; onClick: () => void; children: ReactNode }) {
-  return (
-    <button onClick={onClick}
-      className={`h-8 px-3 rounded-rebrand-sm text-xs font-semibold transition-colors ${active ? 'bg-forest text-canvas' : 'bg-white text-ink border border-line hover:bg-canvas-2'}`}>
-      {children}
-    </button>
+/** Breakpoint do painel. Casado com o `lg:` do grid: se divergir, o clique abre um painel invisível. */
+const PANEL_MQ = '(min-width: 1024px)';
+
+function useHasPanel(): boolean {
+  const [has, setHas] = useState<boolean>(() =>
+    typeof window !== 'undefined' ? window.matchMedia(PANEL_MQ).matches : false,
   );
-}
-function Modal({ title, onClose, children }: { title: string; onClose: () => void; children: ReactNode }) {
-  return (
-    <div className="fixed inset-0 z-50 grid place-items-center p-4" onClick={onClose}>
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" />
-      <div className="relative w-full max-w-2xl max-h-[85vh] flex flex-col rounded-rebrand-lg bg-canvas border border-line overflow-hidden shadow-xl" onClick={(e) => e.stopPropagation()}>
-        <div className="px-5 py-3 flex items-center justify-between border-b border-line bg-white shrink-0">
-          <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">{title}</div>
-          <button onClick={onClose} className="w-8 h-8 grid place-items-center rounded-rebrand-sm text-ink-2 hover:bg-canvas-2" aria-label="Fechar"><X className="w-4 h-4" /></button>
-        </div>
-        <div className="overflow-y-auto minimal-scrollbar p-4">{children}</div>
-      </div>
-    </div>
-  );
+  useEffect(() => {
+    const mql = window.matchMedia(PANEL_MQ);
+    const onChange = (e: MediaQueryListEvent) => setHas(e.matches);
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+  return has;
 }
 
-const STAND_GRID = 'grid grid-cols-[28px_1fr_repeat(4,30px)_40px_44px] gap-2 items-center';
-
-function StandingsTable({ rows, loading, onTeam }: { rows?: FutebolStandingRow[]; loading: boolean; onTeam: (id: number) => void }) {
-  if (loading) return <div className="space-y-1">{Array.from({ length: 12 }).map((_, i) => <Skeleton key={i} className="h-9 w-full bg-canvas-2 rounded-rebrand-sm" />)}</div>;
-  if (!rows?.length) return <div className="bg-white border border-line rounded-rebrand-md p-6 text-center text-sm text-ink-3">Sem classificação pra esse filtro.</div>;
-  const zonesPresent = Array.from(new Set(rows.map((r) => futebolZone(r.rank_description)).filter(Boolean))) as Exclude<FutebolZone, null>[];
-  return (
-    <div className="bg-white border border-line rounded-rebrand-md overflow-hidden">
-      {/* As colunas fixas (#, J, V, E, D, SG, Pts) somam ~486px e não cabem em
-          tela de 320-360px. Em vez de empurrar a página inteira — o que criava
-          rolagem lateral e descolava o header sticky —, a tabela rola dentro
-          do próprio card. */}
-      <div className="overflow-x-auto no-scrollbar">
-      <div className="min-w-[480px]">
-      <div className={`${STAND_GRID} px-4 py-2.5 text-[10px] uppercase tracking-[0.12em] font-bold text-ink-3 bg-canvas-2 border-b border-line`}>
-        <span>#</span><span>Time</span>
-        <span className="text-center">J</span><span className="text-center">V</span><span className="text-center">E</span><span className="text-center">D</span>
-        <span className="text-center">SG</span><span className="text-center">Pts</span>
-      </div>
-      {rows.map((r, i) => {
-        const zone = futebolZone(r.rank_description);
-        return (
-          <button key={r.team_id} onClick={() => onTeam(r.team_id)}
-            className={`${STAND_GRID} w-full px-4 py-2.5 hover:bg-canvas-2 transition ${i ? 'border-t border-line/60' : ''}`}>
-            <span className="flex items-center gap-1.5">
-              {zone && <span className="w-1 h-5 rounded-full shrink-0" style={{ background: ZONE_COLOR[zone] }} title={ZONE_LABEL[zone]} />}
-              <span className="text-[12px] tabular-nums font-semibold text-ink-2">{r.rank}</span>
-            </span>
-            <span className="flex items-center gap-2 min-w-0">
-              <Crest name={r.team_name} id={r.team_id} size={24} />
-              <span className="truncate text-[12px] font-semibold tracking-tight text-ink text-left">{r.team_name}</span>
-            </span>
-            <span className="text-center text-[12px] tabular-nums text-ink-2">{r.played}</span>
-            <span className="text-center text-[12px] tabular-nums text-ink-2">{r.wins}</span>
-            <span className="text-center text-[12px] tabular-nums text-ink-2">{r.draws}</span>
-            <span className="text-center text-[12px] tabular-nums text-ink-2">{r.loses}</span>
-            <span className="text-center text-[12px] tabular-nums" style={{ color: r.goals_diff > 0 ? 'var(--forest)' : r.goals_diff < 0 ? '#be123c' : undefined }}>{r.goals_diff > 0 ? '+' : ''}{r.goals_diff}</span>
-            <span className="text-center text-[14px] font-bold tabular-nums text-ink">{r.points}</span>
-          </button>
-        );
-      })}
-      </div>
-      </div>
-      {zonesPresent.length > 0 && (
-        <div className="px-4 py-2.5 flex items-center gap-3 flex-wrap text-[10px] bg-canvas-2 border-t border-line text-ink-3">
-          {zonesPresent.map((z) => (
-            <span key={z} className="flex items-center gap-1.5"><span className="w-2 h-2 rounded-full" style={{ background: ZONE_COLOR[z] }} />{ZONE_LABEL[z]}</span>
-          ))}
-        </div>
-      )}
-    </div>
-  );
+/**
+ * Intervalo da régua, quantizado no mês do dia escolhido (com folga de 7 dias pras
+ * pontas). Quantizar importa: se o intervalo fosse "dia ± 15", cada clique de seta
+ * mudaria a query key e refetcharia. Assim, andar dentro do mês reusa o cache.
+ */
+function monthRange(dayKey: string): { from: string; to: string } {
+  const [y, m] = dayKey.split('-').map(Number);
+  const mm = String(m).padStart(2, '0');
+  const ultimoDia = new Date(Date.UTC(y, m, 0)).getUTCDate();
+  return {
+    from: addDays(`${y}-${mm}-01`, -7),
+    to: addDays(`${y}-${mm}-${String(ultimoDia).padStart(2, '0')}`, 7),
+  };
 }
 
-function PlayerAvatar({ id, name, size = 28 }: { id: number; name: string; size?: number }) {
-  const [err, setErr] = useState(false);
-  const url = getFutebolPlayerPhotoUrl(id);
-  if (url && !err) return <img src={url} alt={name} onError={() => setErr(true)} style={{ width: size, height: size }} className="rounded-full object-cover bg-canvas-2 shrink-0" loading="lazy" />;
-  return <div style={{ width: size, height: size }} className="rounded-full bg-canvas-2 border border-line grid place-items-center text-[9px] font-bold text-ink-2 shrink-0">{crestInitials(name)}</div>;
-}
-
-function ScorersCard({ leaders, loading, full }: { leaders?: FutebolLeaders; loading: boolean; full?: boolean }) {
-  const scorers = full ? (leaders?.scorers || []) : (leaders?.scorers || []).slice(0, 8);
-  return (
-    <div className="bg-white border border-line rounded-rebrand-md overflow-hidden">
-      {loading ? <div className="p-4 space-y-2">{Array.from({ length: 5 }).map((_, i) => <Skeleton key={i} className="h-7 w-full bg-canvas-2 rounded" />)}</div>
-        : scorers.length ? scorers.map((s, i) => (
-          <div key={s.player_id} className={`px-4 py-2.5 flex items-center gap-3 ${i ? 'border-t border-line/60' : ''}`}>
-            <span className="text-[12px] tabular-nums font-semibold text-ink-3 w-4">{i + 1}</span>
-            <PlayerAvatar id={s.player_id} name={s.player_name} />
-            <span className="text-[13px] font-semibold tracking-tight text-ink flex-1 min-w-0 truncate">{s.player_name}</span>
-            <span className="text-[11px] text-ink-3 truncate max-w-[100px] text-right">{s.team_name}</span>
-            <span className="text-[15px] font-semibold tabular-nums text-forest">{s.goals}</span>
-            <span className="text-[10px] text-ink-3">gols</span>
-          </div>
-        )) : <div className="p-4 text-center text-sm text-ink-3">Sem dados.</div>}
-    </div>
-  );
-}
-
-function FixtureRow({ fixture, best, onClick }: { fixture: FutebolFixture; best: FutebolValueBoardRow | null; onClick: () => void }) {
-  const finished = isFinished(fixture.status_short);
-  return (
-    <button onClick={onClick} className="w-full text-left px-4 py-3 flex items-center gap-3 border-t border-line/60 first:border-t-0 hover:bg-canvas-2 transition">
-      <div className="w-12 shrink-0 text-center">
-        {finished ? <span className="text-[9px] uppercase tracking-[0.12em] font-bold text-ink-3">Fim</span>
-          : <span className="text-[12px] font-semibold tabular-nums text-ink">{fmtTime(fixture.kickoff_utc) || '—'}</span>}
-      </div>
-      <div className="flex items-center gap-2 flex-1 min-w-0 justify-end">
-        <span className="text-[12px] font-semibold tracking-tight truncate text-ink">{fixture.home_team_name}</span>
-        <Crest name={fixture.home_team_name} id={fixture.home_team_id} size={22} />
-      </div>
-      <div className="shrink-0 text-center" style={{ minWidth: 52 }}>
-        {finished ? <span className="text-[15px] font-semibold tabular-nums tracking-tight text-ink">{fixture.goals_home ?? '-'} <span className="text-ink-3">×</span> {fixture.goals_away ?? '-'}</span>
-          : <span className="text-[11px] text-ink-3">×</span>}
-      </div>
-      <div className="flex items-center gap-2 flex-1 min-w-0">
-        <Crest name={fixture.away_team_name} id={fixture.away_team_id} size={22} />
-        <span className="text-[12px] font-semibold tracking-tight truncate text-ink">{fixture.away_team_name}</span>
-      </div>
-      <div className="shrink-0 w-16 text-right">
-        {!finished && (best
-          ? <span className={`px-1.5 h-5 inline-flex items-center rounded text-[9px] font-bold uppercase tracking-[0.1em] ${faixaBadgeCls(best.faixa)}`}>{faixaWord(best.faixa)}</span>
-          : <span className="text-[9px] text-ink-3">sem valor</span>)}
-      </div>
-    </button>
-  );
-}
+const DIA_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export default function FutebolJogos() {
   const navigate = useNavigate();
-  const [competition, setCompetition] = useState<Competition>('brasileirao');
-  const [season, setSeason] = useState<number>(2026);
-  const [roundIdx, setRoundIdx] = useState(0);
-  const [modal, setModal] = useState<null | 'tabela' | 'artilheiros'>(null);
+  const hasPanel = useHasPanel();
+  const [params, setParams] = useSearchParams();
 
-  const { data: fixtures, isLoading, isError } = useFutebolFixtures(competition, season);
-  const { data: standings, isLoading: loadingStandings } = useFutebolStandings(competition, season, true);
-  const { data: leaders, isLoading: loadingLeaders } = useFutebolLeaders(competition, season, true);
+  const diaParam = params.get('dia');
+  const dia = DIA_RE.test(diaParam ?? '') ? (diaParam as string) : brtToday();
+  const jogoParam = Number(params.get('jogo')) || null;
+
+  const { from, to } = useMemo(() => monthRange(dia), [dia]);
+  const { data: fixtures, isLoading, isError } = useFutebolFixturesByDay(dia);
+  const { data: dias } = useFutebolFixtureDays(from, to);
   const { data: board } = useFutebolValueBoard();
 
   const jogosTour = useOnboardingTour(FUT_JOGOS_TOUR_ID, { enabled: !isLoading && !isError });
-  const isDemo = jogosTour.run; // durante o tour, preenche a tela com exemplo
-  const effFixtures = useMemo(() => (isDemo ? demoFutebolFixtures : (fixtures ?? [])), [isDemo, fixtures]);
-  const effStandings = isDemo ? demoFutebolStandings : standings;
-  const effLeaders = isDemo ? demoFutebolLeaders : leaders;
+  const isDemo = jogosTour.run;
+
+  const effFixtures = useMemo<FutebolFixtureByDay[]>(
+    () => (isDemo ? makeDemoAgenda(dia) : (fixtures ?? [])),
+    [isDemo, dia, fixtures],
+  );
 
   const bestByFixture = useMemo(() => {
     const m = new Map<number, FutebolValueBoardRow>();
-    if (isDemo) { demoFutebolBoard.forEach((r) => m.set(r.fixture_id, r)); return m; }
+    if (isDemo) {
+      demoFutebolBoard.forEach((r) => m.set(r.fixture_id, r));
+      return m;
+    }
     groupBoardByFixture(board || []).forEach((bf) => m.set(bf.fixtureId, bf.best));
     return m;
   }, [board, isDemo]);
 
-  const rounds = useMemo(() => {
-    const seen: string[] = [];
-    effFixtures.forEach((f) => { if (f.round && !seen.includes(f.round)) seen.push(f.round); });
-    return seen;
+  const jogosPorDia = useMemo(() => {
+    const m = new Map<string, number>();
+    (dias ?? []).forEach((d) => m.set(d.day_brt, Number(d.jogos)));
+    return m;
+  }, [dias]);
+
+  /** Jogos do dia agrupados por competição, na ordem canônica das ligas. */
+  const grupos = useMemo(() => {
+    const byComp = new Map<string, FutebolFixtureByDay[]>();
+    effFixtures.forEach((f) => {
+      const k = f.competition || '—';
+      if (!byComp.has(k)) byComp.set(k, []);
+      byComp.get(k)!.push(f);
+    });
+    // Ordena por horário dentro da liga. A RPC já devolve ordenado, mas o front não
+    // deveria depender disso pra desenhar certo (os dados de exemplo do tour vêm na
+    // ordem do array, não do relógio).
+    return sortCompetitions([...byComp.keys()]).map(
+      (c) =>
+        [
+          c,
+          [...byComp.get(c)!].sort((a, b) => (a.kickoff_utc ?? '').localeCompare(b.kickoff_utc ?? '')),
+        ] as const,
+    );
   }, [effFixtures]);
 
-  useEffect(() => {
-    if (!effFixtures.length || !rounds.length) return;
-    let bestRound = effFixtures[0].round, bestDelta = Infinity;
-    for (const f of effFixtures) {
-      const d = parseUtc(f.kickoff_utc || f.date_utc);
-      if (!d) continue;
-      const delta = Math.abs(d.getTime() - TODAY.getTime());
-      if (delta < bestDelta) { bestDelta = delta; bestRound = f.round; }
-    }
-    const idx = rounds.indexOf(bestRound as string);
-    setRoundIdx(idx >= 0 ? idx : 0);
-  }, [effFixtures, rounds]);
-
-  const currentRound = rounds[roundIdx];
-  const groups = useMemo(() => {
-    const list = effFixtures.filter((f) => f.round === currentRound);
-    const byDay = new Map<string, FutebolFixture[]>();
-    list.forEach((f) => { const k = f.date_utc || '—'; if (!byDay.has(k)) byDay.set(k, []); byDay.get(k)!.push(f); });
-    return Array.from(byDay.entries()).sort((a, b) => a[0].localeCompare(b[0]));
-  }, [effFixtures, currentRound]);
-  const roundCount = groups.reduce((n, [, g]) => n + g.length, 0);
-
-  // Mantém a temporada se a nova competição também a tiver; senão vai pra mais
-  // recente (SEASONS é crescente — o índice 0 é a mais ANTIGA, ex.: 2024).
-  const handleCompetition = (c: Competition) => {
-    setCompetition(c);
-    const seasons = seasonsFor(c);
-    setSeason(seasons.includes(season) ? season : seasons[seasons.length - 1]);
-  };
-  const goTeam = (id: number) => navigate(`/futebol/time/${id}?c=${competition}&s=${season}`);
-
-  const jogosSteps = useMemo(
-    () => makeFutebolJogosSteps({ hasRounds: !isLoading && !isError && rounds.length > 0 }),
-    [isLoading, isError, rounds.length],
+  const selected = useMemo(
+    () => effFixtures.find((f) => f.fixture_id === jogoParam) ?? null,
+    [effFixtures, jogoParam],
   );
+
+  // Jogo que não existe no dia (link velho, ou o usuário trocou o dia na mão) não
+  // pode deixar `?jogo=` pendurado na URL.
+  useEffect(() => {
+    if (jogoParam && !isLoading && !selected && effFixtures.length > 0) {
+      const next = new URLSearchParams(params);
+      next.delete('jogo');
+      setParams(next, { replace: true });
+    }
+  }, [jogoParam, selected, isLoading, effFixtures.length, params, setParams]);
+
+  const selectDay = (d: string) => {
+    // replace pra seta de dia não empilhar histórico; o jogo selecionado cai fora
+    // porque ele pertencia ao dia anterior.
+    setParams({ dia: d }, { replace: true });
+  };
+
+  const openJogo = (f: FutebolFixtureByDay) => {
+    if (!hasPanel) {
+      navigate(`/futebol/jogo/${f.fixture_id}`);
+      return;
+    }
+    // push: o voltar do navegador fecha o painel, que é o que o usuário espera.
+    setParams({ dia, jogo: String(f.fixture_id) });
+  };
+
+  const closePanel = () => setParams({ dia }, { replace: true });
+
+  /** Dia mais próximo com jogo, pra oferecer saída num dia vazio. */
+  const proximoComJogo = useMemo(() => {
+    const comJogo = (dias ?? []).filter((d) => Number(d.jogos) > 0).map((d) => d.day_brt);
+    const depois = comJogo.find((d) => d > dia);
+    if (depois) return depois;
+    return [...comJogo].reverse().find((d) => d < dia) ?? null;
+  }, [dias, dia]);
+
+  const total = effFixtures.length;
+  /** Quantos jogos do dia têm leitura com preço: é o que o resumo do dia promete. */
+  const comLeitura = effFixtures.filter((f) => bestByFixture.has(f.fixture_id)).length;
+
+  /**
+   * Campeonatos recolhidos. Em dia cheio (16 jogos em 4 ligas) o usuário quase
+   * sempre quer varrer uma liga por vez. O estado é por sessão de tela e some ao
+   * trocar de dia, porque cada dia tem a sua lista.
+   */
+  const [recolhidos, setRecolhidos] = useState<Set<string>>(new Set());
+  useEffect(() => setRecolhidos(new Set()), [dia]);
+  const alternarGrupo = (comp: string) =>
+    setRecolhidos((s) => {
+      const n = new Set(s);
+      if (n.has(comp)) n.delete(comp);
+      else n.add(comp);
+      return n;
+    });
+  const jogosSteps = useMemo(() => makeFutebolJogosSteps({ hasPanel }), [hasPanel]);
 
   return (
     <div className="theme-bolao min-h-screen bg-canvas flex flex-col">
       <AnalyticsNav variant="rebrand" showBack />
       <OnboardingTour tourId={FUT_JOGOS_TOUR_ID} steps={jogosSteps} run={jogosTour.run} onFinish={jogosTour.finish} />
 
-      {/* Header */}
-      <div data-tour="fut-jogos-header" className="bg-white border-b border-line">
-        <div className="max-w-[1480px] w-full mx-auto px-4 md:px-6 py-5 md:py-6 flex flex-col lg:flex-row lg:items-end lg:justify-between gap-4">
-          <div>
-            <div className="text-[11px] uppercase tracking-[0.2em] font-bold text-ink-3 flex items-center gap-2">{competitionLabel(competition)}{isDemo && <DemoBadge />}</div>
-            <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{prettyRound(currentRound)}</h1>
-            <p className="text-[13px] mt-1 text-ink-2">Rodadas, classificação e artilheiros · temporada {season}</p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            {COMPETITIONS.map((c) => <Pill key={c.value} active={competition === c.value} onClick={() => handleCompetition(c.value)}>{c.label}</Pill>)}
-            <span className="w-px h-5 bg-line mx-1" />
-            {seasonsFor(competition).map((s) => <Pill key={s} active={season === s} onClick={() => setSeason(s)}>{s}</Pill>)}
+      {/* Barra do dia: faixa areia colada no cabeçalho, com título, resumo do dia e
+          a régua de datas à direita (protótipo "Futebol Jogos"). O bege é o rótulo
+          da página; o conteúdo abaixo é que fica branco. */}
+      <div style={{ background: 'var(--canvas-2)', borderBottom: '1px solid #ded2b6' }}>
+        <div className="max-w-[1240px] w-full mx-auto px-4 md:px-6 py-2.5 flex items-center gap-x-3 gap-y-2 flex-wrap">
+          <h1 className="font-display text-[17px] font-bold tracking-tight text-ink">Jogos</h1>
+          {isDemo && <DemoBadge />}
+          <span className="text-[12.5px]" style={{ color: '#6b6350' }}>
+            {isLoading
+              ? 'carregando…'
+              : total === 0
+                ? 'nenhum jogo neste dia'
+                : `${total} ${total === 1 ? 'jogo' : 'jogos'} · ${grupos.length} ${grupos.length === 1 ? 'campeonato' : 'campeonatos'} · ${comLeitura} com leitura`}
+          </span>
+          <div className="ml-auto min-w-0" data-tour="fut-jogos-datas">
+            <AgendaDateStrip selectedDay={dia} onSelectDay={selectDay} jogosPorDia={jogosPorDia} />
           </div>
         </div>
       </div>
 
-      <div className="max-w-[1480px] w-full mx-auto px-4 md:px-6 py-6 flex-1">
-        {isDemo && <div className="mb-4"><DemoRibbon show /></div>}
-        {/* Stepper de rodada */}
-        {!isLoading && !isError && rounds.length > 0 && (
-          <div data-tour="fut-jogos-rodada" className="flex items-center justify-between bg-white border border-line rounded-rebrand-md px-2 py-1.5 mb-4 max-w-sm">
-            <button onClick={() => setRoundIdx((i) => Math.max(0, i - 1))} disabled={roundIdx <= 0} className="h-8 w-8 grid place-items-center rounded-rebrand-sm text-ink-2 hover:bg-canvas-2 disabled:opacity-30" aria-label="Rodada anterior"><ChevronLeft className="w-4 h-4" /></button>
-            <div className="text-center">
-              <div className="text-sm font-bold text-ink">{prettyRound(currentRound)}</div>
-              <div className="text-[10px] text-ink-3">{roundCount} jogos · {roundIdx + 1}/{rounds.length}</div>
-            </div>
-            <button onClick={() => setRoundIdx((i) => Math.min(rounds.length - 1, i + 1))} disabled={roundIdx >= rounds.length - 1} className="h-8 w-8 grid place-items-center rounded-rebrand-sm text-ink-2 hover:bg-canvas-2 disabled:opacity-30" aria-label="Próxima rodada"><ChevronRight className="w-4 h-4" /></button>
+      {/* A faixa do dia é rótulo, não parte do card: sem respiro embaixo dela, a
+          lista e o painel pareciam grudados na régua de datas. */}
+      <div className="max-w-[1240px] w-full mx-auto px-4 md:px-6 pt-5 md:pt-6 pb-8 flex-1 w-full">
+        {isDemo && (
+          <div className="mb-4">
+            <DemoRibbon show />
           </div>
         )}
 
         {isError ? (
-          <div className="bg-white border border-line rounded-rebrand-md p-6 text-center text-sm text-status-danger">Erro ao carregar os jogos.</div>
+          <div className="bg-white border border-line rounded-rebrand-md p-6 text-center text-sm text-status-danger">
+            Erro ao carregar os jogos.
+          </div>
         ) : (
-          // `min-w-0` nas duas colunas: item de grid não encolhe abaixo do
-          // próprio conteúdo por padrão, e a tabela de classificação (480px)
-          // empurrava a página inteira em vez de rolar dentro do card.
-          <div className="grid lg:grid-cols-[1.4fr_1fr] gap-6 items-start">
-            {/* Jogos da rodada */}
-            <div data-tour="fut-jogos-lista" className="flex flex-col gap-4 min-w-0">
-              {isLoading ? Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-28 w-full bg-canvas-2 rounded-rebrand-md" />)
-                : roundCount === 0 ? <div className="bg-white border border-line rounded-rebrand-md p-6 text-center text-sm text-ink-3">Nenhum jogo nesta rodada.</div>
-                : groups.map(([day, games]) => (
-                  <div key={day} className="bg-white border border-line rounded-rebrand-md overflow-hidden">
-                    <div className="px-4 py-2.5 text-[11px] uppercase tracking-[0.16em] font-bold text-ink-2 bg-canvas-2 border-b border-line">{fmtDayHeader(day)}</div>
-                    {games.map((f) => (
-                      <FixtureRow key={f.fixture_id} fixture={f} best={bestByFixture.get(f.fixture_id) ?? null} onClick={() => navigate(`/futebol/jogo/${f.fixture_id}`)} />
-                    ))}
+          // 50/50 da Direção B: a lista não precisa de mais da metade (times
+          // empilhados cabem), e o painel deixa de parecer um encosto.
+          <div className="grid lg:grid-cols-2 gap-5 items-start">
+            <div data-tour="fut-jogos-lista" className="min-w-0">
+              {isLoading ? (
+                <div className="flex flex-col gap-4">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="h-28 w-full bg-canvas-2 rounded-rebrand-md" />
+                  ))}
+                </div>
+              ) : total === 0 ? (
+                <div className="bg-white rounded-[20px] p-12 text-center" style={{ border: '1px solid #ded2b6' }}>
+                  <CalendarOff className="w-6 h-6 mx-auto" style={{ color: '#c4bda8' }} />
+                  <p className="text-[13.5px] mt-2.5" style={{ color: '#6b6350' }}>Nenhum jogo em {fmtDayHeader(dia)}.</p>
+                  {proximoComJogo && (
+                    <button
+                      onClick={() => selectDay(proximoComJogo)}
+                      className="mt-3 h-9 px-4 rounded-rebrand-sm text-xs font-semibold bg-forest text-canvas hover:bg-forest-2 transition inline-flex items-center gap-1.5"
+                    >
+                      Ir para {fmtDayHeader(proximoComJogo)}
+                      <ArrowRight className="w-3 h-3" />
+                    </button>
+                  )}
+                </div>
+              ) : (
+                /* Card ÚNICO com as ligas como sub-headers, em vez de um card por
+                   liga: menos moldura repetida, a lista vira uma coisa só. O nome
+                   da liga é o link pra página do campeonato. */
+                <div className="bg-white rounded-[20px] overflow-hidden" style={{ border: '1px solid #ded2b6' }}>
+                  {grupos.map(([comp, jogos]) => {
+                    const recolhido = recolhidos.has(comp);
+                    return (
+                      <div key={comp}>
+                        {/* O cabeçalho recolhe o campeonato; a seta ao lado do nome
+                            abre a página dele. Duas ações separadas, cada uma no seu
+                            alvo, em vez de um clique com dois significados. */}
+                        <div
+                          className="px-4 py-2 flex items-center gap-2"
+                          style={{ background: 'var(--canvas-2)', borderTop: '1px solid #ded2b6', borderBottom: '1px solid #ded2b6' }}
+                        >
+                          <button
+                            onClick={() => alternarGrupo(comp)}
+                            aria-expanded={!recolhido}
+                            className="min-w-0 flex items-center gap-1.5 bg-transparent border-0 p-0 py-1 -my-1 cursor-pointer text-left"
+                          >
+                            <ChevronDown
+                              className="w-3.5 h-3.5 shrink-0 transition-transform"
+                              style={{ color: '#8d8672', transform: `rotate(${recolhido ? -90 : 0}deg)` }}
+                            />
+                            <span
+                              className="text-[10.5px] uppercase tracking-[0.16em] font-bold truncate"
+                              style={{ color: '#6b6350' }}
+                            >
+                              {competitionLabel(comp)}
+                            </span>
+                          </button>
+                          <Link
+                            to={`/futebol/campeonato/${comp}`}
+                            aria-label={`Abrir ${competitionLabel(comp)}`}
+                            className="shrink-0 w-5 h-5 grid place-items-center rounded hover:text-forest transition"
+                            style={{ color: '#8d8672' }}
+                          >
+                            <ArrowUpRight className="w-3.5 h-3.5" />
+                          </Link>
+                          <span className="ml-auto text-[10.5px] shrink-0 tabular-nums" style={{ color: '#8d8672' }}>
+                            {jogos.length} {jogos.length === 1 ? 'jogo' : 'jogos'} ·{' '}
+                            {jogos.filter((j) => bestByFixture.has(j.fixture_id)).length} com leitura
+                          </span>
+                        </div>
+                        {!recolhido &&
+                          jogos.map((f) => (
+                            <FixtureRow
+                              key={f.fixture_id}
+                              fixture={f}
+                              best={bestByFixture.get(f.fixture_id) ?? null}
+                              selected={f.fixture_id === jogoParam}
+                              onClick={() => openJogo(f)}
+                            />
+                          ))}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* Painel só no desktop. Em mobile o clique já navegou pra tela cheia. */}
+            {hasPanel && (
+              <div data-tour="fut-jogos-painel" className="min-w-0 lg:sticky lg:top-4">
+                {selected ? (
+                  <JogoResumoPanel
+                    fixture={selected}
+                    best={bestByFixture.get(selected.fixture_id) ?? null}
+                    onClose={closePanel}
+                  />
+                ) : (
+                  <div className="bg-white rounded-[20px] p-10 text-center" style={{ border: '1px solid #ded2b6' }}>
+                    <div className="text-[10px] uppercase tracking-[0.16em] font-bold" style={{ color: '#8d8672' }}>
+                      Resumo do jogo
+                    </div>
+                    <p className="text-[13px] mt-2 leading-relaxed" style={{ color: '#6b6350' }}>
+                      Clique num jogo da lista para ver por que aquela é a leitura, sem sair da agenda.
+                    </p>
                   </div>
-                ))}
-            </div>
-            {/* Rail: classificação + artilheiros */}
-            <div data-tour="fut-jogos-tabela" className="flex flex-col gap-6 min-w-0">
-              <div>
-                <div className="flex items-center justify-between mb-3">
-                  <div className="text-[11px] uppercase tracking-[0.2em] font-bold text-ink-3">Classificação</div>
-                  <button onClick={() => setModal('tabela')} className="text-[11px] font-semibold inline-flex items-center gap-1 text-forest hover:text-forest-2">Tabela completa <ArrowRight className="w-3 h-3" /></button>
-                </div>
-                <StandingsTable rows={effStandings?.slice(0, 9)} loading={isDemo ? false : loadingStandings} onTeam={goTeam} />
+                )}
               </div>
-              <div>
-                <div className="flex items-center justify-between mb-3">
-                  <div className="text-[11px] uppercase tracking-[0.2em] font-bold text-ink-3">Artilheiros</div>
-                  {(effLeaders?.scorers?.length ?? 0) > 8 && <button onClick={() => setModal('artilheiros')} className="text-[11px] font-semibold inline-flex items-center gap-1 text-forest hover:text-forest-2">Ver todos <ArrowRight className="w-3 h-3" /></button>}
-                </div>
-                <ScorersCard leaders={effLeaders} loading={isDemo ? false : loadingLeaders} />
-              </div>
-            </div>
+            )}
           </div>
         )}
       </div>
-
-      {modal === 'tabela' && (
-        <Modal title="Classificação completa" onClose={() => setModal(null)}>
-          <StandingsTable rows={effStandings} loading={isDemo ? false : loadingStandings} onTeam={(id) => { setModal(null); goTeam(id); }} />
-        </Modal>
-      )}
-      {modal === 'artilheiros' && (
-        <Modal title="Artilheiros" onClose={() => setModal(null)}>
-          <ScorersCard leaders={effLeaders} loading={isDemo ? false : loadingLeaders} full />
-        </Modal>
-      )}
     </div>
   );
 }

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -15,7 +15,12 @@ import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
 import { FUT_JOGOS_TOUR_ID, makeFutebolJogosSteps } from '@/components/onboarding/tours';
 import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
-import { demoFutebolBoard, makeDemoAgenda } from '@/components/onboarding/demo/futebol';
+import {
+  demoFutebolBoard,
+  demoFutebolNumeros,
+  demoFutebolPremissas,
+  makeDemoAgenda,
+} from '@/components/onboarding/demo/futebol';
 
 /**
  * Agenda de jogos por DIA, multi-liga.
@@ -138,6 +143,19 @@ export default function FutebolJogos() {
       setParams(next, { replace: true });
     }
   }, [jogoParam, selected, isLoading, effFixtures.length, params, setParams]);
+
+  // Durante o tour, o painel da direita não pode estar vazio: o passo fala do
+  // resumo e apontava para um "clique num jogo da lista". Escolhe sozinho o jogo
+  // de melhor leitura do dia (ou o primeiro, se nenhum tiver preço) só enquanto o
+  // tour roda; fora dele o vazio continua sendo o estado inicial, porque a
+  // escolha é do usuário.
+  useEffect(() => {
+    if (!jogosTour.run || !hasPanel || jogoParam || !effFixtures.length) return;
+    const melhor = [...effFixtures].sort(
+      (a, b) => (bestByFixture.get(b.fixture_id)?.score ?? -1) - (bestByFixture.get(a.fixture_id)?.score ?? -1),
+    )[0];
+    if (melhor) setParams({ dia, jogo: String(melhor.fixture_id) }, { replace: true });
+  }, [jogosTour.run, hasPanel, jogoParam, effFixtures, bestByFixture, dia, setParams]);
 
   const selectDay = (d: string) => {
     // replace pra seta de dia não empilhar histórico; o jogo selecionado cai fora
@@ -317,6 +335,9 @@ export default function FutebolJogos() {
                     fixture={selected}
                     best={bestByFixture.get(selected.fixture_id) ?? null}
                     onClose={closePanel}
+                    demo={
+                      isDemo ? { premissas: demoFutebolPremissas, numeros: demoFutebolNumeros } : undefined
+                    }
                   />
                 ) : (
                   <div className="bg-white rounded-[20px] p-10 text-center" style={{ border: '1px solid #ded2b6' }}>

--- a/src/pages/GameDetail.tsx
+++ b/src/pages/GameDetail.tsx
@@ -123,7 +123,7 @@ function statusBadgeStyle(status: string | null | undefined): { label: string; c
   if (s.includes('probable')) {
     return { label: 'Prov.', cls: 'bg-lime-100 text-lime-700 border border-lime-200' };
   }
-  return { label: status || '—', cls: 'bg-ink-3 text-ink-2 border border-line' };
+  return { label: status || '—', cls: 'bg-canvas-2 text-ink-2 border border-line' };
 }
 
 // ─── Last 5 V/D ───────────────────────────────────────────────────────────
@@ -697,7 +697,7 @@ function LineupTable({
                     to={`/nba-dashboard/${slugify(p.player_name)}`}
                     className="flex items-center gap-2.5 group"
                   >
-                    <div className="w-8 h-8 rounded-full overflow-hidden bg-ink-3 border border-line shrink-0">
+                    <div className="w-8 h-8 rounded-full overflow-hidden bg-canvas-2 border border-line shrink-0">
                       <img
                         src={getPlayerPhotoUrl(p.player_name, teamAbbr)}
                         alt={p.player_name}
@@ -894,7 +894,7 @@ function BoxScoreTable({
                 <tr key={p.player_id} className="border-t border-line hover:bg-canvas-2/40 transition-colors">
                   <td className="px-4 py-2">
                     <div className="flex items-center gap-2.5">
-                      <div className="w-7 h-7 rounded-full overflow-hidden bg-ink-3 border border-line shrink-0">
+                      <div className="w-7 h-7 rounded-full overflow-hidden bg-canvas-2 border border-line shrink-0">
                         <img
                           src={getPlayerPhotoUrl(p.player_name, team)}
                           alt={p.player_name}
@@ -1030,7 +1030,7 @@ function GameOpportunitiesTable({
                       ? 'bg-emerald-100 text-emerald-700'
                       : (o.score ?? 0) >= 60
                       ? 'bg-amber-100 text-amber-700'
-                      : 'bg-ink-3 text-ink-2'
+                      : 'bg-canvas-2 text-ink-2'
                   }`}>
                     {o.score ?? '—'}
                   </span>
@@ -1150,7 +1150,7 @@ export default function GameDetail() {
 
   if (authLoading) {
     return (
-      <div className="theme-rebrand min-h-screen bg-canvas flex items-center justify-center">
+      <div className="theme-bolao min-h-screen bg-canvas flex items-center justify-center">
         <Loader2 className="w-6 h-6 animate-spin text-forest" />
       </div>
     );
@@ -1275,7 +1275,7 @@ export default function GameDetail() {
         <title>{game ? `${game.home_team_abbreviation} vs ${game.visitor_team_abbreviation}` : 'Jogo'} — Smart Betting</title>
       </Helmet>
 
-      <div className="theme-rebrand min-h-screen bg-canvas text-ink">
+      <div className="theme-bolao min-h-screen bg-canvas text-ink">
         <AnalyticsNav variant="rebrand" showBack backTo="/home-games" />
         <OnboardingTour tourId={NBA_GAME_TOUR_ID} steps={nbaGameSteps} run={gameTour.run} onFinish={gameTour.finish} />
 

--- a/src/pages/Games.tsx
+++ b/src/pages/Games.tsx
@@ -167,7 +167,7 @@ function GameCard({ game, onClick }: { game: Game; onClick: () => void }) {
             {countdown}
           </span>
         ) : (
-          <span className="text-[10px] font-bold px-2 py-0.5 rounded bg-ink-3 text-ink-2 uppercase tracking-wide">
+          <span className="text-[10px] font-bold px-2 py-0.5 rounded bg-canvas-2 text-ink-2 uppercase tracking-wide">
             {time ?? '—'}
           </span>
         )}
@@ -291,7 +291,7 @@ function OpportunityOfDayCard() {
       </div>
 
       <div className="flex items-start gap-3 mb-3">
-        <div className="w-10 h-10 rounded-full overflow-hidden bg-ink-3 border border-line shrink-0 flex items-center justify-center">
+        <div className="w-10 h-10 rounded-full overflow-hidden bg-canvas-2 border border-line shrink-0 flex items-center justify-center">
           <img
             src={getPlayerPhotoUrl(top.backup_player_name, top.trigger_team_abbr)}
             alt={top.backup_player_name}
@@ -593,7 +593,7 @@ export default function Games() {
         <title>Jogos NBA — Smart Betting</title>
       </Helmet>
 
-      <div className="theme-rebrand min-h-screen bg-canvas text-ink">
+      <div className="theme-bolao min-h-screen bg-canvas text-ink">
         <AnalyticsNav variant="rebrand" showBack backTo="/home-nba" />
         <OnboardingTour tourId={NBA_GAMES_TOUR_ID} steps={nbaGamesSteps} run={gamesTour.run} onFinish={gamesTour.finish} />
 

--- a/src/pages/HomeNBA.tsx
+++ b/src/pages/HomeNBA.tsx
@@ -46,7 +46,7 @@ function PlayerPhoto({ name, teamAbbr, size = 'md' }: { name: string; teamAbbr: 
   const sizeClass = size === 'lg' ? 'w-12 h-12' : size === 'md' ? 'w-10 h-10' : 'w-8 h-8';
   const textClass = size === 'lg' ? 'text-sm' : size === 'md' ? 'text-[10px]' : 'text-[9px]';
   return (
-    <div className={`${sizeClass} rounded-full overflow-hidden bg-ink-3 border border-line shrink-0 flex items-center justify-center`}>
+    <div className={`${sizeClass} rounded-full overflow-hidden bg-canvas-2 border border-line shrink-0 flex items-center justify-center`}>
       <img
         src={getPlayerPhotoUrl(name, teamAbbr)}
         alt={`Foto de ${name}`}
@@ -359,7 +359,7 @@ export default function HomeNBA() {
   }, [players, searchTerm]);
 
   return (
-    <div className="theme-rebrand w-full min-h-screen bg-canvas text-ink">
+    <div className="theme-bolao w-full min-h-screen bg-canvas text-ink">
       <Helmet>
         <title>Lesões NBA Hoje e Oportunidades de Apostas do Dia | Smart Betting</title>
         <meta name="description" content="Lesões chave da NBA hoje com impacto nos companheiros, oportunidades de prop bets selecionadas e jogos do dia. Atualizado diariamente." />
@@ -392,7 +392,7 @@ export default function HomeNBA() {
                     return (
                       <a key={player.player_id} href={`/nba-dashboard/${slug}`}
                         onClick={(e) => { if (!e.ctrlKey && !e.metaKey && e.button === 0) { e.preventDefault(); setSearchTerm(''); navigate(`/nba-dashboard/${slug}`); } }}
-                        className="flex items-center gap-2.5 px-3 py-2.5 hover:bg-ink-3/40 transition-colors no-underline border-b border-line last:border-b-0"
+                        className="flex items-center gap-2.5 px-3 py-2.5 hover:bg-canvas-2 transition-colors no-underline border-b border-line last:border-b-0"
                       >
                         <PlayerPhoto name={player.player_name} teamAbbr={player.team_abbreviation} size="sm" />
                         <div className="min-w-0 flex-1">
@@ -539,7 +539,7 @@ export default function HomeNBA() {
             onClick={(e) => { if (!e.ctrlKey && !e.metaKey && e.button === 0) { e.preventDefault(); navigate('/report'); } }}
             className="block text-left rounded-xl px-5 py-4 flex items-center gap-4 transition-colors bg-white border border-line hover:border-forest/30 no-underline"
           >
-            <div className="w-11 h-11 rounded-lg grid place-items-center bg-ink-3/60 text-forest shrink-0">
+            <div className="w-11 h-11 rounded-lg grid place-items-center bg-canvas-2 text-forest shrink-0">
               <FileText className="w-5 h-5" />
             </div>
             <div className="flex-1 min-w-0">

--- a/src/pages/Inicio.tsx
+++ b/src/pages/Inicio.tsx
@@ -146,8 +146,10 @@ export default function Inicio() {
             </h1>
           </header>
 
-          {/* Mobile: retângulos empilhados. Desktop: 2 colunas. */}
-          <div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 sm:gap-4">
+          {/* Mobile: retângulos empilhados. Desktop: os três lado a lado, porque
+              com duas colunas o terceiro caía sozinho numa segunda linha e
+              parecia menos importante que os outros. */}
+          <div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 sm:gap-4 lg:grid-cols-3">
             {DESTINOS.map((d) => {
               const Icon = d.icon;
               return (

--- a/src/pages/NBADashboard.tsx
+++ b/src/pages/NBADashboard.tsx
@@ -627,7 +627,7 @@ export default function NBADashboard() {
 
   if (!player && playerLookupDone && !isDemo) {
     return (
-      <div className="w-full min-h-screen bg-canvas text-ink flex flex-col items-center justify-center gap-4 px-4">
+      <div className="theme-bolao w-full min-h-screen bg-canvas text-ink flex flex-col items-center justify-center gap-4 px-4">
         <p className="text-ink opacity-80">Jogador não encontrado.</p>
         <Button
           variant="outline"
@@ -641,7 +641,7 @@ export default function NBADashboard() {
   }
 
   return (
-    <div className="w-full min-h-screen bg-canvas text-ink">
+    <div className="theme-bolao w-full min-h-screen bg-canvas text-ink">
       <AnalyticsNav variant="rebrand" showBack />
       <OnboardingTour tourId={NBA_DASH_TOUR_ID} steps={dashSteps} run={dashTour.run} onFinish={dashTour.finish} />
       <main className="container mx-auto px-3 py-4">

--- a/src/pages/Picks.tsx
+++ b/src/pages/Picks.tsx
@@ -565,7 +565,7 @@ export default function Picks() {
 
   if (error) {
     return (
-      <div className="theme-rebrand min-h-screen bg-canvas text-ink">
+      <div className="theme-bolao min-h-screen bg-canvas text-ink">
         <AnalyticsNav variant="rebrand" showBack />
         <div className="flex items-center justify-center py-20">
           <div className="text-center">
@@ -584,7 +584,7 @@ export default function Picks() {
   }
 
   return (
-    <div className="theme-rebrand min-h-screen bg-canvas text-ink">
+    <div className="theme-bolao min-h-screen bg-canvas text-ink">
       <Helmet>
         <title>Oportunidades do dia · Smart Betting NBA</title>
         <meta name="description" content="Quem se beneficia quando um titular não joga — ranqueado por score de confiança." />

--- a/src/pages/Report.tsx
+++ b/src/pages/Report.tsx
@@ -151,7 +151,7 @@ export default function Report() {
 
   if (accessLoading) {
     return (
-      <div className="theme-rebrand min-h-screen bg-canvas">
+      <div className="theme-bolao min-h-screen bg-canvas">
         <AnalyticsNav variant="rebrand" showBack backTo="/home-nba" />
         <div className="flex flex-col items-center justify-center py-24 gap-3">
           <Loader2 className="w-6 h-6 animate-spin text-forest opacity-70" />
@@ -162,7 +162,7 @@ export default function Report() {
 
   if (!hasAccess) {
     return (
-      <div className="theme-rebrand min-h-screen bg-canvas">
+      <div className="theme-bolao min-h-screen bg-canvas">
         <AnalyticsNav variant="rebrand" showBack backTo="/home-nba" />
         <div className="max-w-md mx-auto px-4 py-24 flex flex-col items-center text-center gap-4">
           <div className="w-16 h-16 bg-amber-100 border border-amber-200 rounded-full flex items-center justify-center">
@@ -191,7 +191,7 @@ export default function Report() {
         <title>Relatório do dia — Smart Betting</title>
       </Helmet>
 
-      <div className="theme-rebrand min-h-screen bg-canvas text-ink">
+      <div className="theme-bolao min-h-screen bg-canvas text-ink">
         <AnalyticsNav variant="rebrand" showBack backTo="/home-nba" />
 
         {/* Page header (bg-white) */}

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -50,6 +50,119 @@ export interface FutebolFixture {
   goals_away: number | null;
 }
 
+/**
+ * Linha da agenda por dia (RPC get_futebol_fixtures_by_day, migration 092).
+ * Traz `competition` e `season` que o get_futebol_fixtures não devolve: numa lista
+ * de uma liga só o front já sabia qual era, numa lista multi-liga não, e o link do
+ * time é /futebol/time/:id?c=&s=. O `day_brt` vem calculado no banco pelo
+ * public.futebol_dia_brt, então o front não precisa reimplementar a virada de dia.
+ */
+export interface FutebolFixtureByDay extends FutebolFixture {
+  competition: string;
+  season: number;
+  day_brt: string;
+}
+
+/**
+ * Um candidato (mercado + saída + linha) com as premissas acesas e apagadas.
+ * RPC get_futebol_fixture_premissas, migration 093.
+ *
+ * Dois estados só: as tabelas int_* não têm NULL, então premissa sem dado hoje é
+ * indistinguível de premissa apagada. É o T3 da recalibragem; quando ele entrar,
+ * entra um terceiro array aqui.
+ */
+export interface FutebolFixturePremissas {
+  market: string;
+  outcome: string;
+  line_value: number | null;
+  pts_premissas: number;
+  penalidades_pts: number;
+  acesas: string[];
+  apagadas: string[];
+  penalidades: string[];
+}
+
+/**
+ * Números de temporada de um lado do confronto (RPC get_futebol_fixture_numeros).
+ * Serve para EMBASAR as premissas: sem o número, "em boa fase" é adjetivo.
+ * `ate` é o snapshot_date, para a tela declarar a data do dado.
+ */
+export interface FutebolFixtureNumeros {
+  side: 'home' | 'away';
+  team_id: number;
+  team_name: string;
+  posicao: number | null;
+  pontos: number | null;
+  zona: string | null;
+  jogos: number | null;
+  jogos_casa: number | null;
+  jogos_fora: number | null;
+  v_casa: number | null;
+  e_casa: number | null;
+  d_casa: number | null;
+  v_fora: number | null;
+  e_fora: number | null;
+  d_fora: number | null;
+  gf_casa: number | null;
+  ga_casa: number | null;
+  gf_fora: number | null;
+  ga_fora: number | null;
+  gf_total: number | null;
+  ga_total: number | null;
+  clean_sheets: number | null;
+  sem_marcar: number | null;
+  forma: string | null;
+  h2h_jogos: number | null;
+  h2h_vitorias: number | null;
+  h2h_empates: number | null;
+  ate: string | null;
+}
+
+/**
+ * Um jogo passado de um dos times, na competição e temporada do confronto (RPC 095).
+ * É o que permite auditar a média: filtrada pelo mando certo, a média destas linhas
+ * reproduz o mesmo número que a premissa usa (medido: Palmeiras em casa, 10 jogos,
+ * 0,80 gol sofrido, igual ao ga_casa da 094).
+ */
+export interface FutebolFixtureHistorico {
+  side: 'home' | 'away';
+  team_id: number;
+  team_name: string;
+  past_fixture_id: number;
+  data: string;
+  ordem: number;
+  em_casa: boolean;
+  adversario: string;
+  /** Para o escudo do adversário embaixo da barra. */
+  adversario_id: number;
+  gols_pro: number;
+  gols_contra: number;
+  total_gols: number;
+  ambos_marcaram: boolean;
+  sem_sofrer: boolean;
+  sem_marcar: boolean;
+  /** Gols esperados do time no jogo. Null onde a API não entregou (9% dos jogos). */
+  xg: number | null;
+  xg_contra: number | null;
+  resultado: 'V' | 'E' | 'D';
+}
+
+/** Um dia com jogo, pra régua de datas (RPC get_futebol_fixture_days). */
+export interface FutebolFixtureDay {
+  day_brt: string;
+  jogos: number;
+  ligas: number;
+}
+
+/** Competição + temporada que existe de fato no mart (RPC get_futebol_competitions). */
+export interface FutebolCompetitionInfo {
+  competition: string;
+  season: number;
+  jogos: number;
+  primeiro: string | null;
+  ultimo: string | null;
+}
+
 export interface FutebolTeamStats {
   team_side: 'home' | 'away';
   team_id: number | null;
@@ -195,6 +308,9 @@ export interface FutebolStandingRow {
   goals_against: number;
   goals_diff: number;
   rank_description: string | null;
+  /** Grupo da fase de grupos ('Group A'…). Em pontos corridos vem o nome da liga,
+   *  que é como a API marca quem não tem grupo. Ver migration 096. */
+  group_name: string | null;
 }
 
 export type FutebolZone = 'libertadores' | 'sula' | 'rebaixamento' | null;
@@ -454,6 +570,85 @@ export const futebolDataService = {
       });
       if (error) throw error;
       return (data || []) as FutebolFixture[];
+    });
+  },
+
+  /**
+   * Jogos de UM dia (fuso BRT) em todas as ligas. Uma chamada no lugar das N do
+   * useFutebolFixturesMulti (uma por liga, temporada inteira): o pior dia do mart
+   * são 33 jogos em 16 KB, contra ~850 KB das 8 chamadas antigas.
+   */
+  async getFixturesByDay(day: string, competitions?: string[] | null): Promise<FutebolFixtureByDay[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_futebol_fixtures_by_day', {
+        p_day: day,
+        p_competitions: competitions ?? null,
+      });
+      if (error) throw error;
+      return (data || []) as FutebolFixtureByDay[];
+    });
+  },
+
+  /** Dias com jogo num intervalo, com contagem. Alimenta a régua de datas sem baixar jogo. */
+  async getFixtureDays(from: string, to: string): Promise<FutebolFixtureDay[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_futebol_fixture_days', {
+        p_from: from,
+        p_to: to,
+      });
+      if (error) throw error;
+      return (data || []) as FutebolFixtureDay[];
+    });
+  },
+
+  /**
+   * Competições e temporadas presentes no mart. Fonte de verdade do que existe, no
+   * lugar das listas fixas do front (que escondiam a champions_league e as
+   * temporadas 2025 de La Liga, Premier, Libertadores e Sul-Americana).
+   */
+  async getCompetitions(): Promise<FutebolCompetitionInfo[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_futebol_competitions');
+      if (error) throw error;
+      return (data || []) as FutebolCompetitionInfo[];
+    });
+  },
+
+  /**
+   * Mapa de premissas do jogo nos 5 mercados. Funciona onde o preço não existe:
+   * as premissas cobrem os 6.597 jogos do mart (1.177 futuros), enquanto odd só
+   * aparece a partir de T−24h.
+   */
+  async getFixturePremissas(fixtureId: number): Promise<FutebolFixturePremissas[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_futebol_fixture_premissas', {
+        p_fixture_id: fixtureId,
+      });
+      if (error) throw error;
+      return (data || []) as FutebolFixturePremissas[];
+    });
+  },
+
+  /** Números que embasam as premissas (campanha casa/fora, gols por jogo, forma, tabela). */
+  async getFixtureNumeros(fixtureId: number): Promise<FutebolFixtureNumeros[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_futebol_fixture_numeros', {
+        p_fixture_id: fixtureId,
+      });
+      if (error) throw error;
+      return (data || []) as FutebolFixtureNumeros[];
+    });
+  },
+
+  /** Jogo a jogo dos dois times, para auditar a média de cada premissa. */
+  async getFixtureHistorico(fixtureId: number, max = 40): Promise<FutebolFixtureHistorico[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_futebol_fixture_historico', {
+        p_fixture_id: fixtureId,
+        p_max: max,
+      });
+      if (error) throw error;
+      return (data || []) as FutebolFixtureHistorico[];
     });
   },
 

--- a/src/utils/futebol-competitions.ts
+++ b/src/utils/futebol-competitions.ts
@@ -5,7 +5,8 @@
 // só pra ganhar nome bonito + posição no seletor.
 //
 // Slugs confirmados no mart (season 2026): brasileirao, serie_b, copa_do_brasil,
-// libertadores, sudamericana, la_liga, premier_league, copa_mundo.
+// libertadores, sudamericana, la_liga, premier_league, copa_mundo, champions_league,
+// bundesliga, ligue_1, primeira_liga, serie_a_ita.
 
 export const COMPETITION_LABELS: Record<string, string> = {
   brasileirao: 'Brasileirão',
@@ -16,6 +17,35 @@ export const COMPETITION_LABELS: Record<string, string> = {
   la_liga: 'La Liga',
   premier_league: 'Premier League',
   copa_mundo: 'Copa do Mundo',
+  champions_league: 'Champions League',
+  bundesliga: 'Bundesliga',
+  ligue_1: 'Ligue 1',
+  primeira_liga: 'Primeira Liga',
+  // O humanize devolvia "Serie A Ita", que é o único nome feio da lista.
+  serie_a_ita: 'Serie A (Itália)',
+};
+
+/**
+ * Slug do mart → id da liga na API-Football, a mesma numeração de
+ * public.leagues_config (migration 082). É de onde saem os brasões do bucket
+ * futebol-league-logos; pra somar liga nova, entre com ela aqui e no de-para da
+ * edge function mirror-futebol-league-logos, e rode o espelho. Liga sem arquivo
+ * cai no ícone de troféu, sem quebrar nada.
+ */
+export const COMPETITION_API_IDS: Record<string, number> = {
+  copa_mundo: 1,
+  champions_league: 2,
+  sudamericana: 11,
+  libertadores: 13,
+  premier_league: 39,
+  ligue_1: 61,
+  brasileirao: 71,
+  serie_b: 72,
+  copa_do_brasil: 73,
+  bundesliga: 78,
+  primeira_liga: 94,
+  serie_a_ita: 135,
+  la_liga: 140,
 };
 
 // Ordem canônica nos seletores que buscam por slug (pickers). Copa do Mundo por

--- a/src/utils/futebol-datas.test.ts
+++ b/src/utils/futebol-datas.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseUtc,
+  brtDateStr,
+  brtDayOf,
+  addDays,
+  fmtTime,
+  fmtDayHeader,
+  fmtDayChip,
+  fmtDayShort,
+  yearOf,
+  isFinished,
+  isLive,
+} from './futebol-datas';
+
+// Os testes não dependem do fuso da máquina: todo formatador recebe
+// timeZone: 'America/Sao_Paulo' explícito. Rodam igual em CI e no Windows local.
+
+describe('brtDayOf — a virada de dia do jogo noturno', () => {
+  // Caso real do mart (fixture São Paulo x Flamengo, season 2026): kickoff
+  // 00:30 UTC do dia 29 é 21:30 do dia 28 em Brasília. A /futebol/jogos agrupava
+  // por `date_utc` e jogava esse jogo pro dia 29, errado. São 288 de 2.128 jogos
+  // de 2026 nessa condição.
+  it('joga o kickoff 00:30 UTC pro dia anterior em BRT', () => {
+    expect(brtDayOf('2026-01-29T00:30:00')).toBe('2026-01-28');
+  });
+
+  it('não confunde com o dia UTC do mesmo registro', () => {
+    // date_utc do registro é 2026-01-29; o dia BRT tem que ser outro.
+    expect(brtDayOf('2026-01-29T00:30:00')).not.toBe('2026-01-29');
+  });
+
+  it('vira o dia exatamente às 03:00 UTC (meia-noite em BRT)', () => {
+    expect(brtDayOf('2026-01-29T02:59:59')).toBe('2026-01-28');
+    expect(brtDayOf('2026-01-29T03:00:00')).toBe('2026-01-29');
+  });
+
+  it('jogo de tarde fica no mesmo dia nos dois fusos', () => {
+    // 17:00 BRT = 20:00 UTC, mesmo dia civil nos dois.
+    expect(brtDayOf('2026-07-29T20:00:00')).toBe('2026-07-29');
+  });
+
+  it('devolve null pra kickoff ausente', () => {
+    expect(brtDayOf(null)).toBeNull();
+    expect(brtDayOf(undefined)).toBeNull();
+    expect(brtDayOf('')).toBeNull();
+  });
+});
+
+describe('parseUtc', () => {
+  it('trata timestamp sem fuso como UTC, não como hora local', () => {
+    expect(parseUtc('2026-01-29T00:30:00')?.toISOString()).toBe('2026-01-29T00:30:00.000Z');
+  });
+
+  it('aceita data pura', () => {
+    expect(parseUtc('2026-01-29')?.toISOString()).toBe('2026-01-29T00:00:00.000Z');
+  });
+
+  it('respeita fuso explícito quando vem na string', () => {
+    expect(parseUtc('2026-01-29T00:30:00Z')?.toISOString()).toBe('2026-01-29T00:30:00.000Z');
+  });
+
+  it('devolve null pra lixo', () => {
+    expect(parseUtc('nao é data')).toBeNull();
+    expect(parseUtc(null)).toBeNull();
+  });
+});
+
+describe('fmtTime', () => {
+  it('mostra o horário em BRT, não em UTC', () => {
+    expect(fmtTime('2026-01-29T00:30:00')).toBe('21:30');
+    expect(fmtTime('2026-07-29T20:00:00')).toBe('17:00');
+  });
+
+  it('devolve string vazia sem kickoff', () => {
+    expect(fmtTime(null)).toBe('');
+  });
+});
+
+describe('brtDateStr', () => {
+  it('formata como YYYY-MM-DD, que ordena como string', () => {
+    const dias = [
+      brtDateStr(new Date('2026-02-01T15:00:00Z')),
+      brtDateStr(new Date('2026-01-29T15:00:00Z')),
+      brtDateStr(new Date('2026-12-02T15:00:00Z')),
+    ];
+    expect([...dias].sort()).toEqual(['2026-01-29', '2026-02-01', '2026-12-02']);
+  });
+});
+
+describe('addDays', () => {
+  it('anda e volta um dia', () => {
+    expect(addDays('2026-07-29', 1)).toBe('2026-07-30');
+    expect(addDays('2026-07-29', -1)).toBe('2026-07-28');
+  });
+
+  it('atravessa virada de mês e de ano', () => {
+    expect(addDays('2026-07-31', 1)).toBe('2026-08-01');
+    expect(addDays('2026-12-31', 1)).toBe('2027-01-01');
+    expect(addDays('2026-01-01', -1)).toBe('2025-12-31');
+  });
+
+  it('acerta 29 de fevereiro em ano bissexto', () => {
+    expect(addDays('2028-02-28', 1)).toBe('2028-02-29');
+    expect(addDays('2026-02-28', 1)).toBe('2026-03-01');
+  });
+});
+
+describe('fmtDayHeader', () => {
+  it('monta cabeçalho com dia da semana capitalizado', () => {
+    expect(fmtDayHeader('2026-07-29')).toBe('Quarta-feira, 29 de jul');
+  });
+
+  it('não escorrega pro dia vizinho', () => {
+    expect(fmtDayHeader('2026-08-01')).toContain('01');
+    expect(fmtDayHeader('2026-08-01')).not.toContain('31');
+  });
+
+  it('aguenta chave ausente ou inválida', () => {
+    expect(fmtDayHeader(null)).toBe('—');
+    expect(fmtDayHeader('xx')).toBe('—');
+  });
+});
+
+describe('fmtDayChip', () => {
+  it('devolve dia da semana curto e dia/mês', () => {
+    expect(fmtDayChip('2026-07-29')).toEqual({ weekday: 'Qua', day: '29/07' });
+  });
+});
+
+describe('fmtDayShort / yearOf', () => {
+  it('omite o dia da semana', () => {
+    expect(fmtDayShort('2026-03-21')).toBe('21 de mar');
+  });
+
+  it('inclui o ano quando pedido', () => {
+    expect(fmtDayShort('2027-05-30', true)).toBe('30 de mai de 2027');
+  });
+
+  it('yearOf serve pra decidir se a temporada atravessa o ano', () => {
+    expect(yearOf('2026-08-15')).toBe('2026');
+    expect(yearOf('2027-05-30')).toBe('2027');
+    expect(yearOf(null)).toBeNull();
+  });
+
+  it('aguenta chave ausente', () => {
+    expect(fmtDayShort(null)).toBe('—');
+  });
+});
+
+describe('isFinished / isLive', () => {
+  it('encerrado cobre prorrogação e pênaltis', () => {
+    ['FT', 'AET', 'PEN'].forEach((s) => expect(isFinished(s)).toBe(true));
+  });
+
+  it('não confunde ao vivo com encerrado', () => {
+    ['1H', '2H', 'HT', 'ET', 'BT', 'P', 'LIVE'].forEach((s) => {
+      expect(isLive(s)).toBe(true);
+      expect(isFinished(s)).toBe(false);
+    });
+  });
+
+  it('jogo não começado não é nenhum dos dois', () => {
+    expect(isFinished('NS')).toBe(false);
+    expect(isLive('NS')).toBe(false);
+    expect(isFinished(null)).toBe(false);
+    expect(isLive(null)).toBe(false);
+  });
+});

--- a/src/utils/futebol-datas.ts
+++ b/src/utils/futebol-datas.ts
@@ -1,0 +1,135 @@
+// Datas e horários do módulo Futebol, em fuso de Brasília.
+//
+// Existe porque `parseUtc`, `fmtTime` e `isFinished` estavam copiados em
+// FutebolHoje.tsx e FutebolJogos.tsx, e as duas cópias divergiam no ponto que mais
+// importa: qual é "o dia" de um jogo.
+//
+// REGRA: o dia de um jogo vem do KICKOFF convertido pra BRT, nunca de
+// `fact_fixtures.date_utc`. O `date_utc` é data UTC, então jogo às 21:30 de quarta
+// em Brasília (00:30 de quinta em UTC) cai no dia seguinte se você agrupar por ele.
+// São 288 dos 2.128 jogos de 2026, justamente os noturnos. O backend tem a mesma
+// regra em `public.futebol_dia_brt` (migration 092) e a RPC da agenda já devolve
+// `day_brt` pronto; estas funções são pro que o front calcula por conta.
+
+export const SAO_PAULO_TZ = 'America/Sao_Paulo';
+
+/**
+ * Interpreta string do banco como UTC. Aceita data pura (`2026-08-01`) e timestamp
+ * sem fuso (`2026-08-01T00:30:00`), que é o formato de `kickoff_utc`. Sem o `Z`
+ * forçado, o browser leria o timestamp como hora LOCAL e o horário sairia errado.
+ */
+export function parseUtc(raw: string | null | undefined): Date | null {
+  if (!raw) return null;
+  const iso = raw.includes('T') ? raw : `${raw}T00:00:00`;
+  const d = new Date(/[Z]|[+-]\d{2}:?\d{2}$/.test(iso) ? iso : `${iso}Z`);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+/** Dia do jogo em BRT no formato `YYYY-MM-DD`. Espelha `public.futebol_dia_brt`. */
+export function brtDateStr(d: Date): string {
+  // en-CA porque formata como YYYY-MM-DD, que é ordenável como string.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: SAO_PAULO_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(d);
+}
+
+/** Dia BRT direto do kickoff cru do banco. Atalho do par parseUtc + brtDateStr. */
+export function brtDayOf(kickoffUtc: string | null | undefined): string | null {
+  const d = parseUtc(kickoffUtc);
+  return d ? brtDateStr(d) : null;
+}
+
+/** Hoje em BRT (`YYYY-MM-DD`). Chamar na hora do uso, não guardar em const de módulo. */
+export function brtToday(): string {
+  return brtDateStr(new Date());
+}
+
+/** Soma dias a uma chave `YYYY-MM-DD` e devolve outra chave. Imune a fuso: usa meio-dia UTC. */
+export function addDays(dayKey: string, delta: number): string {
+  const d = new Date(`${dayKey}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + delta);
+  return d.toISOString().slice(0, 10);
+}
+
+/** `HH:MM` em BRT. */
+export function fmtTime(raw: string | null | undefined): string {
+  const d = parseUtc(raw);
+  if (!d) return '';
+  return new Intl.DateTimeFormat('pt-BR', {
+    timeZone: SAO_PAULO_TZ,
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(d);
+}
+
+/**
+ * Cabeçalho de dia a partir de uma chave `YYYY-MM-DD` (ex.: "Quarta-feira, 29 de jul").
+ * Recebe a CHAVE do dia, não um kickoff: quem agrupa já resolveu o fuso.
+ */
+export function fmtDayHeader(dayKey: string | null | undefined): string {
+  if (!dayKey) return '—';
+  // Meio-dia UTC: qualquer hora entre 03:00 e 21:00 UTC cai no mesmo dia civil em
+  // BRT (UTC−3), então o rótulo não escorrega pro dia vizinho.
+  const d = new Date(`${dayKey}T12:00:00Z`);
+  if (isNaN(d.getTime())) return '—';
+  const s = new Intl.DateTimeFormat('pt-BR', {
+    timeZone: SAO_PAULO_TZ,
+    weekday: 'long',
+    day: '2-digit',
+    month: 'short',
+  })
+    .format(d)
+    .replace('.', '');
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/**
+ * Dia sem o dia da semana: "21 de mar", ou "21 de mar de 2027" com `comAno`.
+ * Pra intervalo (temporada de 15/ago a 30/mai), repetir "Sábado," nas duas pontas
+ * só ocupa espaço, e o ano importa quando a temporada atravessa o ano.
+ */
+export function fmtDayShort(dayKey: string | null | undefined, comAno = false): string {
+  if (!dayKey) return '—';
+  const d = new Date(`${dayKey}T12:00:00Z`);
+  if (isNaN(d.getTime())) return '—';
+  return new Intl.DateTimeFormat('pt-BR', {
+    timeZone: SAO_PAULO_TZ,
+    day: '2-digit',
+    month: 'short',
+    ...(comAno ? { year: 'numeric' } : {}),
+  })
+    .format(d)
+    .replace('.', '');
+}
+
+/** Ano de uma chave `YYYY-MM-DD`. */
+export function yearOf(dayKey: string | null | undefined): string | null {
+  return dayKey?.slice(0, 4) ?? null;
+}
+
+/** Rótulo curto pra régua de datas: `{ weekday: 'qua', day: '29/07' }`. */
+export function fmtDayChip(dayKey: string): { weekday: string; day: string } {
+  const d = new Date(`${dayKey}T12:00:00Z`);
+  const weekday = new Intl.DateTimeFormat('pt-BR', { timeZone: SAO_PAULO_TZ, weekday: 'short' })
+    .format(d)
+    .replace('.', '');
+  const day = new Intl.DateTimeFormat('pt-BR', { timeZone: SAO_PAULO_TZ, day: '2-digit', month: '2-digit' }).format(d);
+  return { weekday: weekday.charAt(0).toUpperCase() + weekday.slice(1), day };
+}
+
+/** Jogo encerrado (inclui prorrogação e pênaltis). */
+export function isFinished(status: string | null | undefined): boolean {
+  return status === 'FT' || status === 'AET' || status === 'PEN';
+}
+
+/**
+ * Jogo rolando agora. `status_short` da API-Football: 1H/2H primeiro e segundo
+ * tempo, HT intervalo, ET prorrogação, BT pausa antes da prorrogação, P pênaltis,
+ * LIVE genérico.
+ */
+export function isLive(status: string | null | undefined): boolean {
+  return status === '1H' || status === '2H' || status === 'HT' || status === 'ET' || status === 'BT' || status === 'P' || status === 'LIVE';
+}

--- a/src/utils/futebol-evidencias.ts
+++ b/src/utils/futebol-evidencias.ts
@@ -1,0 +1,510 @@
+import type { FutebolFixtureNumeros } from '@/services/futebol-data.service';
+
+// O número que embasa cada premissa.
+//
+// Existe porque check + peso não é análise: "em boa fase, vem ganhando" sem número é
+// adjetivo, e premissa apagada sem número não deixa ver se faltou pouco ou muito.
+// Aqui cada premissa vira uma frase com o dado real, e quando faz sentido, uma
+// comparação lado a lado dos dois times.
+//
+// Regra dura deste arquivo: NUNCA inventar número. Premissa sem métrica agregada no
+// mart devolve null, e a tela mostra isso como "sem número para mostrar" em vez de
+// encher linguiça. Hoje ficam sem número as de xG (não há agregado de temporada),
+// as de histórico over/under, as de movimento de linha e as de rodízio/descanso.
+
+export interface Comparacao {
+  esqLabel: string;
+  esqValor: number;
+  dirLabel: string;
+  dirValor: number;
+  /**
+   * Qual lado destacar. `nenhum` é o caso importante: em "ataque forte contra defesa
+   * frágil" os dois números são de coisas diferentes (gol marcado × gol sofrido) e os
+   * dois altos favorecem a aposta, então pintar o maior de verde mentiria, sugerindo
+   * que a defesa vazada do adversário é o lado "bom" da comparação.
+   */
+  destaque?: 'esq' | 'dir' | 'nenhum';
+}
+
+/** Concordância de número: "1 vitória" e não "1 vitórias". */
+export function plural(n: number, singular: string, plural_: string): string {
+  return `${n} ${n === 1 ? singular : plural_}`;
+}
+
+export interface Evidencia {
+  /** Frase curta com o dado. */
+  texto: string;
+  /**
+   * A comparação dos dois lados, quando o número é de dois lados. O desenho dela
+   * vive nas abas de motivos: o resumo mostra só a frase, por decisão de produto
+   * ("já que é um resumo, não precisa da barra ali").
+   */
+  comparacao?: Comparacao;
+}
+
+const n1 = (v: number | null | undefined): string =>
+  v == null ? '—' : v.toFixed(1).replace('.', ',');
+
+const n2 = (v: number | null | undefined): string =>
+  v == null ? '—' : v.toFixed(2).replace('.', ',');
+
+/**
+ * `form` da API usa D para Draw (empate) e L para Loss. Traduzir direto quebraria,
+ * porque D vira empate em inglês e derrota em português. Esta versão devolve o par
+ * certo já contado.
+ */
+export function contaForma(form: string | null | undefined, n = 5): { v: number; e: number; d: number } {
+  const ult = (form ?? '').slice(-n).split('');
+  return {
+    v: ult.filter((c) => c === 'W').length,
+    e: ult.filter((c) => c === 'D').length,
+    d: ult.filter((c) => c === 'L').length,
+  };
+}
+
+interface Ctx {
+  /** Time da casa. */
+  casa: FutebolFixtureNumeros | undefined;
+  /** Time visitante. */
+  fora: FutebolFixtureNumeros | undefined;
+  /** Lado a que a aposta se refere, quando o mercado tem lado. */
+  lado: 'home' | 'away' | null;
+  /**
+   * A premissa está acesa? Importa para os builders de soma: o limiar exato do mart
+   * é o T5 e a gente não tem, então o nosso número de temporada pode DESMENTIR uma
+   * premissa acesa (caso real: Copa do Brasil com 2 jogos de amostra acendeu
+   * "defesas frágeis" com soma sofrida de 1,0 gol). Nesses casos o builder devolve
+   * null: melhor sem número do que com um número que contradiz o título. Para
+   * premissa APAGADA o mesmo número é mostrado, porque aí ele explica o porquê.
+   */
+  acesa: boolean;
+  /**
+   * A linha escolhida, quando existe. A guarda de contradição olha para ela primeiro:
+   * "defesas firmes" com 2,7 gols somados contradiz a premissa numa linha de 2,5 e
+   * apoia numa de 3,5. Com limiar fixo, a tela dizia "sem número para conferir" no
+   * mesmo lugar onde o consolidado mostrava o 2,7 e explicava que ele sustenta.
+   */
+  linha: number | null;
+}
+
+// Fallback de quando não há linha (1X2, dupla chance): guardas de contradição
+// frontal, não réguas. O limiar real é do mart (T5) e a gente não tem.
+const SOMA_ALTA_MIN = 2.2; // "muitos gols/frágeis" com soma abaixo disto desmente
+const SOMA_BAIXA_MAX = 2.6; // "poucos gols/firmes" com soma acima disto desmente
+
+/** A soma desmente uma premissa de "muito gol"? */
+const desmenteAlta = (ctx: Ctx, soma: number) =>
+  ctx.acesa && (ctx.linha != null ? soma < ctx.linha : soma < SOMA_ALTA_MIN);
+
+/** A soma desmente uma premissa de "pouco gol"? */
+const desmenteBaixa = (ctx: Ctx, soma: number) =>
+  ctx.acesa && (ctx.linha != null ? soma > ctx.linha : soma > SOMA_BAIXA_MAX);
+
+/** O time da aposta e o adversário, quando o mercado tem lado. */
+function porLado(ctx: Ctx): { time?: FutebolFixtureNumeros; adv?: FutebolFixtureNumeros; emCasa: boolean } {
+  if (ctx.lado === 'away') return { time: ctx.fora, adv: ctx.casa, emCasa: false };
+  return { time: ctx.casa, adv: ctx.fora, emCasa: true };
+}
+
+type Builder = (ctx: Ctx) => Evidencia | null;
+
+const BUILDERS: Record<string, Builder> = {
+  // ── Resultado ──────────────────────────────────────────────
+  forma: (ctx) => {
+    const { time } = porLado(ctx);
+    if (!time?.forma) return null;
+    const c = contaForma(time.forma, 5);
+    return {
+      texto: `${time.team_name} nos últimos 5: ${plural(c.v, 'vitória', 'vitórias')}, ${plural(c.e, 'empate', 'empates')} e ${plural(c.d, 'derrota', 'derrotas')}`,
+    };
+  },
+
+  mando: (ctx) => {
+    const { time, emCasa } = porLado(ctx);
+    if (!time) return null;
+    const j = emCasa ? time.jogos_casa : time.jogos_fora;
+    const v = emCasa ? time.v_casa : time.v_fora;
+    const e = emCasa ? time.e_casa : time.e_fora;
+    const d = emCasa ? time.d_casa : time.d_fora;
+    if (j == null) return null;
+    const onde = emCasa ? 'em casa' : 'fora';
+    return {
+      texto: `${plural(v ?? 0, 'vitória', 'vitórias')}, ${plural(e ?? 0, 'empate', 'empates')} e ${plural(d ?? 0, 'derrota', 'derrotas')} em ${j} jogos ${onde}`,
+      comparacao: {
+        esqLabel: `Marca ${onde}`,
+        esqValor: (emCasa ? time.gf_casa : time.gf_fora) ?? 0,
+        dirLabel: `Sofre ${onde}`,
+        dirValor: (emCasa ? time.ga_casa : time.ga_fora) ?? 0,
+        // Marcar muito é bom, sofrer pouco é bom: destacar o ataque é o que o
+        // usuário deve ler primeiro nesta premissa.
+        destaque: 'esq',
+      },
+    };
+  },
+
+  superioridade_tabela: (ctx) => {
+    const { time, adv } = porLado(ctx);
+    if (!time?.posicao || !adv?.posicao) return null;
+    const dif = Math.abs((time.pontos ?? 0) - (adv.pontos ?? 0));
+    return {
+      texto: `${time.posicao}º com ${time.pontos} pontos contra ${adv.posicao}º com ${adv.pontos}. ${dif} pontos de diferença`,
+      comparacao: {
+        esqLabel: `${time.team_name}, ${time.posicao}º`,
+        esqValor: time.pontos ?? 0,
+        dirLabel: `${adv.team_name}, ${adv.posicao}º`,
+        dirValor: adv.pontos ?? 0,
+        destaque: 'esq',
+      },
+    };
+  },
+
+  forca_mismatch: (ctx) => {
+    const { time, adv, emCasa } = porLado(ctx);
+    if (!time || !adv) return null;
+    const ataque = emCasa ? time.gf_casa : time.gf_fora;
+    const defesa = emCasa ? adv.ga_fora : adv.ga_casa;
+    if (ataque == null || defesa == null) return null;
+    return {
+      texto: `${time.team_name} marca ${n1(ataque)} ${emCasa ? 'em casa' : 'fora'} e ${adv.team_name} sofre ${n1(defesa)} ${emCasa ? 'fora' : 'em casa'}`,
+      comparacao: {
+        esqLabel: `${time.team_name} marca`,
+        esqValor: ataque,
+        dirLabel: `${adv.team_name} sofre`,
+        dirValor: defesa,
+        // Neutro: os dois números altos favorecem a aposta, então não existe lado
+        // "melhor" aqui.
+        destaque: 'nenhum',
+      },
+    };
+  },
+
+  h2h_favoravel: (ctx) => {
+    const { time, adv } = porLado(ctx);
+    if (!time?.h2h_jogos) return null;
+    const v = time.h2h_vitorias ?? 0;
+    const e = time.h2h_empates ?? 0;
+    const d = time.h2h_jogos - v - e;
+    return {
+      texto: `Nos últimos ${time.h2h_jogos} confrontos: ${plural(v, 'vitória', 'vitórias')} do ${time.team_name}, ${plural(e, 'empate', 'empates')} e ${plural(d, 'vitória', 'vitórias')} do ${adv?.team_name ?? 'adversário'}`,
+      comparacao: {
+        esqLabel: time.team_name,
+        esqValor: v,
+        dirLabel: adv?.team_name ?? 'Adversário',
+        dirValor: d,
+        destaque: 'nenhum',
+      },
+    };
+  },
+
+  invicto_recente: (ctx) => BUILDERS.forma(ctx),
+
+  // ── Gols ───────────────────────────────────────────────────
+  ataque_combinado: (ctx) => {
+    if (!ctx.casa || !ctx.fora) return null;
+    const a = ctx.casa.gf_casa ?? ctx.casa.gf_total;
+    const b = ctx.fora.gf_fora ?? ctx.fora.gf_total;
+    if (a == null || b == null) return null;
+    if (desmenteAlta(ctx, a + b)) return null; // número desmentiria "somam muitos"
+    return {
+      texto: `Somados, marcam ${n1(a + b)} gols por jogo`,
+      comparacao: {
+        esqLabel: `${ctx.casa.team_name} em casa`,
+        esqValor: a,
+        dirLabel: `${ctx.fora.team_name} fora`,
+        dirValor: b,
+        destaque: 'nenhum',
+      },
+    };
+  },
+
+  ataques_fracos: (ctx) => {
+    if (!ctx.casa || !ctx.fora) return null;
+    const a = ctx.casa.gf_casa ?? ctx.casa.gf_total;
+    const b = ctx.fora.gf_fora ?? ctx.fora.gf_total;
+    if (a == null || b == null) return null;
+    if (desmenteBaixa(ctx, a + b)) return null; // desmentiria "ataques fracos"
+    return BUILDERS.ataque_combinado({ ...ctx, acesa: false });
+  },
+
+  defesas_vazaveis: (ctx) => {
+    if (!ctx.casa || !ctx.fora) return null;
+    const a = ctx.casa.ga_casa ?? ctx.casa.ga_total;
+    const b = ctx.fora.ga_fora ?? ctx.fora.ga_total;
+    if (a == null || b == null) return null;
+    if (desmenteAlta(ctx, a + b)) return null; // desmentiria "defesas frágeis"
+    return {
+      texto: `Somados, sofrem ${n1(a + b)} gols por jogo`,
+      comparacao: {
+        esqLabel: `${ctx.casa.team_name} sofre em casa`,
+        esqValor: a,
+        dirLabel: `${ctx.fora.team_name} sofre fora`,
+        dirValor: b,
+        destaque: 'nenhum',
+      },
+    };
+  },
+
+  defesas_firmes: (ctx) => {
+    if (!ctx.casa || !ctx.fora) return null;
+    const a = ctx.casa.ga_casa ?? ctx.casa.ga_total;
+    const b = ctx.fora.ga_fora ?? ctx.fora.ga_total;
+    if (a == null || b == null) return null;
+    if (desmenteBaixa(ctx, a + b)) return null; // desmentiria "defesas firmes"
+    return BUILDERS.defesas_vazaveis({ ...ctx, acesa: false });
+  },
+
+  clean_sheets_altos: (ctx) => {
+    if (!ctx.casa || !ctx.fora) return null;
+    if (ctx.casa.clean_sheets == null || ctx.fora.clean_sheets == null) return null;
+    return {
+      texto: `Jogos sem sofrer gol: ${ctx.casa.clean_sheets} de ${ctx.casa.jogos ?? '—'} e ${ctx.fora.clean_sheets} de ${ctx.fora.jogos ?? '—'}`,
+      comparacao: {
+        esqLabel: ctx.casa.team_name,
+        esqValor: ctx.casa.clean_sheets,
+        dirLabel: ctx.fora.team_name,
+        dirValor: ctx.fora.clean_sheets,
+        destaque: 'nenhum',
+      },
+    };
+  },
+
+  // ── Handicap ───────────────────────────────────────────────
+  supremacia: (ctx) => BUILDERS.superioridade_tabela(ctx),
+  mando_forte: (ctx) => BUILDERS.mando(ctx),
+
+  // O adversário joga no mando OPOSTO ao do time apostado. Com `ga_fora` fixo, a
+  // aposta no visitante mostrava a defesa do mandante FORA de casa, num jogo em que
+  // ele joga em casa.
+  adversario_fragil_fora: (ctx) => {
+    const { adv, emCasa } = porLado(ctx);
+    if (!adv) return null;
+    const ga = emCasa ? adv.ga_fora : adv.ga_casa;
+    const jogos = emCasa ? adv.jogos_fora : adv.jogos_casa;
+    if (ga == null) return null;
+    return {
+      texto: `${adv.team_name} sofre ${n1(ga)} gol por jogo ${emCasa ? 'fora de casa' : 'em casa'}, em ${jogos ?? '—'} jogos`,
+    };
+  },
+
+  // Mesma correção do outro lado: o azarão pode ser o mandante, e aí a defesa que
+  // importa é a de casa.
+  defesa_fora_solida: (ctx) => {
+    const { time, emCasa } = porLado(ctx);
+    if (!time) return null;
+    const ga = emCasa ? time.ga_casa : time.ga_fora;
+    const jogos = emCasa ? time.jogos_casa : time.jogos_fora;
+    if (ga == null) return null;
+    return {
+      texto: `${time.team_name} sofre ${n1(ga)} gol por jogo ${emCasa ? 'em casa' : 'fora'}, em ${jogos ?? '—'} jogos`,
+    };
+  },
+
+  tende_golear: (ctx) => {
+    const { time, adv, emCasa } = porLado(ctx);
+    if (!time || !adv) return null;
+    const ataque = emCasa ? time.gf_casa : time.gf_fora;
+    const defesa = emCasa ? adv.ga_fora : adv.ga_casa;
+    if (ataque == null || defesa == null) return null;
+    return {
+      texto: `Marca ${n1(ataque)} por jogo contra quem sofre ${n1(defesa)}`,
+      comparacao: {
+        esqLabel: `${time.team_name} marca`,
+        esqValor: ataque,
+        dirLabel: `${adv.team_name} sofre`,
+        dirValor: defesa,
+        destaque: 'nenhum',
+      },
+    };
+  },
+
+  // ── Ambos marcam ───────────────────────────────────────────
+  ambos_marcam: (ctx) => {
+    if (!ctx.casa || !ctx.fora) return null;
+    if (ctx.casa.sem_marcar == null || ctx.fora.sem_marcar == null) return null;
+    return {
+      texto: `Passaram em branco em ${ctx.casa.sem_marcar} e ${ctx.fora.sem_marcar} jogos de ${ctx.casa.jogos ?? '—'}`,
+      comparacao: {
+        esqLabel: `${ctx.casa.team_name} marca`,
+        esqValor: ctx.casa.gf_total ?? 0,
+        dirLabel: `${ctx.fora.team_name} marca`,
+        dirValor: ctx.fora.gf_total ?? 0,
+        destaque: 'nenhum',
+      },
+    };
+  },
+
+  ataque_dos_dois: (ctx) => BUILDERS.ataque_combinado(ctx),
+  defesa_forte: (ctx) => BUILDERS.defesas_vazaveis(ctx),
+
+  // ── Dupla chance ───────────────────────────────────────────
+  lado_coberto_forte: (ctx) => BUILDERS.superioridade_tabela(ctx),
+  adversario_limitado: (ctx) => {
+    const { adv } = porLado(ctx);
+    if (!adv || adv.gf_total == null) return null;
+    return { texto: `${adv.team_name} marca ${n1(adv.gf_total)} gol por jogo e está em ${adv.posicao ?? '—'}º` };
+  },
+};
+
+/**
+ * A evidência de uma premissa, ou null quando não existe métrica agregada no mart
+ * para embasá-la. Null é resposta legítima: melhor a tela dizer que não tem número
+ * do que inventar um.
+ */
+export function evidenciaDe(
+  slug: string,
+  numeros: FutebolFixtureNumeros[] | undefined,
+  lado: 'home' | 'away' | null,
+  acesa = true,
+  linha: number | null = null,
+): Evidencia | null {
+  if (!numeros?.length) return null;
+  const ctx: Ctx = {
+    casa: numeros.find((x) => x.side === 'home'),
+    fora: numeros.find((x) => x.side === 'away'),
+    lado,
+    acesa,
+    linha,
+  };
+  const b = BUILDERS[slug];
+  if (!b) return null;
+  try {
+    return b(ctx);
+  } catch {
+    return null;
+  }
+}
+
+/** O lado do confronto a que a saída se refere, quando existe. */
+export function ladoDaSaida(market: string, outcome: string): 'home' | 'away' | null {
+  if (market === 'match_winner' || market === 'asian_handicap') {
+    if (outcome === 'Home') return 'home';
+    if (outcome === 'Away') return 'away';
+    return null;
+  }
+  if (market === 'double_chance') {
+    if (outcome === '1X') return 'home';
+    if (outcome === 'X2') return 'away';
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Um número-manchete do confronto.
+ *
+ * Forma escolhida pela skill de dataviz: "um punhado de números-manchete" pede uma
+ * KPI row de stat tiles, e explicitamente NÃO um gráfico de barras agrupadas. A
+ * versão anterior desta tela desenhava duas barrinhas por premissa, que é o item da
+ * coluna "não" daquela tabela. O contrato do tile também vem de lá: label em frase,
+ * sem dois-pontos, valor semibold, sub opcional.
+ */
+export interface Tile {
+  label: string;
+  valor: string;
+  sub?: string;
+  /** Destaca em forest. Um por linha no máximo, senão nada destaca nada. */
+  forte?: boolean;
+}
+
+/**
+ * Os 3 ou 4 números que importam naquele mercado. Escolhidos por mercado porque
+ * "gols somados" não diz nada num 1X2 e "campanha em casa" não diz nada num over.
+ */
+export function tilesDe(
+  market: string,
+  numeros: FutebolFixtureNumeros[] | undefined,
+  lado: 'home' | 'away' | null,
+): Tile[] {
+  if (!numeros?.length) return [];
+  const casa = numeros.find((x) => x.side === 'home');
+  const fora = numeros.find((x) => x.side === 'away');
+  if (!casa || !fora) return [];
+  // acesa: false — tiles são "números do confronto", dado neutro; as guardas de
+  // contradição só valem para número colado numa premissa acesa.
+  const { time, adv, emCasa } = porLado({ casa, fora, lado, acesa: false, linha: null });
+
+  if (market === 'goals_over_under' || market === 'btts') {
+    const gfCasa = casa.gf_casa ?? casa.gf_total;
+    const gfFora = fora.gf_fora ?? fora.gf_total;
+    const gaCasa = casa.ga_casa ?? casa.ga_total;
+    const gaFora = fora.ga_fora ?? fora.ga_total;
+    const tiles: Tile[] = [];
+    if (gfCasa != null && gfFora != null) {
+      tiles.push({
+        label: 'Gols somados por jogo',
+        valor: n1(gfCasa + gfFora),
+        sub: `${casa.team_name} ${n1(gfCasa)} em casa · ${fora.team_name} ${n1(gfFora)} fora`,
+        forte: true,
+      });
+    }
+    if (gaCasa != null) tiles.push({ label: `${casa.team_name} sofre em casa`, valor: n1(gaCasa), sub: 'gol por jogo' });
+    if (gaFora != null) tiles.push({ label: `${fora.team_name} sofre fora`, valor: n1(gaFora), sub: 'gol por jogo' });
+    if (casa.clean_sheets != null && fora.clean_sheets != null) {
+      tiles.push({
+        label: 'Jogos sem sofrer gol',
+        valor: `${casa.clean_sheets} e ${fora.clean_sheets}`,
+        sub: `de ${casa.jogos ?? '—'} jogos`,
+      });
+    }
+    return tiles.slice(0, 4);
+  }
+
+  // Mercados com lado: 1X2, handicap, dupla chance.
+  if (!time || !adv) return [];
+  const tiles: Tile[] = [];
+  const j = emCasa ? time.jogos_casa : time.jogos_fora;
+  const v = emCasa ? time.v_casa : time.v_fora;
+  const e = emCasa ? time.e_casa : time.e_fora;
+  const d = emCasa ? time.d_casa : time.d_fora;
+  if (j != null) {
+    tiles.push({
+      label: `Campanha ${emCasa ? 'em casa' : 'fora'}`,
+      valor: `${v ?? 0}V ${e ?? 0}E ${d ?? 0}D`,
+      sub: `em ${j} jogos`,
+      forte: true,
+    });
+  }
+  const ataque = emCasa ? time.gf_casa : time.gf_fora;
+  if (ataque != null) {
+    tiles.push({ label: `${time.team_name} marca`, valor: n1(ataque), sub: `${emCasa ? 'em casa' : 'fora'}, por jogo` });
+  }
+  const defesaAdv = emCasa ? adv.ga_fora : adv.ga_casa;
+  if (defesaAdv != null) {
+    tiles.push({
+      label: `${adv.team_name} sofre`,
+      valor: n1(defesaAdv),
+      sub: `${emCasa ? 'fora' : 'em casa'}, por jogo`,
+    });
+  }
+  if (time.posicao != null && adv.posicao != null) {
+    tiles.push({
+      label: 'Na tabela',
+      valor: `${time.posicao}º e ${adv.posicao}º`,
+      sub: `${Math.abs((time.pontos ?? 0) - (adv.pontos ?? 0))} pontos de diferença`,
+    });
+  }
+  return tiles.slice(0, 4);
+}
+
+/**
+ * A manchete do mercado: uma frase que diz o caso em português, montada a partir da
+ * evidência da premissa de maior peso. Espelha o "Por quê" da /futebol, que é o
+ * padrão do produto para isso e já está no ar.
+ */
+export function manchete(
+  slugsAcesos: string[],
+  ordemPorPeso: string[],
+  numeros: FutebolFixtureNumeros[] | undefined,
+  lado: 'home' | 'away' | null,
+): { texto: string; slug: string } | null {
+  for (const slug of ordemPorPeso) {
+    if (!slugsAcesos.includes(slug)) continue;
+    const ev = evidenciaDe(slug, numeros, lado);
+    // Devolve o slug junto pra lista de premissas não repetir a mesma frase logo
+    // abaixo da manchete.
+    if (ev) return { texto: ev.texto, slug };
+  }
+  return null;
+}
+
+export { n1, n2 };

--- a/src/utils/futebol-historico.ts
+++ b/src/utils/futebol-historico.ts
@@ -1,0 +1,373 @@
+import type { FutebolFixtureHistorico } from '@/services/futebol-data.service';
+import type { Evidencia } from '@/utils/futebol-evidencias';
+import { n1 } from '@/utils/futebol-evidencias';
+
+// Os jogos que produzem a média de cada premissa (RPC 095).
+//
+// Por que existe: a média sozinha ainda pede fé. "Somados, sofrem 3,0 gols por jogo"
+// pode ser dois times que sofrem sempre, ou um vazadouro e uma defesa sólida, ou uma
+// goleada isolada puxando tudo. O gráfico jogo a jogo, com a linha da média e o
+// filtro de mando declarado, deixa o usuário conferir em vez de acreditar.
+//
+// Regra que sustenta a auditoria: o recorte aqui é o MESMO da média (competição,
+// temporada e mando). Medido no dev: Palmeiras em casa, 10 jogos, 0,80 gol sofrido,
+// idêntico ao ga_casa da 094. Se o recorte fosse outro, o gráfico desmentiria o
+// número que ele deveria explicar.
+
+export type Metrica = 'ga' | 'gf' | 'xg' | 'total' | 'resultado';
+
+/** `proprio` = o mando que o time tem NESTE jogo (mandante em casa, visitante fora). */
+export type FiltroMando = 'proprio' | 'todos';
+
+export type Quem = 'time' | 'adversario' | 'ambos';
+
+/**
+ * Para que lado a premissa quer o número. `maior` = jogo com valor acima da régua
+ * joga a favor dela; `menor` = abaixo joga a favor. É o que permite pintar a barra
+ * pelo que ela significa PARA A SAÍDA ESCOLHIDA, e não só "acima ou abaixo da média".
+ */
+export type Direcao = 'maior' | 'menor';
+
+interface SerieSpec {
+  quem: Quem;
+  metrica: Metrica;
+  mando: FiltroMando;
+  direcao: Direcao;
+  /**
+   * Recorta os últimos N jogos. Existe para o gráfico não desmentir a frase: a
+   * premissa de forma fala dos ÚLTIMOS 5, então mostrar 21 jogos ali seria outro
+   * número. Sem isto, entram todos os jogos do recorte.
+   */
+  ultimos?: number;
+}
+
+/**
+ * Que gráfico prova cada premissa. Slug fora do mapa não ganha gráfico: melhor a aba
+ * dizer que não tem como conferir do que desenhar um número que não é o da premissa.
+ */
+const SPECS: Record<string, SerieSpec[]> = {
+  // ── Gols ──
+  defesas_vazaveis: [{ quem: 'ambos', metrica: 'ga', mando: 'proprio', direcao: 'maior' }],
+  defesas_firmes: [{ quem: 'ambos', metrica: 'ga', mando: 'proprio', direcao: 'menor' }],
+  ataque_combinado: [{ quem: 'ambos', metrica: 'gf', mando: 'proprio', direcao: 'maior' }],
+  ataques_fracos: [{ quem: 'ambos', metrica: 'gf', mando: 'proprio', direcao: 'menor' }],
+  clean_sheets_altos: [{ quem: 'ambos', metrica: 'ga', mando: 'todos', direcao: 'menor' }],
+  ambos_vazam: [{ quem: 'ambos', metrica: 'ga', mando: 'todos', direcao: 'maior' }],
+  xg_combinado_alto: [{ quem: 'ambos', metrica: 'xg', mando: 'proprio', direcao: 'maior' }],
+  xg_baixo_combinado: [{ quem: 'ambos', metrica: 'xg', mando: 'proprio', direcao: 'menor' }],
+  historico_over: [{ quem: 'ambos', metrica: 'total', mando: 'todos', direcao: 'maior' }],
+  historico_under: [{ quem: 'ambos', metrica: 'total', mando: 'todos', direcao: 'menor' }],
+
+  // ── Resultado ──
+  forma: [{ quem: 'time', metrica: 'resultado', mando: 'todos', direcao: 'maior', ultimos: 5 }],
+  invicto_recente: [{ quem: 'time', metrica: 'resultado', mando: 'todos', direcao: 'maior', ultimos: 5 }],
+  mando: [{ quem: 'time', metrica: 'resultado', mando: 'proprio', direcao: 'maior' }],
+  mando_forte: [{ quem: 'time', metrica: 'resultado', mando: 'proprio', direcao: 'maior' }],
+  superioridade_xg: [{ quem: 'ambos', metrica: 'xg', mando: 'todos', direcao: 'maior' }],
+  forca_mismatch: [
+    { quem: 'time', metrica: 'gf', mando: 'proprio', direcao: 'maior' },
+    { quem: 'adversario', metrica: 'ga', mando: 'proprio', direcao: 'maior' },
+  ],
+
+  // ── Handicap ──
+  tende_golear: [
+    { quem: 'time', metrica: 'gf', mando: 'proprio', direcao: 'maior' },
+    { quem: 'adversario', metrica: 'ga', mando: 'proprio', direcao: 'maior' },
+  ],
+  adversario_fragil_fora: [{ quem: 'adversario', metrica: 'ga', mando: 'proprio', direcao: 'maior' }],
+  defesa_fora_solida: [{ quem: 'time', metrica: 'ga', mando: 'proprio', direcao: 'menor' }],
+  raramente_perde_por_2: [{ quem: 'time', metrica: 'resultado', mando: 'todos', direcao: 'maior' }],
+
+  // ── Ambos marcam / dupla chance ──
+  ambos_marcam: [{ quem: 'ambos', metrica: 'gf', mando: 'todos', direcao: 'maior' }],
+  ataque_dos_dois: [{ quem: 'ambos', metrica: 'gf', mando: 'proprio', direcao: 'maior' }],
+  defesa_forte: [{ quem: 'ambos', metrica: 'ga', mando: 'proprio', direcao: 'menor' }],
+  adversario_limitado: [{ quem: 'adversario', metrica: 'gf', mando: 'todos', direcao: 'menor' }],
+};
+
+export interface JogoBarra {
+  ordem: number;
+  data: string;
+  adversario: string;
+  adversarioId: number;
+  emCasa: boolean;
+  /** Valor da métrica no jogo. Null = sem dado (xG que a API não entregou). */
+  valor: number | null;
+  /** Placar do jogo, na ótica do time da série. */
+  placar: string;
+  resultado: 'V' | 'E' | 'D';
+  /**
+   * Este jogo puxa para o lado da saída escolhida? É o que a cor da barra diz: num
+   * "mais de 2,5", jogo com muito gol joga a favor; num "menos de 2,5", o contrário.
+   */
+  favorece: boolean;
+}
+
+export interface SerieHistorico {
+  chave: string;
+  /** Para o escudo em cima do próprio gráfico, e não só na legenda longe dele. */
+  teamId: number;
+  teamName: string;
+  /** "Fortaleza em casa" ou "Fortaleza, todos os jogos". */
+  titulo: string;
+  /** "4 jogos" ou "4 jogos, 1 sem dado de gol esperado". */
+  sub: string;
+  metrica: Metrica;
+  direcao: Direcao;
+  /** A média das barras, que é o número que a premissa usa. */
+  media: number | null;
+  jogos: JogoBarra[];
+}
+
+/**
+ * O fechamento da premissa: o número dos dois times somado, comparado com a linha
+ * escolhida. É o que responde "por que essa premissa joga a favor DESTA saída", que
+ * o gráfico de cada time separado não responde sozinho.
+ */
+export interface Consolidado {
+  valor: number;
+  linha: number;
+  direcao: Direcao;
+  favorece: boolean;
+  /** "gols sofridos por jogo, somados" */
+  unidade: string;
+}
+
+export interface Story {
+  series: SerieHistorico[];
+  /** Como ler o gráfico. Uma frase, por métrica. */
+  comoLer: string;
+  /** Referência tracejada, quando a métrica é o total de gols da partida. */
+  referencia?: { valor: number; label: string };
+  consolidado?: Consolidado;
+}
+
+const LADO_OPOSTO = (l: 'home' | 'away') => (l === 'home' ? 'away' : 'home');
+
+/** O lado do confronto de cada papel. Sem lado definido, "time" é o mandante. */
+function papeis(lado: 'home' | 'away' | null): { time: 'home' | 'away'; adversario: 'home' | 'away' } {
+  const t = lado ?? 'home';
+  return { time: t, adversario: LADO_OPOSTO(t) };
+}
+
+function valorDe(r: FutebolFixtureHistorico, m: Metrica): number | null {
+  if (m === 'ga') return r.gols_contra;
+  if (m === 'gf') return r.gols_pro;
+  if (m === 'total') return r.total_gols;
+  if (m === 'xg') return r.xg;
+  return r.gols_pro - r.gols_contra;
+}
+
+const SUFIXO_MANDO = (mando: FiltroMando, emCasa: boolean) =>
+  mando === 'todos' ? ', todos os jogos' : emCasa ? ' em casa' : ' fora';
+
+const COMO_LER: Record<Metrica, string> = {
+  ga: 'Cada barra é um jogo: quanto mais alta, mais gols o time sofreu naquele jogo. A linha é a média, que é o número que a premissa usa.',
+  gf: 'Cada barra é um jogo: quanto mais alta, mais gols o time marcou. A linha é a média, que é o número que a premissa usa.',
+  xg: 'Cada barra é o gol esperado do time no jogo, ou seja, o tanto de chance que ele criou. A linha é a média.',
+  total: 'Cada barra é o total de gols do jogo, somando os dois times. A linha tracejada é a linha que você escolheu.',
+  resultado: 'Cada quadrado é um jogo, com o placar e o adversário. Verde é vitória, cinza empate, vermelho derrota.',
+};
+
+/**
+ * O gráfico que prova (ou derruba) a premissa, com o mesmo recorte da média.
+ * Devolve null quando não existe jogo suficiente ou quando a premissa não tem como
+ * ser auditada com o que o mart entrega.
+ */
+export function storyDaPremissa(
+  slug: string,
+  hist: FutebolFixtureHistorico[] | undefined,
+  lado: 'home' | 'away' | null,
+  linha: number | null,
+): Story | null {
+  const specs = SPECS[slug];
+  if (!specs?.length || !hist?.length) return null;
+  const p = papeis(lado);
+
+  const series: SerieHistorico[] = [];
+  for (const spec of specs) {
+    const lados: ('home' | 'away')[] =
+      spec.quem === 'ambos' ? ['home', 'away'] : spec.quem === 'time' ? [p.time] : [p.adversario];
+    for (const side of lados) {
+      const doLado = hist.filter((r) => r.side === side);
+      if (!doLado.length) continue;
+      const emCasa = side === 'home';
+      const noMando = spec.mando === 'todos' ? doLado : doLado.filter((r) => r.em_casa === emCasa);
+      const filtrados = spec.ultimos ? noMando.slice(-spec.ultimos) : noMando;
+      if (!filtrados.length) continue;
+      const brutos = filtrados.map((r) => ({
+        ordem: r.ordem,
+        data: r.data,
+        adversario: r.adversario,
+        adversarioId: r.adversario_id,
+        emCasa: r.em_casa,
+        valor: valorDe(r, spec.metrica),
+        placar: `${r.gols_pro} a ${r.gols_contra}`,
+        resultado: r.resultado,
+      }));
+      const comValor = brutos.map((j) => j.valor).filter((v): v is number => v != null);
+      const semDado = brutos.length - comValor.length;
+      const media = comValor.length ? comValor.reduce((s, v) => s + v, 0) / comValor.length : null;
+      // A régua de cada jogo: no total de gols é a LINHA escolhida (é ela que decide
+      // a aposta); nas outras métricas é a média, que é o número da premissa.
+      const regua = spec.metrica === 'total' && linha != null ? linha : media;
+      const jogos: JogoBarra[] = brutos.map((j) => ({
+        ...j,
+        favorece:
+          j.valor == null || regua == null
+            ? false
+            : spec.direcao === 'maior'
+              ? j.valor > regua
+              : j.valor < regua,
+        resultado: j.resultado as 'V' | 'E' | 'D',
+      }));
+      series.push({
+        chave: `${slug}-${side}-${spec.metrica}-${spec.mando}`,
+        teamId: filtrados[0].team_id,
+        teamName: filtrados[0].team_name,
+        titulo: spec.ultimos
+          ? `${filtrados[0].team_name}, últimos ${filtrados.length} jogos`
+          : `${filtrados[0].team_name}${SUFIXO_MANDO(spec.mando, emCasa)}`,
+        sub:
+          semDado > 0
+            ? `${jogos.length} ${jogos.length === 1 ? 'jogo' : 'jogos'}, ${semDado} sem o dado`
+            : spec.ultimos && noMando.length > filtrados.length
+              ? `de ${noMando.length} na competição`
+              : `${jogos.length} ${jogos.length === 1 ? 'jogo' : 'jogos'}`,
+        metrica: spec.metrica,
+        direcao: spec.direcao,
+        media,
+        jogos,
+      });
+    }
+  }
+  if (!series.length) return null;
+
+  const metrica = series[0].metrica;
+  const spec0 = specs[0];
+  return {
+    series,
+    comoLer: COMO_LER[metrica],
+    referencia: metrica === 'total' && linha != null ? { valor: linha, label: `linha ${String(linha).replace('.', ',')}` } : undefined,
+    consolidado: consolidadoDe(series, spec0, linha),
+  };
+}
+
+const UNIDADE: Partial<Record<Metrica, string>> = {
+  ga: 'gols sofridos por jogo, somando os dois',
+  gf: 'gols marcados por jogo, somando os dois',
+  xg: 'gols esperados por jogo, somando os dois',
+  total: 'gols por jogo na média dos dois',
+};
+
+/**
+ * O número dos dois times contra a linha. Só existe onde a comparação é honesta: os
+ * dois lados na mesma métrica de gol e uma linha de gols para comparar. Handicap e
+ * 1X2 não entram, porque ali a linha não é total de gol.
+ */
+function consolidadoDe(series: SerieHistorico[], spec: SerieSpec, linha: number | null): Consolidado | null {
+  if (linha == null || spec.quem !== 'ambos') return null;
+  const unidade = UNIDADE[spec.metrica];
+  if (!unidade) return null;
+  const medias = series.map((s) => s.media).filter((v): v is number => v != null);
+  if (medias.length !== series.length || !medias.length) return null;
+  // No total de gols cada jogo já soma os dois times, então o consolidado é a média
+  // das médias, não a soma (senão contaria os gols duas vezes).
+  const valor =
+    spec.metrica === 'total' ? medias.reduce((a, b) => a + b, 0) / medias.length : medias.reduce((a, b) => a + b, 0);
+  return {
+    valor,
+    linha,
+    direcao: spec.direcao,
+    favorece: spec.direcao === 'maior' ? valor > linha : valor < linha,
+    unidade,
+  };
+}
+
+/**
+ * A frase de embasamento das premissas que a 094 não cobre, calculada dos MESMOS
+ * jogos do gráfico. Fecha os buracos de "sem número para conferir" que sobraram:
+ * chance de gol (xG), histórico de muitos/poucos gols e derrota por dois ou mais.
+ */
+export function evidenciaDoHistorico(
+  slug: string,
+  hist: FutebolFixtureHistorico[] | undefined,
+  lado: 'home' | 'away' | null,
+  linha: number | null,
+): Evidencia | null {
+  if (!hist?.length) return null;
+  const p = papeis(lado);
+  const doLado = (s: 'home' | 'away', proprio: boolean) => {
+    const rows = hist.filter((r) => r.side === s);
+    return proprio ? rows.filter((r) => r.em_casa === (s === 'home')) : rows;
+  };
+  const media = (rows: FutebolFixtureHistorico[], f: (r: FutebolFixtureHistorico) => number | null) => {
+    const vs = rows.map(f).filter((v): v is number => v != null);
+    return vs.length ? vs.reduce((a, b) => a + b, 0) / vs.length : null;
+  };
+  const nome = (s: 'home' | 'away') => hist.find((r) => r.side === s)?.team_name ?? '';
+
+  if (slug === 'xg_combinado_alto' || slug === 'xg_baixo_combinado') {
+    const casa = doLado('home', true);
+    const fora = doLado('away', true);
+    const a = media(casa, (r) => r.xg);
+    const b = media(fora, (r) => r.xg);
+    if (a == null || b == null) return null;
+    // Mesma guarda de contradição do futebol-evidencias: gol esperado somado ACIMA
+    // da linha desmente "criam pouca chance", e abaixo dela desmente "criam muita".
+    // Sem isso a tela escrevia "criam pouca chance de gol · somados, criam 3,5".
+    if (linha != null) {
+      const soma = a + b;
+      if (slug === 'xg_baixo_combinado' && soma > linha) return null;
+      if (slug === 'xg_combinado_alto' && soma < linha) return null;
+    }
+    return {
+      texto: `Somados, criam ${n1(a + b)} gols esperados por jogo`,
+      comparacao: {
+        esqLabel: `${nome('home')} em casa`,
+        esqValor: a,
+        dirLabel: `${nome('away')} fora`,
+        dirValor: b,
+        destaque: 'nenhum',
+      },
+    };
+  }
+
+  if (slug === 'superioridade_xg') {
+    const a = media(doLado(p.time, false), (r) => r.xg);
+    const b = media(doLado(p.adversario, false), (r) => r.xg);
+    if (a == null || b == null) return null;
+    return {
+      texto: `${nome(p.time)} cria ${n1(a)} gols esperados por jogo contra ${n1(b)} do adversário`,
+      comparacao: {
+        esqLabel: nome(p.time),
+        esqValor: a,
+        dirLabel: nome(p.adversario),
+        dirValor: b,
+        destaque: 'esq',
+      },
+    };
+  }
+
+  if (slug === 'historico_over' || slug === 'historico_under') {
+    if (linha == null) return null;
+    const todos = hist;
+    const acima = todos.filter((r) => r.total_gols > linha).length;
+    const alvo = slug === 'historico_over' ? acima : todos.length - acima;
+    const comp = slug === 'historico_over' ? 'passaram de' : 'ficaram abaixo de';
+    return {
+      texto: `${alvo} dos ${todos.length} jogos dos dois times ${comp} ${String(linha).replace('.', ',')} gols`,
+    };
+  }
+
+  if (slug === 'raramente_perde_por_2') {
+    const rows = doLado(p.time, false);
+    if (!rows.length) return null;
+    const k = rows.filter((r) => r.gols_contra - r.gols_pro >= 2).length;
+    return {
+      texto: `${nome(p.time)} perdeu por dois ou mais em ${k} dos ${rows.length} jogos`,
+    };
+  }
+
+  return null;
+}

--- a/src/utils/futebol-leitura.ts
+++ b/src/utils/futebol-leitura.ts
@@ -1,0 +1,89 @@
+import type { FutebolFixturePremissas, FutebolFixtureValueRow } from '@/services/futebol-data.service';
+import {
+  MERCADOS,
+  PORTA_PREMISSAS,
+  contaQueValem,
+  melhorCandidato,
+  premissasDaSaida,
+  type MercadoInfo,
+} from '@/utils/futebol-premissas';
+
+// A leitura do jogo, calculada UMA vez e reusada em toda a tela (Protótipo 1b):
+// resumo, bancada, ranking e hero derivam daqui, para não existirem duas verdades.
+//
+// Regra de honestidade da adaptação: o protótipo mostra Score/odd/chance sempre,
+// mas no dado real esses números SÓ existem quando há odds coletadas
+// (get_futebol_fixture_value). Sem odds, a leitura vive das premissas — o próprio
+// protótipo tem esse padrão no "sem preço" do BTTS.
+
+/** Casa uma linha de valor (odds reais) com um candidato de premissas. */
+export function valueDoCandidato(
+  valueRows: FutebolFixtureValueRow[] | null | undefined,
+  market: string,
+  outcome: string,
+  line: number | null,
+): FutebolFixtureValueRow | null {
+  if (!valueRows?.length) return null;
+  return (
+    valueRows.find(
+      (v) =>
+        v.market === market &&
+        v.outcome === outcome &&
+        ((v.line_value == null && line == null) ||
+          (v.line_value != null && line != null && Math.abs(v.line_value - line) < 0.011)),
+    ) ?? null
+  );
+}
+
+export interface MercadoResumo {
+  mercado: MercadoInfo;
+  /** O candidato que representa o mercado (saída/linha com mais premissas). */
+  candidato: FutebolFixturePremissas;
+  nValem: number;
+  totalQueValem: number;
+  /** Linha de valor real (odds), quando coletada. */
+  value: FutebolFixtureValueRow | null;
+  /**
+   * Passa a régua? Com odds, régua de Score (40). Sem odds, a porta de contexto
+   * (2+ premissas) — que é o que existe para afirmar.
+   */
+  passa: boolean;
+}
+
+export const REGUA_SCORE = 40;
+
+export function resumoDosMercados(
+  rows: FutebolFixturePremissas[] | null | undefined,
+  valueRows: FutebolFixtureValueRow[] | null | undefined,
+): MercadoResumo[] {
+  if (!rows?.length) return [];
+  return MERCADOS.flatMap((m) => {
+    const c = melhorCandidato(rows, m.slug);
+    if (!c) return [];
+    const nValem = contaQueValem(m.slug, c.acesas);
+    // Denominador só do lado da saída: para um Over, "defesas firmes" e as outras do
+    // Under nunca poderiam acender, então contá-las fazia "2 de 8" onde o certo é
+    // "2 de 3".
+    const totalQueValem = premissasDaSaida(m, c.outcome, c.line_value, c.acesas).filter(
+      (p) => p.peso == null || p.peso > 0,
+    ).length;
+    // O valor pode estar em qualquer saída do mercado; o candidato de contexto e o
+    // de preço podem divergir. Preferimos o do próprio candidato; se não houver,
+    // olhamos o melhor Score do mercado inteiro.
+    const doCandidato = valueDoCandidato(valueRows, m.slug, c.outcome, c.line_value);
+    const doMercado = (valueRows ?? [])
+      .filter((v) => v.market === m.slug)
+      .sort((a, b) => b.score - a.score)[0] ?? null;
+    const value = doCandidato ?? doMercado;
+    const passa = value ? value.score >= REGUA_SCORE : nValem >= PORTA_PREMISSAS;
+    return [{ mercado: m, candidato: c, nValem, totalQueValem, value, passa }];
+  });
+}
+
+/** A "melhor leitura do jogo": maior Score real; sem odds, mais contexto. */
+export function melhorLeitura(resumos: MercadoResumo[]): MercadoResumo | null {
+  if (!resumos.length) return null;
+  const comValor = resumos.filter((r) => r.value != null);
+  if (comValor.length) return [...comValor].sort((a, b) => (b.value!.score) - (a.value!.score))[0];
+  return [...resumos].sort((a, b) => b.nValem - a.nValem)[0];
+}

--- a/src/utils/futebol-logos.ts
+++ b/src/utils/futebol-logos.ts
@@ -13,6 +13,18 @@ export function getFutebolTeamLogoUrl(teamId: number | null | undefined): string
 }
 
 /**
+ * URL pública do brasão do campeonato no nosso Storage (bucket
+ * futebol-league-logos), populado pela edge function mirror-futebol-league-logos.
+ * O arquivo é salvo com o nome do slug do mart (`brasileirao.png`), então a tela
+ * não precisa conhecer o id da API. Sem arquivo, o <img> 404 → cai no troféu.
+ */
+export function getFutebolLeagueLogoUrl(slug: string | null | undefined): string | null {
+  if (!slug) return null;
+  const { data } = supabase.storage.from('futebol-league-logos').getPublicUrl(`${slug}.png`);
+  return data.publicUrl;
+}
+
+/**
  * URL pública da foto do jogador no nosso Storage (bucket futebol-player-photos),
  * espelhada da API-Sports pela edge function mirror-futebol-player-photos. Por player_id.
  * 404 → o componente cai pras iniciais (onError).
@@ -21,4 +33,13 @@ export function getFutebolPlayerPhotoUrl(playerId: number | null | undefined): s
   if (!playerId) return null;
   const { data } = supabase.storage.from('futebol-player-photos').getPublicUrl(`${playerId}.png`);
   return data.publicUrl;
+}
+
+/**
+ * Sigla de até 3 letras pro fallback de imagem (escudo de time ou foto de jogador)
+ * quando o mirror ainda não tem o arquivo. Mora aqui porque é sempre o outro lado
+ * do mesmo `onError` dos getters acima.
+ */
+export function crestInitials(name: string): string {
+  return name.replace(/[^A-Za-zÀ-ÿ\s]/g, '').trim().slice(0, 3).toUpperCase() || '?';
 }

--- a/src/utils/futebol-premissas.ts
+++ b/src/utils/futebol-premissas.ts
@@ -1,0 +1,422 @@
+import type { FutebolFixturePremissas } from '@/services/futebol-data.service';
+
+// Catálogo das premissas do Score: rótulo, peso e agrupamento.
+//
+// O dado (quais acenderam) vem da RPC get_futebol_fixture_premissas (migration 093).
+// O que mora AQUI é o que é copy e decisão de produto: como cada premissa se chama
+// para o usuário, quanto ela vale e em qual grupo ela entra.
+//
+// Fonte dos pesos: docs/premissas-recalibragem.md (01/08/2026), seções "Pesos
+// decididos" de cada mercado. Os pesos NOVOS são os da recalibragem, não os que o
+// mart aplica hoje, porque o objetivo da tela é mostrar o que decide de verdade.
+//
+// O agrupamento sai do achado transversal do doc: "premissa de histórico recente não
+// ajuda em nenhum mercado (histórico over, histórico seco, histórico de ambos marcam,
+// confronto direto e invicto recente). É o dado mais fácil de olhar, então a casa de
+// aposta já olhou antes da gente. E o que ajuda é sempre característica estrutural do
+// time: como ele defende, como ele ataca, quanto ele descansou."
+//
+// Por isso os dois grupos:
+//   'decide' → característica estrutural, peso novo > 0
+//   'preco'  → o mercado já cobra, peso novo 0 ou quase
+//
+// ATENÇÃO ao mexer: Ambos Marcam e Dupla Chance estão marcados como PENDENTES no doc
+// (não são recalibragem, são decisão de destravar ou aposentar), então peso `null`.
+// Não inventar peso para eles.
+
+export type GrupoPremissa = 'decide' | 'preco';
+
+export interface Premissa {
+  slug: string;
+  /** Rótulo para o usuário. Segue as strings que o backend já manda no Telegram. */
+  label: string;
+  /**
+   * O mesmo rótulo escrito no negativo, para quando a premissa NÃO acendeu.
+   *
+   * Existe porque "Os dois somam muitos gols" com um "não aconteceu" embaixo é lido
+   * como afirmação: o olho pega o título e passa. Escrito "Os dois não somam muitos
+   * gols", a linha diz o que é sem depender do rodapé.
+   */
+  negativo: string;
+  grupo: GrupoPremissa;
+  /** Peso na recalibragem. `null` = mercado ainda não recalibrado. */
+  peso: number | null;
+  /** Por que vale pouco ou zero. Só preenchido quando ajuda a entender. */
+  motivo?: string;
+  /**
+   * Rótulos por mando da aposta. "Manda bem em casa" aparecia para o visitante, e
+   * "Defesa sólida jogando fora" aparecia para o mandante. Onde o mando muda o
+   * sentido da frase, o par certo mora aqui; onde não muda, fica só o label.
+   */
+  labelCasa?: string;
+  negativoCasa?: string;
+  labelFora?: string;
+  negativoFora?: string;
+  /**
+   * O lado do mercado a que a premissa pertence.
+   *
+   * Existe porque o catálogo de um mercado guarda os DOIS lados juntos, mas cada
+   * saída só pode acender o seu: "defesas frágeis" é do Over, "defesas firmes" é do
+   * Under, e as duas medem o mesmo número. Sem esta marca a tela mostrava, na mesma
+   * saída, "defesas frágeis dos dois lados" a favor e "defesas firmes dos dois
+   * lados" como premissa que não aconteceu, as duas com o mesmo 3,0 gols embaixo.
+   * Confirmado na base (RPC 093): linha Over acende só premissa de Over, linha Under
+   * só de Under, e no handicap o lado sai do sinal da linha.
+   */
+  lado?: LadoPremissa;
+}
+
+/** O lado do mercado a que uma premissa pertence. `undefined` = vale para os dois. */
+export type LadoPremissa = 'favorito' | 'azarao' | 'over' | 'under' | 'sim' | 'nao';
+
+/** Premissas que o doc manda NÃO mostrar. Ver 093 e "Frente 4: limpeza". */
+export const PREMISSAS_OCULTAS = new Set([
+  // "favorito_irregular sai da tela": acende em 43% das linhas, vale 0 ponto, e
+  // aparecia como evidência ("O favorito não costuma golear").
+  'favorito_irregular',
+]);
+
+const P = (
+  slug: string,
+  label: string,
+  negativo: string,
+  grupo: GrupoPremissa,
+  peso: number | null,
+  extra: {
+    motivo?: string;
+    lado?: LadoPremissa;
+    labelCasa?: string;
+    negativoCasa?: string;
+    labelFora?: string;
+    negativoFora?: string;
+  } = {},
+): Premissa => ({ slug, label, negativo, grupo, peso, ...extra });
+
+/**
+ * O rótulo da premissa para o mando da aposta. Só muda onde o mando importa; nas
+ * outras a frase já serve para os dois.
+ */
+export function rotuloPremissa(p: Premissa, lado: 'home' | 'away' | null, negativo = false): string {
+  if (lado === 'home') return (negativo ? p.negativoCasa : p.labelCasa) ?? (negativo ? p.negativo : p.label);
+  if (lado === 'away') return (negativo ? p.negativoFora : p.labelFora) ?? (negativo ? p.negativo : p.label);
+  return negativo ? p.negativo : p.label;
+}
+
+/** Resultado (1X2). Teto de premissa 51 → 30, de 7 ativas para 4. */
+const P_1X2: Premissa[] = [
+  P('forma', 'Em boa fase, vem ganhando', 'Não vem em boa fase', 'decide', 10),
+  P('mando', 'Manda bem em casa', 'Não manda bem em casa', 'decide', 8, {
+    labelFora: 'Vai bem fora de casa',
+    negativoFora: 'Não vai bem fora de casa',
+  }),
+  P('superioridade_tabela', 'Bem à frente na tabela', 'Não está bem à frente na tabela', 'decide', 8),
+  P('forca_mismatch', 'Ataque forte contra defesa frágil', 'O ataque não pega uma defesa frágil', 'decide', 4, {
+    motivo: 'entende o jogo, mas o preço já cobra quase tudo',
+  }),
+  P('superioridade_xg', 'Cria mais chances de gol que o adversário', 'Não cria mais chances de gol que o adversário', 'preco', 0, {
+    motivo: 'chance de gol prevê gols, não quem ganha',
+  }),
+  P('h2h_favoravel', 'Leva vantagem no histórico do confronto', 'Não leva vantagem no histórico do confronto', 'preco', 0, {
+    motivo: 'todo mundo olha, então já está na odd',
+  }),
+  P('desfalque_adversario', 'Adversário desfalcado', 'Adversário sem desfalque conhecido', 'preco', 0, {
+    motivo: 'sem dado em 99,5% dos jogos futuros',
+  }),
+];
+
+/** Gols (Over/Under). Teto do Over 56 → 34, do Under 52 → 40. De 13 ativas para 8. */
+const P_OU: Premissa[] = [
+  P('defesas_firmes', 'Defesas firmes dos dois lados', 'As defesas não são firmes', 'decide', 14, { lado: 'under' }),
+  P('defesas_vazaveis', 'Defesas frágeis dos dois lados', 'As defesas não são frágeis', 'decide', 12, { lado: 'over' }),
+  P('ataque_combinado', 'Os dois somam muitos gols', 'Os dois não somam muitos gols', 'decide', 12, { lado: 'over' }),
+  P('xg_baixo_combinado', 'Os dois criam pouca chance de gol', 'Os dois criam bastante chance de gol', 'decide', 10, { lado: 'under' }),
+  P('xg_combinado_alto', 'Os dois criam muita chance de gol', 'Os dois não criam muita chance de gol', 'decide', 10, { lado: 'over' }),
+  P('clean_sheets_altos', 'Os dois seguram muito jogo sem sofrer gol', 'Os dois sofrem gol na maioria dos jogos', 'decide', 10, { lado: 'under' }),
+  P('ataques_fracos', 'Ataques fracos dos dois lados', 'Os ataques não são fracos', 'decide', 3, { lado: 'under', motivo: 'o preço já cobra' }),
+  P('historico_under', 'Histórico de jogo com poucos gols', 'O histórico não é de jogo com poucos gols', 'preco', 3, { lado: 'under', motivo: 'sinal fraco' }),
+  P('ambos_vazam', 'Os dois sofrem gol quase todo jogo', 'Os dois não sofrem gol quase todo jogo', 'preco', 0, {
+    lado: 'over',
+    motivo: 'o preço cobra mais do que ela vale',
+  }),
+  P('ritmo_alto', 'Jogo de ritmo alto', 'O jogo não é de ritmo alto', 'preco', 0, { lado: 'over', motivo: 'atrapalha nos dois testes' }),
+  P('historico_over', 'Histórico de jogo com muitos gols', 'O histórico não é de jogo com muitos gols', 'preco', 0, { lado: 'over', motivo: 'atrapalha nos dois testes' }),
+  P('linha_subindo', 'Mercado puxando a linha pra cima', 'O mercado não está puxando a linha pra cima', 'preco', 0, { lado: 'over', motivo: 'atrapalha nos dois testes' }),
+  P('linha_descendo', 'Mercado puxando a linha pra baixo', 'O mercado não está puxando a linha pra baixo', 'preco', 0, {
+    lado: 'under',
+    motivo: 'atrapalha nos dois testes',
+  }),
+];
+
+/** Handicap asiático. Teto equilibrado em 35 nos dois lados (azarão era 13). */
+const P_AH: Premissa[] = [
+  P('tende_golear', 'Costuma ganhar por muitos gols', 'Não costuma ganhar por muitos gols', 'decide', 16, { lado: 'favorito' }),
+  P('supremacia', 'Muito superior ao adversário', 'Não é muito superior ao adversário', 'decide', 12, { lado: 'favorito' }),
+  P('defesa_fora_solida', 'Defesa sólida jogando fora', 'A defesa não é sólida jogando fora', 'decide', 10, {
+    lado: 'azarao',
+    labelCasa: 'Defesa sólida em casa',
+    negativoCasa: 'A defesa não é sólida em casa',
+  }),
+  P('sem_rodizio', 'Não deve poupar jogadores', 'Pode poupar jogadores', 'decide', 3, { lado: 'favorito' }),
+  P('raramente_perde_por_2', 'Raramente perde por dois ou mais', 'Perde por dois ou mais com frequência', 'decide', 3, {
+    lado: 'azarao',
+    motivo: 'sinal quase nulo, mas é o que abre a porta do azarão',
+  }),
+  P('adversario_fragil_fora', 'Adversário fraco fora de casa', 'O adversário não é fraco fora de casa', 'preco', 2, {
+    lado: 'favorito',
+    motivo: 'o preço já cobra tudo',
+    labelFora: 'Adversário fraco em casa',
+    negativoFora: 'O adversário não é fraco em casa',
+  }),
+  P('mando_forte', 'Manda muito bem em casa', 'Não manda tão bem em casa', 'preco', 2, {
+    lado: 'favorito',
+    motivo: 'o preço já cobra tudo',
+    labelFora: 'Vai muito bem fora de casa',
+    negativoFora: 'Não vai tão bem fora de casa',
+  }),
+];
+
+/** Ambos marcam. PENDENTE no doc: hoje nunca publica (a Pinnacle não cota o mercado). */
+const P_BTTS: Premissa[] = [
+  P('ambos_marcam', 'Os dois costumam marcar', 'Os dois não costumam marcar', 'decide', null, { lado: 'sim' }),
+  P('ataque_dos_dois', 'Os dois atacam bem', 'Os dois não atacam bem', 'decide', null, { lado: 'sim' }),
+  P('defesas_vazaveis', 'Defesas frágeis dos dois lados', 'As defesas não são frágeis', 'decide', null, { lado: 'sim' }),
+  P('defesa_forte', 'Defesa forte de um dos lados', 'Nenhum dos lados tem defesa forte', 'decide', null, { lado: 'nao' }),
+  P('ataque_trava', 'Ataque que trava', 'Nenhum dos ataques trava', 'decide', null, { lado: 'nao' }),
+  P('historico_btts', 'Histórico dos dois marcando', 'O histórico não é dos dois marcando', 'preco', null, { lado: 'sim', motivo: 'histórico já está na odd' }),
+  P('historico_seco', 'Histórico de jogo seco', 'O histórico não é de jogo seco', 'preco', null, { lado: 'nao', motivo: 'histórico já está na odd' }),
+];
+
+/** Dupla chance. PENDENTE no doc: Score máximo simulado 39 contra régua de 40. */
+const P_DC: Premissa[] = [
+  P('lado_coberto_forte', 'O lado coberto é forte', 'O lado coberto não é forte', 'decide', null),
+  P('equilibrio_defensivo', 'Equilíbrio defensivo', 'Sem equilíbrio defensivo', 'decide', null),
+  P('adversario_limitado', 'Adversário limitado', 'O adversário não é limitado', 'decide', null),
+  P('invicto_recente', 'Invicto nos últimos jogos', 'Não está invicto nos últimos jogos', 'preco', null, { motivo: 'histórico já está na odd' }),
+];
+
+/** Penalidades, por mercado. Peso negativo. */
+const PEN: Record<string, Premissa[]> = {
+  match_winner: [
+    P('pick_empate', 'Aposta no empate', 'Não é aposta no empate', 'decide', 0, { motivo: 'suspensa até ter amostra' }),
+    P('desfalque_proprio', 'O próprio time está desfalcado', 'O próprio time não tem desfalque', 'decide', -15),
+  ],
+  goals_over_under: [P('linha_extrema', 'Linha muito longe do normal', 'A linha não está longe do normal', 'decide', -10)],
+  asian_handicap: [P('handicap_alto', 'Handicap muito alto', 'O handicap não é alto', 'decide', 0, { motivo: 'efeito zero nos dois testes' })],
+  btts: [],
+  double_chance: [],
+};
+
+export interface MercadoInfo {
+  slug: string;
+  label: string;
+  /** Teto de premissa depois da recalibragem. `null` = mercado pendente. */
+  teto: number | null;
+  premissas: Premissa[];
+  penalidades: Premissa[];
+  /** Aviso de estado do mercado, quando houver. */
+  aviso?: string;
+}
+
+export const MERCADOS: MercadoInfo[] = [
+  { slug: 'goals_over_under', label: 'Gols (mais ou menos)', teto: 40, premissas: P_OU, penalidades: PEN.goals_over_under },
+  { slug: 'match_winner', label: 'Resultado', teto: 30, premissas: P_1X2, penalidades: PEN.match_winner },
+  { slug: 'asian_handicap', label: 'Handicap asiático', teto: 35, premissas: P_AH, penalidades: PEN.asian_handicap },
+  {
+    slug: 'btts',
+    label: 'Ambos marcam',
+    teto: null,
+    premissas: P_BTTS,
+    penalidades: PEN.btts,
+    aviso: 'Mercado em revisão: hoje não gera aposta porque falta referência de preço.',
+  },
+  {
+    slug: 'double_chance',
+    label: 'Dupla chance',
+    teto: null,
+    premissas: P_DC,
+    penalidades: PEN.double_chance,
+    aviso: 'Mercado em revisão: hoje não gera aposta porque não alcança a régua.',
+  },
+];
+
+const PREMISSA_POR_SLUG = new Map<string, Premissa>();
+MERCADOS.forEach((m) =>
+  [...m.premissas, ...m.penalidades].forEach((p) => {
+    // Mesmo slug pode existir em dois mercados (defesas_vazaveis em Gols e BTTS)
+    // com peso diferente. A chave é mercado+slug.
+    PREMISSA_POR_SLUG.set(`${m.slug}:${p.slug}`, p);
+  }),
+);
+
+/** Busca a premissa pelo par mercado+slug. Devolve null pra slug desconhecido. */
+export function premissaDe(market: string, slug: string): Premissa | null {
+  return PREMISSA_POR_SLUG.get(`${market}:${slug}`) ?? null;
+}
+
+export function mercadoDe(slug: string): MercadoInfo | null {
+  return MERCADOS.find((m) => m.slug === slug) ?? null;
+}
+
+/** Número da linha em pt-BR: 1,5 e não 1.5. */
+function fmtLinha(line: number): string {
+  return String(line).replace('.', ',');
+}
+
+/** Rótulo da saída da aposta, na linguagem do apostador. */
+export function outcomeLabel(market: string, outcome: string, home: string, away: string, line: number | null): string {
+  if (market === 'match_winner') {
+    if (outcome === 'Home') return `Vitória do ${home}`;
+    if (outcome === 'Away') return `Vitória do ${away}`;
+    return 'Empate';
+  }
+  if (market === 'goals_over_under') {
+    return `${outcome === 'Over' ? 'Mais' : 'Menos'} de ${line != null ? fmtLinha(line) : ''} gols`;
+  }
+  if (market === 'asian_handicap') {
+    // `line` vem na ótica do mandante (mesma convenção do pickLabel e da liquidação):
+    // o handicap do visitante é o oposto, senão o card do Vasco dizia "Vasco −1,5"
+    // numa linha em que ele recebe +1,5.
+    const daSaida = line != null ? (outcome === 'Away' ? -line : line) : null;
+    const time = outcome === 'Home' ? home : away;
+    return daSaida != null ? `${time} ${daSaida > 0 ? '+' : '−'}${fmtLinha(Math.abs(daSaida))}` : time;
+  }
+  if (market === 'btts') return outcome === 'Yes' ? 'Os dois marcam' : 'Não marcam os dois';
+  if (market === 'double_chance') {
+    if (outcome === '1X') return `${home} ou empate`;
+    if (outcome === 'X2') return `${away} ou empate`;
+    return `${home} ou ${away}`;
+  }
+  return outcome;
+}
+
+/**
+ * A porta nova de publicação: 2+ premissas acesas, contando SÓ as que sobreviveram
+ * à recalibragem daquele mercado. O doc é explícito: contar as antigas deixaria a
+ * porta aberta justamente pelas premissas cortadas por atrapalhar.
+ */
+export const PORTA_PREMISSAS = 2;
+
+/**
+ * O candidato que representa um mercado (a saída/linha com mais premissas que
+ * valem). Vive aqui, e não no componente do mapa, porque o painel da agenda também
+ * resume o jogo por ele.
+ */
+export function melhorCandidato(
+  rows: FutebolFixturePremissas[],
+  market: string,
+): FutebolFixturePremissas | null {
+  const doMercado = rows
+    .filter((r) => r.market === market)
+    // Handicap zero nunca acende premissa (as 7 são de favorito ou de azarão) e o doc
+    // manda excluir explicitamente em vez de deixar sumir em silêncio.
+    .filter((r) => !(market === 'asian_handicap' && r.line_value === 0));
+  if (!doMercado.length) return null;
+  const nota = (r: FutebolFixturePremissas) => contaQueValem(market, r.acesas);
+  const nPen = (r: FutebolFixturePremissas) => (r.penalidades ?? []).length;
+  // Distância da linha padrão do mercado de gols. Desempata linhas empatadas em
+  // premissas ("Over 0,5 / 0,75 / 1") em favor da linha que o mercado de fato
+  // negocia. Premissa DEPENDE da linha aqui: no dev, Over 1,5 acende 5 e Over 3,5
+  // acende 1 no mesmo jogo.
+  const centro = (r: FutebolFixturePremissas) => (r.line_value == null ? 0 : Math.abs(r.line_value - 2.5));
+  return [...doMercado].sort(
+    (a, b) =>
+      nota(b) - nota(a) ||
+      // Candidato penalizado (linha extrema etc.) perde de um limpo empatado.
+      nPen(a) - nPen(b) ||
+      centro(a) - centro(b) ||
+      b.pts_premissas - a.pts_premissas,
+  )[0];
+}
+
+export function contaQueValem(market: string, acesas: string[]): number {
+  return acesas.filter((s) => {
+    const p = premissaDe(market, s);
+    // Mercado pendente (peso null) conta, porque ali ainda não houve corte.
+    return p != null && (p.peso == null || p.peso > 0);
+  }).length;
+}
+
+// ── Vocabulário do Protótipo 1b (Claude Design) ─────────────────────────────
+// O número do peso não vai à tela: vira palavra. E as premissas apagadas não são
+// uma lista única — são três estados que nunca se misturam: não aconteceu neste
+// jogo, não conta neste mercado (o preço já cobra), e não avaliada (mercado sem
+// calibragem, caso do BTTS e da dupla chance).
+
+/** Peso da premissa em palavra, no lugar da cifra interna da fórmula. */
+export function pesoPalavra(p: Premissa): string {
+  if (p.peso == null) return 'Peso a calibrar';
+  if (p.peso >= 10) return 'Pesa muito';
+  if (p.peso >= 5) return 'Pesa';
+  // Peso zero é o corte da recalibragem: aconteceu, mas não soma. Chamar de "pesa
+  // pouco" contradizia o grupo das apagadas, que diz "não conta neste mercado".
+  if (p.peso === 0) return 'Não conta';
+  return 'Pesa pouco';
+}
+
+/** Premissa que de fato decide (peso calibrado e relevante). */
+export function pesoForte(p: Premissa): boolean {
+  return p.peso != null && p.peso >= 5;
+}
+
+/**
+ * Selo de força da leitura, a partir das premissas ACESAS que valem.
+ *
+ * O nome era "contexto forte/parcial/fraco" e não comunicava: "contexto" é palavra
+ * de quem fez a metodologia, não de quem aposta. "Leitura" é o termo que o resto do
+ * produto já usa ("a leitura do jogo", "melhor leitura do jogo") e responde a
+ * pergunta certa: o quanto o jogo sustenta esta aposta.
+ */
+export function contextoDoMercado(acesasFortes: number, semCalibragem: boolean): {
+  label: string;
+  tone: 'forte' | 'parcial' | 'fraco' | 'semcal';
+} {
+  if (semCalibragem) return { label: 'Mercado em revisão', tone: 'semcal' };
+  if (acesasFortes >= 2) return { label: 'Leitura forte', tone: 'forte' };
+  if (acesasFortes === 1) return { label: 'Leitura parcial', tone: 'parcial' };
+  return { label: 'Leitura fraca', tone: 'fraco' };
+}
+
+/**
+ * O lado do mercado a que uma saída pertence, quando o mercado tem dois lados.
+ *
+ * No handicap o `line_value` da RPC é o handicap do MANDANTE, e o visitante recebe o
+ * oposto: quem dá gol de vantagem (handicap negativo) é o favorito. Conferido na
+ * base: Home −1,5 acende premissa de favorito, Home +0,5 acende de azarão.
+ */
+export function ladoDaSaidaNoMercado(market: string, outcome: string, line: number | null): LadoPremissa | null {
+  if (market === 'goals_over_under') return outcome === 'Over' ? 'over' : 'under';
+  if (market === 'btts') return outcome === 'Yes' ? 'sim' : 'nao';
+  if (market === 'asian_handicap') {
+    if (line == null || line === 0) return null;
+    const hcap = outcome === 'Home' ? line : -line;
+    return hcap < 0 ? 'favorito' : 'azarao';
+  }
+  return null;
+}
+
+/**
+ * As premissas que aquela saída pode acender. As do outro lado ficam fora: elas não
+ * "deixaram de acontecer", elas contam para a aposta contrária.
+ *
+ * `acesas` entra como rede de segurança: se o mart algum dia acender uma premissa do
+ * outro lado, ela continua aparecendo em vez de sumir da tela em silêncio.
+ */
+export function premissasDaSaida(
+  m: MercadoInfo,
+  outcome: string,
+  line: number | null,
+  acesas: string[] = [],
+): Premissa[] {
+  const lado = ladoDaSaidaNoMercado(m.slug, outcome, line);
+  const acesasSet = new Set(acesas);
+  return m.premissas.filter(
+    (p) =>
+      !PREMISSAS_OCULTAS.has(p.slug) &&
+      (lado == null || p.lado == null || p.lado === lado || acesasSet.has(p.slug)),
+  );
+}
+
+// As premissas do outro lado não viram lista: a tela mostra os dois lados como
+// cards e o usuário troca de lado clicando. Listar os espelhos ("defesas frágeis"
+// embaixo de uma análise de "defesas firmes") fazia a tela se contradizer, mesmo
+// sem número, porque o rótulo já é a negação do que está sendo afirmado ao lado.

--- a/src/utils/futebol-rodadas.ts
+++ b/src/utils/futebol-rodadas.ts
@@ -1,0 +1,78 @@
+// ============================================================
+// futebol-rodadas.ts — o nome da rodada em português
+// ============================================================
+// O mart guarda o texto da API-Football, em inglês e em três formatos diferentes:
+// "Regular Season - 22" nas ligas, "Group Stage - 3" na fase de grupos e
+// "Round of 16" / "Quarter-finals" / "1/128-finals" no mata-mata. A tela precisa
+// de duas versões: a CURTA, que cabe num chip da régua, e a LONGA, que vira
+// título. Antes existia só um `prettyRound` que cuidava do "Regular Season" e
+// deixava o resto em inglês na tela.
+// ============================================================
+
+/** Número da rodada quando a competição é de pontos corridos, senão null. */
+export function numeroDaRodada(round: string | null | undefined): number | null {
+  const m = (round ?? '').match(/Regular Season\s*-\s*(\d+)/i);
+  return m ? Number(m[1]) : null;
+}
+
+/** true quando a lista de rodadas é de liga (pontos corridos), não de mata-mata. */
+export function ehCampeonatoDePontos(rounds: string[]): boolean {
+  return rounds.some((r) => numeroDaRodada(r) != null);
+}
+
+const FASES: Array<[RegExp, string, string]> = [
+  // [padrão, curto (chip), longo (título)]
+  [/^final$/i, 'Final', 'Final'],
+  [/semi[- ]?finals?/i, 'Semi', 'Semifinal'],
+  [/quarter[- ]?finals?/i, 'Quartas', 'Quartas de final'],
+  [/round of 16|1\/8[- ]?finals?/i, 'Oitavas', 'Oitavas de final'],
+  [/round of 32|1\/16[- ]?finals?/i, '16 avos', '16 avos de final'],
+  [/round of 64|1\/32[- ]?finals?/i, '32 avos', '32 avos de final'],
+  [/round of 128|1\/64[- ]?finals?/i, '64 avos', '64 avos de final'],
+  [/1\/128[- ]?finals?/i, '1ª fase', 'Primeira fase'],
+  [/1\/256[- ]?finals?/i, 'Pré', 'Fase preliminar'],
+  [/play[- ]?offs?/i, 'Playoff', 'Playoff'],
+  [/3rd qualifying/i, '3ª pré', 'Terceira fase preliminar'],
+  [/2nd qualifying/i, '2ª pré', 'Segunda fase preliminar'],
+  [/1st qualifying/i, '1ª pré', 'Primeira fase preliminar'],
+];
+
+/** true quando a rodada é de mata-mata (nem pontos corridos, nem fase de grupos). */
+export function ehMataMata(round: string | null | undefined): boolean {
+  const r = (round ?? '').trim();
+  if (!r || numeroDaRodada(r) != null) return false;
+  return !/group stage/i.test(r);
+}
+
+/** Rótulo de chip: curto o suficiente pra caber na régua. */
+export function rodadaCurta(round: string | null | undefined): string {
+  const n = numeroDaRodada(round);
+  if (n != null) return String(n);
+  const r = (round ?? '').trim();
+  if (!r) return '—';
+
+  const grupo = r.match(/group stage\s*-\s*(\d+)/i);
+  if (grupo) return `Grupos ${grupo[1]}`;
+  const qual = r.match(/qualification round\s*(\d+)/i);
+  if (qual) return `Pré ${qual[1]}`;
+
+  for (const [re, curto] of FASES) if (re.test(r)) return curto;
+  return r;
+}
+
+/** Rótulo de título: a rodada por extenso. */
+export function rodadaLonga(round: string | null | undefined): string {
+  const n = numeroDaRodada(round);
+  if (n != null) return `Rodada ${n}`;
+  const r = (round ?? '').trim();
+  if (!r) return 'Rodada';
+
+  const grupo = r.match(/group stage\s*-\s*(\d+)/i);
+  if (grupo) return `Fase de grupos, ${grupo[1]}ª rodada`;
+  const qual = r.match(/qualification round\s*(\d+)/i);
+  if (qual) return `${qual[1]}ª fase preliminar`;
+  if (/group stage/i.test(r)) return 'Fase de grupos';
+
+  for (const [re, , longo] of FASES) if (re.test(r)) return longo;
+  return r;
+}

--- a/src/utils/futebol-score.ts
+++ b/src/utils/futebol-score.ts
@@ -57,6 +57,19 @@ export function marketLabel(market: string): string {
   return market;
 }
 
+/**
+ * Nome curto do mercado, para etiqueta em caixa alta na lista e no painel da
+ * agenda. "Gols (Over/Under)" em 9px com letter-spacing vira uma tira de ruído.
+ */
+export function marketShort(market: string): string {
+  if (market === 'match_winner') return 'Resultado';
+  if (market === 'goals_over_under') return 'Gols';
+  if (market === 'asian_handicap') return 'Handicap';
+  if (market === 'btts') return 'Ambos marcam';
+  if (market === 'double_chance') return 'Dupla chance';
+  return market;
+}
+
 /** Linha do handicap com sinal e vírgula decimal (ex.: -1,5 / +1,5). */
 function fmtHandicapLine(line: number): string {
   const sign = line > 0 ? '+' : line < 0 ? '−' : '';

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -54,3 +54,7 @@ verify_jwt = false
 [functions.mirror-futebol-player-photos]
 # Espelha fotos dos jogadores do futebol no bucket futebol-player-photos — header x-cron-secret.
 verify_jwt = false
+
+[functions.mirror-futebol-league-logos]
+# Espelha brasões dos campeonatos no bucket futebol-league-logos — header x-cron-secret.
+verify_jwt = false

--- a/supabase/functions/mirror-futebol-league-logos/index.ts
+++ b/supabase/functions/mirror-futebol-league-logos/index.ts
@@ -1,0 +1,122 @@
+// ============================================================
+// mirror-futebol-league-logos — espelha os brasões dos campeonatos no Storage
+// ============================================================
+// Mesmo motivo do mirror-futebol-team-logos: a api-sports entrega a imagem
+// servidor-a-servidor, mas bloqueia o <img> no navegador (hotlink). A função
+// baixa o brasão de cada liga e sobe no bucket público `futebol-league-logos`.
+//
+// Duas diferenças em relação ao mirror dos times:
+//
+// 1. O arquivo é salvo pelo SLUG DO MART (`brasileirao.png`), não pelo id da
+//    API. Assim o front monta a URL com o que já tem em mãos
+//    (futebol.fact_fixtures.competition) e ninguém precisa carregar o id da
+//    API-Football pela tela. O de-para mora aqui e em COMPETITION_API_IDS
+//    (src/utils/futebol-competitions.ts); liga nova entra nos dois.
+//
+// 2. A imagem é REDIMENSIONADA antes de subir. O original vem em ~150px e 80 a
+//    160 KB (PNG de 32 bits) para aparecer a 26px na tela. O resize para 96px
+//    derruba pra faixa de 1 a 10 KB. Se o encoder falhar por qualquer motivo, o
+//    original sobe do mesmo jeito: brasão pesado é melhor que brasão faltando.
+//
+// Idempotente (upsert). Deploy com verify_jwt=false; protegida pelo header
+// x-cron-secret (CRON_SECRET), padrão dos outros mirrors. Disparo manual: são
+// ~12 arquivos que quase nunca mudam, não vale cron.
+//
+// Disparo (SQL editor, o segredo sai do vault e não aparece em lugar nenhum):
+//   select net.http_post(
+//     url := 'https://<ref>.supabase.co/functions/v1/mirror-futebol-league-logos',
+//     headers := jsonb_build_object(
+//       'Content-Type', 'application/json',
+//       'x-cron-secret', (select decrypted_secret from vault.decrypted_secrets
+//                         where name = 'ingest_fixtures_cron_secret')),
+//     body := '{}'::jsonb);
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { Image } from "https://deno.land/x/imagescript@1.2.15/mod.ts";
+
+const BUCKET = "futebol-league-logos";
+const LADO = 96; // a tela usa 26px; 96 cobre retina com folga
+
+// slug do mart → id da liga na API-Football (mesma numeração de leagues_config).
+// Copa do Mundo (id 1) fica de fora de propósito: o CDN responde 200 mas entrega
+// o escudo cinza de "sem imagem", que em tela fica pior que o ícone de troféu.
+// Se um dia subirem o brasão de verdade, é só voltar `copa_mundo: 1` aqui.
+const LIGAS: Record<string, number> = {
+  champions_league: 2,
+  sudamericana: 11,
+  libertadores: 13,
+  premier_league: 39,
+  ligue_1: 61,
+  brasileirao: 71,
+  serie_b: 72,
+  copa_do_brasil: 73,
+  bundesliga: 78,
+  primeira_liga: 94,
+  serie_a_ita: 135,
+  la_liga: 140,
+};
+
+serve(async (req) => {
+  const cronSecret = Deno.env.get("CRON_SECRET") || "";
+  if ((req.headers.get("x-cron-secret") || "") !== cronSecret || !cronSecret) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL") || "",
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+  );
+
+  try {
+    let mirrored = 0;
+    let failed = 0;
+    const erros: string[] = [];
+    const tamanhos: Record<string, number> = {};
+
+    for (const [slug, leagueId] of Object.entries(LIGAS)) {
+      try {
+        const res = await fetch(`https://media.api-sports.io/football/leagues/${leagueId}.png`, {
+          redirect: "follow",
+        });
+        if (!res.ok) { failed++; erros.push(`${slug}: http ${res.status}`); continue; }
+        const original = new Uint8Array(await res.arrayBuffer());
+        if (original.byteLength === 0) { failed++; erros.push(`${slug}: vazio`); continue; }
+
+        let bytes = original;
+        try {
+          const img = await Image.decode(original);
+          const escala = LADO / Math.max(img.width, img.height);
+          if (escala < 1) {
+            bytes = await img
+              .resize(Math.round(img.width * escala), Math.round(img.height * escala))
+              .encode();
+          }
+        } catch (e) {
+          erros.push(`${slug}: resize falhou (subiu original) — ${(e as Error)?.message ?? "erro"}`);
+        }
+
+        const { error: upErr } = await supabase.storage
+          .from(BUCKET)
+          .upload(`${slug}.png`, bytes, { contentType: "image/png", upsert: true });
+        if (upErr) { failed++; erros.push(`${slug}: ${upErr.message}`); continue; }
+        mirrored++;
+        tamanhos[slug] = bytes.byteLength;
+      } catch (e) {
+        failed++;
+        erros.push(`${slug}: ${(e as Error)?.message ?? "erro"}`);
+      }
+    }
+
+    return json({ ok: true, total: Object.keys(LIGAS).length, mirrored, failed, erros, tamanhos });
+  } catch (e) {
+    console.error("mirror-futebol-league-logos error:", e);
+    return json({ error: (e as Error)?.message ?? "Internal error" }, 500);
+  }
+});
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/supabase/migrations/092_futebol_agenda_por_dia.sql
+++ b/supabase/migrations/092_futebol_agenda_por_dia.sql
@@ -1,0 +1,163 @@
+-- ============================================================
+-- 092_futebol_agenda_por_dia — agenda multi-liga por DIA (fuso BRT)
+-- ============================================================
+-- Contexto: a /futebol/jogos organiza tudo em campeonato → rodada → dia, o que
+-- obriga o usuário a saber em qual competição está o jogo antes de achar o jogo.
+-- "Rodada 21" também atravessa três datas, então "o que tem hoje" não tem
+-- resposta naquela tela. Vamos inverter o eixo para dia → ligas → jogos.
+--
+-- Duas coisas impedem fazer isso só no front:
+--
+-- 1) CUSTO. Hoje o front usa get_futebol_fixtures (uma liga + temporada inteira)
+--    e, para simular multi-liga, dispara UMA query por liga (useFutebolFixturesMulti).
+--    São 8 chamadas de ~1,7s e ~161 KB cada, ou seja ~850 KB de JSON para desenhar
+--    UM dia. O pior dia da temporada 2026 tem 29 jogos, o que caberia em ~12 KB.
+--    E o custo cresce linear por liga nova, exatamente na direção contrária do
+--    roadmap (vamos somar ligas).
+--
+-- 2) FUSO. O front agrupa por fact_fixtures.date_utc, que é data UTC. Jogo às
+--    21:30 de quarta em Brasília é 00:30 de quinta em UTC, então cai no dia
+--    seguinte na tela. São 288 dos 2.128 jogos de 2026 (13,5%), justamente os
+--    noturnos, que é o horário que mais interessa ao apostador brasileiro.
+--    A regra do dia passa a viver AQUI, em um lugar só, em vez de ser reimplementada
+--    em cada tela (a /futebol já fazia certo, a /jogos não).
+--
+-- Também exponho `competition` e `season` nas linhas, que o get_futebol_fixtures
+-- não devolve. Numa lista de uma liga só isso não fazia falta (o front sabia qual
+-- era); numa lista multi-liga faz, porque o link do time é /futebol/time/:id?c=&s=.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- Helper: o dia do jogo no fuso de Brasília.
+-- IMMUTABLE de propósito: as três conversões abaixo são imutáveis
+-- (timestamp → timestamptz → timestamp → date), nenhuma depende do TimeZone da
+-- sessão. Isso mantém a porta aberta para índice de expressão se a tabela
+-- crescer. Hoje ela tem ~6,6 mil linhas e 2,6 MB, então seq scan por dia é
+-- barato e não vale criar índice que o pipeline do Mateus pode derrubar num
+-- refresh.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.futebol_dia_brt(p_kickoff_utc timestamp without time zone)
+RETURNS date
+LANGUAGE sql IMMUTABLE
+AS $function$
+  select (p_kickoff_utc at time zone 'UTC' at time zone 'America/Sao_Paulo')::date;
+$function$;
+
+COMMENT ON FUNCTION public.futebol_dia_brt(timestamp without time zone) IS
+  'Dia do jogo no fuso America/Sao_Paulo a partir do kickoff em UTC. Fonte única da regra de virada de dia da agenda de futebol: NÃO usar fact_fixtures.date_utc para agrupar por dia, ele é data UTC e joga jogo noturno brasileiro para o dia seguinte (288 de 2.128 jogos em 2026).';
+
+-- ------------------------------------------------------------
+-- 1) Jogos de UM dia, em todas as ligas (ou nas ligas pedidas).
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_futebol_fixtures_by_day(
+  p_day          date,
+  p_competitions text[] DEFAULT NULL
+)
+RETURNS TABLE(
+  fixture_id      bigint,
+  competition     text,
+  season          bigint,
+  day_brt         date,
+  round           text,
+  kickoff_utc     timestamp without time zone,
+  date_utc        date,
+  status_short    text,
+  status_long     text,
+  home_team_id    bigint,
+  home_team_name  text,
+  home_team_logo  text,
+  away_team_id    bigint,
+  away_team_name  text,
+  away_team_logo  text,
+  goals_home      bigint,
+  goals_away      bigint
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO ''
+AS $function$
+  select f.fixture_id, f.competition, f.season,
+         public.futebol_dia_brt(f.kickoff_utc),
+         f.round, f.kickoff_utc, f.date_utc,
+         f.status_short, f.status_long,
+         f.home_team_id, f.home_team_name, ht.team_logo_url,
+         f.away_team_id, f.away_team_name, at2.team_logo_url,
+         f.goals_home, f.goals_away
+  from futebol.fact_fixtures f
+  left join futebol.dim_teams ht  on ht.team_id  = f.home_team_id
+  left join futebol.dim_teams at2 on at2.team_id = f.away_team_id
+  where f.kickoff_utc is not null
+    and public.futebol_dia_brt(f.kickoff_utc) = p_day
+    and (p_competitions is null or f.competition = any(p_competitions))
+  -- horário primeiro: numa agenda multi-liga o usuário lê a grade por hora, e o
+  -- agrupamento por competição é feito no front sobre esta ordem.
+  order by f.kickoff_utc, f.competition, f.fixture_id;
+$function$;
+
+COMMENT ON FUNCTION public.get_futebol_fixtures_by_day(date, text[]) IS
+  'Jogos de um dia (fuso BRT) em todas as competições, ou só nas de p_competitions. Base da agenda da /futebol/jogos. Substitui o padrão de N chamadas de get_futebol_fixtures (uma por liga, temporada inteira) que custava ~850 KB para desenhar um dia.';
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_fixtures_by_day(date, text[]) TO anon, authenticated, service_role;
+
+-- ------------------------------------------------------------
+-- 2) Quais dias têm jogo, para a régua de datas.
+-- Serve para a navegação saber onde tem jogo e quantos, sem baixar jogo nenhum.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_days(
+  p_from date,
+  p_to   date
+)
+RETURNS TABLE(
+  day_brt date,
+  jogos   bigint,
+  ligas   bigint
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO ''
+AS $function$
+  select public.futebol_dia_brt(f.kickoff_utc) as day_brt,
+         count(*)                              as jogos,
+         count(distinct f.competition)         as ligas
+  from futebol.fact_fixtures f
+  where f.kickoff_utc is not null
+    and public.futebol_dia_brt(f.kickoff_utc) between p_from and p_to
+  group by 1
+  order by 1;
+$function$;
+
+COMMENT ON FUNCTION public.get_futebol_fixture_days(date, date) IS
+  'Dias com jogo (fuso BRT) num intervalo, com contagem de jogos e de ligas. Alimenta a régua de datas da agenda sem trazer as linhas dos jogos.';
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_fixture_days(date, date) TO anon, authenticated, service_role;
+
+-- ------------------------------------------------------------
+-- 3) Que competições e temporadas existem de fato no mart.
+-- Hoje o front decide isso por lista fixa em src/utils/futebol-competitions.ts
+-- (ALL_COMPETITIONS) e por um mapa fixo de temporadas por liga (SEASONS_BY_COMP).
+-- Consequência real: a champions_league existe no mart com 76 jogos em 2026 e não
+-- aparece em NENHUMA tela, apesar de o comentário daquele arquivo prometer que
+-- liga nova aparece sozinha. Com esta RPC a lista fixa volta a ser só o que ela
+-- diz ser: rótulo bonito e ordem de exibição.
+-- ------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_futebol_competitions()
+RETURNS TABLE(
+  competition text,
+  season      bigint,
+  jogos       bigint,
+  primeiro    date,
+  ultimo      date
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO ''
+AS $function$
+  select f.competition,
+         f.season,
+         count(*)                                        as jogos,
+         min(public.futebol_dia_brt(f.kickoff_utc))       as primeiro,
+         max(public.futebol_dia_brt(f.kickoff_utc))       as ultimo
+  from futebol.fact_fixtures f
+  where f.kickoff_utc is not null
+  group by f.competition, f.season
+  order by f.season desc, f.competition;
+$function$;
+
+COMMENT ON FUNCTION public.get_futebol_competitions() IS
+  'Competições e temporadas realmente presentes no mart, com contagem e janela de datas (BRT). Fonte de verdade do seletor de campeonatos e das temporadas disponíveis por liga, no lugar das listas fixas do front.';
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_competitions() TO anon, authenticated, service_role;

--- a/supabase/migrations/093_futebol_mapa_premissas.sql
+++ b/supabase/migrations/093_futebol_mapa_premissas.sql
@@ -1,0 +1,221 @@
+-- ============================================================
+-- 093_futebol_mapa_premissas — as premissas de um jogo, acesas E apagadas
+-- ============================================================
+-- Contexto: a tela de jogo mostra hoje "a aposta e o preço". A revisão da
+-- metodologia (docs/premissas-recalibragem.md, 01/08/2026) provou que essa é a
+-- ordem errada: a porta de publicação passa a ser o CONTEXTO (2+ premissas
+-- acesas) e o preço vira filtro de sanidade. A regra antiga (edge > 0) é a única
+-- das quatro testadas que perde dinheiro (R$ 100 → R$ 85 em 393 apostas), contra
+-- R$ 110 de "2 premissas, sem olhar preço" em 1.087 apostas.
+--
+-- Consequência de produto: o pick deixa de ser o conteúdo da tela e passa a ser
+-- uma CONSEQUÊNCIA. O conteúdo é o mapa de premissas, e ele precisa mostrar
+-- também o que NÃO acendeu, porque "faltou pouco" e "não passou nem perto" são
+-- leituras diferentes que hoje viram a mesma ausência.
+--
+-- Por que isto destrava a tela: odds só existem a partir de T−24h, então a
+-- maioria dos jogos da agenda não tem preço nenhum. As premissas, ao contrário,
+-- cobrem TODOS os 6.597 jogos do mart, incluindo 1.177 jogos futuros. O mapa de
+-- premissas é o único conteúdo analítico que existe para um jogo de amanhã.
+--
+-- LIMITE CONHECIDO, e é o T3 da recalibragem: as colunas booleanas não têm NULL
+-- (medido: zero nulos nas duas tabelas maiores). Ou seja, premissa sem dado hoje
+-- virou `false` em silêncio, e por isso esta RPC devolve dois estados (acesa /
+-- apagada) e não três. Quando o T3 entrar, `apagadas` se divide em apagada e
+-- sem_dado sem mudar a assinatura: é só passar a devolver um terceiro array.
+--
+-- Também não devolve "por quanto faltou": o limiar de cada premissa é a fórmula
+-- que o Matheus ainda precisa entregar (T5). As tabelas int_* guardam só o
+-- booleano, não a métrica que o gerou.
+--
+-- Formato: uma linha por CANDIDATO (mercado + saída + linha), com as premissas em
+-- arrays de slug. Mesmo padrão do `evidencias text[]` que o
+-- get_futebol_fixture_value já usa. O rótulo humano, o peso e o agrupamento
+-- ficam no front (src/utils/futebol-premissas.ts), porque são copy e decisão de
+-- produto, não dado.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_premissas(p_fixture_id bigint)
+RETURNS TABLE(
+  market          text,
+  outcome         text,
+  line_value      double precision,
+  pts_premissas   bigint,
+  penalidades_pts bigint,
+  acesas          text[],
+  apagadas        text[],
+  penalidades     text[]
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO ''
+AS $function$
+  -- Resultado (1X2)
+  select 'match_winner'::text,
+         p.outcome,
+         null::double precision,
+         p.pts_premissas,
+         p.penalidades_1x2_pts,
+         array_remove(array[
+           case when p.forma                 then 'forma' end,
+           case when p.mando                 then 'mando' end,
+           case when p.superioridade_tabela  then 'superioridade_tabela' end,
+           case when p.forca_mismatch        then 'forca_mismatch' end,
+           case when p.superioridade_xg      then 'superioridade_xg' end,
+           case when p.h2h_favoravel         then 'h2h_favoravel' end,
+           case when p.desfalque_adversario  then 'desfalque_adversario' end
+         ], null),
+         array_remove(array[
+           case when not p.forma                then 'forma' end,
+           case when not p.mando                then 'mando' end,
+           case when not p.superioridade_tabela then 'superioridade_tabela' end,
+           case when not p.forca_mismatch       then 'forca_mismatch' end,
+           case when not p.superioridade_xg     then 'superioridade_xg' end,
+           case when not p.h2h_favoravel        then 'h2h_favoravel' end,
+           case when not p.desfalque_adversario then 'desfalque_adversario' end
+         ], null),
+         array_remove(array[
+           case when p.pick_empate       then 'pick_empate' end,
+           case when p.desfalque_proprio then 'desfalque_proprio' end
+         ], null)
+  from futebol.int_futebol_premissas_1x2 p
+  where p.fixture_id = p_fixture_id
+
+  union all
+
+  -- Gols (Over/Under). As premissas dos dois lados vivem na mesma tabela; cada
+  -- linha já é de um lado só (outcome Over ou Under), então listamos todas e o
+  -- lado errado simplesmente nunca acende.
+  select 'goals_over_under'::text,
+         p.outcome,
+         p.line_value,
+         p.pts_premissas,
+         p.penalidades_ou_pts,
+         array_remove(array[
+           case when p.defesas_firmes      then 'defesas_firmes' end,
+           case when p.defesas_vazaveis    then 'defesas_vazaveis' end,
+           case when p.ataque_combinado    then 'ataque_combinado' end,
+           case when p.xg_baixo_combinado  then 'xg_baixo_combinado' end,
+           case when p.xg_combinado_alto   then 'xg_combinado_alto' end,
+           case when p.clean_sheets_altos  then 'clean_sheets_altos' end,
+           case when p.ataques_fracos      then 'ataques_fracos' end,
+           case when p.historico_under     then 'historico_under' end,
+           case when p.historico_over      then 'historico_over' end,
+           case when p.ambos_vazam         then 'ambos_vazam' end,
+           case when p.ritmo_alto          then 'ritmo_alto' end,
+           case when p.linha_subindo       then 'linha_subindo' end,
+           case when p.linha_descendo      then 'linha_descendo' end
+         ], null),
+         array_remove(array[
+           case when not p.defesas_firmes     then 'defesas_firmes' end,
+           case when not p.defesas_vazaveis   then 'defesas_vazaveis' end,
+           case when not p.ataque_combinado   then 'ataque_combinado' end,
+           case when not p.xg_baixo_combinado then 'xg_baixo_combinado' end,
+           case when not p.xg_combinado_alto  then 'xg_combinado_alto' end,
+           case when not p.clean_sheets_altos then 'clean_sheets_altos' end,
+           case when not p.ataques_fracos     then 'ataques_fracos' end,
+           case when not p.historico_under    then 'historico_under' end,
+           case when not p.historico_over     then 'historico_over' end,
+           case when not p.ambos_vazam        then 'ambos_vazam' end,
+           case when not p.ritmo_alto         then 'ritmo_alto' end,
+           case when not p.linha_subindo      then 'linha_subindo' end,
+           case when not p.linha_descendo     then 'linha_descendo' end
+         ], null),
+         array_remove(array[
+           case when p.linha_extrema then 'linha_extrema' end
+         ], null)
+  from futebol.int_futebol_premissas_ou p
+  where p.fixture_id = p_fixture_id
+
+  union all
+
+  -- Handicap asiático
+  select 'asian_handicap'::text,
+         p.outcome,
+         p.line_value,
+         p.pts_premissas,
+         p.penalidades_ah_pts,
+         array_remove(array[
+           case when p.supremacia             then 'supremacia' end,
+           case when p.tende_golear           then 'tende_golear' end,
+           case when p.adversario_fragil_fora then 'adversario_fragil_fora' end,
+           case when p.mando_forte            then 'mando_forte' end,
+           case when p.sem_rodizio            then 'sem_rodizio' end,
+           case when p.raramente_perde_por_2  then 'raramente_perde_por_2' end,
+           case when p.defesa_fora_solida     then 'defesa_fora_solida' end
+         ], null),
+         array_remove(array[
+           case when not p.supremacia             then 'supremacia' end,
+           case when not p.tende_golear           then 'tende_golear' end,
+           case when not p.adversario_fragil_fora then 'adversario_fragil_fora' end,
+           case when not p.mando_forte            then 'mando_forte' end,
+           case when not p.sem_rodizio            then 'sem_rodizio' end,
+           case when not p.raramente_perde_por_2  then 'raramente_perde_por_2' end,
+           case when not p.defesa_fora_solida     then 'defesa_fora_solida' end
+         ], null),
+         array_remove(array[
+           case when p.favorito_irregular then 'favorito_irregular' end,
+           case when p.handicap_alto      then 'handicap_alto' end
+         ], null)
+  from futebol.int_futebol_premissas_ah p
+  where p.fixture_id = p_fixture_id
+
+  union all
+
+  -- Ambos marcam (BTTS)
+  select 'btts'::text,
+         p.outcome,
+         null::double precision,
+         p.pts_premissas,
+         p.penalidades_btts_pts,
+         array_remove(array[
+           case when p.ambos_marcam     then 'ambos_marcam' end,
+           case when p.ataque_dos_dois  then 'ataque_dos_dois' end,
+           case when p.defesas_vazaveis then 'defesas_vazaveis' end,
+           case when p.historico_btts   then 'historico_btts' end,
+           case when p.defesa_forte     then 'defesa_forte' end,
+           case when p.ataque_trava     then 'ataque_trava' end,
+           case when p.historico_seco   then 'historico_seco' end
+         ], null),
+         array_remove(array[
+           case when not p.ambos_marcam     then 'ambos_marcam' end,
+           case when not p.ataque_dos_dois  then 'ataque_dos_dois' end,
+           case when not p.defesas_vazaveis then 'defesas_vazaveis' end,
+           case when not p.historico_btts   then 'historico_btts' end,
+           case when not p.defesa_forte     then 'defesa_forte' end,
+           case when not p.ataque_trava     then 'ataque_trava' end,
+           case when not p.historico_seco   then 'historico_seco' end
+         ], null),
+         '{}'::text[]
+  from futebol.int_futebol_premissas_btts p
+  where p.fixture_id = p_fixture_id
+
+  union all
+
+  -- Dupla chance
+  select 'double_chance'::text,
+         p.outcome,
+         null::double precision,
+         p.pts_premissas,
+         p.penalidades_dc_pts,
+         array_remove(array[
+           case when p.lado_coberto_forte   then 'lado_coberto_forte' end,
+           case when p.equilibrio_defensivo then 'equilibrio_defensivo' end,
+           case when p.adversario_limitado  then 'adversario_limitado' end,
+           case when p.invicto_recente      then 'invicto_recente' end
+         ], null),
+         array_remove(array[
+           case when not p.lado_coberto_forte   then 'lado_coberto_forte' end,
+           case when not p.equilibrio_defensivo then 'equilibrio_defensivo' end,
+           case when not p.adversario_limitado  then 'adversario_limitado' end,
+           case when not p.invicto_recente      then 'invicto_recente' end
+         ], null),
+         '{}'::text[]
+  from futebol.int_futebol_premissas_dc p
+  where p.fixture_id = p_fixture_id
+
+  order by 1, 4 desc, 2, 3;
+$function$;
+
+COMMENT ON FUNCTION public.get_futebol_fixture_premissas(bigint) IS
+  'Mapa de premissas de um jogo nos 5 mercados, com as acesas E as apagadas, por candidato (mercado + saída + linha). Base da tela de jogo depois da revisão que trocou a porta de publicação de preço para contexto. Dois estados só: as colunas int_* não têm NULL, então premissa sem dado hoje é indistinguível de premissa apagada (T3 da recalibragem). Não devolve o limiar nem a métrica: só o booleano existe no mart (T5).';
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_fixture_premissas(bigint) TO anon, authenticated, service_role;

--- a/supabase/migrations/094_futebol_numeros_do_jogo.sql
+++ b/supabase/migrations/094_futebol_numeros_do_jogo.sql
@@ -1,0 +1,149 @@
+-- ============================================================
+-- 094_futebol_numeros_do_jogo — o número que embasa cada premissa
+-- ============================================================
+-- Contexto: a 093 entregou QUAIS premissas acenderam. Na revisão de UI ficou claro
+-- que isso não basta: "em boa fase, vem ganhando" sem número é adjetivo, não
+-- análise. E premissa apagada sem número é pior ainda, porque não dá pra saber se
+-- faltou pouco ou se não passou nem perto.
+--
+-- Esta RPC devolve, por lado do confronto, os números que sustentam (ou derrubam)
+-- cada premissa:
+--   forma                → a sequência de resultados
+--   mando                → campanha em casa e fora, separada
+--   forca_mismatch       → ataque de um contra defesa do outro, no mando certo
+--   ataque_combinado     → gols marcados por jogo dos dois
+--   defesas_*            → gols sofridos por jogo dos dois
+--   clean_sheets_altos   → jogos sem sofrer gol
+--   superioridade_tabela → posição e pontos
+--
+-- Fonte: futebol.fact_team_season_stats (médias já separadas por casa e fora, que é
+-- o corte que importa: Palmeiras marca 1,70 em casa e o Vasco sofre 1,90 fora) mais
+-- a classificação oficial.
+--
+-- `ate` devolve o snapshot_date de propósito: a tela precisa poder dizer "dados até
+-- 27/07" em vez de fingir que o número é de hoje. O mesmo snapshot é o que a
+-- premissa viu quando foi avaliada.
+--
+-- NÃO tem xG aqui: as premissas de xG (superioridade_xg, xg_combinado_alto,
+-- xg_baixo_combinado) só têm valor por jogo em fact_fixture_stats, sem agregado de
+-- temporada. Essas quatro continuam sem embasamento numérico até existir o agregado.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_numeros(p_fixture_id bigint)
+RETURNS TABLE(
+  side          text,
+  team_id       bigint,
+  team_name     text,
+  posicao       bigint,
+  pontos        bigint,
+  zona          text,
+  jogos         bigint,
+  jogos_casa    bigint,
+  jogos_fora    bigint,
+  v_casa        bigint,
+  e_casa        bigint,
+  d_casa        bigint,
+  v_fora        bigint,
+  e_fora        bigint,
+  d_fora        bigint,
+  gf_casa       double precision,
+  ga_casa       double precision,
+  gf_fora       double precision,
+  ga_fora       double precision,
+  gf_total      double precision,
+  ga_total      double precision,
+  clean_sheets  bigint,
+  sem_marcar    bigint,
+  forma         text,
+  -- Confronto direto, do ponto de vista DESTE lado. Existe porque
+  -- `h2h_favoravel` é uma premissa que acende e, sem número, ficava na tela como
+  -- afirmação sem lastro, que é o pior caso possível.
+  h2h_jogos     bigint,
+  h2h_vitorias  bigint,
+  h2h_empates   bigint,
+  ate           date
+)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO ''
+AS $function$
+  with jogo as (
+    select f.fixture_id, f.competition, f.season, f.home_team_id, f.away_team_id
+    from futebol.fact_fixtures f
+    where f.fixture_id = p_fixture_id
+  ),
+  lados as (
+    select 'home'::text as side, j.home_team_id as team_id, j.competition, j.season from jogo j
+    union all
+    select 'away'::text, j.away_team_id, j.competition, j.season from jogo j
+  ),
+  -- Um time pode ter vários snapshots; interessa o mais recente.
+  stats as (
+    select distinct on (t.team_id, t.competition, t.season) t.*
+    from futebol.fact_team_season_stats t
+    join lados l on l.team_id = t.team_id and l.competition = t.competition and l.season = t.season
+    order by t.team_id, t.competition, t.season, t.snapshot_date desc
+  ),
+  -- Confronto direto: conta por lado quantos cada um venceu.
+  h2h as (
+    select l.team_id,
+           count(*)                                          as jogos,
+           count(*) filter (
+             where (hh.home_team_id = l.team_id and hh.goals_home > hh.goals_away)
+                or (hh.away_team_id = l.team_id and hh.goals_away > hh.goals_home)
+           )                                                 as vitorias,
+           count(*) filter (where hh.goals_home = hh.goals_away) as empates
+    from jogo j
+    join futebol.fact_h2h hh
+      on (hh.home_team_id = j.home_team_id and hh.away_team_id = j.away_team_id)
+      or (hh.home_team_id = j.away_team_id and hh.away_team_id = j.home_team_id)
+    join lados l on true
+    where hh.goals_home is not null and hh.goals_away is not null
+    group by l.team_id
+  ),
+  tabela as (
+    select distinct on (s.team_id) s.team_id, s.rank_pos, s.pontos, s.zona
+    from (
+      select st.team_id,
+             st."rank"::bigint          as rank_pos,
+             st.points::bigint          as pontos,
+             st.rank_description        as zona
+      from jogo j,
+           public.get_futebol_standings_official(j.competition, j.season) st
+    ) s
+    order by s.team_id
+  )
+  select l.side,
+         l.team_id,
+         coalesce(st.team_name, dt.team_name),
+         tb.rank_pos,
+         tb.pontos,
+         tb.zona,
+         st.played_total,
+         st.played_home,
+         st.played_away,
+         st.wins_home,
+         st.draws_home,
+         st.loses_home,
+         st.wins_away,
+         st.draws_away,
+         st.loses_away,
+         st.goals_for_avg_home,
+         st.goals_against_avg_home,
+         st.goals_for_avg_away,
+         st.goals_against_avg_away,
+         st.goals_for_avg_total,
+         st.goals_against_avg_total,
+         st.clean_sheet_total,
+         st.failed_to_score_total,
+         st.form,
+         st.snapshot_date
+  from lados l
+  left join stats st on st.team_id = l.team_id
+  left join tabela tb on tb.team_id = l.team_id
+  left join futebol.dim_teams dt on dt.team_id = l.team_id
+  order by l.side desc;
+$function$;
+
+COMMENT ON FUNCTION public.get_futebol_fixture_numeros(bigint) IS
+  'Números de temporada dos dois times de um jogo (campanha casa/fora separada, gols por jogo, clean sheets, forma) mais posição e pontos. Serve para EMBASAR cada premissa do mapa: sem o número, "em boa fase" é adjetivo. Devolve `ate` = snapshot_date para a tela declarar a data do dado em vez de fingir que é de hoje. Não cobre as premissas de xG: falta agregado de temporada.';
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_fixture_numeros(bigint) TO anon, authenticated, service_role;

--- a/supabase/migrations/095_futebol_historico_por_jogo.sql
+++ b/supabase/migrations/095_futebol_historico_por_jogo.sql
@@ -1,0 +1,132 @@
+-- ============================================================
+-- 095_futebol_historico_por_jogo — os jogos que produzem a média
+-- ============================================================
+-- Contexto: a 094 entregou a MÉDIA que embasa cada premissa ("somados, sofrem 3,0
+-- gols por jogo"). Na revisão de UI o usuário pediu o passo seguinte: mostrar os
+-- jogos que produziram essa média, para a conclusão ("as defesas dos dois lados são
+-- frágeis") poder ser conferida em vez de aceita.
+--
+-- Esta RPC devolve, por lado do confronto, UMA LINHA POR JOGO já encerrado do time
+-- na MESMA competição e temporada do jogo em questão, antes dele. O recorte é o
+-- mesmo de fact_team_season_stats, que é a fonte da média: se fosse outro, o
+-- gráfico desmentiria o número que ele deveria explicar.
+--
+-- Traz também o expected_goals do jogo, de fact_fixture_stats. É o que destrava as
+-- premissas de chance de gol (xg_combinado_alto, xg_baixo_combinado,
+-- superioridade_xg), que até aqui apareciam na tela sem número nenhum. Cobertura
+-- medida no dev em 04/08/2026: 1.518 de 1.668 linhas de 2026 encerradas (91%). Onde
+-- falta, vem NULL e a tela não desenha, em vez de inventar.
+--
+-- NÃO resolve: ritmo_alto, historico_over/under, linha_subindo/descendo e
+-- sem_rodizio. Os flags vêm dos modelos dbt do Matheus (int_futebol_premissas_*
+-- guarda só o boolean) e o critério não está neste repo. Os insumos de ritmo
+-- existem em fact_fixture_stats (total_shots, corner_kicks, ball_possession), mas
+-- publicar um número nosso como se fosse o da premissa seria fingir auditoria.
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.get_futebol_fixture_historico(bigint, integer);
+
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_historico(
+  p_fixture_id bigint,
+  p_max integer DEFAULT 40
+)
+RETURNS TABLE(
+  side            text,
+  team_id         bigint,
+  team_name       text,
+  past_fixture_id bigint,
+  data            date,
+  ordem           bigint,
+  em_casa         boolean,
+  adversario      text,
+  adversario_id   bigint,
+  gols_pro        integer,
+  gols_contra     integer,
+  total_gols      integer,
+  ambos_marcaram  boolean,
+  sem_sofrer      boolean,
+  sem_marcar      boolean,
+  xg              double precision,
+  xg_contra       double precision,
+  resultado       text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+  with alvo as (
+    select f.fixture_id, f.competition, f.season, f.kickoff_utc,
+           f.home_team_id, f.home_team_name, f.away_team_id, f.away_team_name
+    from futebol.fact_fixtures f
+    where f.fixture_id = p_fixture_id
+  ),
+  lados as (
+    select 'home'::text as side, a.home_team_id as team_id, a.home_team_name as team_name, a.* from alvo a
+    union all
+    select 'away'::text, a.away_team_id, a.away_team_name, a.* from alvo a
+  ),
+  jogos as (
+    select l.side, l.team_id, l.team_name,
+           f.fixture_id as past_fixture_id,
+           -- Dia em BRT, igual ao resto do produto: date_utc joga o jogo noturno
+           -- para o dia seguinte.
+           (f.kickoff_utc at time zone 'UTC' at time zone 'America/Sao_Paulo')::date as data,
+           (f.home_team_id = l.team_id) as em_casa,
+           case when f.home_team_id = l.team_id then f.away_team_name else f.home_team_name end as adversario,
+           -- O id do adversário existe para a tela poder desenhar o escudo dele
+           -- embaixo da barra: o gráfico vira "contra quem foi", não só "quanto foi".
+           case when f.home_team_id = l.team_id then f.away_team_id else f.home_team_id end as adversario_id,
+           (case when f.home_team_id = l.team_id then f.goals_home else f.goals_away end)::integer as gols_pro,
+           (case when f.home_team_id = l.team_id then f.goals_away else f.goals_home end)::integer as gols_contra
+    from lados l
+    join futebol.fact_fixtures f
+      on f.competition = l.competition
+     and f.season = l.season
+     and f.status_short in ('FT', 'AET', 'PEN')
+     and f.kickoff_utc < l.kickoff_utc
+     and (f.home_team_id = l.team_id or f.away_team_id = l.team_id)
+     and f.goals_home is not null
+     and f.goals_away is not null
+  ),
+  recentes as (
+    select j.*, row_number() over (partition by j.side order by j.data desc, j.past_fixture_id desc) as rn
+    from jogos j
+  ),
+  janela as (
+    select r.*, row_number() over (partition by r.side order by r.data asc, r.past_fixture_id asc) as ordem
+    from recentes r
+    where r.rn <= greatest(p_max, 1)
+  )
+  select w.side,
+         w.team_id,
+         w.team_name,
+         w.past_fixture_id,
+         w.data,
+         w.ordem,
+         w.em_casa,
+         w.adversario,
+         w.adversario_id,
+         w.gols_pro,
+         w.gols_contra,
+         (w.gols_pro + w.gols_contra)::integer as total_gols,
+         (w.gols_pro > 0 and w.gols_contra > 0) as ambos_marcaram,
+         (w.gols_contra = 0) as sem_sofrer,
+         (w.gols_pro = 0) as sem_marcar,
+         s.expected_goals as xg,
+         sa.expected_goals as xg_contra,
+         case when w.gols_pro > w.gols_contra then 'V'
+              when w.gols_pro = w.gols_contra then 'E'
+              else 'D' end as resultado
+  from janela w
+  left join futebol.fact_fixture_stats s
+         on s.fixture_id = w.past_fixture_id and s.team_id = w.team_id
+  left join futebol.fact_fixture_stats sa
+         on sa.fixture_id = w.past_fixture_id and sa.team_id <> w.team_id
+  order by w.side, w.ordem;
+$$;
+
+COMMENT ON FUNCTION public.get_futebol_fixture_historico(bigint, integer) IS
+  'Jogo a jogo dos dois times na competição/temporada do confronto, para auditar a média que embasa cada premissa. Inclui expected_goals quando existe.';
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_fixture_historico(bigint, integer) TO anon, authenticated, service_role;

--- a/supabase/migrations/096_futebol_standings_grupo.sql
+++ b/supabase/migrations/096_futebol_standings_grupo.sql
@@ -1,0 +1,62 @@
+-- ============================================================
+-- 096_futebol_standings_grupo — a classificação sabendo dizer o grupo
+-- ============================================================
+-- Contexto: a tela de campeonato passou a abrir por fase. Em copa com fase de
+-- grupos (Libertadores e Sul-Americana têm 8 grupos, Copa do Mundo tem 12), a
+-- pergunta da fase de grupos é "como está o meu grupo", e a RPC devolvia a
+-- classificação sem dizer a que grupo cada linha pertence: os 32 times da
+-- Libertadores vinham numa lista só, com rank de 1 a 4 repetindo oito vezes.
+--
+-- A coluna JÁ EXISTE no mart (futebol.fact_standings_snapshot.group_name); era só
+-- a assinatura da função que não a expunha. Valores conferidos no dev (2026):
+-- 'Group A'..'Group H' na Libertadores e na Sul-Americana, 'Group A'..'Group L' na
+-- Copa do Mundo, e o nome da liga ('Serie A', 'Premier League') em pontos
+-- corridos, que é como a API marca quem não tem grupo.
+--
+-- DROP + CREATE porque o CREATE OR REPLACE não muda o tipo de retorno. Para quem
+-- consome via PostgREST isso é compatível: coluna nova no fim, o front antigo
+-- ignora. Mesmo corpo de antes, só com a coluna a mais.
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.get_futebol_standings_official(text, bigint);
+
+CREATE FUNCTION public.get_futebol_standings_official(p_competition text, p_season bigint)
+RETURNS TABLE(
+  team_id bigint,
+  team_name text,
+  rank bigint,
+  points bigint,
+  played bigint,
+  wins bigint,
+  draws bigint,
+  loses bigint,
+  goals_for bigint,
+  goals_against bigint,
+  goals_diff bigint,
+  rank_description text,
+  group_name text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+declare v_date date;
+begin
+  select max(s.snapshot_date) into v_date
+  from futebol.fact_standings_snapshot s
+  where s.competition = p_competition and s.season = p_season;
+
+  return query
+  select s.team_id, s.team_name, s.rank, s.points,
+         s.played_total, s.wins_total, s.draws_total, s.loses_total,
+         s.goals_for_total, s.goals_against_total, s.goals_diff, s.rank_description,
+         s.group_name
+  from futebol.fact_standings_snapshot s
+  where s.competition = p_competition and s.season = p_season and s.snapshot_date = v_date
+  order by s.group_name, s.rank;
+end; $function$;
+
+COMMENT ON FUNCTION public.get_futebol_standings_official(text, bigint) IS
+  'Classificação oficial do último snapshot, agora com group_name para as competições de fase de grupos.';
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_standings_official(text, bigint) TO anon, authenticated, service_role;


### PR DESCRIPTION
## O que muda

O módulo de futebol passa a girar em torno de **onde os jogos estão** e de **por que uma leitura existe**, e o rebrand areia deixa de valer só para o futebol.

### Futebol

- **`/futebol/jogos` vira agenda por dia**, multi-liga, com a leitura na própria linha (mercado, aposta, odd, chance e o Score em selo) e o resumo do jogo ao lado. Antes era campeonato → rodada → dia, o que exigia saber a competição antes de achar o jogo.
- **Tela do jogo em torno das premissas**: faixa da partida em forest, os cinco mercados sempre à vista, a folha do mercado aberto, régua de linhas arrastável e, em cada premissa, os jogos que produziram o número.
- **Rota de campeonato** (`/futebol/campeonatos` e `/futebol/campeonato/:slug`): régua de rodadas, classificação por zona com o miolo recolhível, chaveamento nas copas, tabelas dos grupos na fase de grupos, artilheiros e os números da temporada.
- **Brasões de campeonato** espelhados no nosso Storage, no mesmo padrão dos escudos de time.

### Rebrand

- Chão areia (`--canvas` #f8f4ea) e borda areia (`--line` #ded2b6) como token, aplicados também no **Betinho** e na **NBA**, que estavam num invólucro de tema que só definia a fonte.
- O `bg-ink-3`, que é token de texto, deixou de ser usado como fundo em 145 lugares.

### Correções que apareceram no caminho

- **Dia em BRT**: 288 dos 2.128 jogos da temporada (os noturnos) apareciam no dia seguinte, porque a tela agrupava por data UTC.
- **Premissa com lado**: a tela dizia "defesas frágeis" a favor e "defesas firmes" apagada, as duas com o mesmo número. E dois rótulos de mando estavam invertidos, com o número errado junto.
- **Cabeçalho da NBA sumia** nas rotas de detalhe (`/analise-360/:id`, `/game/:id`, `/nba-dashboard/:jogador`), porque a faixa de seções exigia rota exata.
- **Tour do futebol** refeito para as telas novas (estava apontando para alvos que não existem mais) e conferido também no celular.

## Banco

Migrations **092 a 096**, aplicadas **só no projeto dev**:

| # | o que é |
|---|---|
| 092 | agenda por dia em BRT (`futebol_dia_brt`, `get_futebol_fixtures_by_day`, `get_futebol_fixture_days`, `get_futebol_competitions`) |
| 093 | `get_futebol_fixture_premissas` (acesas e apagadas, 5 mercados) |
| 094 | `get_futebol_fixture_numeros` (o número que embasa cada premissa) |
| 095 | `get_futebol_fixture_historico` (jogo a jogo no mesmo recorte da média, com xG) |
| 096 | `get_futebol_standings_official` recriada com `group_name` |

## Antes de subir para produção

1. Aplicar as migrations 092 a 096 em staging e prod.
2. Criar o bucket público `futebol-league-logos` e disparar a `mirror-futebol-league-logos` em cada ambiente (mesmo runbook dos escudos de time; está no cabeçalho da função).

## Como testar

- `/futebol/jogos`: navegue pelos dias, recolha um campeonato, clique num jogo e veja o resumo ao lado. Em dia passado, o selo do Score vira certo ou errado.
- `/futebol/jogo/:id`: troque de mercado, arraste a linha nos gols e abra "ver os jogos" numa premissa.
- `/futebol/campeonato/brasileirao`: régua de rodadas e classificação por zona. Em `copa_do_brasil` e `libertadores`, o chaveamento (com "expandir") e, numa fase de grupos, as tabelas dos grupos.
- `/bets`, `/betting-dashboard`, `/home-nba`: o chão bege.
- Tudo em 1440 e 390.

## Verificação

`tsc -p tsconfig.app.json` limpo nos arquivos tocados (o repo tem erros pré-existentes em bolao, bigquery e player-stats), `eslint` sem erros novos, 26 testes de data passando, e cada tela conferida no navegador em desktop e celular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
