### PR TITLE
fix(futebol): RPCs de serving deixam de escolher janela e mercado no acaso

### DIFF
--- a/supabase/migrations/097_futebol_rpc_janela_daily.sql
+++ b/supabase/migrations/097_futebol_rpc_janela_daily.sql
@@ -1,0 +1,222 @@
+-- 097_futebol_rpc_janela_daily.sql
+--
+-- C8, parte 1 de 2: a tela de odds pode mostrar preço de dias atrás.
+--
+-- Numerada 097 porque a develop ja usa ate a 096 (092-096 sao as RPCs da agenda,
+-- das premissas e dos grupos). Nenhuma delas toca as funcoes alteradas aqui.
+--
+-- DEFEITO
+-- As duas RPCs de odds escolhem a janela de coleta corrente com um CASE que
+-- conhece apenas tres janelas:
+--
+--     case when collection_window = 't15m' then 3
+--          when collection_window = 't1h'  then 2
+--          else 1 end
+--
+-- A quarta janela, 'daily', entrou em 07/08/2026 com a coleta de 7 dias
+-- (data-engineering#34) e caiu no ELSE, empatando com 't24h'. Em empate o
+-- DISTINCT ON do Postgres resolve arbitrariamente, e pode trocar de resposta
+-- entre chamadas sem nenhuma mudanca de dado.
+--
+-- ALCANCE MEDIDO
+-- 27.066 chaves (fixture, casa, mercado, saida) empatadas em 25 fixtures no PRD
+-- (medicao do Mateus, 10/08). Reproduzido no espelho de staging: 26 fixtures.
+-- Sao exatamente os jogos que ja tem 'daily' e 't24h' e ainda nao tem 't1h' /
+-- 't15m', ou seja os que estao entrando na janela de 24h -- justamente os que o
+-- assinante esta olhando.
+--
+-- CORRECAO
+-- Ordem total e explicita entre as quatro janelas, sem ELSE ambiguo:
+--     t15m (4) > t1h (3) > t24h (2) > daily (1) > qualquer outra (0)
+--
+-- O 'else 0' cobre janela nova que venha a existir sem ninguem lembrar deste
+-- arquivo: ela perde de todas as conhecidas em vez de empatar com uma delas.
+-- Foi o empate, e nao a ausencia, que causou o defeito.
+--
+-- ============================================================================
+-- ATENCAO ANTES DE APLICAR
+--
+-- 1. Os corpos abaixo foram extraidos de pg_get_functiondef no espelho de
+--    STAGING (kpbjuplcwiyrymafhehz), nao do PRD. Nao tenho acesso de leitura ao
+--    PRD. Se o PRD tiver alteracao que o staging nao tem, este CREATE OR REPLACE
+--    a reverte em silencio.
+--    => DIFERENCIAR CONTRA O PRD ANTES DE APLICAR. O unico trecho alterado por
+--       esta migration e o CASE da janela; qualquer outra diferenca e sinal de
+--       divergencia entre os ambientes.
+--
+-- 2. docs/futebol-prod-deploy.sql JA ESTAVA OBSOLETO. A definicao viva de
+--    get_futebol_fixture_odds tem um filtro que o arquivo nao tem
+--    ("where (a.market_name <> 'Asian Handicap' or a.n_books >= 3)").
+--    Nao usar aquele arquivo como fonte.
+--
+-- 3. Esta migration NAO altera assinatura de funcao, entao nao exige DROP e nao
+--    interfere na ordem de deploy do dbt. Pode ir sozinha.
+--
+-- ============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1/2  get_futebol_fixture_odds  (tela de detalhe do jogo)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_odds(p_fixture_id bigint)
+ RETURNS TABLE(market_key text, market_label text, outcome_label text, outcome_order integer, line double precision, pinnacle_odd double precision, avg_odd double precision, best_odd double precision, best_book text, n_books integer, pin_open double precision, pin_close double precision)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+begin
+  return query
+  with base as (
+    select o.market_name, o.outcome_label, o.bookmaker_name, o.collection_window, o.odd_decimal, o.line_value
+    from futebol.fact_odds_snapshot o
+    where o.fixture_id = p_fixture_id
+      and ( o.market_name = 'Match Winner'
+         or o.market_name = 'Both Teams Score'
+         or o.market_name = 'Double Chance'
+         or (o.market_name = 'Goals Over/Under' and o.outcome_label in
+             ('Over 0.5','Under 0.5','Over 1.5','Under 1.5','Over 2.5','Under 2.5','Over 3.5','Under 3.5','Over 4.5','Under 4.5'))
+         or (o.market_name = 'Asian Handicap' and abs(o.line_value - trunc(o.line_value)) = 0.5 and abs(o.line_value) <= 2.5) )
+  ),
+  win_rank as ( select *, case when collection_window='t15m' then 4 when collection_window='t1h' then 3 when collection_window='t24h' then 2 when collection_window='daily' then 1 else 0 end wr from base ),
+  cur_pick as (
+    select distinct on (b.market_name, b.outcome_label, b.bookmaker_name)
+      b.market_name, b.outcome_label, b.bookmaker_name, b.odd_decimal, b.line_value
+    from win_rank b
+    order by b.market_name, b.outcome_label, b.bookmaker_name, b.wr desc
+  ),
+  agg as (
+    select c.market_name, c.outcome_label, max(c.line_value) line_value,
+      count(distinct c.bookmaker_name)::int n_books, avg(c.odd_decimal) avg_odd
+    from cur_pick c group by c.market_name, c.outcome_label
+  ),
+  best_bk as (
+    select distinct on (c.market_name, c.outcome_label)
+      c.market_name, c.outcome_label, c.bookmaker_name best_book, c.odd_decimal best_odd
+    from cur_pick c order by c.market_name, c.outcome_label, c.odd_decimal desc
+  ),
+  pin as (
+    select b.market_name, b.outcome_label,
+      max(b.odd_decimal) filter (where b.collection_window='t24h') t24,
+      max(b.odd_decimal) filter (where b.collection_window='t1h')  t1,
+      max(b.odd_decimal) filter (where b.collection_window='t15m') t15
+    from base b where b.bookmaker_name = 'Pinnacle'
+    group by b.market_name, b.outcome_label
+  )
+  select
+    case a.market_name when 'Match Winner' then 'match_winner'
+      when 'Goals Over/Under' then 'over_under'
+      when 'Both Teams Score' then 'btts'
+      when 'Double Chance' then 'double_chance'
+      when 'Asian Handicap' then 'asian_handicap' end,
+    a.market_name, a.outcome_label,
+    case when a.outcome_label in ('Home','Yes','Home/Draw') or a.outcome_label like 'Over %' or a.outcome_label like 'Home %' then 1
+         when a.outcome_label in ('Draw','No','Home/Away') or a.outcome_label like 'Under %' or a.outcome_label like 'Away %' then 2 else 3 end,
+    case when a.market_name in ('Goals Over/Under','Asian Handicap') then a.line_value else null end,
+    coalesce(p.t15, p.t1, p.t24), a.avg_odd,
+    bb.best_odd, bb.best_book, a.n_books, p.t24, coalesce(p.t15, p.t1)
+  from agg a
+  join best_bk bb on bb.market_name = a.market_name and bb.outcome_label = a.outcome_label
+  left join pin p on p.market_name = a.market_name and p.outcome_label = a.outcome_label
+  where (a.market_name <> 'Asian Handicap' or a.n_books >= 3)
+  order by 1, 5 nulls first, 4;
+end $function$;
+
+-- ---------------------------------------------------------------------------
+-- 2/2  get_futebol_odds_board  (board de odds)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.get_futebol_odds_board()
+ RETURNS TABLE(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market_key text, market_label text, outcome_label text, outcome_order integer, line double precision, pinnacle_odd double precision, avg_odd double precision, best_odd double precision, best_book text, n_books integer, pin_open double precision, pin_close double precision)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+begin
+  return query
+  with base as (
+    select o.fixture_id, o.market_name, o.outcome_label, o.bookmaker_name, o.collection_window, o.odd_decimal, o.line_value
+    from futebol.fact_odds_snapshot o
+    where ( o.market_name = 'Match Winner'
+         or o.market_name = 'Both Teams Score'
+         or o.market_name = 'Double Chance'
+         or (o.market_name = 'Goals Over/Under' and o.outcome_label in
+             ('Over 0.5','Under 0.5','Over 1.5','Under 1.5','Over 2.5','Under 2.5','Over 3.5','Under 3.5','Over 4.5','Under 4.5')) )
+  ),
+  cur_pick as (
+    select distinct on (b.fixture_id, b.market_name, b.outcome_label, b.bookmaker_name)
+      b.fixture_id, b.market_name, b.outcome_label, b.bookmaker_name, b.odd_decimal, b.line_value
+    from base b
+    order by b.fixture_id, b.market_name, b.outcome_label, b.bookmaker_name,
+             case when b.collection_window='t15m' then 4 when b.collection_window='t1h' then 3 when b.collection_window='t24h' then 2 when b.collection_window='daily' then 1 else 0 end desc
+  ),
+  agg as (
+    select c.fixture_id, c.market_name, c.outcome_label, max(c.line_value) line_value,
+      count(distinct c.bookmaker_name)::int n_books, avg(c.odd_decimal) avg_odd
+    from cur_pick c group by c.fixture_id, c.market_name, c.outcome_label
+  ),
+  best_bk as (
+    select distinct on (c.fixture_id, c.market_name, c.outcome_label)
+      c.fixture_id, c.market_name, c.outcome_label, c.bookmaker_name best_book, c.odd_decimal best_odd
+    from cur_pick c order by c.fixture_id, c.market_name, c.outcome_label, c.odd_decimal desc
+  ),
+  pin as (
+    select b.fixture_id, b.market_name, b.outcome_label,
+      max(b.odd_decimal) filter (where b.collection_window='t24h') t24,
+      max(b.odd_decimal) filter (where b.collection_window='t1h')  t1,
+      max(b.odd_decimal) filter (where b.collection_window='t15m') t15
+    from base b where b.bookmaker_name = 'Pinnacle'
+    group by b.fixture_id, b.market_name, b.outcome_label
+  )
+  select
+    a.fixture_id, f.home_team_id, f.away_team_id, f.home_team_name, f.away_team_name,
+    f.competition, f.kickoff_utc, f.status_short,
+    case a.market_name when 'Match Winner' then 'match_winner'
+      when 'Goals Over/Under' then 'over_under'
+      when 'Both Teams Score' then 'btts'
+      when 'Double Chance' then 'double_chance' end,
+    a.market_name, a.outcome_label,
+    case when a.outcome_label in ('Home','Yes','Home/Draw') or a.outcome_label like 'Over %' then 1
+         when a.outcome_label in ('Draw','No','Home/Away') or a.outcome_label like 'Under %' then 2 else 3 end,
+    case when a.market_name = 'Goals Over/Under' then a.line_value else null end,
+    coalesce(p.t15, p.t1, p.t24), a.avg_odd,
+    bb.best_odd, bb.best_book, a.n_books, p.t24, coalesce(p.t15, p.t1)
+  from agg a
+  join futebol.fact_fixtures f on f.fixture_id = a.fixture_id
+  join best_bk bb on bb.fixture_id=a.fixture_id and bb.market_name=a.market_name and bb.outcome_label=a.outcome_label
+  left join pin p on p.fixture_id=a.fixture_id and p.market_name=a.market_name and p.outcome_label=a.outcome_label
+  order by a.fixture_id, 9, 13 nulls first, 12;
+end $function$;
+
+-- ============================================================================
+-- VERIFICACAO APOS APLICAR
+--
+-- 1. As duas funcoes passam a conhecer a janela 'daily':
+--
+--    select p.proname,
+--           position('daily' in pg_get_functiondef(p.oid)) > 0 as conhece_daily
+--    from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+--    where n.nspname = 'public'
+--      and p.proname in ('get_futebol_fixture_odds','get_futebol_odds_board');
+--    -- esperado: true nas duas
+--
+-- 2. Nenhuma chave empatada sobra. Antes da migration esta consulta devolvia
+--    linhas; depois tem que devolver zero:
+--
+--    with s as (
+--      select fixture_id, bookmaker_id, market_id,
+--             coalesce(outcome_side, outcome_label) as saida,
+--             coalesce(line_value, -999) as linha,
+--             count(*) filter (where collection_window in ('daily','t24h')) as empatadas,
+--             count(*) filter (where collection_window in ('t1h','t15m'))   as mais_novas
+--      from futebol.fact_odds_snapshot
+--      group by 1,2,3,4,5
+--    )
+--    select count(*) from s where empatadas = 2 and mais_novas = 0;
+--    -- a consulta acima mede a POPULACAO em risco, que continua existindo.
+--    -- O que a migration garante e que a escolha entre as duas deixa de ser
+--    -- arbitraria: 't24h' sempre vence 'daily'. Para provar, chamar a RPC duas
+--    -- vezes seguidas num fixture dessa lista e conferir que a odd nao muda.
+--
+-- 3. Chamar get_futebol_fixture_odds no mesmo fixture 3x seguidas e conferir
+--    que pinnacle_odd, best_odd e avg_odd sao identicos nas tres.
+-- ============================================================================

--- a/supabase/migrations/098_futebol_rpc_desempate_e_fase.sql
+++ b/supabase/migrations/098_futebol_rpc_desempate_e_fase.sql
@@ -1,0 +1,272 @@
+-- 098_futebol_rpc_desempate_e_fase.sql
+--
+-- C8, parte 2 de 2. Dois defeitos, um em cada funcao.
+--
+-- Parte 1 (097) tratou o defeito visivel na tela. Esta trata os dois que
+-- bloqueiam a fila: o desempate de janela no detalhe da oportunidade, que e o
+-- que destrava a C5, e a fase da escalacao, que quebra quando a C1 subir.
+--
+-- ============================================================================
+-- DEFEITO A -- get_futebol_fixture_value escolhe a janela arbitrariamente
+--
+-- A funcao le as quatro penalidades de odd de um CTE assim:
+--
+--     select distinct on (fixture_id, outcome_side, line_value)
+--            fixture_id, outcome_side, line_value,
+--            pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
+--     from futebol.int_futebol_odds_devig
+--     order by fixture_id, outcome_side, line_value
+--
+-- Sem desempate alem das proprias chaves. Faltam DUAS colunas na chave:
+--
+--   janela_usada -- a C5 mudou o grao do de-vig para uma linha por janela.
+--                   Antes havia 1 linha por (fixture, saida, linha); agora ha
+--                   ate 4. O DISTINCT ON passa a escolher qualquer uma delas.
+--                   Efeito medido em producao pelo Mateus em 10/08: uma Over 2.5
+--                   que fechou em 2,05 aparecia com "Odd alta (zebra), entra com
+--                   cautela", aviso calculado do preco de 5,20 da janela diaria.
+--                   E qual linha ganhava mudava entre syncs, sem mudanca de dado.
+--
+--   market_id    -- defeito que JA EXISTIA antes da C5 e ninguem tinha visto.
+--                   Gols O/U (mercado 5) e Gols O/U 1o Tempo (mercado 6) tem
+--                   Over/Under na MESMA line_value. Sem market_id na chave, uma
+--                   linha de 1o tempo pode fornecer as penalidades de uma linha
+--                   de jogo inteiro.
+--
+-- ALCANCE MEDIDO (espelho de staging, 15/08, ja com o grao da C5):
+--   26.932 grupos de (fixture, saida, linha) no de-vig
+--   23.804 com colisao, ou 88,4%
+--     - 22.855 colidem por janela
+--     -  6.455 colidem por mercado
+--
+-- Exemplo real encontrado durante a verificacao, fixture 1489392: a linha
+-- "Under 3.5" do mercado 5 nao tem penalidade nenhuma, mas a "Under 3.5" do
+-- mercado 6 (1o tempo) tem. Sem market_id na chave, o detalhe do jogo podia
+-- exibir o aviso da linha errada.
+--
+-- CORRECAO
+--   1. chave do DISTINCT ON passa a ser
+--      (fixture_id, market_id, outcome_side, line_value, janela_usada)
+--   2. o join passa a casar tambem por janela e por mercado, traduzindo o
+--      market text do mart para o market_id do de-vig
+--
+-- COMPATIVEL NOS DOIS SENTIDOS: funciona com o grao antigo (uma janela por
+-- linha) e com o novo (quatro). Nao depende da ordem de deploy da C5.
+--
+-- ============================================================================
+-- DEFEITO B -- get_futebol_fixture_extras nao distingue a fase da escalacao
+--
+-- A funcao agrega fact_fixture_lineups e fact_fixture_lineups_players sem
+-- filtro de fase e sem projetar lineup_phase. O app nao consegue distinguir as
+-- duas, entao cada time e cada jogador apareceriam DUAS VEZES na tela.
+--
+-- HOJE ISSO NAO ACONTECE, e o motivo importa: nenhum fixture tem as duas fases
+-- ao mesmo tempo (medido: 0). Nao e porque a funcao esta certa, e porque o
+-- "ultimo vence" da consolidacao destroi a escalacao pre-jogo quando a pos-jogo
+-- chega. E exatamente isso que a C1 conserta.
+--
+-- => Este conserto tem que estar em producao ANTES da C1 subir. Ele nao arruma
+--    nada hoje; ele impede que a C1 quebre a tela.
+--
+-- AS DUAS FASES, medidas no espelho:
+--   'confirmed' -- escalacao confirmada, publicada antes do apito.
+--                    8 linhas / 4 jogos em lineups
+--                  399 linhas / 137 jogos em lineups_players
+--   'real'      -- registro pos-jogo, com quem de fato entrou.
+--                16.183 linhas / 8.097 jogos em lineups
+--               350.947 linhas / 8.067 jogos em lineups_players
+--
+-- ⚠️ NOMENCLATURA: nao existe escalacao "provavel" na fonte. A API nao publica
+--    escalacao provavel em momento nenhum (sondado pelo Mateus). As duas fases
+--    sao CONFIRMADA (pre-jogo) e REAL (pos-jogo). O produto deve nomear assim.
+--
+-- CORRECAO (decisao do Victor, 15/08): devolver UMA fase so, nunca as duas
+--   misturadas. Prefere 'confirmed'; cai para 'real' quando nao houver
+--   confirmada naquele fixture. lineup_phase e projetado dentro do jsonb para o
+--   app saber o que esta exibindo.
+--
+--   POR QUE COM FALLBACK, e nao 'confirmed' puro: hoje so 4 jogos tem escalacao
+--   confirmada em fact_fixture_lineups, contra 8.097 com a real. Filtrar apenas
+--   'confirmed' apagaria a escalacao de praticamente todo jogo ja encerrado.
+--
+--   As duas tabelas sao avaliadas SEPARADAMENTE porque discordam entre si:
+--   confirmada existe em 4 jogos de fact_fixture_lineups e em 137 de
+--   fact_fixture_lineups_players. Uma variavel so faria uma delas mentir.
+--
+-- ⚠️ A ASSINATURA NAO MUDA. A funcao ja retorna jsonb, e acrescentar campo
+--    dentro do jsonb nao altera RETURNS. Portanto NAO exige DROP FUNCTION e NAO
+--    entra na ordem rigida de deploy do dbt. (A avaliacao inicial supunha que
+--    exigiria; supunha que lineup_phase sairia fora do jsonb.)
+--
+--    O front PRECISA ser atualizado junto, porque a partir da C1 vao chegar as
+--    duas fases e sem tratamento a tela duplica.
+--
+-- ============================================================================
+-- ATENCAO ANTES DE APLICAR
+--
+-- O corpo do DEFEITO B abaixo foi extraido do espelho de STAGING. Nao tenho
+-- acesso de leitura ao PRD. Diferenciar antes de aplicar: o unico trecho que
+-- esta migration altera e a projecao de lineup_phase e a ordenacao.
+--
+-- O DEFEITO A e aplicado por substituicao guardada sobre a definicao VIVA, e
+-- por isso nao corre esse risco: ele altera o que estiver no ar, e aborta se
+-- nao encontrar exatamente o texto que espera. A escolha e deliberada -- a
+-- funcao tem 10 mil caracteres, o repositorio nao e a fonte da verdade dela, e
+-- transcrever o corpo inteiro para ca criaria justamente o risco de reverter
+-- alteracao que so exista no PRD.
+-- ============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- DEFEITO A  get_futebol_fixture_value  (substituicao guardada)
+-- ---------------------------------------------------------------------------
+
+DO $migration$
+DECLARE v text;
+BEGIN
+  SELECT pg_get_functiondef(p.oid) INTO v
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'get_futebol_fixture_value';
+
+  IF v IS NULL THEN
+    RAISE EXCEPTION 'get_futebol_fixture_value nao existe';
+  END IF;
+
+  -- Guarda: se a definicao viva nao for a esperada, aborta sem tocar em nada.
+  IF position('distinct on (fixture_id, outcome_side, line_value)' in v) = 0
+     OR position('left join d on d.fixture_id = v.fixture_id and d.outcome_side = v.outcome and d.line_value is not distinct from v.line_value' in v) = 0 THEN
+    RAISE EXCEPTION 'get_futebol_fixture_value: definicao viva divergente do esperado. Revisar antes de aplicar.';
+  END IF;
+
+  -- Guarda de idempotencia: se ja tem o desempate, nao faz nada.
+  IF position('d.janela_usada is not distinct from v.janela_usada' in v) > 0 THEN
+    RAISE NOTICE 'get_futebol_fixture_value ja tem o desempate. Nada a fazer.';
+    RETURN;
+  END IF;
+
+  v := replace(v,
+    'select distinct on (fixture_id, outcome_side, line_value) fixture_id, outcome_side, line_value,',
+    'select distinct on (fixture_id, market_id, outcome_side, line_value, janela_usada) fixture_id, market_id, outcome_side, line_value, janela_usada,');
+
+  v := replace(v,
+    'from futebol.int_futebol_odds_devig order by fixture_id, outcome_side, line_value',
+    'from futebol.int_futebol_odds_devig order by fixture_id, market_id, outcome_side, line_value, janela_usada');
+
+  v := replace(v,
+    'left join d on d.fixture_id = v.fixture_id and d.outcome_side = v.outcome and d.line_value is not distinct from v.line_value',
+    'left join d on d.fixture_id = v.fixture_id and d.outcome_side = v.outcome and d.line_value is not distinct from v.line_value and d.janela_usada is not distinct from v.janela_usada and d.market_id = (case v.market when ''match_winner'' then 1 when ''asian_handicap'' then 4 when ''goals_over_under'' then 5 when ''btts'' then 8 when ''double_chance'' then 12 end)');
+
+  EXECUTE v;
+END
+$migration$;
+
+
+-- ---------------------------------------------------------------------------
+-- DEFEITO B  get_futebol_fixture_extras  (corpo explicito)
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_extras(p_fixture_id bigint)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+declare
+  v_fix record;
+  v_fase_times text;
+  v_fase_jogadores text;
+begin
+  select f.* into v_fix from futebol.fact_fixtures f where f.fixture_id = p_fixture_id limit 1;
+  if not found then return jsonb_build_object('events', '[]'::jsonb); end if;
+
+  -- Uma fase so, nunca as duas. Prefere a confirmada; cai para a real quando
+  -- nao houver confirmada. As duas tabelas sao decididas em separado porque
+  -- discordam entre si.
+  select case when count(*) filter (where lineup_phase = 'confirmed') > 0
+              then 'confirmed' else 'real' end
+    into v_fase_times
+    from futebol.fact_fixture_lineups where fixture_id = p_fixture_id;
+
+  select case when count(*) filter (where lineup_phase = 'confirmed') > 0
+              then 'confirmed' else 'real' end
+    into v_fase_jogadores
+    from futebol.fact_fixture_lineups_players where fixture_id = p_fixture_id;
+
+  return jsonb_build_object(
+    'events', coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'minute', e.minute, 'minute_extra', e.minute_extra, 'team_side', e.team_side,
+        'team_name', e.team_name, 'player_name', e.player_name, 'assist_player_name', e.assist_player_name,
+        'event_type', e.event_type, 'event_detail', e.event_detail
+      ) order by e.minute nulls last, e.event_order)
+      from futebol.fact_fixture_events e where e.fixture_id = p_fixture_id
+    ), '[]'::jsonb),
+    'player_stats', coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'player_id', p.player_id, 'team_side', p.team_side, 'player_name', p.player_name,
+        'minutes', p.minutes, 'rating', p.rating, 'goals', p.goals_total, 'assists', p.assists,
+        'shots_total', p.shots_total, 'shots_on', p.shots_on, 'passes_key', p.passes_key,
+        'tackles_total', p.tackles_total, 'is_substitute', p.is_substitute
+      ))
+      from futebol.fact_fixture_player_stats p where p.fixture_id = p_fixture_id
+    ), '[]'::jsonb),
+    'form_home', public._futebol_team_form(v_fix.home_team_id, v_fix.competition, v_fix.season, v_fix.date_utc),
+    'form_away', public._futebol_team_form(v_fix.away_team_id, v_fix.competition, v_fix.season, v_fix.date_utc),
+    'lineups', coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'team_id', l.team_id, 'team_name', l.team_name, 'team_side', l.team_side,
+        'formation', l.formation, 'coach_name', l.coach_name, 'lineup_phase', l.lineup_phase
+      ) order by l.team_side) from (
+        select team_id, team_name, team_side, formation, coach_name, lineup_phase
+        from futebol.fact_fixture_lineups
+        where fixture_id = p_fixture_id and lineup_phase = v_fase_times
+      ) l
+    ), '[]'::jsonb),
+    'lineup_players', coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'team_id', lp.team_id, 'team_side', lp.team_side, 'is_starter', lp.is_starter,
+        'player_slot', lp.player_slot, 'player_id', lp.player_id, 'player_name', lp.player_name,
+        'shirt_number', lp.shirt_number, 'position', lp.position, 'grid', lp.grid,
+        'lineup_phase', lp.lineup_phase
+      ) order by lp.team_side, lp.is_starter desc nulls last, lp.player_slot) from (
+        select team_id, team_side, is_starter, player_slot, player_id, player_name, shirt_number, position, grid, lineup_phase
+        from futebol.fact_fixture_lineups_players
+        where fixture_id = p_fixture_id and lineup_phase = v_fase_jogadores
+      ) lp
+    ), '[]'::jsonb)
+  );
+end; $function$;
+
+
+-- ============================================================================
+-- VERIFICACAO APOS APLICAR
+--
+-- A) o desempate entrou nas duas dimensoes:
+--
+--    select position('janela_usada' in pg_get_functiondef(p.oid)) > 0 as tem_janela,
+--           position('when ''match_winner'' then 1' in pg_get_functiondef(p.oid)) > 0 as tem_mercado
+--    from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+--    where n.nspname = 'public' and p.proname = 'get_futebol_fixture_value';
+--    -- esperado: true, true
+--
+-- B) nenhuma linha perdida no join mais estrito. Para qualquer fixture do
+--    board, a funcao tem que devolver exatamente o que o mart tem:
+--
+--    with alvos as (select distinct fixture_id from futebol.fact_value_opportunities limit 20)
+--    select a.fixture_id,
+--      (select count(*) from public.get_futebol_fixture_value(a.fixture_id)) as devolvidas,
+--      (select count(*) from futebol.fact_value_opportunities v where v.fixture_id = a.fixture_id) as no_mart
+--    from alvos a;
+--    -- esperado: devolvidas = no_mart em todas
+--
+-- C) o join casa em exatamente uma linha (nao zero, nao duas):
+--    ver a consulta de conferencia de chave no comentario da C8.
+--
+-- D) a fase chega ao app:
+--
+--    select jsonb_path_query_first(
+--             public.get_futebol_fixture_extras(f.fixture_id),
+--             '$.lineups[0].lineup_phase')
+--    from futebol.fact_fixture_lineups f limit 1;
+--    -- esperado: "confirmed" ou "real", nunca null
+-- ============================================================================


