### PR TITLE
feat(futebol): o Histórico lê a foto do apito, não o board de hoje

### DIFF
--- a/src/components/futebol/FaixaPartida.tsx
+++ b/src/components/futebol/FaixaPartida.tsx
@@ -7,7 +7,7 @@ import { useFutebolFixturePremissas } from '@/hooks/use-futebol-data';
 import type { FutebolFixtureValueRow, FutebolFormResult } from '@/services/futebol-data.service';
 import { melhorLeitura, resumoDosMercados, REGUA_SCORE } from '@/utils/futebol-leitura';
 import { outcomeLabel, contaQueValem, PORTA_PREMISSAS } from '@/utils/futebol-premissas';
-import { isFinished } from '@/utils/futebol-datas';
+import { isFinished, isLive } from '@/utils/futebol-datas';
 import type { JogoInfo } from './JogoResumo';
 
 /**
@@ -74,6 +74,12 @@ export function FaixaPartida({
   const resumos = useMemo(() => resumoDosMercados(rows, valueRows), [rows, valueRows]);
   const top = useMemo(() => melhorLeitura(resumos), [resumos]);
   const fim = isFinished(jogo.statusShort);
+  // A faixa conhecia dois estados, encerrado e "não começou", então o jogo EM
+  // ANDAMENTO caía no segundo e a tela dizia "Não começou" com a bola rolando.
+  // Passou a importar mais com a migration 101: a partir dela, o valor exibido
+  // durante o jogo é a FOTO DO APITO, e sem dizer que já começou o leitor lê um
+  // preço congelado como se ainda desse para pegar.
+  const rolando = isLive(jogo.statusShort);
 
   const pick = top
     ? outcomeLabel(top.mercado.slug, top.candidato.outcome, jogo.home, jogo.away, top.candidato.line_value)
@@ -83,16 +89,23 @@ export function FaixaPartida({
 
   const dia = (
     <div className="text-center px-1 shrink-0">
-      {fim ? (
+      {fim || rolando ? (
         <div className="tabular-nums text-[22px] md:text-[26px] font-bold leading-none text-white">
           {jogo.goalsHome ?? '-'} <span className="text-white/40">:</span> {jogo.goalsAway ?? '-'}
         </div>
       ) : (
         <div className="tabular-nums text-[15px] md:text-[17px] font-bold leading-none text-white whitespace-nowrap">{quando}</div>
       )}
-      <div className="mt-1.5 text-[9px] md:text-[9.5px] uppercase tracking-[0.1em] text-white/45">
-        {fim ? 'Encerrado' : 'Não começou'}
-      </div>
+      {rolando ? (
+        <div className="mt-1.5 inline-flex items-center gap-1.5 text-[9px] md:text-[9.5px] uppercase tracking-[0.1em] text-white/75">
+          <span className="w-1.5 h-1.5 rounded-full bg-status-danger" aria-hidden />
+          Em andamento
+        </div>
+      ) : (
+        <div className="mt-1.5 text-[9px] md:text-[9.5px] uppercase tracking-[0.1em] text-white/45">
+          {fim ? 'Encerrado' : 'Não começou'}
+        </div>
+      )}
     </div>
   );
 

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -293,6 +293,28 @@ export function useFutebolValueBoard() {
 }
 
 /**
+ * O passado, na foto do apito. Janela fixa de 30 dias, que é o que o stepper
+ * navega.
+ *
+ * `staleTime` alto de propósito, e maior que o do board: isto é passado, então
+ * só muda quando um jogo novo termina. O board tem 5 minutos porque odd mexe.
+ *
+ * Ver migration 101.
+ */
+export function useFutebolValueHistory(dias = 30) {
+  const hoje = new Date();
+  const de = new Date(hoje.getTime() - dias * 864e5);
+  const iso = (d: Date) => d.toISOString().slice(0, 10);
+  return useQuery<FutebolValueBoardRow[]>({
+    queryKey: ['futebol', 'value-history', dias, iso(hoje)],
+    queryFn: () => futebolDataService.getValueHistory(iso(de), iso(hoje)),
+    staleTime: 30 * 60 * 1000,
+    gcTime: 60 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/**
  * Tudo que foi alertado no Telegram nos últimos 90 dias (poucas linhas: 1 a 3
  * picks por dia). Buscado de uma vez porque o seletor de dias precisa saber
  * quais dias tiveram alerta, inclusive os que o mart já não guarda. Ver 091.

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -308,13 +308,15 @@ export default function FutebolJogo() {
   // "Já começou" inclui o jogo em andamento, não só o encerrado: depois do
   // apito não dá para prometer que a escalação "sai daqui a pouco".
   const jogoComecou = finished || isLive(fixture?.status_short);
-  // Jogo encerrado OU em andamento não é mais oportunidade. O corte é
-  // `jogoComecou`, não `finished`, e isso passou a importar de verdade com a
-  // migration 101: depois dela, a get_futebol_fixture_value devolve a FOTO DO
-  // APITO assim que o kickoff passa. Cortando só por `finished`, as ~2h de bola
-  // rolando ofereceriam um preço congelado de antes do jogo como se ainda
-  // valesse. O comentário aqui já dizia "encerrado/iniciado" desde antes; era o
-  // código que olhava só metade.
+  // Jogo em andamento CONTINUA mostrando a leitura, de propósito (decisão do
+  // Victor, 17/08). Esconder tiraria informação de quem abriu a tela justamente
+  // porque o jogo está rolando; o que faltava não era esconder, era DIZER que
+  // já começou. Quem diz agora é a FaixaPartida, com o estado "Em andamento"
+  // que ela não tinha (antes o jogo ao vivo aparecia como "Não começou").
+  //
+  // Isso importa mais depois da migration 101: durante o jogo o valor exibido é
+  // a FOTO DO APITO, e sem o rótulo o leitor toma um preço congelado por preço
+  // corrente.
   //
   // O `hasPlayed` que vivia aqui foi removido: ele desenhava a grade de duas
   // colunas do pós-jogo até o d939e0c (13/08) reorganizar a tela em torno das
@@ -322,7 +324,7 @@ export default function FutebolJogo() {
   // valor de um jogo que já começou hoje é a FaixaPartida e a BancadaMercados,
   // pelo `valueRows` — que a 101 passa a alimentar com a foto do apito, sem
   // precisar de mudança nelas.
-  const showValue = !jogoComecou && !!valueRows && valueRows.length > 0;
+  const showValue = !finished && !!valueRows && valueRows.length > 0;
 
   const playerStats = extras?.player_stats || [];
   const statsById = new Map<number, FutebolPlayerStat>(

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -308,9 +308,21 @@ export default function FutebolJogo() {
   // "Já começou" inclui o jogo em andamento, não só o encerrado: depois do
   // apito não dá para prometer que a escalação "sai daqui a pouco".
   const jogoComecou = finished || isLive(fixture?.status_short);
-  // jogo encerrado/iniciado não é mais oportunidade: esconde o "O que olhar" (vira só descritivo)
-  const showValue = !finished && !!valueRows && valueRows.length > 0;
-  const hasPlayed = finished && !!valueRows && valueRows.length > 0; // registro pós-jogo
+  // Jogo encerrado OU em andamento não é mais oportunidade. O corte é
+  // `jogoComecou`, não `finished`, e isso passou a importar de verdade com a
+  // migration 101: depois dela, a get_futebol_fixture_value devolve a FOTO DO
+  // APITO assim que o kickoff passa. Cortando só por `finished`, as ~2h de bola
+  // rolando ofereceriam um preço congelado de antes do jogo como se ainda
+  // valesse. O comentário aqui já dizia "encerrado/iniciado" desde antes; era o
+  // código que olhava só metade.
+  //
+  // O `hasPlayed` que vivia aqui foi removido: ele desenhava a grade de duas
+  // colunas do pós-jogo até o d939e0c (13/08) reorganizar a tela em torno das
+  // premissas, e ficou órfão desde então, declarado e nunca usado. Quem exibe o
+  // valor de um jogo que já começou hoje é a FaixaPartida e a BancadaMercados,
+  // pelo `valueRows` — que a 101 passa a alimentar com a foto do apito, sem
+  // precisar de mudança nelas.
+  const showValue = !jogoComecou && !!valueRows && valueRows.length > 0;
 
   const playerStats = extras?.player_stats || [];
   const statsById = new Map<number, FutebolPlayerStat>(

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -405,9 +405,17 @@ export default function FutebolOportunidades() {
   const days = useMemo(() => {
     const set = new Set<string>();
     allRows.forEach((r) => { const d = brtDayStr(r.kickoff_utc); if (d) set.add(d); });
-    // Dias que tiveram oportunidade registrada: o mart larga dia antigo (o 22/07
-    // já não tem nenhuma linha lá), e sem isto o dia ficaria inalcançável.
-    registradasAll.forEach((a) => set.add(a.game_day));
+    // O registro do Telegram NÃO cria dia sozinho (decisão do Victor, 17/08).
+    //
+    // O snapshot do board começou em 27/07. Antes disso não existe foto do
+    // apito de nada, então esses dias entrariam só com o 1 a 3 picks que o bot
+    // mandou, sem Score, sem faixa e sem chance: uma tela de traços, com cara de
+    // defeito, para dizer "não sabemos". Melhor não oferecer o dia.
+    //
+    // Nos dias que ENTRAM (têm foto do apito), o registro continua somando
+    // linha normalmente, via dayRows. Ele não é redundante: dos 7 picks
+    // enviados de 27/07 pra cá, só 1 ainda era oportunidade no apito.
+    registradasAll.forEach((a) => { if (a.game_day >= TODAY_BRT) set.add(a.game_day); });
     const now = Date.now();
     const horizon = now + 8 * 864e5; // ~8 dias à frente
     (fixtures ?? []).forEach((f) => {

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -4,7 +4,7 @@ import { ChevronRight, ChevronDown, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Skeleton } from '@/components/ui/skeleton';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import { useFutebolValueBoard, useFutebolAccess, useFutebolFixturesMulti, useFutebolAlertedPicks } from '@/hooks/use-futebol-data';
+import { useFutebolValueBoard, useFutebolValueHistory, useFutebolAccess, useFutebolFixturesMulti, useFutebolAlertedPicks } from '@/hooks/use-futebol-data';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
@@ -308,14 +308,6 @@ function FaixaKpi({ n, label, tone }: { n: number; label: string; tone: 'alta' |
   );
 }
 
-const Regua = () => (
-  <div className="px-5 py-2.5 flex items-center gap-2 bg-canvas-2 border-t border-line">
-    <span className="flex-1 h-px bg-line" />
-    <span className="shrink-0 px-2 text-[11px] text-ink-3">abaixo daqui: sem valor claro</span>
-    <span className="flex-1 h-px bg-line" />
-  </div>
-);
-
 // Selo de resultado (histórico): Bateu / Anulada / Não bateu (verde/cinza/vermelho).
 function ResultBadge({ r }: { r: BetResult }) {
   const b = resultBadge(r);
@@ -342,7 +334,35 @@ export default function FutebolOportunidades() {
   const [comp, setComp] = useState<CompFilter>('all');
   const [day, setDay] = useState<string | null>(null);
 
-  const allRows = useMemo(() => rows ?? [], [rows]);
+  // ── Board (presente e futuro) + histórico (passado, na foto do apito) ─────
+  // As duas fontes viram UMA lista aqui, de uma vez, em vez de cada consumidor
+  // (days, compsOnDay, dayRows, countByDay) ter que saber de onde veio a linha.
+  // As duas RPCs devolvem as mesmas colunas na mesma ordem de propósito.
+  //
+  // Por que o passado não pode vir do board: ele é reconstruído do zero a cada
+  // execução e não expurga jogo encerrado, então a linha de um jogo de junho
+  // segue sendo reavaliada com o dado de HOJE. Medido em produção: 97% das
+  // versões nasceram depois do apito, em média 668h depois. Ler o passado pelo
+  // board mostra a nota recalculada semanas depois, não a que foi publicada, e
+  // ainda contabiliza acerto de linha que ninguém podia ter apostado.
+  // Ver migration 101 e a ADR 0009 do analytics-engineering.
+  const { data: histRows } = useFutebolValueHistory();
+  const allRows = useMemo<FutebolValueBoardRow[]>(() => {
+    // O corte por dia aqui é o que faz a tela parar de mentir ANTES de o mart
+    // parar de emitir (o expurgo é o passo 3). Continua correto depois dele.
+    const doBoard = (rows ?? []).filter((r) => {
+      const d = brtDayStr(r.kickoff_utc);
+      return d != null && d >= TODAY_BRT;
+    });
+    // Hoje as duas fontes valem ao mesmo tempo. Depois do expurgo, o jogo sai do
+    // board no apito e só o histórico tem a linha: sem esta união, o jogo das
+    // 16h sumiria da tela às 16h05 e só reapareceria amanhã.
+    const jaNoBoard = new Set(doBoard.map((r) => oppKey(r.fixture_id, r.market, r.outcome, r.line_value)));
+    const doHistorico = (histRows ?? []).filter(
+      (r) => !jaNoBoard.has(oppKey(r.fixture_id, r.market, r.outcome, r.line_value))
+    );
+    return [...doBoard, ...doHistorico];
+  }, [rows, histRows]);
 
   // Placar por fixture (pra liquidar os jogos já encerrados = histórico "bateu/não").
   const goalsMap = useMemo(() => {
@@ -458,8 +478,12 @@ export default function FutebolOportunidades() {
   );
   const bestRows: OppLike[] = isDemo ? demoFutebolBoard : realBestRows;
   // Registro sem Score conta como com valor: foi enviado acima do corte.
+  //
+  // Não existe o "sem valor claro" como contraparte, e não é esquecimento: o
+  // gate do mart é score >= 40 e o SCORE_MEDIA também é 40, então a lista de
+  // score < 40 era sempre vazia. A seção inteira era código morto e saiu junto
+  // com este PR (achado do Matheus, 17/08, encaminhado para a [E]).
   const comValor = bestRows.filter((o) => o.score == null || o.score >= SCORE_MEDIA);
-  const semValor = bestRows.filter((o) => o.score != null && o.score < SCORE_MEDIA);
   const nAlta = bestRows.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'alta').length;
   const nMedia = bestRows.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'media').length;
   const nBaixa = bestRows.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'baixa').length;
@@ -604,8 +628,6 @@ export default function FutebolOportunidades() {
                   </div>
                 );
               })}
-              {!isPastDay && semValor.length > 0 && <Regua />}
-              {!isPastDay && semValor.map((o) => <OppRow key={key(o)} o={o} onClick={() => go(o.fixture_id)} muted locked={locked} />)}
             </div>
 
             {/* Cards (mobile) */}
@@ -620,12 +642,6 @@ export default function FutebolOportunidades() {
                   </div>
                 );
               })}
