### PR TITLE
fix(futebol): aviso de premissa sem dado sai da vitrine, fica na folha

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -789,7 +789,7 @@ export function BancadaMercados({
           const semDado = avisoSemDado(valPrincipal?.premissas_sem_dado);
           return semDado ? (
             <div className="px-6 md:px-8 py-3.5 text-[11.5px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#5a625a' }}>
-              {semDado.longo}
+              {semDado}
             </div>
           ) : null;
         })()}

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -13,7 +13,6 @@ import {
   pickLabel, marketLabel, fmtEdgeScore, freqEmDez, groupBoardByFixture,
   faixaBadgeCls, faixaWord, faixaTone, topEvidencia, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
-import { avisoSemDado } from '@/utils/futebol-sem-dado';
 import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
@@ -96,7 +95,6 @@ function HeroStat({ label, value, dark, locked }: { label: string; value: string
 function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow; onClick: () => void; atencao?: string | null; locked?: boolean }) {
   const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
   const ev = topEvidencia(o.evidencias);
-  const semDado = avisoSemDado(o.premissas_sem_dado);
   const d = true; // hero sempre no fundo forest (mockup); a faixa vai no selo, não na cor do card
   const chance = chancePct(o.prob_justa_fechamento);
   const porque = chance != null
@@ -147,15 +145,6 @@ function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow
               </div>
             </div>
           )}
-          {/* Ressalva, NÃO alerta. Fora da caixa âmbar do "ponto de atenção" de
-              propósito: aquilo ali é aposta com sinal contra, isto é aposta com
-              menos informação. Sem ícone de aviso, sem cor de erro, sem
-              desconto do lado. Ver futebol-sem-dado.ts. */}
-          {semDado && (
-            <p className={`mt-3 text-[11px] leading-relaxed ${d ? 'text-white/55' : 'text-ink-3'}`}>
-              {semDado.longo}
-            </p>
-          )}
         </div>
 
         {/* Direita — confiabilidade + números */}