### PR DESCRIPTION
Fecha a **C8**. Quatro defeitos na camada de serving, todos pela mesma causa: chave incompleta num `DISTINCT ON`.

Um deles está no ar agora. Os outros três bloqueiam a fila da [C].

## 097 · A tela de odds pode mostrar preço de dias atrás

As duas RPCs de odds escolhiam a janela corrente com um `CASE` que conhecia **três** janelas. A quarta, `daily`, entrou em 07/08 com a coleta de 7 dias e caiu no `ELSE`, **empatando com `t24h`**. Em empate o `DISTINCT ON` do Postgres resolve arbitrariamente, e pode trocar de resposta entre chamadas sem mudança de dado.

| | |
| --- | --- |
| Chaves empatadas | 9.338, em 43 jogos |
| Preço igual nas duas janelas | 75,6% |
| **Preço diferente** | **24,4%** |
| Desvio médio quando difere | 3,8% |
| Cauda | até 300 pontos de odd |

E são os piores jogos possíveis para isso: os que já têm `daily` e `t24h` e ainda não têm `t1h`/`t15m`, ou seja **os que estão entrando na janela de 24h**, que é onde o assinante está olhando.

A ordem passa a ser total e explícita: `t15m > t1h > t24h > daily > qualquer outra`.

O `else 0` é deliberado. Janela nova que apareça **perde de todas as conhecidas em vez de empatar com uma**. Foi o empate, não a ausência, que causou o defeito.

