### PR TITLE
feat(futebol): o contador de premissas sem dado chega ao app

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -507,7 +507,8 @@ create table futebol.int_futebol_premissas_1x2 (
   "s_missing" bigint,
   "pts_premissas" bigint,
   "penalidades_1x2_pts" bigint,
-  "dbt_loaded_at" timestamp
+  "dbt_loaded_at" timestamp,
+  "premissas_sem_dado" bigint
 );
 
 drop table if exists futebol.int_futebol_premissas_ou cascade;
@@ -533,7 +534,8 @@ create table futebol.int_futebol_premissas_ou (
   "linha_extrema" boolean,
   "pts_premissas" bigint,
   "penalidades_ou_pts" bigint,
-  "dbt_loaded_at" timestamp
+  "dbt_loaded_at" timestamp,
+  "premissas_sem_dado" bigint
 );
 
 drop table if exists futebol.int_futebol_premissas_ah cascade;
@@ -557,7 +559,8 @@ create table futebol.int_futebol_premissas_ah (
   "handicap_alto" boolean,
   "pts_premissas" bigint,
   "penalidades_ah_pts" bigint,
-  "dbt_loaded_at" timestamp
+  "dbt_loaded_at" timestamp,
+  "premissas_sem_dado" bigint
 );
 
 drop table if exists futebol.int_futebol_premissas_btts cascade;
@@ -575,7 +578,8 @@ create table futebol.int_futebol_premissas_btts (
   "historico_seco" boolean,
   "pts_premissas" bigint,
   "penalidades_btts_pts" bigint,
-  "dbt_loaded_at" timestamp
+  "dbt_loaded_at" timestamp,
+  "premissas_sem_dado" bigint
 );
 
 drop table if exists futebol.int_futebol_premissas_dc cascade;
@@ -590,7 +594,8 @@ create table futebol.int_futebol_premissas_dc (
   "invicto_recente" boolean,
   "pts_premissas" bigint,
   "penalidades_dc_pts" bigint,
-  "dbt_loaded_at" timestamp
+  "dbt_loaded_at" timestamp,
+  "premissas_sem_dado" bigint
 );
 
 drop table if exists futebol.fact_value_opportunities cascade;
@@ -621,7 +626,8 @@ create table futebol.fact_value_opportunities (
   "linha_sharp_confirma" boolean,
   "pin_n_outcomes" bigint,
   "is_half_line" boolean,
-  "dbt_loaded_at" timestamp
+  "dbt_loaded_at" timestamp,
+  "premissas_sem_dado" bigint
 );
 
 -- ── 2a. Infra do sync: estado incremental (o Cloud Run sync lê/escreve aqui) ──
@@ -667,7 +673,8 @@ create table futebol.fact_value_opportunities_hist (
   "dbt_scd_id" text,
   "dbt_updated_at" timestamp,
   "dbt_valid_from" timestamp,
-  "dbt_valid_to" timestamp
+  "dbt_valid_to" timestamp,
+  "premissas_sem_dado" bigint
 );
 
 -- ── 2b. Lockdown RPC-only (espelha nba_mart): acesso só via RPCs security definer

--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -988,7 +988,7 @@ end $function$
 ;
 
 CREATE OR REPLACE FUNCTION public.get_futebol_fixture_value(p_fixture_id bigint)
- RETURNS TABLE(market text, outcome text, outcome_order integer, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, penalidades_globais_pts integer, penalidades_especificas_pts integer, score integer, faixa text, modelo_api_concorda boolean, linha_sharp_confirma boolean, evidencias text[], avisos text[], contras text[])
+ RETURNS TABLE(market text, outcome text, outcome_order integer, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, penalidades_globais_pts integer, penalidades_especificas_pts integer, score integer, faixa text, modelo_api_concorda boolean, linha_sharp_confirma boolean, evidencias text[], avisos text[], contras text[], premissas_sem_dado integer)
  LANGUAGE sql
  SECURITY DEFINER
  SET search_path TO ''
@@ -1098,7 +1098,8 @@ AS $function$
       case when v.outcome='No' and not coalesce(bt.ataque_trava, true) then 'Os dois ataques costumam marcar' end,
       case when not coalesce(dc.lado_coberto_forte, true) then 'O lado coberto não é claramente o mais forte' end,
       case when not coalesce(dc.adversario_limitado, true) then 'Adversário não é tão limitado' end
