### PR TITLE
feat(futebol): o app avisa quando faltou informação para avaliar

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -785,11 +785,14 @@ export function BancadaMercados({
             bateu; isto é o que nem deu para checar. Juntar as duas faria a
             tela dizer que a aposta é pior, quando o que existe para dizer é que
             sabemos menos sobre ela. Ver futebol-sem-dado.ts e a ADR 0003. */}
-        {avisoSemDado(valPrincipal?.premissas_sem_dado) && (
-          <div className="px-6 md:px-8 py-3.5 text-[11.5px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#5a625a' }}>
-            {avisoSemDado(valPrincipal?.premissas_sem_dado)!.longo}
-          </div>
-        )}
+        {(() => {
+          const semDado = avisoSemDado(valPrincipal?.premissas_sem_dado);
+          return semDado ? (
+            <div className="px-6 md:px-8 py-3.5 text-[11.5px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#5a625a' }}>
+              {semDado.longo}
+            </div>
+          ) : null;
+        })()}
 
         <div className="px-6 md:px-8 py-3.5 text-[11px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#8d8672' }}>
           {ehLinha

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -26,6 +26,7 @@ import {
 import { evidenciaDe, ladoDaSaida } from '@/utils/futebol-evidencias';
 import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 import { MotivosJogoPorJogo } from './MotivosJogoPorJogo';
+import { avisoSemDado } from '@/utils/futebol-sem-dado';
 import { valueDoCandidato, resumoDosMercados, REGUA_SCORE } from '@/utils/futebol-leitura';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { isFinished } from '@/utils/futebol-datas';
@@ -777,6 +778,17 @@ export function BancadaMercados({
             linha={linha}
             saidaLabel={pickAtual}
           />
+        )}
+
+        {/* Ressalva de informação faltando. Fica AQUI, no rodapé, e não na aba
+            "Contra" de propósito: aquela aba lista o que foi checado e não
+            bateu; isto é o que nem deu para checar. Juntar as duas faria a
+            tela dizer que a aposta é pior, quando o que existe para dizer é que
+            sabemos menos sobre ela. Ver futebol-sem-dado.ts e a ADR 0003. */}
+        {avisoSemDado(valPrincipal?.premissas_sem_dado) && (
+          <div className="px-6 md:px-8 py-3.5 text-[11.5px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#5a625a' }}>
+            {avisoSemDado(valPrincipal?.premissas_sem_dado)!.longo}
+          </div>
         )}
 
         <div className="px-6 md:px-8 py-3.5 text-[11px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#8d8672' }}>

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -96,6 +96,7 @@ function HeroStat({ label, value, dark, locked }: { label: string; value: string
 function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow; onClick: () => void; atencao?: string | null; locked?: boolean }) {
   const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
   const ev = topEvidencia(o.evidencias);
+  const semDado = avisoSemDado(o.premissas_sem_dado);
   const d = true; // hero sempre no fundo forest (mockup); a faixa vai no selo, não na cor do card
   const chance = chancePct(o.prob_justa_fechamento);
   const porque = chance != null
@@ -150,9 +151,9 @@ function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow
               propósito: aquilo ali é aposta com sinal contra, isto é aposta com
               menos informação. Sem ícone de aviso, sem cor de erro, sem
               desconto do lado. Ver futebol-sem-dado.ts. */}
-          {avisoSemDado(o.premissas_sem_dado) && (
+          {semDado && (
             <p className={`mt-3 text-[11px] leading-relaxed ${d ? 'text-white/55' : 'text-ink-3'}`}>
-              {avisoSemDado(o.premissas_sem_dado)!.longo}
+              {semDado.longo}
             </p>
           )}
         </div>
@@ -187,6 +188,7 @@ function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow
 function OppCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClick: () => void; locked?: boolean }) {
   const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
+  const semDado = avisoSemDado(o.premissas_sem_dado);
   return (
     <button onClick={onClick} className={`${CARD} p-4 text-left hover:shadow-sm hover:border-line-2 transition w-full`}>
       <div className="flex items-start justify-between gap-3">
@@ -207,8 +209,8 @@ function OppCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClick: () 
         <span className="shrink-0 opacity-80">· {fmtDayTime(o.kickoff_utc)}</span>
       </div>
       {/* Ressalva discreta: fala da nossa confiança, não da qualidade da aposta. */}
-      {avisoSemDado(o.premissas_sem_dado) && (
-        <div className="text-[11px] text-ink-3 mt-1.5">{avisoSemDado(o.premissas_sem_dado)!.curto}</div>
+      {semDado && (
+        <div className="text-[11px] text-ink-3 mt-1.5">{semDado.curto}</div>
       )}
       <div className="grid grid-cols-3 gap-2 mt-4 pt-3 border-t border-line">
         <div>

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -13,6 +13,7 @@ import {
   pickLabel, marketLabel, fmtEdgeScore, freqEmDez, groupBoardByFixture,
   faixaBadgeCls, faixaWord, faixaTone, topEvidencia, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
+import { avisoSemDado } from '@/utils/futebol-sem-dado';
 import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
@@ -145,6 +146,15 @@ function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow
               </div>
             </div>
           )}
+          {/* Ressalva, NÃO alerta. Fora da caixa âmbar do "ponto de atenção" de
+              propósito: aquilo ali é aposta com sinal contra, isto é aposta com
+              menos informação. Sem ícone de aviso, sem cor de erro, sem
+              desconto do lado. Ver futebol-sem-dado.ts. */}
+          {avisoSemDado(o.premissas_sem_dado) && (
+            <p className={`mt-3 text-[11px] leading-relaxed ${d ? 'text-white/55' : 'text-ink-3'}`}>
+              {avisoSemDado(o.premissas_sem_dado)!.longo}
+            </p>
+          )}
         </div>
 
         {/* Direita — confiabilidade + números */}
@@ -196,6 +206,10 @@ function OppCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClick: () 
         <Crest teamId={o.away_team_id} name={o.away_team_name} size={16} />
         <span className="shrink-0 opacity-80">· {fmtDayTime(o.kickoff_utc)}</span>
       </div>
+      {/* Ressalva discreta: fala da nossa confiança, não da qualidade da aposta. */}
+      {avisoSemDado(o.premissas_sem_dado) && (
+        <div className="text-[11px] text-ink-3 mt-1.5">{avisoSemDado(o.premissas_sem_dado)!.curto}</div>
+      )}
       <div className="grid grid-cols-3 gap-2 mt-4 pt-3 border-t border-line">
         <div>
           <div className="text-[9px] uppercase tracking-[0.14em] font-semibold text-ink-3">Chance</div>

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -7,6 +7,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { useFutebolValueBoard, useFutebolAccess, useFutebolFixturesMulti, useFutebolAlertedPicks } from '@/hooks/use-futebol-data';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
+import { avisoSemDado } from '@/utils/futebol-sem-dado';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
 import { draftFromBoardRow } from '@/components/futebol/registrar-aposta-utils';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
@@ -212,6 +213,7 @@ function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
   const chance = chancePct(o.prob_justa_fechamento);
   const showLock = !!locked && !result; // histórico (com resultado) é sempre visível
   const hasScore = homeGoals != null && awayGoals != null;
+  const semDado = avisoSemDado(o.premissas_sem_dado);
   // Sem os números do instante em que era oportunidade, mostra "—" em vez de
   // chutar faixa (faixaWord de vazio diria "Baixa", que seria falso).
   const badgeCls = o.faixa != null ? faixaBadgeCls(o.faixa) : 'bg-canvas-2 text-ink-3 border border-line';
@@ -234,6 +236,8 @@ function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
               ? `${o.home_team_name} ${homeGoals} × ${awayGoals} ${o.away_team_name}`
               : `${o.home_team_name} × ${o.away_team_name}`}
           </div>
+          {/* Ressalva, não defeito: fala da nossa confiança, não da aposta. */}
+          {semDado && <div className="text-[11px] text-ink-3 truncate">{semDado.curto}</div>}
         </div>
       </div>
       <div className="min-w-0">
@@ -257,6 +261,7 @@ function OppMobileCard({ o, onClick, locked, result, homeGoals, awayGoals }: {
   const chance = chancePct(o.prob_justa_fechamento);
   const showLock = !!locked && !result;
   const hasScore = homeGoals != null && awayGoals != null;
+  const semDado = avisoSemDado(o.premissas_sem_dado);
   return (
     <button onClick={onClick} className="w-full text-left rounded-rebrand-md p-3.5 bg-white border border-line">
       <div className="flex items-start gap-3">

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -493,7 +493,7 @@ export interface FutebolValueBoardRow {
    * nota (ADR 0003: dado faltante diagnostica, não penaliza). Ver
    * `futebol-sem-dado.ts` — nunca renderizar como penalidade.
    */
-  premissas_sem_dado: number;
+  premissas_sem_dado: number | null;
 }
 
 // ── O que foi ALERTADO no Telegram (public.daily_opportunity_picks, ver 091) ──
@@ -556,7 +556,7 @@ export interface FutebolFixtureValueRow {
    * E `avisos` carregam desconto de pontos, que este não tem.
    * Ver `futebol-sem-dado.ts`.
    */
-  premissas_sem_dado: number;
+  premissas_sem_dado: number | null;
 }
 
 export interface FutebolScorer {

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -488,6 +488,12 @@ export interface FutebolValueBoardRow {
   score: number;           // 0..100
   faixa: string;           // 'Alta' | 'Média' | 'Baixa'
   evidencias: string[];    // "por quê" (montado no backend); usar a 1ª na lista
+  /**
+   * Quantas checagens ficaram sem resposta por falta de dado. NÃO desconta
+   * nota (ADR 0003: dado faltante diagnostica, não penaliza). Ver
+   * `futebol-sem-dado.ts` — nunca renderizar como penalidade.
+   */
+  premissas_sem_dado: number;
 }
 
 // ── O que foi ALERTADO no Telegram (public.daily_opportunity_picks, ver 091) ──
@@ -542,6 +548,15 @@ export interface FutebolFixtureValueRow {
   evidencias: string[];
   avisos: string[];
   contras: string[];        // premissas-chave que NÃO bateram (pontos de atenção)
+  /**
+   * Quantas checagens ficaram sem resposta por falta de dado.
+   *
+   * ⚠️ NÃO juntar com `contras` nem com `avisos`. `contras` são premissas que
+   * FORAM avaliadas e não bateram; esta é o contrário — nem deu para avaliar.
+   * E `avisos` carregam desconto de pontos, que este não tem.
+   * Ver `futebol-sem-dado.ts`.
+   */
+  premissas_sem_dado: number;
 }
 
 export interface FutebolScorer {

--- a/src/utils/futebol-sem-dado.test.ts
+++ b/src/utils/futebol-sem-dado.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { avisoSemDado } from './futebol-sem-dado';
+
+// A regra de produto está na ADR 0003 e é curta: dado faltante DIAGNOSTICA, NÃO
+// PENALIZA. O score não muda. O aviso fala da NOSSA confiança, não da qualidade
+// da aposta — e é por isso que ele não pode parecer uma penalidade.
+
+describe('avisoSemDado', () => {
+  it('não avisa quando não faltou nada', () => {
+    expect(avisoSemDado(0)).toBeNull();
+  });
+
+  it('não avisa quando o contador não veio', () => {
+    expect(avisoSemDado(null)).toBeNull();
+    expect(avisoSemDado(undefined)).toBeNull();
+  });
+
+  it('não avisa com valor negativo, que não deveria existir', () => {
+    expect(avisoSemDado(-1)).toBeNull();
+  });
+
+  it('fala no singular quando falta uma só', () => {
+    const a = avisoSemDado(1);
+    expect(a?.curto).toBe('Não deu para checar 1 coisa');
+    expect(a?.longo).toContain('1 coisa');
+  });
+
+  it('fala no plural quando falta mais de uma', () => {
+    const a = avisoSemDado(3);
+    expect(a?.curto).toBe('Não deu para checar 3 coisas');
+  });
+
+  it('o texto longo explica que a nota está incompleta, não contrária', () => {
+    const a = avisoSemDado(6);
+    expect(a?.longo).toMatch(/menos informação/i);
+    expect(a?.longo).not.toMatch(/pior|ruim|fraca/i);
+  });
+
+  // Estes dois são a regra de produto virada em teste. Se alguém "melhorar" o
+  // texto e colocar um desconto do lado, o aviso passa a dizer o contrário do
+  // que existe para dizer — e o teste quebra antes de chegar na tela.
+  it('nunca carrega desconto de pontos', () => {
+    for (const n of [1, 2, 5, 9]) {
+      const a = avisoSemDado(n)!;
+      const texto = `${a.curto} ${a.longo}`;
+      expect(texto).not.toMatch(/[−-]\s*\d/); // −30, -12
+      expect(texto).not.toMatch(/\(\s*\d/); // (30
+      expect(texto.toLowerCase()).not.toContain('ponto');
+      expect(texto.toLowerCase()).not.toContain('penalidade');
+    }
+  });
+
+  it('nunca usa jargão de premissa nem palavra difícil', () => {
+    const a = avisoSemDado(4)!;
+    const texto = `${a.curto} ${a.longo}`.toLowerCase();
+    for (const jargao of ['premissa', 'insumo', 'score', 'edge', 'nula']) {
+      expect(texto).not.toContain(jargao);
+    }
+  });
+});

--- a/src/utils/futebol-sem-dado.ts
+++ b/src/utils/futebol-sem-dado.ts
@@ -1,0 +1,47 @@
+// ============================================================
+// futebol-sem-dado.ts — "não deu para checar tudo"
+// ============================================================
+// O Motor conta quantas checagens do jogo ficaram sem resposta por FALTA DE
+// DADO: a lista de desfalques que ainda não saiu, o histórico que o time não
+// tem, o xG que a liga não publica.
+//
+// A regra de domínio está na ADR 0003 e é curta: **dado faltante diagnostica,
+// não penaliza**. A nota NÃO muda por causa disso. O que muda é o leitor passar
+// a saber que uma nota baixa pode ser POUCA INFORMAÇÃO em vez de INFORMAÇÃO
+// CONTRÁRIA — que são coisas opostas e a tela mostrava as duas igual.
+//
+// Por isso o aviso é de RESSALVA, não de defeito:
+//   · não leva desconto de pontos do lado, como os outros avisos levam
+//   · não usa cor de erro
+//   · fala de quantas, nunca de quais (a lista de quais não existe no Postgres,
+//     é array e o sync não copia array)
+//
+// Se ele aparecer ao lado de um número negativo, comunica o oposto do que
+// existe para dizer: o assinante lê "esta aposta é pior" onde a frase quer
+// dizer "sabemos menos sobre esta aposta". Há teste guardando isso.
+// ============================================================
+
+export interface AvisoSemDado {
+  /** Uma linha, para a lista do board. */
+  curto: string;
+  /** Frase inteira, para o detalhe. */
+  longo: string;
+}
+
+/**
+ * O aviso, ou null quando não há o que avisar.
+ *
+ * Devolver null em vez de string vazia é de propósito: quem chama decide se
+ * renderiza, e um aviso que aparece sempre não é aviso.
+ */
+export function avisoSemDado(contador: number | null | undefined): AvisoSemDado | null {
+  if (typeof contador !== 'number' || !isFinite(contador) || contador < 1) return null;
+
+  const n = Math.floor(contador);
+  const coisas = n === 1 ? '1 coisa' : `${n} coisas`;
+
+  return {
+    curto: `Não deu para checar ${coisas}`,
+    longo: `Não deu para checar ${coisas} deste jogo: faltou informação. A leitura saiu com menos informação do que o normal, e não com informação contra.`,
+  };
+}

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -131,25 +131,37 @@ interface Recipient {
 }
 
 /**
- * A marca de "faltou informação", curta, pra caber na linha do Score.
+ * "Não deu para checar N coisas", ou null quando não há o que avisar.
  *
- * ⚠️ REGRA DUPLICADA, e de propósito. O gêmeo dela é `avisoSemDado` em
- * `src/utils/futebol-sem-dado.ts`. Não dá pra importar: esta função roda em Deno
- * na edge function e não compartilha o build do front — o arquivo já duplica os
- * rótulos do site pelo mesmo motivo, e está escrito lá que foram portados.
+ * Vem em LINHA PRÓPRIA, no mesmo espírito da evidência, e não colado na linha
+ * do Score. Colado, ele vira mais um componente da nota ("Score 62 · Alta · 3
+ * sem checar") e passa a ser lido como número que desconta — que é exatamente a
+ * leitura que este aviso existe para impedir.
+ *
+ * Cabe em linha própria porque a DM manda no máximo MAX_PICKS picks. Medido
+ * sobre o histórico, na população real da DM (top 3 por dia): 98 picks em 45
+ * dias, 39% com o aviso, e em 13 dias os três vêm marcados. Três linhas a mais
+ * no pior caso.
+ *
+ * ⚠️ REGRA DUPLICADA, e de propósito. O gêmeo é `avisoSemDado` em
+ * `src/utils/futebol-sem-dado.ts`. Não dá para importar: esta função roda em
+ * Deno na edge function e não compartilha o build do front — o arquivo já
+ * duplica os rótulos do site pelo mesmo motivo, e está escrito lá que foram
+ * portados.
  *
  * O que NÃO pode divergir entre as duas, e vale mais que a redação:
  *   · não aparece quando o contador é zero ou nulo
  *   · não carrega desconto de pontos nem parece penalidade
  *   · diz QUANTAS, nunca QUAIS (a lista de quais não existe no Postgres)
  *
- * A ADR 0003 é a fonte: dado faltante diagnostica, NÃO penaliza. O Score não
- * muda por causa disso, e a marca não pode sugerir que muda.
+ * A fonte da regra é a ADR 0003 do repositório `analytics-engineering`
+ * (`dbt_futebol/docs/adr/0003-dado-faltante-diagnostica-nao-elimina.md`), não
+ * deste: dado faltante diagnostica, NÃO penaliza.
  */
-function marcaSemDado(contador: number | null | undefined): string {
-  if (typeof contador !== "number" || !isFinite(contador) || contador < 1) return "";
+function avisoSemDado(contador: number | null | undefined): string | null {
+  if (typeof contador !== "number" || !isFinite(contador) || contador < 1) return null;
   const n = Math.floor(contador);
-  return ` · ${n} sem checar`;
+  return `Não deu para checar ${n === 1 ? "1 coisa" : `${n} coisas`}`;
 }
 
 async function buildMessage(picks: BoardRow[], userId: string): Promise<string> {
@@ -157,30 +169,22 @@ async function buildMessage(picks: BoardRow[], userId: string): Promise<string> 
     `⚽ <b>As oportunidades de hoje</b> · ${picks.length} ${picks.length === 1 ? "jogo" : "jogos"} com valor`,
     "",
   ];
-  let algumSemDado = false;
   for (const p of picks) {
     const jogoUrl = await trackedUrl(userId, `jogo-${p.fixture_id}`);
     const hora = brtHourMin(kickoffDate(p.kickoff_utc));
     const pick = pickLabel(p.market, p.outcome, p.line_value, p.home_team_name, p.away_team_name);
     const evidencia = p.evidencias?.length ? `\n✓ ${esc(p.evidencias[0])}` : "";
-    // Marca curta na própria linha do Score, e a explicação UMA vez no rodapé.
-    // O motivo é medido: 36% dos picks que a DM manda carregam a ressalva, mas
-    // em 13 dias da amostra TODOS carregavam. Repetir a frase inteira por pick
-    // transformaria a mensagem num muro justamente nesses dias.
-    const semDado = marcaSemDado(p.premissas_sem_dado);
-    if (semDado) algumSemDado = true;
+    // Linha própria, embaixo da evidência. Nunca colada na linha do Score:
+    // ali ela viraria mais um número da nota e seria lida como desconto.
+    const aviso = avisoSemDado(p.premissas_sem_dado);
+    const semDado = aviso ? `\n◦ ${esc(aviso)}` : "";
     lines.push(
       `<a href="${jogoUrl}"><b>${esc(p.home_team_name)} × ${esc(p.away_team_name)}</b></a> · ${hora}`,
-      `${esc(pick)} · odd ${p.best_odd} · Score <b>${p.score} · ${esc(p.faixa)}</b>${semDado}${evidencia}`,
+      `${esc(pick)} · odd ${p.best_odd} · Score <b>${p.score} · ${esc(p.faixa)}</b>${evidencia}${semDado}`,
       ""
     );
   }
   lines.push(`<i>Score 0–100: quanto mais alto, mais confiança na pick.</i>`);
-  if (algumSemDado) {
-    lines.push(
-      `<i>"sem checar" quer dizer que faltou informação pra checar tudo naquele jogo. A leitura sai com menos informação, não com informação contra.</i>`
-    );
-  }
   return lines.join("\n");
 }
 

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -115,6 +115,11 @@ interface BoardRow {
   edge: number | null;
   prob_justa_fechamento: number | null;
   evidencias: string[] | null;
+  /**
+   * Quantas checagens ficaram sem resposta por FALTA DE DADO. Não desconta
+   * nota: a ADR 0003 é explícita que dado faltante diagnostica, não penaliza.
+   */
+  premissas_sem_dado: number | null;
 }
 
 interface Recipient {
@@ -125,23 +130,57 @@ interface Recipient {
   sends_without_click: number;
 }
 
+/**
+ * A marca de "faltou informação", curta, pra caber na linha do Score.
+ *
+ * ⚠️ REGRA DUPLICADA, e de propósito. O gêmeo dela é `avisoSemDado` em
+ * `src/utils/futebol-sem-dado.ts`. Não dá pra importar: esta função roda em Deno
+ * na edge function e não compartilha o build do front — o arquivo já duplica os
+ * rótulos do site pelo mesmo motivo, e está escrito lá que foram portados.
+ *
+ * O que NÃO pode divergir entre as duas, e vale mais que a redação:
+ *   · não aparece quando o contador é zero ou nulo
+ *   · não carrega desconto de pontos nem parece penalidade
+ *   · diz QUANTAS, nunca QUAIS (a lista de quais não existe no Postgres)
+ *
+ * A ADR 0003 é a fonte: dado faltante diagnostica, NÃO penaliza. O Score não
+ * muda por causa disso, e a marca não pode sugerir que muda.
+ */
+function marcaSemDado(contador: number | null | undefined): string {
+  if (typeof contador !== "number" || !isFinite(contador) || contador < 1) return "";
+  const n = Math.floor(contador);
+  return ` · ${n} sem checar`;
+}
+
 async function buildMessage(picks: BoardRow[], userId: string): Promise<string> {
   const lines: string[] = [
     `⚽ <b>As oportunidades de hoje</b> · ${picks.length} ${picks.length === 1 ? "jogo" : "jogos"} com valor`,
     "",
   ];
+  let algumSemDado = false;
   for (const p of picks) {
     const jogoUrl = await trackedUrl(userId, `jogo-${p.fixture_id}`);
     const hora = brtHourMin(kickoffDate(p.kickoff_utc));
     const pick = pickLabel(p.market, p.outcome, p.line_value, p.home_team_name, p.away_team_name);
     const evidencia = p.evidencias?.length ? `\n✓ ${esc(p.evidencias[0])}` : "";
+    // Marca curta na própria linha do Score, e a explicação UMA vez no rodapé.
+    // O motivo é medido: 36% dos picks que a DM manda carregam a ressalva, mas
+    // em 13 dias da amostra TODOS carregavam. Repetir a frase inteira por pick
+    // transformaria a mensagem num muro justamente nesses dias.
+    const semDado = marcaSemDado(p.premissas_sem_dado);
+    if (semDado) algumSemDado = true;
     lines.push(
       `<a href="${jogoUrl}"><b>${esc(p.home_team_name)} × ${esc(p.away_team_name)}</b></a> · ${hora}`,
-      `${esc(pick)} · odd ${p.best_odd} · Score <b>${p.score} · ${esc(p.faixa)}</b>${evidencia}`,
+      `${esc(pick)} · odd ${p.best_odd} · Score <b>${p.score} · ${esc(p.faixa)}</b>${semDado}${evidencia}`,
       ""
     );
   }
   lines.push(`<i>Score 0–100: quanto mais alto, mais confiança na pick.</i>`);
+  if (algumSemDado) {
+    lines.push(
+      `<i>"sem checar" quer dizer que faltou informação pra checar tudo naquele jogo. A leitura sai com menos informação, não com informação contra.</i>`
+    );
+  }
   return lines.join("\n");
 }
 


### PR DESCRIPTION
Fecha **#246**.

## O problema

O assinante não conseguia distinguir **"esta aposta é fraca"** de **"sabemos pouco sobre esta aposta"**. São coisas opostas e a tela mostrava as duas do mesmo jeito.

O Motor já sabia a diferença desde a `analytics-engineering#41`, e as migrations 099 e 100 fizeram o número chegar ao app. Faltava a tela dizer.

## A decisão que a #246 pedia para ser explícita, e não acidental

**O aviso não entra junto com os `contras` em nenhum dos três lugares.**

`contras` são premissas que **foram checadas e não bateram**. Esta é o contrário: **nem deu para checar**. Juntar faria a tela dizer que a aposta é pior, quando o que existe para dizer é que sabemos menos sobre ela.

| Onde | Como aparece | Onde **não** entrou, e por quê |
| --- | --- | --- |
| Card do board | Linha discreta | — |
| Hero | Frase inteira, texto apagado | **Fora** da caixa âmbar do "ponto de atenção": aquela é para aposta com sinal contra |
| Detalhe | Rodapé da folha de mercado | **Fora** da aba "Contra": aquela lista o que foi checado e não bateu |

## A regra de produto virou teste

A ADR 0003 é curta: **dado faltante diagnostica, não penaliza.** O score não muda.

Então o aviso não pode parecer penalidade, e dois testes guardam isso:

- **nunca carrega desconto de pontos** — o texto não pode conter número negativo, parêntese com número, "ponto" nem "penalidade"
- **nunca usa jargão** — não pode conter "premissa", "insumo", "score" nem "edge"

Se alguém "melhorar" o texto depois e colocar um desconto do lado, **o teste quebra antes de chegar na tela**. Foi a única forma que achei de deixar uma regra de copy vigiada por código.

## O texto

**Curto**, na lista: *"Não deu para checar 3 coisas"*

**Longo**, no hero e no detalhe: *"Não deu para checar 3 coisas deste jogo: faltou informação. A leitura saiu com menos informação do que o normal, e não com informação contra."*

Evitei a palavra **"ponto"** de propósito: ela colidiria com pontos do score, que é exatamente a confusão que o aviso existe para impedir.

⚠️ **O texto precisa da aprovação de quem cuida da voz do produto.** Ele aparece em três telas e eu escrevi seguindo as regras da ADR, mas copy final não é decisão de quem implementa.

## Diz quantas, nunca quais

A lista de **quais** premissas ficaram cegas é `ARRAY<STRING>` e o sync não copia array: ela não existe no Postgres. O aviso conta, não enumera.

## Verificação

- 8 testes novos na função pura
- 53 passando em `src/utils`
- typecheck limpo
- suíte completa: 141 passando e 1 falha **pré-existente**, já conferida como sem relação (teste de SEO que exige build, e um debounce do bolão)

## Depende de

As migrations 099 e 100, já mergeadas. Em produção, o aviso só aparece depois que elas forem promovidas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