## 098 · O detalhe da oportunidade lê penalidade da linha errada

`get_futebol_fixture_value` agrupava as quatro penalidades de odd por `(fixture, saída, linha)`. Faltavam **duas** colunas na chave:

**`janela_usada`** — a C5 mudou o grão do de-vig para uma linha por janela. Antes 1 linha por aposta, agora até 4, e o `DISTINCT ON` escolhia qualquer uma. O efeito já foi observado em produção em 10/08: uma Over 2.5 que fechou em 2,05 aparecia com *"Odd alta (zebra), entra com cautela"*, aviso calculado do preço de 5,20 da janela diária.

**`market_id`** — defeito **anterior à C5**. Gols O/U (5) e Gols O/U 1º Tempo (6) têm Over/Under na mesma `line_value`, então uma linha de primeiro tempo podia fornecer as penalidades de uma linha de jogo inteiro. Reproduzido no fixture 1489392 durante a verificação: a linha do mercado 5 não tem penalidade e a do mercado 6 tem.

**23.804 grupos com colisão de 26.932, ou 88,4%.** Compatível com o grão antigo e com o novo, então não depende da ordem de deploy da C5.

## 098 · A escalação não distinguia a fase

`get_futebol_fixture_extras` agregava as duas fases sem filtro e sem projetar `lineup_phase`.