-    ], null))[1:3]
+    ], null))[1:3],
+    v.premissas_sem_dado::int
   from futebol.fact_value_opportunities v
   left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
   left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
@@ -1491,7 +1492,7 @@ end; $function$
 ;
 
 CREATE OR REPLACE FUNCTION public.get_futebol_value_board()
- RETURNS TABLE(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, score integer, faixa text, evidencias text[])
+ RETURNS TABLE(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, score integer, faixa text, evidencias text[], premissas_sem_dado integer)
  LANGUAGE sql
  SECURITY DEFINER
  SET search_path TO ''
@@ -1553,7 +1554,8 @@ AS $function$
       case when v.modelo_api_concorda and v.linha_sharp_confirma then 'As principais casas e o modelo da API apontam o mesmo lado'
            when v.modelo_api_concorda then 'Modelo da API concorda com esse lado'
            when v.linha_sharp_confirma then 'As principais casas vêm baixando a odd desse lado' end
-    ], null)
+    ], null),
+    v.premissas_sem_dado::int
   from futebol.fact_value_opportunities v
   join futebol.fact_fixtures f on f.fixture_id = v.fixture_id
   left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome

--- a/supabase/migrations/099_futebol_board_contador_sem_dado.sql
+++ b/supabase/migrations/099_futebol_board_contador_sem_dado.sql
@@ -76,19 +76,24 @@ BEGIN
     RAISE EXCEPTION 'get_futebol_value_board nao existe';
   END IF;
 
-  -- Idempotencia: ja tem a coluna, nada a fazer.
-  IF position('premissas_sem_dado' in v) > 0 THEN
+  -- Idempotencia. Testa a ASSINATURA, nao o texto inteiro: procurar so por
+  -- 'premissas_sem_dado' casaria com uma mencao em comentario dentro do corpo, e
+  -- a migration sairia anunciando "nada a fazer" sem ter feito nada.
+  IF position('premissas_sem_dado integer)' in v) > 0 THEN
     RAISE NOTICE 'get_futebol_value_board ja devolve premissas_sem_dado. Nada a fazer.';
     RETURN;
   END IF;
 
-  -- Guarda: os dois pontos de alteracao tem que existir exatamente assim.
-  IF position('evidencias text[])' in v) = 0 THEN
-    RAISE EXCEPTION 'get_futebol_value_board: nao encontrei o fim do RETURNS TABLE. Definicao viva divergente do esperado.';
+  -- Guardas: cada ancora tem que existir EXATAMENTE UMA VEZ.
+  -- Contar em vez de so testar existencia importa porque replace() troca TODAS
+  -- as ocorrencias. Com a ancora repetida, a substituicao corromperia a funcao
+  -- em silencio -- e o corpo muda quando a A1 do Score mexer nele.
+  IF array_length(string_to_array(v, 'evidencias text[])'), 1) - 1 <> 1 THEN
+    RAISE EXCEPTION 'get_futebol_value_board: a ancora do RETURNS TABLE nao aparece exatamente uma vez. Definicao viva divergente do esperado.';
   END IF;
 
-  IF position(E'], null)\n  from futebol.fact_value_opportunities v' in v) = 0 THEN
-    RAISE EXCEPTION 'get_futebol_value_board: nao encontrei o fim da projecao. Definicao viva divergente do esperado.';
+  IF array_length(string_to_array(v, E'], null)\n  from futebol.fact_value_opportunities v'), 1) - 1 <> 1 THEN
+    RAISE EXCEPTION 'get_futebol_value_board: a ancora da projecao nao aparece exatamente uma vez. Definicao viva divergente do esperado.';
   END IF;
 
   -- 1. a coluna entra no fim do RETURNS TABLE
@@ -108,6 +113,14 @@ BEGIN
 
   DROP FUNCTION IF EXISTS public.get_futebol_value_board();
   EXECUTE v_novo;
+
+  -- Reemitir o grant. Neste projeto ha ALTER DEFAULT PRIVILEGES em `public`
+  -- concedendo execute a anon/authenticated/service_role, entao a funcao nova
+  -- ja nasceria com ele -- verificado no espelho. Fica explicito assim mesmo:
+  -- o DROP apaga a ACL, e depender de um padrao implicito do ambiente para
+  -- restaurar acesso e o tipo de coisa que funciona ate o dia em que alguem
+  -- muda o padrao e ninguem liga uma coisa na outra.
+  GRANT EXECUTE ON FUNCTION public.get_futebol_value_board() TO anon, authenticated, service_role;
 END
 $migration$;
 
