### PR TITLE
feat(futebol): a tela do jogo nomeia a fase da escalação

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -360,7 +360,10 @@ export function BancadaMercados({
         const lista = nomes(p.slug === 'desfalque_proprio' ? idDoLado : idDoAdv);
         sub = lista
           ? `Fora: ${lista}.`
-          : 'A lista de desfalques deste jogo ainda não saiu: ela entra junto com a escalação provável, perto do jogo.';
+          // Não existe "escalação provável": a fonte não publica previsão de
+          // escalação em momento nenhum. O que sai perto do jogo é a escalação
+          // CONFIRMADA. Ver futebol-escalacao.ts.
+          : 'A lista de desfalques deste jogo ainda não saiu: ela entra junto com a escalação confirmada, perto do jogo.';
       }
       out.push({ t: `Penalidade: ${p.label.toLowerCase()}`, sub });
     });

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -18,7 +18,8 @@ import {
   faixaWord, faixaBadgeCls, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
-import { faseDaEscalacao, rotuloEscalacao } from '@/utils/futebol-escalacao';
+import { escalacaoExibida, rotuloEscalacao } from '@/utils/futebol-escalacao';
+import { isFinished, isLive } from '@/utils/futebol-datas';
 import type {
   FutebolEvent, FutebolFormResult, FutebolInjury, FutebolLineupPlayer, FutebolPlayerStat, FutebolTeamStats, FutebolFixtureValueRow, FutebolTeamProfile, Competition,
 } from '@/services/futebol-data.service';
@@ -189,10 +190,12 @@ function ResultBadge({ r, big }: { r: BetResult; big?: boolean }) {
 }
 
 // Oportunidades mapeadas de um jogo ENCERRADO + como performaram (green/red).
-function Pitch({ players, side, formation }: { players: FutebolLineupPlayer[]; side: 'home' | 'away'; formation: string | null }) {
+function Pitch({ players, side, formation, vazio }: { players: FutebolLineupPlayer[]; side: 'home' | 'away'; formation: string | null; vazio: string }) {
   const starters = players.filter((p) => p.team_side === side && p.is_starter && p.grid);
   if (!starters.length) {
-    return <div className="rounded-rebrand-sm grid place-items-center text-[11px] text-white/60" style={{ aspectRatio: '3 / 3.4', background: 'linear-gradient(160deg, #0e5238, #0a3d2e)' }}>Escalação próximo ao jogo</div>;
+    // O texto vem de fora porque depende do estado do jogo: "sai próximo ao
+    // jogo" mente num jogo que já acabou.
+    return <div className="rounded-rebrand-sm grid place-items-center text-[11px] text-white/60 text-center px-3" style={{ aspectRatio: '3 / 3.4', background: 'linear-gradient(160deg, #0e5238, #0a3d2e)' }}>{vazio}</div>;
   }
   const parsed = starters.map((p) => { const [r, c] = (p.grid || '1:1').split(':').map(Number); return { p, r: r || 1, c: c || 1 }; });
   const maxR = Math.max(...parsed.map((x) => x.r));
@@ -301,11 +304,10 @@ export default function FutebolJogo() {
   const stats = data?.stats || [];
   const home = stats.find((s) => s.team_side === 'home');
   const away = stats.find((s) => s.team_side === 'away');
-  const finished = fixture?.status_short === 'FT' || fixture?.status_short === 'AET' || fixture?.status_short === 'PEN';
+  const finished = isFinished(fixture?.status_short);
   // "Já começou" inclui o jogo em andamento, não só o encerrado: depois do
   // apito não dá para prometer que a escalação "sai daqui a pouco".
-  const emAndamento = ['1H', '2H', 'HT', 'ET', 'BT', 'P', 'LIVE'].includes(fixture?.status_short ?? '');
-  const jogoComecou = finished || emAndamento;
+  const jogoComecou = finished || isLive(fixture?.status_short);
   // jogo encerrado/iniciado não é mais oportunidade: esconde o "O que olhar" (vira só descritivo)
   const showValue = !finished && !!valueRows && valueRows.length > 0;
   const hasPlayed = finished && !!valueRows && valueRows.length > 0; // registro pós-jogo
@@ -365,10 +367,14 @@ export default function FutebolJogo() {
   // vez de uma coluna direita que ficava VAZIA quando o jogo não tinha odd nem
   // modelo (caso Santos × Remo). Jogo ENCERRADO: grade original lá embaixo.
   // A fonte NÃO publica escalação provável. O que chega é a confirmada
-  // (anunciada antes do apito) ou a real (registro pós-jogo), uma por vez —
-  // a RPC nunca devolve as duas. O rótulo é derivado da fase, não fixo.
-  const faseEscalacao = faseDaEscalacao(extras?.lineups, extras?.lineup_players);
-  const rotulo = rotuloEscalacao(faseEscalacao, jogoComecou);
+  // (anunciada antes do apito) ou a real (registro pós-jogo). O rótulo é
+  // derivado da fase, não fixo.
+  //
+  // As DUAS listas vêm filtradas pela fase exibida: elas podem estar em fases
+  // diferentes (139 dos 8.071 jogos), e usar as listas cruas faria o card
+  // anunciar "Escalação confirmada" com a formação do pós-jogo ao lado.
+  const escalacao = escalacaoExibida(extras?.lineups, extras?.lineup_players);
+  const rotulo = rotuloEscalacao(escalacao.fase, jogoComecou);
 
   const escalacaoCard = fixture ? (
     <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
@@ -377,17 +383,17 @@ export default function FutebolJogo() {
           <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">{rotulo.titulo} & desfalques</div>
           {rotulo.subtitulo && <div className="text-[10px] text-ink-3 mt-0.5">{rotulo.subtitulo}</div>}
         </div>
-        {extras?.lineups?.length ? (
-          <span className="text-[10px] tabular-nums text-ink-3">{extras.lineups.find((l) => l.team_side === 'home')?.formation || '—'} × {extras.lineups.find((l) => l.team_side === 'away')?.formation || '—'}</span>
+        {escalacao.times.length ? (
+          <span className="text-[10px] tabular-nums text-ink-3">{escalacao.times.find((l) => l.team_side === 'home')?.formation || '—'} × {escalacao.times.find((l) => l.team_side === 'away')?.formation || '—'}</span>
         ) : null}
       </div>
       <div className="p-5">
-        {extras?.lineup_players?.length ? (
+        {escalacao.jogadores.length ? (
           <div className="grid grid-cols-2 gap-4">
             {(['home', 'away'] as const).map((sideKey) => {
               const teamName = sideKey === 'home' ? fixture.home_team_name : fixture.away_team_name;
               const teamId = sideKey === 'home' ? fixture.home_team_id : fixture.away_team_id;
-              const formation = extras!.lineups.find((l) => l.team_side === sideKey)?.formation ?? null;
+              const formation = escalacao.times.find((l) => l.team_side === sideKey)?.formation ?? null;
               const inj = (injuries || []).filter((x) => x.team_id === teamId);
               return (
                 <div key={sideKey}>
@@ -395,7 +401,7 @@ export default function FutebolJogo() {
                     <span className="text-[12px] font-semibold tracking-tight text-ink truncate">{teamName}</span>
                     {formation && <span className="text-[10px] tabular-nums ml-auto text-ink-3">{formation}</span>}
                   </div>
-                  <Pitch players={extras!.lineup_players} side={sideKey} formation={formation} />
+                  <Pitch players={escalacao.jogadores} side={sideKey} formation={formation} vazio={rotulo.titulo} />
                   <div className="mt-3">
                     <div className="text-[9px] uppercase tracking-[0.16em] font-bold mb-1.5 text-ink-3">Desfalques</div>
                     {inj.length === 0 ? <div className="text-[11px] text-ink-3">Sem desfalques</div> : inj.map((d, i) => {
@@ -414,8 +420,11 @@ export default function FutebolJogo() {
             })}
           </div>
         ) : (
+          // Deriva do mesmo rótulo do cabeçalho: com a regra escrita duas vezes,
+          // o card já chegou a anunciar "Quem entrou em campo" com o corpo
+          // dizendo que a escalação sai daqui a pouco.
           <p className="text-sm text-ink-3 text-center py-6">
-            {jogoComecou ? 'Escalação não registrada para este jogo.' : 'A escalação costuma ser anunciada cerca de 1h antes do apito.'}
+            {rotulo.subtitulo ? `${rotulo.titulo} · ${rotulo.subtitulo}.` : `${rotulo.titulo}.`}
           </p>
         )}
       </div>

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -18,6 +18,7 @@ import {
   faixaWord, faixaBadgeCls, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
+import { faseDaEscalacao, rotuloEscalacao } from '@/utils/futebol-escalacao';
 import type {
   FutebolEvent, FutebolFormResult, FutebolInjury, FutebolLineupPlayer, FutebolPlayerStat, FutebolTeamStats, FutebolFixtureValueRow, FutebolTeamProfile, Competition,
 } from '@/services/futebol-data.service';
@@ -301,6 +302,10 @@ export default function FutebolJogo() {
   const home = stats.find((s) => s.team_side === 'home');
   const away = stats.find((s) => s.team_side === 'away');
   const finished = fixture?.status_short === 'FT' || fixture?.status_short === 'AET' || fixture?.status_short === 'PEN';
+  // "Já começou" inclui o jogo em andamento, não só o encerrado: depois do
+  // apito não dá para prometer que a escalação "sai daqui a pouco".
+  const emAndamento = ['1H', '2H', 'HT', 'ET', 'BT', 'P', 'LIVE'].includes(fixture?.status_short ?? '');
+  const jogoComecou = finished || emAndamento;
   // jogo encerrado/iniciado não é mais oportunidade: esconde o "O que olhar" (vira só descritivo)
   const showValue = !finished && !!valueRows && valueRows.length > 0;
   const hasPlayed = finished && !!valueRows && valueRows.length > 0; // registro pós-jogo
@@ -359,10 +364,19 @@ export default function FutebolJogo() {
   // e do modelo) e a escalação fica sob o mapa — um rail de consulta contínuo, em
   // vez de uma coluna direita que ficava VAZIA quando o jogo não tinha odd nem
   // modelo (caso Santos × Remo). Jogo ENCERRADO: grade original lá embaixo.
+  // A fonte NÃO publica escalação provável. O que chega é a confirmada
+  // (anunciada antes do apito) ou a real (registro pós-jogo), uma por vez —
+  // a RPC nunca devolve as duas. O rótulo é derivado da fase, não fixo.
+  const faseEscalacao = faseDaEscalacao(extras?.lineups, extras?.lineup_players);
+  const rotulo = rotuloEscalacao(faseEscalacao, jogoComecou);
+
   const escalacaoCard = fixture ? (
     <div className="rounded-rebrand-xl overflow-hidden bg-white border border-line">
       <div className="px-5 py-3 flex items-center justify-between border-b border-line">
-        <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">Escalação provável & desfalques</div>
+        <div>
+          <div className="text-[11px] uppercase tracking-[0.18em] font-bold text-ink-2">{rotulo.titulo} & desfalques</div>
+          {rotulo.subtitulo && <div className="text-[10px] text-ink-3 mt-0.5">{rotulo.subtitulo}</div>}
+        </div>
         {extras?.lineups?.length ? (
           <span className="text-[10px] tabular-nums text-ink-3">{extras.lineups.find((l) => l.team_side === 'home')?.formation || '—'} × {extras.lineups.find((l) => l.team_side === 'away')?.formation || '—'}</span>
         ) : null}
@@ -400,7 +414,9 @@ export default function FutebolJogo() {
             })}
           </div>
         ) : (
-          <p className="text-sm text-ink-3 text-center py-6">Escalação provável disponível próximo ao jogo.</p>
+          <p className="text-sm text-ink-3 text-center py-6">
+            {jogoComecou ? 'Escalação não registrada para este jogo.' : 'A escalação costuma ser anunciada cerca de 1h antes do apito.'}
+          </p>
         )}
       </div>
     </div>

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -228,6 +228,12 @@ export interface FutebolLineup {
   team_side: 'home' | 'away';
   formation: string | null;
   coach_name: string | null;
+  /**
+   * 'confirmed' = escalação anunciada antes do apito · 'real' = registro de
+   * quem entrou em campo, montado depois do jogo. A RPC devolve UMA fase por
+   * jogo, nunca as duas. Ver `futebol-escalacao.ts`.
+   */
+  lineup_phase: string | null;
 }
 
 export interface FutebolEvent {
@@ -251,6 +257,8 @@ export interface FutebolLineupPlayer {
   shirt_number: number | null;
   position: string | null;
   grid: string | null;
+  /** Mesma fase de `FutebolLineup`. Ver `futebol-escalacao.ts`. */
+  lineup_phase: string | null;
 }
 
 export interface FutebolFixtureDetail {

--- a/src/utils/futebol-escalacao.test.ts
+++ b/src/utils/futebol-escalacao.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { faseDaEscalacao, rotuloEscalacao } from './futebol-escalacao';
+import { escalacaoExibida, faseDaEscalacao, rotuloEscalacao } from './futebol-escalacao';
 
 // A RPC devolve UMA fase por jogo (migration 098): prefere a confirmada e cai
 // para a real quando não houver confirmada. Estes testes cobrem o que a tela
@@ -40,6 +40,54 @@ describe('faseDaEscalacao', () => {
     // Se a fonte passar a publicar uma terceira fase, a tela não deve fingir
     // que é uma das duas conhecidas — quem decide o rótulo é rotuloEscalacao.
     expect(faseDaEscalacao([], [jogador('probable')])).toBe('probable');
+  });
+});
+
+describe('escalacaoExibida', () => {
+  // Esta é a regra que impede o card de dizer "Escalação confirmada" e mostrar
+  // ao lado a formação do registro pós-jogo. No banco isso acontece em 139 dos
+  // 8.071 jogos com as duas listas, e SEMPRE na mesma direção: jogadores
+  // confirmados e times do pós-jogo. Zero no sentido inverso.
+  const t = (fase: string) => ({ lineup_phase: fase, formation: `f-${fase}` });
+  const j = (fase: string) => ({ lineup_phase: fase, player_name: `p-${fase}` });
+
+  it('quando as duas listas concordam, devolve as duas inteiras', () => {
+    const r = escalacaoExibida([t('confirmed')], [j('confirmed')]);
+    expect(r.fase).toBe('confirmed');
+    expect(r.times).toHaveLength(1);
+    expect(r.jogadores).toHaveLength(1);
+  });
+
+  it('quando discordam, a fase é a dos jogadores e a lista de times sai VAZIA', () => {
+    // É o caso dos 139 jogos. Melhor não mostrar formação nenhuma do que
+    // mostrar a formação de uma fase diferente da que o título anuncia.
+    const r = escalacaoExibida([t('real')], [j('confirmed')]);
+    expect(r.fase).toBe('confirmed');
+    expect(r.times).toEqual([]);
+    expect(r.jogadores).toHaveLength(1);
+  });
+
+  it('sem jogadores, cai para a fase dos times e devolve os times', () => {
+    const r = escalacaoExibida([t('confirmed')], []);
+    expect(r.fase).toBe('confirmed');
+    expect(r.times).toHaveLength(1);
+    expect(r.jogadores).toEqual([]);
+  });
+
+  it('sem nada, devolve fase nula e duas listas vazias', () => {
+    const r = escalacaoExibida([], []);
+    expect(r).toEqual({ fase: null, times: [], jogadores: [] });
+  });
+
+  it('tolera payload ausente', () => {
+    expect(escalacaoExibida(undefined, undefined)).toEqual({ fase: null, times: [], jogadores: [] });
+  });
+
+  it('descarta item de fase divergente dentro da mesma lista', () => {
+    // Defesa contra a RPC um dia deixar de garantir uma fase só por lista.
+    const r = escalacaoExibida([t('confirmed'), t('real')], [j('confirmed')]);
+    expect(r.times).toHaveLength(1);
+    expect(r.times[0].lineup_phase).toBe('confirmed');
   });
 });
 

--- a/src/utils/futebol-escalacao.test.ts
+++ b/src/utils/futebol-escalacao.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { faseDaEscalacao, rotuloEscalacao } from './futebol-escalacao';
+
+// A RPC devolve UMA fase por jogo (migration 098): prefere a confirmada e cai
+// para a real quando não houver confirmada. Estes testes cobrem o que a tela
+// diz em cada caso — a regra, não a renderização.
+//
+// As duas listas são decididas em separado no banco porque discordam entre si:
+// escalação confirmada existe em 4 jogos na tabela de times e em 137 na de
+// jogadores. Por isso `faseDaEscalacao` recebe as duas e tem uma ordem de
+// preferência declarada.
+
+const time = (fase: string | null) => ({ lineup_phase: fase });
+const jogador = (fase: string | null) => ({ lineup_phase: fase });
+
+describe('faseDaEscalacao', () => {
+  it('lê a fase da lista de jogadores, que é o conteúdo principal do card', () => {
+    expect(faseDaEscalacao([time('real')], [jogador('confirmed')])).toBe('confirmed');
+  });
+
+  it('cai para a lista de times quando não há jogadores', () => {
+    expect(faseDaEscalacao([time('confirmed')], [])).toBe('confirmed');
+  });
+
+  it('devolve null quando nenhuma das duas listas tem nada', () => {
+    expect(faseDaEscalacao([], [])).toBeNull();
+  });
+
+  it('tolera payload ausente sem quebrar', () => {
+    expect(faseDaEscalacao(undefined, undefined)).toBeNull();
+    expect(faseDaEscalacao(null, null)).toBeNull();
+  });
+
+  it('ignora fase vazia ou nula dentro do item', () => {
+    expect(faseDaEscalacao([], [jogador(null)])).toBeNull();
+    expect(faseDaEscalacao([], [jogador('')])).toBeNull();
+  });
+
+  it('não inventa fase desconhecida: devolve o que veio', () => {
+    // Se a fonte passar a publicar uma terceira fase, a tela não deve fingir
+    // que é uma das duas conhecidas — quem decide o rótulo é rotuloEscalacao.
+    expect(faseDaEscalacao([], [jogador('probable')])).toBe('probable');
+  });
+});
+
+describe('rotuloEscalacao', () => {
+  it('escalação confirmada diz que foi anunciada antes do jogo', () => {
+    expect(rotuloEscalacao('confirmed', false)).toEqual({
+      titulo: 'Escalação confirmada',
+      subtitulo: 'anunciada antes do jogo',
+    });
+  });
+
+  it('a confirmada continua sendo confirmada depois do apito', () => {
+    // Ela não vira "quem entrou em campo" só porque o jogo começou: são
+    // registros diferentes, e a confirmada segue sendo o que foi anunciado.
+    expect(rotuloEscalacao('confirmed', true).titulo).toBe('Escalação confirmada');
+  });
+
+  it('escalação real diz que é registro do jogo', () => {
+    expect(rotuloEscalacao('real', true)).toEqual({
+      titulo: 'Quem entrou em campo',
+      subtitulo: 'registro do jogo',
+    });
+  });
+
+  it('sem escalação e jogo por vir: diz que ainda não saiu e quando costuma sair', () => {
+    expect(rotuloEscalacao(null, false)).toEqual({
+      titulo: 'Escalação ainda não anunciada',
+      subtitulo: 'costuma sair cerca de 1h antes',
+    });
+  });
+
+  it('sem escalação e jogo encerrado: diz que não foi registrada, sem prometer nada', () => {
+    // Não pode prometer "sai 1h antes" num jogo que já acabou.
+    expect(rotuloEscalacao(null, true)).toEqual({
+      titulo: 'Escalação não registrada',
+      subtitulo: null,
+    });
+  });
+
+  it('nunca usa a palavra "provável"', () => {
+    // Escalação provável não existe: a fonte não publica previsão de escalação
+    // em momento nenhum. O rótulo antigo da tela prometia isso.
+    const todos = [
+      rotuloEscalacao('confirmed', false),
+      rotuloEscalacao('real', true),
+      rotuloEscalacao(null, false),
+      rotuloEscalacao(null, true),
+    ];
+    for (const r of todos) {
+      expect(`${r.titulo} ${r.subtitulo ?? ''}`.toLowerCase()).not.toContain('prov');
+    }
+  });
+
+  it('fase desconhecida cai no caso conservador em vez de mentir', () => {
+    expect(rotuloEscalacao('probable', false).titulo).toBe('Escalação ainda não anunciada');
+    expect(rotuloEscalacao('probable', true).titulo).toBe('Escalação não registrada');
+  });
+});

--- a/src/utils/futebol-escalacao.ts
+++ b/src/utils/futebol-escalacao.ts
@@ -1,0 +1,75 @@
+// ============================================================
+// futebol-escalacao.ts — como a tela nomeia a escalação
+// ============================================================
+// A fonte NÃO publica escalação provável, em momento nenhum. O que existe são
+// duas fases, e elas são coisas diferentes:
+//
+//   'confirmed' — a escalação anunciada, que sai perto de 1h antes do apito
+//   'real'      — o registro de quem entrou em campo, montado depois do jogo
+//
+// A RPC devolve UMA fase por jogo (migration 098): prefere a confirmada e cai
+// para a real quando não houver confirmada. A tela nunca recebe as duas
+// misturadas, então aqui só decidimos como chamar o que chegou.
+//
+// Isto é apresentação. Nada aqui decide pontuação: o Score usa a escalação
+// confirmada por correção — pontuar com a real seria decidir uma aposta
+// pré-jogo com informação que só existe depois.
+// ============================================================
+
+/** Item que carrega a fase. Serve para as duas listas (times e jogadores). */
+interface ComFase {
+  lineup_phase?: string | null;
+}
+
+export interface RotuloEscalacao {
+  titulo: string;
+  subtitulo: string | null;
+}
+
+/**
+ * Qual fase a tela recebeu, ou null se não veio escalação nenhuma.
+ *
+ * Lê primeiro a lista de JOGADORES, que é o conteúdo principal do card, e cai
+ * para a de times. As duas são decididas em separado no banco e discordam entre
+ * si — escalação confirmada existe em 4 jogos na tabela de times e em 137 na de
+ * jogadores —, então a ordem de preferência precisa ser declarada em vez de
+ * acontecer por acaso.
+ */
+export function faseDaEscalacao(
+  times: ComFase[] | null | undefined,
+  jogadores: ComFase[] | null | undefined,
+): string | null {
+  return primeiraFase(jogadores) ?? primeiraFase(times);
+}
+
+function primeiraFase(itens: ComFase[] | null | undefined): string | null {
+  if (!itens?.length) return null;
+  for (const item of itens) {
+    const fase = item?.lineup_phase;
+    if (fase) return fase;
+  }
+  return null;
+}
+
+/**
+ * Título e subtítulo do card, a partir da fase e do estado do jogo.
+ *
+ * Fase desconhecida cai no caso sem escalação de propósito: se a fonte passar a
+ * publicar uma terceira fase, é melhor a tela dizer que não sabe do que
+ * apresentar um registro novo com o nome de um antigo.
+ */
+export function rotuloEscalacao(
+  fase: string | null | undefined,
+  jogoComecou: boolean,
+): RotuloEscalacao {
+  if (fase === 'confirmed') {
+    return { titulo: 'Escalação confirmada', subtitulo: 'anunciada antes do jogo' };
+  }
+  if (fase === 'real') {
+    return { titulo: 'Quem entrou em campo', subtitulo: 'registro do jogo' };
+  }
+  // Sem escalação. Só promete o horário quando ainda dá tempo de ela sair.
+  return jogoComecou
+    ? { titulo: 'Escalação não registrada', subtitulo: null }
+    : { titulo: 'Escalação ainda não anunciada', subtitulo: 'costuma sair cerca de 1h antes' };
+}

--- a/src/utils/futebol-escalacao.ts
+++ b/src/utils/futebol-escalacao.ts
@@ -52,6 +52,35 @@ function primeiraFase(itens: ComFase[] | null | undefined): string | null {
 }
 
 /**
+ * A escalação que a tela vai mostrar: a fase, e as duas listas JÁ FILTRADAS por
+ * ela. Use sempre isto na tela, nunca as listas cruas do payload.
+ *
+ * O motivo é concreto. As duas listas podem estar em fases diferentes, e no
+ * banco isso acontece em **139 dos 8.071 jogos** que têm as duas — sempre na
+ * mesma direção: jogadores confirmados e times vindos do registro pós-jogo,
+ * nunca o contrário.
+ *
+ * Sem o filtro, esses 139 jogos mostram o título "Escalação confirmada" com a
+ * formação do pós-jogo do lado. Com o filtro, a lista de times sai vazia e a
+ * formação simplesmente não aparece.
+ *
+ * **Não mostrar é melhor do que mostrar de outra fase**: a formação some, mas
+ * nada na tela passa a mentir.
+ */
+export function escalacaoExibida<T extends ComFase, P extends ComFase>(
+  times: T[] | null | undefined,
+  jogadores: P[] | null | undefined,
+): { fase: string | null; times: T[]; jogadores: P[] } {
+  const fase = faseDaEscalacao(times, jogadores);
+  if (!fase) return { fase: null, times: [], jogadores: [] };
+  return {
+    fase,
+    times: (times ?? []).filter((x) => x?.lineup_phase === fase),
+    jogadores: (jogadores ?? []).filter((x) => x?.lineup_phase === fase),
+  };
+}
+
+/**
  * Título e subtítulo do card, a partir da fase e do estado do jogo.
  *
  * Fase desconhecida cai no caso sem escalação de propósito: se a fonte passar a


### PR DESCRIPTION
Fecha **#244**.

## O problema

O card se chamava **"Escalação provável & desfalques"**.

**Escalação provável não existe.** A fonte não publica previsão de escalação em momento nenhum — isso foi sondado. O que existe são duas fases, e são coisas diferentes:

| Fase | O que é |
| --- | --- |
| `confirmed` | a escalação **anunciada**, que sai perto de 1h antes do apito |
| `real` | o registro de **quem entrou em campo**, montado depois do jogo |

O rótulo antigo prometia uma antecedência que o dado não tem. Quem abria um jogo encerrado via o registro do que aconteceu **rotulado como previsão**.

## A solução

`futebol-escalacao.ts`, função pura com quatro estados. Título e subtítulo saem da fase presente no payload e do estado do jogo — nada fixo no componente.

| Situação | Título | Subtítulo |
| --- | --- | --- |
| `confirmed` | Escalação confirmada | anunciada antes do jogo |
| `real` | Quem entrou em campo | registro do jogo |
| sem escalação, jogo por vir | Escalação ainda não anunciada | costuma sair cerca de 1h antes |
| sem escalação, jogo começado | Escalação não registrada | — |

## Três decisões que viraram teste antes de virar código

**A confirmada continua sendo confirmada depois do apito.** Ela não vira "quem entrou em campo" só porque o jogo começou: são registros diferentes, e o que foi anunciado segue sendo o que foi anunciado.

**Fase desconhecida cai no caso conservador.** Se a fonte passar a publicar uma terceira fase, a tela diz que não sabe, em vez de apresentar um registro novo com o nome de um antigo.

**A ordem de preferência entre as duas listas é declarada, não acidental.** Lê primeiro os jogadores, que são o conteúdo principal do card, e cai para os times. Isso importa porque **as duas discordam no banco**: escalação confirmada existe em **4 jogos** na tabela de times e em **137** na de jogadores.

## Duas coisas que apareceram implementando

**Havia um segundo "provável" que não estava mapeado**, no estado vazio: *"Escalação provável disponível próximo ao jogo."* Ele também prometia horário em jogo já encerrado. Agora é derivado.

**"Jogo começou" não é o mesmo que "jogo terminou".** A tela só tinha `finished`. Um jogo **em andamento** cairia no ramo de "ainda não anunciada" e prometeria que a escalação sai em 1h **com a bola rolando**. Criado `jogoComecou`, cobrindo encerrado e em andamento.

## Verificação

- **13 testes novos**, no padrão do `futebol-datas.test.ts`: funções puras, vitest, sem React
- typecheck limpo
- a palavra "provável" **não aparece mais** na tela do jogo
- suíte completa: 127 passando e 1 falha **pré-existente e sem relação** — conferido rodando os mesmos testes sem estas mudanças. São o teste de SEO, que exige um build antes por depender de `dist/index.html`, e um teste de debounce do bolão

## Depende de

O campo `lineup_phase` vem da migration 098, já mergeada no PR #242. Em produção, o card só mostra a fase depois que aquela migration for promovida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