**Hoje isso não duplica**, e o motivo importa: nenhum fixture tem as duas fases ao mesmo tempo. Não é a função estar certa, é o "último vence" da consolidação **destruindo a escalação pré-jogo**. É o que a C1 conserta, e por isso este conserto precisa estar no ar **antes** dela.

Passa a devolver **uma fase só**, preferindo a confirmada e caindo para a real quando não houver confirmada. As duas tabelas são decididas em separado porque discordam: confirmada existe em **4 jogos** de `fact_fixture_lineups` e em **137** de `fact_fixture_lineups_players`.

⚠️ **Nomenclatura, para o produto não prometer o que a fonte não dá:** não existe escalação "provável". A API não publica escalação provável em momento nenhum. As duas fases são **CONFIRMADA** (pré-jogo) e **REAL** (pós-jogo).

E uma consequência de correção que vale escrever: **o Score tem que usar a confirmada.** Pontuar com a real seria decidir uma aposta pré-jogo com informação que só existe depois, que é a classe de erro que a task [0] passou semanas removendo.

## Deploy

**Nenhuma das duas altera assinatura de função**, então não exigem `DROP FUNCTION` e **não entram na ordem rígida** de deploy do dbt. Podem subir sozinhas, e a 097 deveria subir logo, porque conserta algo visível.