@@ -131,9 +144,22 @@ $migration$;
 --    where r.premissas_sem_dado is distinct from v.premissas_sem_dado::int;
 --    -- esperado: 0
 --
--- C) nenhuma linha perdida no DROP + recriar:
+-- C) nenhuma linha perdida no DROP + recriar.
 --
---    select (select count(*) from public.get_futebol_value_board()) as da_rpc,
---           (select count(*) from futebol.fact_value_opportunities) as da_tabela;
---    -- esperado: iguais
+--    ⚠️ Comparar a contagem da RPC com a da tabela NAO serve como assercao: a
+--    RPC faz INNER JOIN em fact_fixtures, entao oportunidade sem fixture
+--    correspondente sai do resultado por desenho, e nao por causa do DROP.
+--    Hoje sao 0 dessas, mas isso e estado do dado, nao garantia.
+--
+--    A comparacao que de fato prova o DROP e antes/depois da propria RPC:
+--
+--    -- ANTES de aplicar:
+--    select count(*) from public.get_futebol_value_board();
+--    -- DEPOIS: mesmo numero.
+--
+--    E, se quiser explicar uma diferenca eventual:
+--    select count(*) from futebol.fact_value_opportunities v
+--    where not exists (select 1 from futebol.fact_fixtures f
+--                      where f.fixture_id = v.fixture_id);
+--    -- quantas oportunidades o INNER JOIN descarta
 -- ============================================================================

