### PR TITLE
fix(lp): a landing não promete "escalação provável", que não existe

### DIFF
--- a/src/pages/FutebolLP.tsx
+++ b/src/pages/FutebolLP.tsx
@@ -430,7 +430,10 @@ const FutebolLP = () => {
               {
                 num: "04",
                 title: "A leitura do jogo inteira",
-                text: "Modelo de gols, escalação provável, desfalques, confrontos diretos e estatísticas da temporada — pra você bater o martelo com o jogo na frente, não no escuro.",
+                // "Escalação provável" não existe: a fonte não publica previsão
+                // de escalação em momento nenhum. O que sai antes do apito é a
+                // CONFIRMADA. Ver src/utils/futebol-escalacao.ts.
+                text: "Modelo de gols, escalação confirmada, desfalques, confrontos diretos e estatísticas da temporada — pra você bater o martelo com o jogo na frente, não no escuro.",
               },
             ].map((f) => (
               <div key={f.num} className="grid grid-cols-[56px_1fr] sm:grid-cols-[88px_1fr] gap-4 sm:gap-8 py-7 border-t border-line last:border-b">


### PR DESCRIPTION
A LP vendia **"modelo de gols, escalação provável, desfalques..."** como recurso.

A fonte **não publica previsão de escalação em momento nenhum** — isso foi sondado. O que existe é a **confirmada**, que sai perto de 1h antes do apito, e a **real**, que é o registro pós-jogo.

Vender "provável" promete uma antecedência que o dado não tem, e o assinante que entra por causa disso não acha na tela.

**Uma palavra trocada.** O recurso continua existindo e continua bom, só passa a ser chamado pelo nome certo — o mesmo que a tela do jogo usa desde o PR #249.

Achado durante a revisão do #249, e deixado de fora daquele PR de propósito: copy de venda não é escopo de ticket técnico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)