## Duas notas de método, para a revisão

**O corpo de `get_futebol_fixture_value` é aplicado por substituição guardada sobre a definição viva, não transcrito.** A função tem 10 mil caracteres, o repositório não é a fonte da verdade dela, e colar um corpo lido do staging numa migration de produção **reverteria em silêncio qualquer alteração que só exista no PRD**. A substituição aborta se não encontrar o texto esperado, e é idempotente.

**Os demais corpos foram lidos de `pg_get_functiondef` no espelho de staging**, não do PRD e **não** do `docs/futebol-prod-deploy.sql`, que já estava obsoleto: a definição viva de `get_futebol_fixture_odds` tem um filtro de `n_books` que o arquivo não tem. Se eu tivesse escrito a partir dele, teria apagado esse filtro sem perceber.

⚠️ **Como eu não tenho leitura no PRD, diferenciar contra ele antes de aplicar.** O único trecho que estas migrations alteram é o citado; qualquer outra diferença no diff é sinal de que os ambientes divergiram.

## Verificação feita

As duas foram aplicadas no espelho de staging e conferidas:

- as duas RPCs de odds passaram a conhecer a `daily`
- `get_futebol_fixture_value` devolve **exatamente** as mesmas linhas que o mart tem, e o join casa em **uma** linha por aposta, na janela certa
- a escalação devolve só a confirmada onde ela existe (2 times, 45 jogadores) e só a real onde não existe (2 times, 46 jogadores), **nunca as duas**

As consultas de verificação estão no rodapé de cada arquivo.

Numeradas 097 e 098 porque a develop já usa até a 096.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