--- a/supabase/migrations/099_futebol_board_contador_sem_dado.sql
+++ b/supabase/migrations/099_futebol_board_contador_sem_dado.sql
@@ -1,0 +1,139 @@
+-- 099_futebol_board_contador_sem_dado.sql
+--
+-- Ticket #245. O contador de premissas sem dado chega ao app.
+--
+-- ============================================================================
+-- O QUE E
+--
+-- O Motor ja calcula e o Postgres ja tem: a coluna premissas_sem_dado esta
+-- populada nas 7 tabelas de futebol desde 14/08 (analytics-engineering#41).
+-- Medido no espelho em 15/08: 122 linhas no board, 43 com contador > 0,
+-- media 0,70, maximo 7.
+--
+-- O que faltava e a RPC devolver a coluna. Sem isso o numero existe no banco e
+-- nao chega a tela.
+--
+-- A decisao de dominio esta na ADR 0003 e e curta: dado faltante DIAGNOSTICA,
+-- NAO PENALIZA. O score nao muda. O que muda e o leitor passar a saber que uma
+-- nota baixa pode ser POUCA INFORMACAO em vez de INFORMACAO CONTRARIA.
+--
+-- ============================================================================
+-- POR QUE E DROP + RECRIAR, E NAO CREATE OR REPLACE
+--
+-- Acrescentar coluna ao RETURNS TABLE altera a assinatura da funcao, e o
+-- Postgres recusa CREATE OR REPLACE nesse caso. Nao ha como evitar o DROP.
+--
+-- ⚠️ ORDEM DE DEPLOY: esta migration antes do sync. Invertida, o parity check
+--    encontra divergencia de schema e aborta as 21 tabelas de uma vez.
+--
+-- ============================================================================
+-- POR QUE O CORPO E CAPTURADO DA DEFINICAO VIVA
+--
+-- Mesmo racional da 098, e aqui ainda mais forte: o corpo tem 5.800 caracteres
+-- e e quase todo string acentuada em portugues ("Ataque forte contra defesa
+-- fragil do adversario", e outras 40). Transcrever isso a mao para ca e um
+-- gerador de erro silencioso -- basta um acento trocado para o texto que o
+-- assinante le mudar.
+--
+-- Entao o corpo nao e transcrito: e lido de pg_get_functiondef, alterado em
+-- dois pontos declarados, e reexecutado. A migration aborta se nao encontrar
+-- exatamente os dois pontos, e nao faz nada se a coluna ja estiver la.
+--
+-- Efeito colateral bom: o que estiver no PRD e o que sera alterado. Nao ha como
+-- esta migration reverter em silencio uma mudanca que so exista la.
+--
+-- ============================================================================
+-- O QUE NAO ENTRA
+--
+-- premissas_cegas (a lista de QUAIS premissas ficaram cegas) NAO entra. E
+-- ARRAY<STRING>, e o sync pula colunas array -- como ja pula evidencias e
+-- avisos. Ela nao existe no Postgres.
+--
+-- Consequencia de produto, e vale estar escrita aqui: o aviso na tela diz
+-- QUANTAS premissas ficaram sem dado, nunca QUAIS.
+--
+-- ============================================================================
+-- NOTA SOBRE UMA SEGUNDA MUDANCA DE ASSINATURA
+--
+-- A frente A1 do Redesenho do Score vai REMOVER pts_valor, pts_corroboracao e
+-- penalidades desta mesma RPC, o que exige outro DROP.
+--
+-- Decidido nao esperar: a A1 esta atras de outras frentes na fila e pode levar
+-- semanas. O custo de nao esperar e uma migration a mais. O custo de esperar e
+-- o contador ficar na gaveta com o dado pronto no banco.
+-- ============================================================================
+
+DO $migration$
+DECLARE
+  v text;
+  v_novo text;
+BEGIN
+  SELECT pg_get_functiondef(p.oid) INTO v
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'get_futebol_value_board';
+
+  IF v IS NULL THEN
+    RAISE EXCEPTION 'get_futebol_value_board nao existe';
+  END IF;
+
+  -- Idempotencia: ja tem a coluna, nada a fazer.
+  IF position('premissas_sem_dado' in v) > 0 THEN
+    RAISE NOTICE 'get_futebol_value_board ja devolve premissas_sem_dado. Nada a fazer.';
+    RETURN;
+  END IF;
+
+  -- Guarda: os dois pontos de alteracao tem que existir exatamente assim.
+  IF position('evidencias text[])' in v) = 0 THEN
+    RAISE EXCEPTION 'get_futebol_value_board: nao encontrei o fim do RETURNS TABLE. Definicao viva divergente do esperado.';
+  END IF;
+
+  IF position(E'], null)\n  from futebol.fact_value_opportunities v' in v) = 0 THEN
+    RAISE EXCEPTION 'get_futebol_value_board: nao encontrei o fim da projecao. Definicao viva divergente do esperado.';
+  END IF;
+
+  -- 1. a coluna entra no fim do RETURNS TABLE
+  v_novo := replace(v,
+    'evidencias text[])',
+    'evidencias text[], premissas_sem_dado integer)');
+
+  -- 2. e no fim da projecao, na mesma posicao, senao a ordem nao casa.
+  --    ::int porque a coluna e bigint no Postgres e a assinatura declara integer.
+  v_novo := replace(v_novo,
+    E'], null)\n  from futebol.fact_value_opportunities v',
+    E'], null),\n    v.premissas_sem_dado::int\n  from futebol.fact_value_opportunities v');
+
+  IF v_novo = v THEN
+    RAISE EXCEPTION 'get_futebol_value_board: nenhuma substituicao aplicada. Abortado.';
+  END IF;
+
+  DROP FUNCTION IF EXISTS public.get_futebol_value_board();
+  EXECUTE v_novo;
+END
+$migration$;
+
+-- ============================================================================
+-- VERIFICACAO APOS APLICAR
+--
+-- A) a coluna esta na assinatura:
+--
+--    select position('premissas_sem_dado' in pg_get_functiondef(p.oid)) > 0
+--    from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+--    where n.nspname = 'public' and p.proname = 'get_futebol_value_board';
+--    -- esperado: true
+--
+-- B) o que a RPC devolve bate com a tabela, linha a linha:
+--
+--    select count(*) as divergentes
+--    from public.get_futebol_value_board() r
+--    join futebol.fact_value_opportunities v
+--      on v.fixture_id = r.fixture_id and v.market = r.market
+--     and v.outcome = r.outcome and v.line_value is not distinct from r.line_value
+--    where r.premissas_sem_dado is distinct from v.premissas_sem_dado::int;
+--    -- esperado: 0
+--
+-- C) nenhuma linha perdida no DROP + recriar:
+--
+--    select (select count(*) from public.get_futebol_value_board()) as da_rpc,
+--           (select count(*) from futebol.fact_value_opportunities) as da_tabela;
+--    -- esperado: iguais
+-- ============================================================================