@@ -188,7 +177,6 @@ function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow
 function OppCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClick: () => void; locked?: boolean }) {
   const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
-  const semDado = avisoSemDado(o.premissas_sem_dado);
   return (
     <button onClick={onClick} className={`${CARD} p-4 text-left hover:shadow-sm hover:border-line-2 transition w-full`}>
       <div className="flex items-start justify-between gap-3">
@@ -208,10 +196,6 @@ function OppCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClick: () 
         <Crest teamId={o.away_team_id} name={o.away_team_name} size={16} />
         <span className="shrink-0 opacity-80">· {fmtDayTime(o.kickoff_utc)}</span>
       </div>
-      {/* Ressalva discreta: fala da nossa confiança, não da qualidade da aposta. */}
-      {semDado && (
-        <div className="text-[11px] text-ink-3 mt-1.5">{semDado.curto}</div>
-      )}
       <div className="grid grid-cols-3 gap-2 mt-4 pt-3 border-t border-line">
         <div>
           <div className="text-[9px] uppercase tracking-[0.14em] font-semibold text-ink-3">Chance</div>

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -7,7 +7,6 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { useFutebolValueBoard, useFutebolAccess, useFutebolFixturesMulti, useFutebolAlertedPicks } from '@/hooks/use-futebol-data';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
-import { avisoSemDado } from '@/utils/futebol-sem-dado';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
 import { draftFromBoardRow } from '@/components/futebol/registrar-aposta-utils';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
@@ -213,7 +212,6 @@ function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
   const chance = chancePct(o.prob_justa_fechamento);
   const showLock = !!locked && !result; // histórico (com resultado) é sempre visível
   const hasScore = homeGoals != null && awayGoals != null;
-  const semDado = avisoSemDado(o.premissas_sem_dado);
   // Sem os números do instante em que era oportunidade, mostra "—" em vez de
   // chutar faixa (faixaWord de vazio diria "Baixa", que seria falso).
   const badgeCls = o.faixa != null ? faixaBadgeCls(o.faixa) : 'bg-canvas-2 text-ink-3 border border-line';
@@ -236,8 +234,6 @@ function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
               ? `${o.home_team_name} ${homeGoals} × ${awayGoals} ${o.away_team_name}`
               : `${o.home_team_name} × ${o.away_team_name}`}
           </div>
-          {/* Ressalva, não defeito: fala da nossa confiança, não da aposta. */}
-          {semDado && <div className="text-[11px] text-ink-3 truncate">{semDado.curto}</div>}
         </div>
       </div>
       <div className="min-w-0">
@@ -261,7 +257,6 @@ function OppMobileCard({ o, onClick, locked, result, homeGoals, awayGoals }: {
   const chance = chancePct(o.prob_justa_fechamento);
   const showLock = !!locked && !result;
   const hasScore = homeGoals != null && awayGoals != null;
-  const semDado = avisoSemDado(o.premissas_sem_dado);
   return (
     <button onClick={onClick} className="w-full text-left rounded-rebrand-md p-3.5 bg-white border border-line">
       <div className="flex items-start gap-3">

--- a/src/utils/futebol-sem-dado.test.ts
+++ b/src/utils/futebol-sem-dado.test.ts
@@ -3,7 +3,7 @@ import { avisoSemDado } from './futebol-sem-dado';
 
 // A regra de produto está na ADR 0003 e é curta: dado faltante DIAGNOSTICA, NÃO
 // PENALIZA. O score não muda. O aviso fala da NOSSA confiança, não da qualidade
-// da aposta — e é por isso que ele não pode parecer uma penalidade.
+// da aposta, e é por isso que ele não pode parecer uma penalidade.
 
 describe('avisoSemDado', () => {
   it('não avisa quando não faltou nada', () => {
@@ -20,29 +20,25 @@ describe('avisoSemDado', () => {
   });
 
   it('fala no singular quando falta uma só', () => {
-    const a = avisoSemDado(1);
-    expect(a?.curto).toBe('Não deu para checar 1 coisa');
-    expect(a?.longo).toContain('1 coisa');
+    expect(avisoSemDado(1)).toContain('1 premissa ');
   });
 
   it('fala no plural quando falta mais de uma', () => {
-    const a = avisoSemDado(3);
-    expect(a?.curto).toBe('Não deu para checar 3 coisas');
+    expect(avisoSemDado(3)).toContain('3 premissas');
   });
 
-  it('o texto longo explica que a nota está incompleta, não contrária', () => {
-    const a = avisoSemDado(6);
-    expect(a?.longo).toMatch(/menos informação/i);
-    expect(a?.longo).not.toMatch(/pior|ruim|fraca/i);
+  it('explica que a nota está incompleta, não contrária', () => {
+    const a = avisoSemDado(6)!;
+    expect(a).toMatch(/menos informação/i);
+    expect(a).not.toMatch(/pior|ruim|fraca/i);
   });
 
-  // Estes dois são a regra de produto virada em teste. Se alguém "melhorar" o
-  // texto e colocar um desconto do lado, o aviso passa a dizer o contrário do
-  // que existe para dizer — e o teste quebra antes de chegar na tela.
+  // Este é a regra de produto virada em teste. Se alguém "melhorar" o texto e
+  // colocar um desconto do lado, o aviso passa a dizer o contrário do que
+  // existe para dizer, e o teste quebra antes de chegar na tela.
   it('nunca carrega desconto de pontos', () => {
     for (const n of [1, 2, 5, 9]) {
-      const a = avisoSemDado(n)!;
-      const texto = `${a.curto} ${a.longo}`;
+      const texto = avisoSemDado(n)!;
       expect(texto).not.toMatch(/[−-]\s*\d/); // −30, -12
       expect(texto).not.toMatch(/\(\s*\d/); // (30
       expect(texto.toLowerCase()).not.toContain('ponto');
@@ -50,11 +46,21 @@ describe('avisoSemDado', () => {
     }
   });
 
-  it('nunca usa jargão de premissa nem palavra difícil', () => {
-    const a = avisoSemDado(4)!;
-    const texto = `${a.curto} ${a.longo}`.toLowerCase();
-    for (const jargao of ['premissa', 'insumo', 'score', 'edge', 'nula']) {
+  // "premissa" NÃO está nesta lista, e isso é decisão, não esquecimento: a
+  // própria folha de mercado diz "3 premissas a favor" logo acima deste aviso.
+  // A palavra é vocabulário da tela, então usá-la aqui deixa o texto mais
+  // concreto, não mais técnico. O que continua proibido é o vocabulário do
+  // motor, que o assinante nunca viu.
+  it('nunca usa palavra de bastidor', () => {
+    const texto = avisoSemDado(4)!.toLowerCase();
+    for (const jargao of ['insumo', 'score', 'edge', 'nula', 'null']) {
       expect(texto).not.toContain(jargao);
     }
+  });
+
+  // "checar" saiu a pedido do Victor: palavra feia para o público. "conferir"
+  // faz o mesmo trabalho e soa como gente falando.
+  it('não usa "checar"', () => {
+    expect(avisoSemDado(2)!.toLowerCase()).not.toContain('checar');
   });
 });

--- a/src/utils/futebol-sem-dado.ts
+++ b/src/utils/futebol-sem-dado.ts
@@ -1,32 +1,52 @@
 // ============================================================
-// futebol-sem-dado.ts — "não deu para checar tudo"
+// futebol-sem-dado.ts — "não deu para conferir tudo"
 // ============================================================
-// O Motor conta quantas checagens do jogo ficaram sem resposta por FALTA DE
+// O Motor conta quantas premissas do jogo ficaram sem resposta por FALTA DE
 // DADO: a lista de desfalques que ainda não saiu, o histórico que o time não
 // tem, o xG que a liga não publica.
 //
-// A regra de domínio está na ADR 0003 e é curta: **dado faltante diagnostica,
-// não penaliza**. A nota NÃO muda por causa disso. O que muda é o leitor passar
-// a saber que uma nota baixa pode ser POUCA INFORMAÇÃO em vez de INFORMAÇÃO
-// CONTRÁRIA — que são coisas opostas e a tela mostrava as duas igual.
+// O leitor passa a saber que uma nota baixa pode ser POUCA INFORMAÇÃO em vez de
+// INFORMAÇÃO CONTRÁRIA — que são coisas opostas e a tela mostrava as duas igual.
 //
 // Por isso o aviso é de RESSALVA, não de defeito:
 //   · não leva desconto de pontos do lado, como os outros avisos levam
 //   · não usa cor de erro
-//   · fala de quantas, nunca de quais (a lista de quais não existe no Postgres,
-//     é array e o sync não copia array)
+//   · fala de quantas, nunca de quais (os nomes não chegam no Postgres; ver
+//     "Por que só o número" abaixo)
 //
 // Se ele aparecer ao lado de um número negativo, comunica o oposto do que
 // existe para dizer: o assinante lê "esta aposta é pior" onde a frase quer
 // dizer "sabemos menos sobre esta aposta". Há teste guardando isso.
+//
+// ------------------------------------------------------------
+// POR QUE SÓ NA FOLHA DE MERCADO (decisão do Victor, 15/08/2026)
+// ------------------------------------------------------------
+// O aviso já esteve na lista do board, no destaque do dia e na DM do Betinho.
+// Saiu dos três, medido: aparecia em 1 de cada 3 linhas do board, e a distância
+// de Score entre "tudo conferido" e "6+ sem dado" é de 4 pontos. Aviso em um
+// terço da tela sobre algo que move 4 pontos é ruído, e "3 premissas" sem os
+// nomes não é acionável.
+//
+// Fica na folha de mercado porque ali o leitor já está lendo premissa por
+// premissa e vê a lista curta. A linha não é aviso, é o rodapé fechando uma
+// conta que ele está fazendo na frente dele.
+//
+// ------------------------------------------------------------
+// POR QUE SÓ O NÚMERO, E O QUE DESTRAVARIA OS NOMES
+// ------------------------------------------------------------
+// Não é limitação da nossa camada, e não adianta procurar aqui. Cada premissa é
+// uma coluna booleana em `futebol.int_futebol_premissas_*`, e quando o insumo
+// não existe ela chega como `false`, não como `null`. Conferido:
+//
+//   select forca_mismatch, superioridade_xg, mando, desfalque_adversario
+//   from futebol.int_futebol_premissas_1x2 where premissas_sem_dado = 7;
+//   -- as sete voltam false, nenhuma null
+//
+// Ou seja, o achatamento acontece no dbt e os nomes já chegam apagados. Só o
+// contador atravessa. Pedido aberto com o Matheus na task [C] do ClickUp; se os
+// nomes vierem, este arquivo passa a dizer "faltou a escalação" e aí volta a
+// discussão de mostrar na vitrine.
 // ============================================================
-
-export interface AvisoSemDado {
-  /** Uma linha, para a lista do board. */
-  curto: string;
-  /** Frase inteira, para o detalhe. */
-  longo: string;
-}
 
 /**
  * O aviso, ou null quando não há o que avisar.
@@ -34,14 +54,11 @@ export interface AvisoSemDado {
  * Devolver null em vez de string vazia é de propósito: quem chama decide se
  * renderiza, e um aviso que aparece sempre não é aviso.
  */
-export function avisoSemDado(contador: number | null | undefined): AvisoSemDado | null {
+export function avisoSemDado(contador: number | null | undefined): string | null {
   if (typeof contador !== 'number' || !isFinite(contador) || contador < 1) return null;
 
   const n = Math.floor(contador);
-  const coisas = n === 1 ? '1 coisa' : `${n} coisas`;
+  const premissas = n === 1 ? '1 premissa' : `${n} premissas`;
 
-  return {
-    curto: `Não deu para checar ${coisas}`,
-    longo: `Não deu para checar ${coisas} deste jogo: faltou informação. A leitura saiu com menos informação do que o normal, e não com informação contra.`,
-  };
+  return `Faltou informação para conferir ${premissas} deste jogo. A leitura saiu com menos informação do que o normal, e não com informação contra.`;
 }

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -130,39 +130,12 @@ interface Recipient {
   sends_without_click: number;
 }
 
-/**
- * "Não deu para checar N coisas", ou null quando não há o que avisar.
- *
- * Vem em LINHA PRÓPRIA, no mesmo espírito da evidência, e não colado na linha
- * do Score. Colado, ele vira mais um componente da nota ("Score 62 · Alta · 3
- * sem checar") e passa a ser lido como número que desconta — que é exatamente a
- * leitura que este aviso existe para impedir.
- *
- * Cabe em linha própria porque a DM manda no máximo MAX_PICKS picks. Medido
- * sobre o histórico, na população real da DM (top 3 por dia): 98 picks em 45
- * dias, 39% com o aviso, e em 13 dias os três vêm marcados. Três linhas a mais
- * no pior caso.
- *
- * ⚠️ REGRA DUPLICADA, e de propósito. O gêmeo é `avisoSemDado` em
- * `src/utils/futebol-sem-dado.ts`. Não dá para importar: esta função roda em
- * Deno na edge function e não compartilha o build do front — o arquivo já
- * duplica os rótulos do site pelo mesmo motivo, e está escrito lá que foram
- * portados.
- *
- * O que NÃO pode divergir entre as duas, e vale mais que a redação:
- *   · não aparece quando o contador é zero ou nulo
- *   · não carrega desconto de pontos nem parece penalidade
- *   · diz QUANTAS, nunca QUAIS (a lista de quais não existe no Postgres)
- *
- * A fonte da regra é a ADR 0003 do repositório `analytics-engineering`
- * (`dbt_futebol/docs/adr/0003-dado-faltante-diagnostica-nao-elimina.md`), não
- * deste: dado faltante diagnostica, NÃO penaliza.
- */
-function avisoSemDado(contador: number | null | undefined): string | null {
-  if (typeof contador !== "number" || !isFinite(contador) || contador < 1) return null;
-  const n = Math.floor(contador);
-  return `Não deu para checar ${n === 1 ? "1 coisa" : `${n} coisas`}`;
-}
+// O aviso de premissa sem dado NÃO entra na DM, e a duplicação da regra que
+// existia aqui saiu junto. Medido: aparecia em 39% dos picks do top 3, e a
+// distância de Score entre "tudo conferido" e "6+ sem dado" é de 4 pontos. Numa
+// mensagem de três picks, isso é uma ressalva a cada três linhas sobre algo que
+// não muda a decisão. Ele vive na folha de mercado, onde o leitor já está
+// olhando premissa por premissa. Ver src/utils/futebol-sem-dado.ts.
 
 async function buildMessage(picks: BoardRow[], userId: string): Promise<string> {
   const lines: string[] = [
@@ -174,13 +147,9 @@ async function buildMessage(picks: BoardRow[], userId: string): Promise<string> 
     const hora = brtHourMin(kickoffDate(p.kickoff_utc));
     const pick = pickLabel(p.market, p.outcome, p.line_value, p.home_team_name, p.away_team_name);
     const evidencia = p.evidencias?.length ? `\n✓ ${esc(p.evidencias[0])}` : "";
-    // Linha própria, embaixo da evidência. Nunca colada na linha do Score:
-    // ali ela viraria mais um número da nota e seria lida como desconto.
-    const aviso = avisoSemDado(p.premissas_sem_dado);
-    const semDado = aviso ? `\n◦ ${esc(aviso)}` : "";
     lines.push(
       `<a href="${jogoUrl}"><b>${esc(p.home_team_name)} × ${esc(p.away_team_name)}</b></a> · ${hora}`,
-      `${esc(pick)} · odd ${p.best_odd} · Score <b>${p.score} · ${esc(p.faixa)}</b>${evidencia}${semDado}`,
+      `${esc(pick)} · odd ${p.best_odd} · Score <b>${p.score} · ${esc(p.faixa)}</b>${evidencia}`,
       ""
     );
   }


### PR DESCRIPTION
O aviso estava em quatro lugares: lista do board, destaque do dia, lista de oportunidades e DM do Betinho. **Sai de todos, menos da folha de mercado.**

## Por que, medido

| Premissas sem dado | Oportunidades no board | Score médio |
|---|---|---|
| Nenhuma | 65% | 49,5 |
| 1 ou 2 | 28% | 47,1 |
| 3 a 5 | 7% | 46,9 |
| 6 ou mais | 1% | 45,0 |

O aviso apareceria em **1 de cada 3 linhas** (43 de 122), avisando de algo cuja ponta a ponta são **4 pontos de Score**. Não vira Alta em Média, não muda a odd, não muda a recomendação.

Um aviso nessa frequência sobre algo desse tamanho deixa o produto mais inseguro sem deixar o leitor mais informado.

**Fica na folha de mercado** porque ali a pessoa já está lendo premissa por premissa e enxerga a lista curta. A linha deixa de ser aviso e vira o rodapé fechando uma conta que ela está fazendo na frente dela.

## Texto

```
antes:  Não deu para checar 3 coisas deste jogo: faltou informação. (...)
depois: Faltou informação para conferir 3 premissas deste jogo. (...)
```

**"checar" para "conferir"**, palavra feia para o público.

**"coisas" para "premissas"**. Eu tinha proibido "premissa" no teste como se fosse jargão, e estava errado: a própria folha diz "3 premissas a favor" logo acima deste aviso. É vocabulário da tela.

## O que continua vago, e por quê

Quais premissas ficaram cegas. Achei o motivo enquanto media, e está escrito no cabeçalho do `futebol-sem-dado.ts`: **quando o insumo não existe, a coluna booleana chega como `false`, não como `null`.**

```sql
select forca_mismatch, superioridade_xg, mando, desfalque_adversario
from futebol.int_futebol_premissas_1x2 where premissas_sem_dado = 7;
-- as sete voltam false, nenhuma null
```

O achatamento é no dbt e os nomes já chegam apagados, então não adianta procurar do lado do Postgres (tentei contar `is null` nas colunas, não funciona). Pedido aberto com o Matheus na task [C] do ClickUp. Se os nomes vierem, a discussão de mostrar na vitrine reabre.

## Faxina que veio junto

A API encolheu de `{curto, longo}` para uma string, porque com um consumidor só a versão curta virou código morto. Na edge function a regra duplicada saiu inteira, junto com o comentário que explicava a duplicação.

**Achado colateral:** o `OppMobileCard` calculava o aviso e nunca renderizava.

## Testes

9 passando em `futebol-sem-dado.test.ts`, typecheck limpo. As duas falhas da suíte (`gen-route-heads` precisa de `dist/`, e o debounce do `MatchPredictionCard`) foram conferidas na develop sem estas mudanças e já falhavam lá.

Como é mexida de tela, **quero teu aval visual antes do merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)