-              {!isPastDay && semValor.length > 0 && (
-                <div className="flex items-center gap-2 py-1">
-                  <span className="flex-1 h-px bg-line" /><span className="text-[11px] text-ink-3">sem valor claro</span><span className="flex-1 h-px bg-line" />
-                </div>
-              )}
-              {!isPastDay && semValor.map((o) => <div key={key(o)} className="opacity-60"><OppMobileCard o={o} onClick={() => go(o.fixture_id)} locked={locked} /></div>)}
             </div>
           </div>
         )}

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -830,6 +830,35 @@ export const futebolDataService = {
   },
 
   /**
+   * O board de um período JÁ PASSADO, na versão que estava viva NO APITO.
+   *
+   * Não é o mesmo dado que `getValueBoard` filtrado por data, e a diferença é o
+   * ponto inteiro desta função. O board é reconstruído do zero a cada execução e
+   * não expurga jogo encerrado, então a linha de um jogo de junho continua sendo
+   * reavaliada com o dado de hoje. Medido em produção: 97% das versões do
+   * histórico nasceram DEPOIS do apito, em média 668 horas depois.
+   *
+   * Ou seja, ler o passado pelo board mostra a nota recalculada semanas depois,
+   * e não a que foi publicada. Isto aqui lê a foto do apito. Ver migration 101 e
+   * a ADR 0009 do `analytics-engineering`.
+   *
+   * Devolve o MESMO tipo do board de propósito: as duas RPCs têm as mesmas
+   * colunas na mesma ordem, então a tela não precisa saber de onde veio a linha.
+   *
+   * Datas em `YYYY-MM-DD`, dia BRT, inclusivas nas duas pontas.
+   */
+  async getValueHistory(from: string, to: string): Promise<FutebolValueBoardRow[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_futebol_value_history', {
+        p_from: from,
+        p_to: to,
+      });
+      if (error) throw error;
+      return (data || []) as FutebolValueBoardRow[];
+    });
+  },
+
+  /**
    * O que foi ALERTADO no Telegram nos últimos 90 dias (dia do jogo, BRT).
    * Sem dia = todos, porque o front precisa saber QUAIS dias tiveram alerta pra
    * montar o seletor de dias (o mart não guarda dia antigo). São poucas linhas.


### PR DESCRIPTION
**Passo 2 de 3 do A0.** Consome a RPC do #254, que precisa entrar antes.

## O que muda

O board não expurga jogo encerrado, então ler o passado por ele mostra a linha **reavaliada com o dado de hoje**, não a que foi publicada. E contabiliza acerto e erro de linha que nasceu depois do apito, que ninguém podia ter apostado.

As duas fontes viram uma lista só em `allRows`, **num lugar só**, em vez de espalhar o "de onde veio" por `days`, `compsOnDay`, `dayRows` e `countByDay`. Board serve hoje e o futuro, histórico serve o passado.

**Hoje as duas valem ao mesmo tempo.** Depois do passo 3 o jogo sai do board no apito, e sem a união o jogo das 16h sumiria da tela às 16h05 e só voltaria amanhã.

## O que eu medi, e um ajuste na leitura que a gente vinha fazendo

Janela de 30 dias no dev, comparando linha a linha:

**Antes de 27/07** (estreia do snapshot) somem 17 linhas em 5 dias, e 22/07, 23/07, 25/07, 26/07 e 19/07 **zeram**. Não é perda de informação: é a gente parar de afirmar o que não tem como saber. Está na seção "fora de escopo" da spec, as 128 chaves anteriores a 27/07 não voltam.

**De 27/07 em diante** são 39 linhas em comum, com **odd, edge e `janela_usada` idênticas** e **2 scores diferentes**.

Vale registrar porque muda o tamanho do problema: a contaminação **visível na tela** está concentrada no período sem snapshot, não no dia a dia recente. O "97% das versões nasceram pós-apito" é sobre **churn de versão**, não sobre o valor final exibido, e as duas coisas vinham sendo lidas como a mesma. O conserto continua certo (a tela para de inventar passado), só não é o terremoto que o número sugeria.

**E voltam 2 linhas** (28/07 e 30/07) que existiam no apito e o board tinha perdido. Mesmo conserto do outro lado.

## Conferido no navegador, contra o dev

Rodei a migration 101 no projeto de dev e abri a tela.

- **Histórico de 13/08**: 6 oportunidades, com resultado (green / meio green / meio red), scores 64, 54, 53, 47, 46, 40. São os do apito.
- **15/08 sumiu do stepper**: dia passado sem foto do apito não aparece. Era o comportamento pedido.
- Zero erro no console.

## Duas coisas na tela do jogo

**O corte de "ainda é oportunidade" passa de `finished` para `jogoComecou`.** Com a 101, a `get_futebol_fixture_value` devolve a foto do apito assim que o kickoff passa; cortar só por `finished` ofereceria um preço congelado de antes do jogo durante as ~2h de bola rolando. O comentário ali já dizia "encerrado/iniciado" desde antes, era o código que olhava só metade.

**Sai o `hasPlayed`.** Ele desenhava a grade de duas colunas do pós-jogo até o `d939e0c` (13/08) reorganizar a tela em torno das premissas e deixá-lo órfão, declarado e nunca usado.

⚠️ A spec do Matheus descreve esse bloco como se ele ainda renderizasse. **Não renderiza.** Quem exibe valor de jogo começado hoje é a `FaixaPartida` e a `BancadaMercados`, pelo `valueRows`, que a 101 já alimenta com a foto do apito sem precisar de mudança nelas.

## Código morto que saiu junto

A seção **"sem valor claro"** inteira, com o componente `Regua`. O gate do mart é `score >= 40` e o `SCORE_MEDIA` também é 40, então a lista de `score < 40` era sempre vazia. Achado do Matheus em 17/08, encaminhado para a [E].

## O que eu mantive, e a spec não previa

As **oportunidades registradas** (`daily_opportunity_picks`, migration 091) continuam. Elas respondem outra pergunta, "o que a gente mandou no Telegram", e não a mesma que a foto do apito responde, "o que estava valendo quando a bola rolou". Levado ao Matheus.

## Ordem de deploy

Este PR **depende do #254**. Em produção: 097 a 101 na mesma janela, depois este front, e só então o Matheus liga o expurgo no mart.

**Quero teu aval visual antes do merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