--- a/supabase/migrations/100_futebol_detalhe_contador_sem_dado.sql
+++ b/supabase/migrations/100_futebol_detalhe_contador_sem_dado.sql
@@ -1,0 +1,114 @@
+-- 100_futebol_detalhe_contador_sem_dado.sql
+--
+-- Ticket #245, segunda metade: o contador tambem chega a tela de DETALHE.
+--
+-- A 099 fez a RPC do board devolver premissas_sem_dado. Esta faz o mesmo na
+-- get_futebol_fixture_value, que alimenta a bancada de mercados do detalhe.
+--
+-- ============================================================================
+-- POR QUE UMA COLUNA, E NAO UMA FRASE DENTRO DE `avisos`
+--
+-- A #241 sugeriu que o aviso coubesse no array `avisos`, que esta funcao ja
+-- monta. Discordo, e o motivo e de produto:
+--
+-- Todo aviso daquele array carrega desconto de pontos entre parenteses
+-- (−30, −12, −15, −10). Sao penalidades de verdade: cada um tira nota.
+--
+-- Este NAO tira. A ADR 0003 e explicita -- dado faltante DIAGNOSTICA, NAO
+-- PENALIZA, e o score nao muda. Se ele entrar no mesmo array, herda a mesma
+-- renderizacao, aparece ao lado de numeros negativos, e passa a comunicar
+-- exatamente o oposto do que existe para dizer: o assinante le "esta aposta e
+-- pior" quando a frase quer dizer "sabemos menos sobre esta aposta".
+--
+-- Expondo o NUMERO, o front decide a forma: sem pontos, sem cor de erro, tom de
+-- ressalva. E o que o ticket #246 exige, e nao daria para cumprir com a frase
+-- pronta vindo de dentro do array.
+--
+-- ============================================================================
+-- ORDEM E CONFLITO
+--
+-- Esta migration vem DEPOIS da 098, que corrigiu o desempate de janela e de
+-- mercado na mesma funcao por substituicao guardada.
+--
+-- Como o corpo aqui e capturado da definicao VIVA, ele ja inclui a correcao da
+-- 098 -- e por isso as duas nao se atropelam. Se esta rodar antes da 098 por
+-- engano, a 098 ainda funciona depois: ela e idempotente e so aplica o patch se
+-- encontrar o texto antigo.
+--
+-- ⚠️ E DROP + recriar, pelo mesmo motivo da 099: acrescentar coluna ao
+--    RETURNS TABLE altera a assinatura. Migration antes do sync.
+--
+-- Mesmo racional da 099 para nao transcrever o corpo: sao 10.295 caracteres,
+-- quase todos frases acentuadas em portugues que o assinante le na tela.
+-- ============================================================================
+
+DO $migration$
+DECLARE
+  v text;
+  v_novo text;
+BEGIN
+  SELECT pg_get_functiondef(p.oid) INTO v
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'get_futebol_fixture_value';
+
+  IF v IS NULL THEN
+    RAISE EXCEPTION 'get_futebol_fixture_value nao existe';
+  END IF;
+
+  IF position('premissas_sem_dado' in v) > 0 THEN
+    RAISE NOTICE 'get_futebol_fixture_value ja devolve premissas_sem_dado. Nada a fazer.';
+    RETURN;
+  END IF;
+
+  IF position('contras text[])' in v) = 0 THEN
+    RAISE EXCEPTION 'get_futebol_fixture_value: nao encontrei o fim do RETURNS TABLE.';
+  END IF;
+
+  IF position(E'], null))[1:3]\n  from futebol.fact_value_opportunities v' in v) = 0 THEN
+    RAISE EXCEPTION 'get_futebol_fixture_value: nao encontrei o fim da projecao.';
+  END IF;
+
+  -- Aviso se a 098 ainda nao rodou: nao impede, mas quem le o log precisa saber.
+  IF position('d.janela_usada is not distinct from v.janela_usada' in v) = 0 THEN
+    RAISE WARNING 'get_futebol_fixture_value ainda nao tem o desempate de janela da 098. Rodar a 098 depois desta.';
+  END IF;
+
+  v_novo := replace(v,
+    'contras text[])',
+    'contras text[], premissas_sem_dado integer)');
+
+  v_novo := replace(v_novo,
+    E'], null))[1:3]\n  from futebol.fact_value_opportunities v',
+    E'], null))[1:3],\n    v.premissas_sem_dado::int\n  from futebol.fact_value_opportunities v');
+
+  IF v_novo = v THEN
+    RAISE EXCEPTION 'get_futebol_fixture_value: nenhuma substituicao aplicada. Abortado.';
+  END IF;
+
+  DROP FUNCTION IF EXISTS public.get_futebol_fixture_value(bigint);
+  EXECUTE v_novo;
+END
+$migration$;
+
+-- ============================================================================
+-- VERIFICACAO APOS APLICAR
+--
+-- A) a coluna esta na assinatura e o desempate da 098 sobreviveu:
+--
+--    select position('premissas_sem_dado' in pg_get_functiondef(p.oid)) > 0 as tem_contador,
+--           position('d.janela_usada is not distinct from v.janela_usada' in pg_get_functiondef(p.oid)) > 0 as manteve_098
+--    from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+--    where n.nspname = 'public' and p.proname = 'get_futebol_fixture_value';
+--    -- esperado: true, true
+--
+-- B) o valor bate com a tabela, e nenhuma linha se perdeu:
+--
+--    with alvos as (select distinct fixture_id from futebol.fact_value_opportunities limit 20)
+--    select count(*) as divergentes
+--    from alvos a, public.get_futebol_fixture_value(a.fixture_id) r
+--    join futebol.fact_value_opportunities v
+--      on v.fixture_id = a.fixture_id and v.market = r.market and v.outcome = r.outcome
+--     and v.line_value is not distinct from r.line_value
+--    where r.premissas_sem_dado is distinct from v.premissas_sem_dado::int;
+--    -- esperado: 0
+-- ============================================================================

--- a/supabase/migrations/100_futebol_detalhe_contador_sem_dado.sql
+++ b/supabase/migrations/100_futebol_detalhe_contador_sem_dado.sql
@@ -55,17 +55,21 @@ BEGIN
     RAISE EXCEPTION 'get_futebol_fixture_value nao existe';
   END IF;
 
-  IF position('premissas_sem_dado' in v) > 0 THEN
+  -- Idempotencia pela ASSINATURA, nao pelo texto inteiro: procurar so por
+  -- 'premissas_sem_dado' casaria com mencao em comentario dentro do corpo.
+  IF position('premissas_sem_dado integer)' in v) > 0 THEN
     RAISE NOTICE 'get_futebol_fixture_value ja devolve premissas_sem_dado. Nada a fazer.';
     RETURN;
   END IF;
 
-  IF position('contras text[])' in v) = 0 THEN
-    RAISE EXCEPTION 'get_futebol_fixture_value: nao encontrei o fim do RETURNS TABLE.';
+  -- Cada ancora tem que aparecer EXATAMENTE UMA VEZ: replace() troca todas as
+  -- ocorrencias, entao ancora repetida corromperia a funcao em silencio.
+  IF array_length(string_to_array(v, 'contras text[])'), 1) - 1 <> 1 THEN
+    RAISE EXCEPTION 'get_futebol_fixture_value: a ancora do RETURNS TABLE nao aparece exatamente uma vez.';
   END IF;
 
-  IF position(E'], null))[1:3]\n  from futebol.fact_value_opportunities v' in v) = 0 THEN
-    RAISE EXCEPTION 'get_futebol_fixture_value: nao encontrei o fim da projecao.';
+  IF array_length(string_to_array(v, E'], null))[1:3]\n  from futebol.fact_value_opportunities v'), 1) - 1 <> 1 THEN
+    RAISE EXCEPTION 'get_futebol_fixture_value: a ancora da projecao nao aparece exatamente uma vez.';
   END IF;
 
   -- Aviso se a 098 ainda nao rodou: nao impede, mas quem le o log precisa saber.
@@ -87,6 +91,11 @@ BEGIN
 
   DROP FUNCTION IF EXISTS public.get_futebol_fixture_value(bigint);
   EXECUTE v_novo;
+
+  -- Mesmo racional da 099: o DROP apaga a ACL. Ha ALTER DEFAULT PRIVILEGES no
+  -- projeto que ja repoe, mas depender de padrao implicito do ambiente para
+  -- restaurar acesso e fragil. Explicito.
+  GRANT EXECUTE ON FUNCTION public.get_futebol_fixture_value(bigint) TO anon, authenticated, service_role;
 END
 $migration$;
 


### PR DESCRIPTION
Fecha **#245**. Destrava **#246** e **#247**.

O Motor já calculava e o Postgres já tinha. **Faltava a RPC devolver.**

A coluna `premissas_sem_dado` está populada nas 7 tabelas de futebol desde 14/08 (`analytics-engineering#41`). Medido no espelho em 15/08: **122 linhas no board, 43 com contador maior que zero**, média 0,70, máximo 7.

A decisão de domínio está na ADR 0003 e é curta: **dado faltante diagnostica, não penaliza.** O score não muda. O que muda é o leitor passar a saber que uma nota baixa pode ser *pouca informação* em vez de *informação contrária*.

## O que mudou

**099** · `get_futebol_value_board()` devolve o contador. E o shape file ganha a coluna nas **7 tabelas** — elas já a receberam por `ALTER` em dev e prod, mas o arquivo que provisiona o schema do zero não sabia, e um provisionamento novo nasceria divergente do BigQuery e **abortaria o sync inteiro** no primeiro parity check.

⚠️ **`bigint`, nunca `integer`**: o parity check canonicaliza `integer` como INT32 contra o INT64 do BigQuery e aborta sozinho por `type_mismatch`.

**100** · `get_futebol_fixture_value()` devolve o contador, para a tela de detalhe.

### Uma discordância deliberada com a #241

A #241 sugeriu que o aviso coubesse dentro do array `avisos`, que essa função já monta. **Não seguimos**, e o motivo é de produto.

Todo aviso daquele array **carrega desconto entre parênteses** (`−30`, `−12`, `−15`, `−10`). São penalidades de verdade: cada um tira nota.

**Este não tira.** Entrando no mesmo array, ele herdaria a mesma renderização, apareceria ao lado de números negativos, e comunicaria **o oposto** do que existe para dizer — o assinante leria *"esta aposta é pior"* onde a frase quer dizer *"sabemos menos sobre esta aposta"*.

Expondo o **número**, o front decide a forma: sem pontos, sem cor de erro, tom de ressalva. É o que a #246 exige, e não daria para cumprir com a frase pronta vindo de dentro do array.

## Por que é DROP + recriar

Acrescentar coluna ao `RETURNS TABLE` **altera a assinatura**, e o Postgres recusa `CREATE OR REPLACE` nesse caso. Não há como evitar.

⚠️ **Ordem de deploy: migration antes do sync.** Invertida, o parity check encontra divergência de schema e derruba as 21 tabelas de uma vez.

## Por que o corpo é capturado da definição viva

Mesmo racional da 098, e aqui mais forte: os corpos têm **5.800 e 10.295 caracteres**, quase todos frases acentuadas em português — são mais de 40 frases de evidência que o assinante lê na tela. Transcrever isso à mão gera erro silencioso: basta um acento trocado para o texto mudar, e o diff não denuncia.

Então o corpo é lido de `pg_get_functiondef`, alterado em dois pontos declarados, e reexecutado. Cada migration **aborta** se não encontrar exatamente os dois pontos, e **não faz nada** se a coluna já estiver lá.

Efeito colateral bom: altera o que estiver no PRD, então não tem como reverter em silêncio uma mudança que só exista lá.

## O que NÃO entra

`premissas_cegas`, a lista de **quais** premissas ficaram cegas, é `ARRAY<STRING>` e o sync pula colunas array, como já pula `evidencias` e `avisos`. Ela não existe no Postgres.

Consequência de produto: **o aviso na tela diz quantas, nunca quais.**

## Verificado no espelho de staging

- a coluna está na assinatura das duas RPCs
- board: **122 linhas da RPC contra 122 da tabela** — nenhuma perdida no `DROP`
- board: **0 divergências** entre o valor da RPC e o da tabela
- detalhe: 34 linhas comparadas, **0 divergências**, 16 com contador
- **o desempate de janela e o de mercado da 098 sobreviveram ao `DROP`** da 100 — era o risco real desta entrega, já que as duas mexem na mesma função
- as evidências acentuadas continuam intactas depois do recriar

## Nota sobre uma segunda mudança de assinatura

A frente **A1 do Redesenho do Score** vai *remover* `pts_valor`, `pts_corroboracao` e `penalidades` dessas mesmas RPCs, o que exige outro `DROP`.

**Decidido não esperar.** A A1 está atrás de outras frentes na fila e pode levar semanas. O custo de não esperar é uma migration a mais; o de esperar é o contador ficar na gaveta com o dado pronto no banco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
