### PR TITLE
feat(futebol): funde o PR #259 do Matheus, e conserta a fase da escalação

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -692,6 +692,10 @@ CREATE INDEX IF NOT EXISTS fact_fixtures_away_team_id_idx ON futebol.fact_fixtur
 CREATE INDEX IF NOT EXISTS fact_fixtures_competition_season_round_idx ON futebol.fact_fixtures USING btree (competition, season, round);
 CREATE INDEX IF NOT EXISTS fact_fixtures_fixture_id_idx ON futebol.fact_fixtures USING btree (fixture_id);
 CREATE INDEX IF NOT EXISTS fact_fixtures_home_team_id_idx ON futebol.fact_fixtures USING btree (home_team_id);
+-- Janela de data das RPCs de histórico (migration 102): a tabela não tinha
+-- índice em kickoff_utc e o planner varria as 10,5k linhas. Medido: a seleção
+-- PIT de 30 dias caiu de 85 ms para 6,3 ms.
+CREATE INDEX IF NOT EXISTS fact_fixtures_kickoff_utc_idx ON futebol.fact_fixtures USING btree (kickoff_utc);
 CREATE INDEX IF NOT EXISTS fact_h2h_h2h_pair_key_idx ON futebol.fact_h2h USING btree (h2h_pair_key);
 CREATE INDEX IF NOT EXISTS fact_injuries_snapshot_fixture_id_idx ON futebol.fact_injuries_snapshot USING btree (fixture_id);
 CREATE INDEX IF NOT EXISTS fact_odds_snapshot_fixture_id_idx ON futebol.fact_odds_snapshot USING btree (fixture_id);
@@ -830,10 +834,29 @@ CREATE OR REPLACE FUNCTION public.get_futebol_fixture_extras(p_fixture_id bigint
  SECURITY DEFINER
  SET search_path TO ''
 AS $function$
-declare v_fix record;
+declare
+  v_fix record;
+  v_fase_times text;
+  v_fase_jogadores text;
 begin
   select f.* into v_fix from futebol.fact_fixtures f where f.fixture_id = p_fixture_id limit 1;
   if not found then return jsonb_build_object('events', '[]'::jsonb); end if;
+
+  select case
+           when v_fix.kickoff_utc <= (now() at time zone 'UTC')
+                and count(*) filter (where lineup_phase = 'real') > 0 then 'real'
+           when count(*) filter (where lineup_phase = 'confirmed') > 0 then 'confirmed'
+           else 'real' end
+    into v_fase_times
+    from futebol.fact_fixture_lineups where fixture_id = p_fixture_id;
+
+  select case
+           when v_fix.kickoff_utc <= (now() at time zone 'UTC')
+                and count(*) filter (where lineup_phase = 'real') > 0 then 'real'
+           when count(*) filter (where lineup_phase = 'confirmed') > 0 then 'confirmed'
+           else 'real' end
+    into v_fase_jogadores
+    from futebol.fact_fixture_lineups_players where fixture_id = p_fixture_id;
 
   return jsonb_build_object(
     'events', coalesce((
@@ -855,23 +878,41 @@ begin
     ), '[]'::jsonb),
     'form_home', public._futebol_team_form(v_fix.home_team_id, v_fix.competition, v_fix.season, v_fix.date_utc),
     'form_away', public._futebol_team_form(v_fix.away_team_id, v_fix.competition, v_fix.season, v_fix.date_utc),
+    -- migrations 098 e 103. A C1 do analytics-engineering faz a escalação
+    -- `confirmed` (anunciada antes do apito) e a `real` (registro pós-jogo)
+    -- COEXISTIREM. Sem filtro de fase, cada time e cada jogador apareceriam
+    -- duas vezes: o front pega a formação com `.find()` sobre array sem ordem e
+    -- passaria a sortear entre as duas, podendo virar entre dois carregamentos
+    -- da mesma página, e o campinho desenharia cada jogador duplicado.
+    --
+    -- A escolha é por TEMPO, não por existência (103): depois do apito vale
+    -- quem entrou em campo. A regra por existência que a 098 trouxe
+    -- ("se houver qualquer linha confirmed, use confirmed") vira a tela inteira
+    -- com base numa linha só, e a `confirmed` é justamente a que chega
+    -- incompleta: medido no dev, 2,0 jogadores por jogo contra 46,5 da `real`.
+    --
+    -- As duas tabelas decidem SEPARADAS de propósito: elas divergem no dado, e
+    -- forçar uma fase comum esvaziaria uma das duas.
     'lineups', coalesce((
       select jsonb_agg(jsonb_build_object(
         'team_id', l.team_id, 'team_name', l.team_name, 'team_side', l.team_side,
-        'formation', l.formation, 'coach_name', l.coach_name
-      )) from (
-        select team_id, team_name, team_side, formation, coach_name
-        from futebol.fact_fixture_lineups where fixture_id = p_fixture_id
+        'formation', l.formation, 'coach_name', l.coach_name, 'lineup_phase', l.lineup_phase
+      ) order by l.team_side) from (
+        select team_id, team_name, team_side, formation, coach_name, lineup_phase
+        from futebol.fact_fixture_lineups
+        where fixture_id = p_fixture_id and lineup_phase = v_fase_times
       ) l
     ), '[]'::jsonb),
     'lineup_players', coalesce((
       select jsonb_agg(jsonb_build_object(
         'team_id', lp.team_id, 'team_side', lp.team_side, 'is_starter', lp.is_starter,
         'player_slot', lp.player_slot, 'player_id', lp.player_id, 'player_name', lp.player_name,
-        'shirt_number', lp.shirt_number, 'position', lp.position, 'grid', lp.grid
+        'shirt_number', lp.shirt_number, 'position', lp.position, 'grid', lp.grid,
+        'lineup_phase', lp.lineup_phase
       ) order by lp.team_side, lp.is_starter desc nulls last, lp.player_slot) from (
-        select team_id, team_side, is_starter, player_slot, player_id, player_name, shirt_number, position, grid
-        from futebol.fact_fixture_lineups_players where fixture_id = p_fixture_id
+        select team_id, team_side, is_starter, player_slot, player_id, player_name, shirt_number, position, grid, lineup_phase
+        from futebol.fact_fixture_lineups_players
+        where fixture_id = p_fixture_id and lineup_phase = v_fase_jogadores
       ) lp
     ), '[]'::jsonb)
   );
@@ -914,7 +955,11 @@ begin
              ('Over 0.5','Under 0.5','Over 1.5','Under 1.5','Over 2.5','Under 2.5','Over 3.5','Under 3.5','Over 4.5','Under 4.5'))
          or (o.market_name = 'Asian Handicap' and abs(o.line_value - trunc(o.line_value)) = 0.5 and abs(o.line_value) <= 2.5) )
   ),
-  win_rank as ( select *, case when collection_window='t15m' then 3 when collection_window='t1h' then 2 else 1 end wr from base ),
+  -- migration 097: a janela `daily` (>24h até 7d) entrou em 07/08 e caía no
+  -- `else`, empatando com `t24h`. Com empate o DISTINCT ON desempata sozinho e
+  -- pode virar entre duas chamadas, sem mudança de dado. Medido no PRD em
+  -- 10/08: 27.066 chaves empatadas em 25 fixtures.
+  win_rank as ( select *, case when collection_window='t15m' then 4 when collection_window='t1h' then 3 when collection_window='t24h' then 2 when collection_window='daily' then 1 else 0 end wr from base ),
   cur_pick as (
     select distinct on (b.market_name, b.outcome_label, b.bookmaker_name)
       b.market_name, b.outcome_label, b.bookmaker_name, b.odd_decimal, b.line_value
@@ -993,10 +1038,44 @@ CREATE OR REPLACE FUNCTION public.get_futebol_fixture_value(p_fixture_id bigint)
  SECURITY DEFINER
  SET search_path TO ''
 AS $function$
-  with d as (
-    select distinct on (fixture_id, outcome_side, line_value) fixture_id, outcome_side, line_value,
+  -- migration 101: a fonte deixa de ser fixa. Kickoff no futuro lê o board;
+  -- kickoff já passado lê a FOTO DO APITO no snapshot. É *kickoff passado* e
+  -- não *jogo terminado*, senão as ~2h de bola rolando ficariam sem linha
+  -- depois que o mart passar a expurgar os status ao vivo (ADR 0009).
+  with v_src as (
+    select fixture_id, market, outcome, line_value, competition, season, edge, pts_valor,
+           pts_premissas, pts_corroboracao, penalidades, score, faixa, best_odd, best_book,
+           avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
+           penalidades_globais_pts, penalidades_especificas_pts, modelo_api_concorda,
+           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado
+    from futebol.fact_value_opportunities
+    where fixture_id = p_fixture_id
+      and exists (select 1 from futebol.fact_fixtures fx
+                   where fx.fixture_id = p_fixture_id and fx.kickoff_utc > now())
+    union all
+    select fixture_id, market, outcome, line_value, competition, season, edge, pts_valor,
+           pts_premissas, pts_corroboracao, penalidades, score, faixa, best_odd, best_book,
+           avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
+           penalidades_globais_pts, penalidades_especificas_pts, modelo_api_concorda,
+           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado
+    from futebol.fact_value_opportunities_hist h
+    where h.fixture_id = p_fixture_id
+      and exists (select 1 from futebol.fact_fixtures fx
+                   where fx.fixture_id = p_fixture_id
+                     and fx.kickoff_utc <= now()
+                     and h.dbt_valid_from <= fx.kickoff_utc
+                     and (h.dbt_valid_to is null or fx.kickoff_utc < h.dbt_valid_to))
+  ),
+  -- migration 098: o DISTINCT ON ignorava `market_id` e `janela_usada`.
+  -- Sem `janela_usada`, o aviso de penalidade vinha de janela arbitrária (uma
+  -- Over 2.5 que fechou em 2,05 exibia "zebra" calculado do 5,20 do `daily`).
+  -- Sem `market_id`, Gols (5) e Gols do 1º tempo (6) colidiam na mesma linha.
+  d as (
+    select distinct on (fixture_id, market_id, outcome_side, line_value, janela_usada)
+      fixture_id, market_id, outcome_side, line_value, janela_usada,
       pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
-    from futebol.int_futebol_odds_devig order by fixture_id, outcome_side, line_value
+    from futebol.int_futebol_odds_devig
+    order by fixture_id, market_id, outcome_side, line_value, janela_usada
   )
   select v.market, v.outcome,
     (case when v.market = 'match_winner'
@@ -1100,13 +1179,13 @@ AS $function$
       case when not coalesce(dc.adversario_limitado, true) then 'Adversário não é tão limitado' end
     ], null))[1:3],
     v.premissas_sem_dado::int
-  from futebol.fact_value_opportunities v
+  from v_src v
   left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
   left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
   left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
   left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
   left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
-  left join d on d.fixture_id = v.fixture_id and d.outcome_side = v.outcome and d.line_value is not distinct from v.line_value
+  left join d on d.fixture_id = v.fixture_id and d.outcome_side = v.outcome and d.line_value is not distinct from v.line_value and d.janela_usada is not distinct from v.janela_usada and d.market_id = (case v.market when 'match_winner' then 1 when 'asian_handicap' then 4 when 'goals_over_under' then 5 when 'btts' then 8 when 'double_chance' then 12 end)
   where v.fixture_id = p_fixture_id
   order by (case v.market when 'match_winner' then 1 when 'goals_over_under' then 2 when 'asian_handicap' then 3 when 'btts' then 4 when 'double_chance' then 5 else 9 end), 3;
 $function$
@@ -1261,7 +1340,8 @@ begin
       b.fixture_id, b.market_name, b.outcome_label, b.bookmaker_name, b.odd_decimal, b.line_value
     from base b
     order by b.fixture_id, b.market_name, b.outcome_label, b.bookmaker_name,
-             case when b.collection_window='t15m' then 3 when b.collection_window='t1h' then 2 else 1 end desc
+             -- migration 097, mesmo conserto do get_futebol_fixture_odds.
+             case when b.collection_window='t15m' then 4 when b.collection_window='t1h' then 3 when b.collection_window='t24h' then 2 when b.collection_window='daily' then 1 else 0 end desc
   ),
   agg as (
     select c.fixture_id, c.market_name, c.outcome_label, max(c.line_value) line_value,
@@ -1568,6 +1648,128 @@ $function$
 
 ;
 
+-- ── 5b. Histórico point-in-time do board (ADR 0009, migrations 101 e 102) ────
+-- O board é reconstruído inteiro a cada execução e não filtra data, então ler o
+-- passado por ele mostra a nota RECALCULADA, não a que foi publicada. Medido no
+-- PRD em 17/08: 121 linhas no board e 2 de jogo futuro, a mais antiga de 19/06;
+-- 97% das versões do `_hist` nasceram DEPOIS do apito, em média 668h depois.
+--
+-- Aqui vem a oportunidade como foi publicada: a versão do snapshot viva no
+-- apito. Decisões travadas:
+--
+--   · PIT estrito: dbt_valid_from <= kickoff < dbt_valid_to (nulo = aberta).
+--     Chave sem versão viva no apito não aparece, não cai para a mais próxima.
+--   · `kickoff < now()` obrigatório: sem ele, a versão aberta de um jogo FUTURO
+--     satisfaz o predicado à toa e uma chave que já saiu do board voltaria à
+--     tela como oportunidade viva. Medido no dev: 7 versões nessa situação.
+--   · `DISTINCT ON (opportunity_key)` com desempate explícito, blindando o grão
+--     caso o snapshot algum dia produza janelas sobrepostas.
+--   · Janela em DIA DE BRASÍLIA, convertida uma vez (sargável): 21:30 BRT é
+--     00:30 UTC do dia seguinte, horário de metade do calendário brasileiro.
+--   · `RETURNS TABLE` espelha o de `get_futebol_value_board`, incluindo
+--     `premissas_sem_dado`, para o front reaproveitar `FutebolValueBoardRow`.
+--   · `get_futebol_value_board` NÃO é tocada.
+--
+-- Crédito: `kickoff < now()`, DISTINCT ON, janela sargável e o índice acima vêm
+-- do PR #259 do Matheus, que implementou a mesma entrega em paralelo.
+--
+-- ⚠️ DÍVIDA: a cascata de `evidencias` abaixo é a TERCEIRA cópia verbatim (as
+-- outras em `get_futebol_value_board` e `get_futebol_fixture_value`). Mercado
+-- novo mexe em três RPCs. Extrair exige tocar nas três de uma vez.
+
+CREATE OR REPLACE FUNCTION public.get_futebol_value_history(p_from date, p_to date)
+ RETURNS TABLE(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, score integer, faixa text, evidencias text[], premissas_sem_dado integer)
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+  with pit as (
+    select distinct on (h.opportunity_key)
+      h.fixture_id, h.market, h.outcome, h.line_value, h.edge,
+      h.best_odd, h.best_book, h.avg_odd, h.n_casas, h.janela_usada,
+      h.prob_justa_fechamento, h.pts_valor, h.pts_premissas, h.pts_corroboracao,
+      h.penalidades, h.score, h.faixa,
+      h.modelo_api_concorda, h.linha_sharp_confirma, h.premissas_sem_dado
+    from futebol.fact_value_opportunities_hist h
+    join futebol.fact_fixtures fx on fx.fixture_id = h.fixture_id
+    where fx.kickoff_utc >= ((p_from::timestamp at time zone 'America/Sao_Paulo') at time zone 'UTC')
+      and fx.kickoff_utc <  (((p_to + 1)::timestamp at time zone 'America/Sao_Paulo') at time zone 'UTC')
+      and fx.kickoff_utc <  (now() at time zone 'UTC')
+      and h.dbt_valid_from <= fx.kickoff_utc
+      and (h.dbt_valid_to is null or fx.kickoff_utc < h.dbt_valid_to)
+    order by h.opportunity_key, h.dbt_valid_from desc
+  )
+  select v.fixture_id, f.home_team_id, f.away_team_id, f.home_team_name, f.away_team_name,
+    f.competition, f.kickoff_utc, f.status_short,
+    v.market, v.outcome, v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
+    v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int, v.score::int, v.faixa,
+    array_remove(array[
+      case when p.forca_mismatch then 'Ataque forte contra defesa frágil do adversário' end,
+      case when p.superioridade_xg then 'Cria mais chances de gol do que o adversário' end,
+      case when p.mando then (case v.outcome when 'Home' then 'Manda bem em casa' when 'Away' then 'Vai bem fora de casa' else 'Mando relevante' end) end,
+      case when p.desfalque_adversario then 'Adversário com desfalque de titular importante' end,
+      case when p.superioridade_tabela then 'Bem à frente na tabela' end,
+      case when p.forma then 'Em boa fase (vitórias recentes)' end,
+      case when p.h2h_favoravel then 'Histórico favorável no confronto direto' end
+    ], null)
+    || array_remove(array[
+      case when o.ataque_combinado then 'Os dois somam muitos gols (casa + fora)' end,
+      case when o.defesas_vazaveis then 'Defesas frágeis dos dois lados' end,
+      case when o.xg_combinado_alto then 'Os dois criam muitas chances de gol' end,
+      case when o.ritmo_alto then 'Jogo de ritmo alto (muitas finalizações)' end,
+      case when o.ambos_vazam then 'Os dois sofrem gol quase todo jogo' end,
+      case when o.historico_over then 'Últimos jogos goleadores' end,
+      case when o.linha_subindo then 'Mercado puxando a linha pra cima' end,
+      case when o.defesas_firmes then 'Defesas firmes dos dois lados' end,
+      case when o.clean_sheets_altos then 'Os dois passam muitos jogos sem sofrer gol' end,
+      case when o.xg_baixo_combinado then 'Os dois criam pouca coisa na frente' end,
+      case when o.ataques_fracos then 'Ataque fraco (passam em branco com frequência)' end,
+      case when o.historico_under then 'Últimos jogos truncados' end,
+      case when o.linha_descendo then 'Mercado puxando a linha pra baixo' end
+    ], null)
+    || array_remove(array[
+      case when ah.supremacia then 'Muito superior ao adversário' end,
+      case when ah.tende_golear then 'Costuma vencer com boa diferença de gols' end,
+      case when ah.adversario_fragil_fora then 'Adversário tem defesa frágil' end,
+      case when ah.mando_forte then 'Manda muito bem em casa' end,
+      case when ah.sem_rodizio then 'Deve entrar com força máxima' end,
+      case when ah.raramente_perde_por_2 then 'Raramente perde por 2 gols ou mais' end,
+      case when ah.defesa_fora_solida then 'Defesa sólida jogando fora' end,
+      case when ah.favorito_irregular then 'O favorito não costuma golear' end
+    ], null)
+    || array_remove(array[
+      case when bt.ambos_marcam then 'Os dois quase sempre marcam' end,
+      case when bt.ataque_dos_dois then 'Os dois ataques vêm produzindo' end,
+      case when bt.defesas_vazaveis then 'As duas defesas sofrem gol com frequência' end,
+      case when bt.historico_btts then 'Nos últimos jogos, os dois marcaram' end,
+      case when bt.defesa_forte then 'Uma das defesas segura bem o placar' end,
+      case when bt.ataque_trava then 'Um dos ataques costuma passar em branco' end,
+      case when bt.historico_seco then 'Jogos recentes sem os dois marcarem' end
+    ], null)
+    || array_remove(array[
+      case when dc.lado_coberto_forte then 'O lado coberto é claramente o mais forte' end,
+      case when dc.equilibrio_defensivo then 'Defesas parelhas — empate é desfecho plausível' end,
+      case when dc.adversario_limitado then 'Adversário com campanha fraca' end,
+      case when dc.invicto_recente then 'Vem sem perder nos últimos jogos' end
+    ], null)
+    || array_remove(array[
+      case when v.modelo_api_concorda and v.linha_sharp_confirma then 'As principais casas e o modelo da API apontam o mesmo lado'
+           when v.modelo_api_concorda then 'Modelo da API concorda com esse lado'
+           when v.linha_sharp_confirma then 'As principais casas vêm baixando a odd desse lado' end
+    ], null),
+    v.premissas_sem_dado::int
+  from pit v
+  join futebol.fact_fixtures f on f.fixture_id = v.fixture_id
+  left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
+  left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
+  left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
+  order by f.kickoff_utc desc, v.score desc, v.edge desc;
+$function$
+
+;
+
 -- ── 6. Grants de execução (anon / authenticated / service_role) ──────────────
 grant execute on function public._futebol_team_form(p_team_id bigint, p_competition text, p_season bigint, p_before date) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_access() to anon, authenticated, service_role;
@@ -1588,6 +1790,7 @@ grant execute on function public.get_futebol_team_profile(p_team_id bigint, p_co
 grant execute on function public.get_futebol_team_season(p_team_id bigint, p_competition text, p_season bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_teams() to anon, authenticated, service_role;
 grant execute on function public.get_futebol_value_board() to anon, authenticated, service_role;
+grant execute on function public.get_futebol_value_history(p_from date, p_to date) to anon, authenticated, service_role;
 
 -- ── 7. Reverse trial (7 dias, sem cartão) — colunas no public.users ──────────
 alter table public.users add column if not exists futebol_trial_started_at timestamptz;

--- a/docs/plano-fusao-pit.md
+++ b/docs/plano-fusao-pit.md
@@ -1,0 +1,60 @@
+# Plano: fundir o PR #259 do Matheus com o que já está na develop
+
+**Contexto (18/08/2026).** O A0 foi implementado duas vezes, sem ninguém saber do outro: a gente entregou nos PRs #254 e #256 (mergeados em 17/08 à noite), o Matheus entregou no #259 (aberto em 18/08 de manhã, hoje em conflito com a develop). Decisão do Victor: não descartar nenhum dos dois, absorver o melhor de cada um.
+
+## O que cada lado tem que o outro não tem
+
+**Já na develop (nosso):**
+- Migration 101: RPC `get_futebol_value_history` + `get_futebol_fixture_value` caindo na foto do apito quando o kickoff passou (o escopo do ticket #260 dele, que ele NÃO implementou)
+- Coluna `premissas_sem_dado` no retorno do histórico (espelha o board pós-099)
+- FaixaPartida com o estado "Em andamento" (antes jogo rolando dizia "Não começou")
+- Decisão do Victor: dia pré-27/07 fora do stepper
+- Remoção do código morto "sem valor claro"
+
+**Só no #259 (dele):**
+1. **Guarda `kickoff < now()`** na RPC de histórico. A nossa não tem, e o furo é real: 7 versões abertas de jogos futuros passam no predicado PIT hoje. Uma chave que saiu do board voltaria à tela como oportunidade viva.
+2. **`DISTINCT ON (opportunity_key)`** blindando o grão. A gente decidiu confiar no dado ("zero sobreposição hoje"); ele blindou contra o dia em que o SCD produzir janela sobreposta. A blindagem é barata e o desempate é explícito (`dbt_valid_from desc`), então não é o desempate arbitrário que a 098 corrigiu.
+3. **Janela BRT sargável**: ele converte os limites do dia UMA vez (`p_from at time zone 'America/Sao_Paulo'`), a nossa chama `futebol_dia_brt(kickoff)` linha a linha, o que impede índice.
+4. **Índice `fact_fixtures_kickoff_utc_idx`**: medido por ele, a seleção PIT cai de 85ms para 6,3ms.
+5. **Módulo puro `futebol-history.ts` com 130 linhas de teste**, incluindo a regra de fusão do dia corrente.
+6. **Regra do dia corrente MELHOR que a nossa**: no dia de hoje, kickoff já passou → vence a linha do hist (foto do apito); kickoff futuro → vence o board. A nossa dava o board pra tudo de hoje, o que descasa da tela de detalhe (que já mostra a foto do apito assim que o jogo começa). Com a dele, lista e detalhe contam a mesma história.
+7. **Shape file atualizado** (a dívida da #250, na parte do histórico).
+
+## Divergência a resolver: a coluna `premissas_sem_dado`
+
+A RPC dele NÃO devolve `premissas_sem_dado`, espelhando o board de PRODUÇÃO. Só que produção está atrasada: a 099 (já na develop, aguardando deploy) põe a coluna no board. E o próprio shape file, desde o PR #248, declara o board COM a coluna, então o espelho dele contradiz a regra dele ("espelhar o RETURNS do board").
+
+**Decisão: a coluna FICA.** O deploy é das 097-101 juntas, então o board de produção vai ter a coluna no mesmo instante em que o histórico nascer lá.
+
+## O que NÃO absorver do #259
+
+- O `RETURNS TABLE` sem `premissas_sem_dado` (acima).
+- As funções de calendário do módulo dele (`kickoffMs`, `brtDay`, `addDaysBrt`): duplicam `futebol-datas.ts`, que já existe e já tem teste. O módulo absorvido importa de lá.
+- A parte do front dele que refaz o que o nosso já faz (união inline): a base é a nossa página, que já carrega as decisões do Victor.
+
+## Execução (ordem)
+
+**1. Migration 102 — endurecer a RPC de histórico.** Corpo novo com: guarda `kickoff < now()`, `DISTINCT ON (opportunity_key)` com desempate explícito, janela BRT sargável, e o índice `fact_fixtures_kickoff_utc_idx`. Mantém as colunas nossas (com `premissas_sem_dado`). Crédito ao #259 no cabeçalho.
+
+**2. Migration 103 — fase da escalação por TEMPO, não por existência.** A 098 escolhe `confirmed` se existir qualquer linha `confirmed`. Medido: nos 154 jogos com as duas fases, `confirmed` tem 2 jogadores/jogo contra 46,5 da `real` — a regra atual desenharia um campinho com 2 jogadores depois que a C1 do Matheus deployar. Regra nova, por tabela: kickoff passou E existe `real` → `real`; senão `confirmed` se existir; senão `real`. **É o que destrava a C1 dele (PR #88 em draft no analytics-engineering).**
+
+**3. Front — adotar o módulo testado dele.** `futebol-history.ts` (só `mergeBoardAndHistory`, `opportunityKey`, `historyWindow`; calendário importado de `futebol-datas`) + os testes adaptados. `FutebolOportunidades` passa a usar `mergeBoardAndHistory` no lugar da união inline, ganhando a regra do dia corrente. As decisões do Victor (pré-27/07, código morto) não mudam.
+
+**4. Shape file — catch-up completo, fecha a #250.** O `docs/futebol-prod-deploy.sql` ganha: as correções 097/098 nos corpos das RPCs de odds e valor, a fase por tempo (103), a RPC de histórico versão 102 (base no bloco dele, ajustado), e o índice. Depois disso o arquivo volta a ser espelho fiel.
+
+**5. Comunicação.**
+- **PR #259**: comentário com o que foi absorvido e onde, crédito explícito, e o apontamento da divergência do `premissas_sem_dado`. Ele fecha o #259.
+- **Tickets #257 e #260**: fecham quando o PR de fusão mergear (o escopo dos dois está coberto).
+- **ClickUp C1**: a RPC passa a filtrar por tempo na 103; o gate dele (não buildar antes do deploy) continua até 097-103 chegarem em produção; aí ele tira o #88 de draft.
+- **Causa raiz da colisão**: propor a convenção de reivindicar o ticket com um comentário "em execução" antes de começar. Um comentário de uma linha teria evitado um dia de trabalho dobrado.
+
+**6. Deploy em produção: janela única com 097-103.** Depois dela: Matheus liga o expurgo (passo 3 do A0) E builda a C1.
+
+## Aceite
+
+- `get_futebol_value_history` não devolve nenhuma linha de kickoff futuro (hoje devolveria 7 versões).
+- Grão de 1 linha por `opportunity_key` garantido por construção, não por sorte.
+- Detalhe de jogo com as duas fases de escalação mostra a `real` depois do apito (46,5 jogadores, não 2).
+- Testes do módulo de fusão passando; suíte sem regressão além das 2 falhas pré-existentes.
+- Shape file espelha exatamente as funções vivas do dev (conferido por `pg_get_functiondef`).
+- #250, #257, #260 fechadas; #259 fechado pelo autor; C1 destravada.

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -1,6 +1,8 @@
 import { useQuery, useQueries } from '@tanstack/react-query';
 import { useMemo } from 'react';
 import { useAuth } from '@/hooks/use-auth';
+import { brtToday } from '@/utils/futebol-datas';
+import { historyWindow } from '@/utils/futebol-history';
 import {
   futebolDataService,
   type FutebolAccess,
@@ -301,13 +303,15 @@ export function useFutebolValueBoard() {
  *
  * Ver migration 101.
  */
-export function useFutebolValueHistory(dias = 30) {
-  const hoje = new Date();
-  const de = new Date(hoje.getTime() - dias * 864e5);
-  const iso = (d: Date) => d.toISOString().slice(0, 10);
+export function useFutebolValueHistory() {
+  // Dia de BRASÍLIA, não UTC. A primeira versão disto usava `toISOString()`, que
+  // dá a data em UTC: depois das 21h de Brasília o "hoje" já virava o dia
+  // seguinte e a janela inteira andava um dia, escondendo o jogo da noite.
+  const hoje = brtToday();
+  const { from, to } = historyWindow(hoje);
   return useQuery<FutebolValueBoardRow[]>({
-    queryKey: ['futebol', 'value-history', dias, iso(hoje)],
-    queryFn: () => futebolDataService.getValueHistory(iso(de), iso(hoje)),
+    queryKey: ['futebol', 'value-history', from, to],
+    queryFn: () => futebolDataService.getValueHistory(from, to),
     staleTime: 30 * 60 * 1000,
     gcTime: 60 * 60 * 1000,
     refetchOnWindowFocus: false,

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -16,6 +16,7 @@ import {
   faixaBadgeCls, faixaWord, faixaTone, chancePct, SCORE_MEDIA,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
+import { mergeBoardAndHistory } from '@/utils/futebol-history';
 import type { FutebolValueBoardRow, FutebolAlertedPick, FutebolFixture } from '@/services/futebol-data.service';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
@@ -345,24 +346,17 @@ export default function FutebolOportunidades() {
   // versões nasceram depois do apito, em média 668h depois. Ler o passado pelo
   // board mostra a nota recalculada semanas depois, não a que foi publicada, e
   // ainda contabiliza acerto de linha que ninguém podia ter apostado.
-  // Ver migration 101 e a ADR 0009 do analytics-engineering.
+  // Ver migrations 101/102 e a ADR 0009 do analytics-engineering.
+  //
+  // A regra da fusão vive em futebol-history.ts, testada. O desempate de HOJE é
+  // por kickoff: jogo que já começou vence pelo histórico, jogo que não começou
+  // vence pelo board. É o que mantém esta lista contando a mesma história que a
+  // tela de detalhe, que cai na foto do apito assim que o kickoff passa.
   const { data: histRows } = useFutebolValueHistory();
-  const allRows = useMemo<FutebolValueBoardRow[]>(() => {
-    // O corte por dia aqui é o que faz a tela parar de mentir ANTES de o mart
-    // parar de emitir (o expurgo é o passo 3). Continua correto depois dele.
-    const doBoard = (rows ?? []).filter((r) => {
-      const d = brtDayStr(r.kickoff_utc);
-      return d != null && d >= TODAY_BRT;
-    });
-    // Hoje as duas fontes valem ao mesmo tempo. Depois do expurgo, o jogo sai do
-    // board no apito e só o histórico tem a linha: sem esta união, o jogo das
-    // 16h sumiria da tela às 16h05 e só reapareceria amanhã.
-    const jaNoBoard = new Set(doBoard.map((r) => oppKey(r.fixture_id, r.market, r.outcome, r.line_value)));
-    const doHistorico = (histRows ?? []).filter(
-      (r) => !jaNoBoard.has(oppKey(r.fixture_id, r.market, r.outcome, r.line_value))
-    );
-    return [...doBoard, ...doHistorico];
-  }, [rows, histRows]);
+  const allRows = useMemo<FutebolValueBoardRow[]>(
+    () => mergeBoardAndHistory(rows ?? [], histRows ?? [], Date.now()),
+    [rows, histRows]
+  );
 
   // Placar por fixture (pra liquidar os jogos já encerrados = histórico "bateu/não").
   const goalsMap = useMemo(() => {

--- a/src/utils/futebol-history.test.ts
+++ b/src/utils/futebol-history.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import {
+  mergeBoardAndHistory,
+  opportunityKey,
+  historyWindow,
+  HISTORY_WINDOW_DAYS,
+} from './futebol-history';
+import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
+
+// Testes portados do PR #259 do Matheus e estendidos. A regra que eles guardam:
+// passado é território da foto do apito, futuro é do board, e HOJE depende de a
+// bola já ter rolado. É a única parte da fusão que dá pra testar sem tela.
+
+// 2026-08-18 15:00 BRT = 18:00 UTC. Um horário de tarde de propósito: com ele o
+// mesmo dia BRT tem jogo antes e depois de agora.
+const AGORA = Date.parse('2026-08-18T18:00:00Z');
+const HOJE = '2026-08-18';
+
+function linha(over: Partial<FutebolValueBoardRow> & { kickoff_utc: string }): FutebolValueBoardRow {
+  return {
+    fixture_id: 1, home_team_id: 10, away_team_id: 20,
+    home_team_name: 'Casa', away_team_name: 'Fora', competition: 'brasileirao',
+    status_short: 'NS', market: 'match_winner', outcome: 'Home', line_value: null,
+    edge: 5, best_odd: 2, best_book: 'x', avg_odd: 1.9, n_casas: 8,
+    janela_usada: 't24h', prob_justa_fechamento: 0.5,
+    pts_valor: 10, pts_premissas: 10, pts_corroboracao: 0, penalidades: 0,
+    score: 50, faixa: 'Média', evidencias: [], premissas_sem_dado: 0,
+    ...over,
+  } as FutebolValueBoardRow;
+}
+
+describe('opportunityKey', () => {
+  it('separa mercados diferentes do mesmo jogo', () => {
+    const a = opportunityKey({ fixture_id: 1, market: 'match_winner', outcome: 'Home', line_value: null });
+    const b = opportunityKey({ fixture_id: 1, market: 'goals_over_under', outcome: 'Over', line_value: 2.5 });
+    expect(a).not.toBe(b);
+  });
+
+  it('separa linhas diferentes do mesmo mercado', () => {
+    const a = opportunityKey({ fixture_id: 1, market: 'goals_over_under', outcome: 'Over', line_value: 2.5 });
+    const b = opportunityKey({ fixture_id: 1, market: 'goals_over_under', outcome: 'Over', line_value: 3.5 });
+    expect(a).not.toBe(b);
+  });
+
+  it('trata linha nula e ausente como a mesma coisa', () => {
+    const a = opportunityKey({ fixture_id: 1, market: 'btts', outcome: 'Yes', line_value: null });
+    const b = opportunityKey({ fixture_id: 1, market: 'btts', outcome: 'Yes', line_value: null });
+    expect(a).toBe(b);
+  });
+});
+
+describe('historyWindow', () => {
+  it('cobre 30 dias contando hoje', () => {
+    const { from, to } = historyWindow('2026-08-18');
+    expect(to).toBe('2026-08-18');
+    expect(from).toBe('2026-07-20'); // 18/08 menos 29 dias
+    expect(HISTORY_WINDOW_DAYS).toBe(30);
+  });
+
+  it('atravessa virada de mês sem quebrar', () => {
+    expect(historyWindow('2026-03-01').from).toBe('2026-01-31');
+  });
+});
+
+describe('mergeBoardAndHistory', () => {
+  it('dia passado vem só do histórico, nunca do board', () => {
+    const board = [linha({ kickoff_utc: '2026-08-10T20:00:00', score: 99 })];
+    const hist = [linha({ kickoff_utc: '2026-08-10T20:00:00', score: 44 })];
+    const r = mergeBoardAndHistory(board, hist, AGORA);
+    expect(r).toHaveLength(1);
+    expect(r[0].score).toBe(44); // a nota publicada, não a recalculada
+  });
+
+  // O coração do conserto: linha que o board inventou depois do jogo não tem
+  // versão viva no apito, então não existe no histórico e some da tela.
+  it('linha que só o board tem no passado desaparece', () => {
+    const board = [linha({ kickoff_utc: '2026-08-10T20:00:00' })];
+    const r = mergeBoardAndHistory(board, [], AGORA);
+    expect(r).toHaveLength(0);
+  });
+
+  it('dia futuro vem só do board', () => {
+    const board = [linha({ kickoff_utc: '2026-08-25T20:00:00', score: 70 })];
+    const r = mergeBoardAndHistory(board, [], AGORA);
+    expect(r).toHaveLength(1);
+    expect(r[0].score).toBe(70);
+  });
+
+  // Sem esta regra, o jogo das 16h sumiria da tela às 16h05 e só voltaria no
+  // dia seguinte, porque o board (pós-expurgo) larga a linha no apito.
+  it('hoje, jogo que JÁ COMEÇOU vence pelo histórico', () => {
+    const kickoff = '2026-08-18T17:00:00'; // 1h atrás
+    const board = [linha({ kickoff_utc: kickoff, score: 88 })];
+    const hist = [linha({ kickoff_utc: kickoff, score: 55 })];
+    const r = mergeBoardAndHistory(board, hist, AGORA);
+    expect(r).toHaveLength(1);
+    expect(r[0].score).toBe(55);
+  });
+
+  it('hoje, jogo que AINDA NÃO começou vence pelo board', () => {
+    const kickoff = '2026-08-18T22:00:00'; // daqui a 4h
+    const board = [linha({ kickoff_utc: kickoff, score: 88 })];
+    const hist = [linha({ kickoff_utc: kickoff, score: 55 })];
+    const r = mergeBoardAndHistory(board, hist, AGORA);
+    expect(r).toHaveLength(1);
+    expect(r[0].score).toBe(88);
+  });
+
+  it('hoje, nunca duplica a mesma oportunidade', () => {
+    const kickoff = '2026-08-18T17:00:00';
+    const r = mergeBoardAndHistory(
+      [linha({ kickoff_utc: kickoff })],
+      [linha({ kickoff_utc: kickoff })],
+      AGORA,
+    );
+    expect(r).toHaveLength(1);
+  });
+
+  it('hoje, jogo que começou e só o histórico tem continua aparecendo', () => {
+    const kickoff = '2026-08-18T17:00:00';
+    const r = mergeBoardAndHistory([], [linha({ kickoff_utc: kickoff, score: 33 })], AGORA);
+    expect(r).toHaveLength(1);
+    expect(r[0].score).toBe(33);
+  });
+
+  it('hoje, jogo que não começou e só o histórico tem não é descartado', () => {
+    const kickoff = '2026-08-18T22:00:00';
+    const r = mergeBoardAndHistory([], [linha({ kickoff_utc: kickoff, score: 33 })], AGORA);
+    expect(r).toHaveLength(1);
+  });
+
+  it('mercados diferentes do mesmo jogo não se canibalizam', () => {
+    const kickoff = '2026-08-18T17:00:00';
+    const r = mergeBoardAndHistory(
+      [linha({ kickoff_utc: kickoff, market: 'match_winner' })],
+      [
+        linha({ kickoff_utc: kickoff, market: 'match_winner' }),
+        linha({ kickoff_utc: kickoff, market: 'goals_over_under', outcome: 'Over', line_value: 2.5 }),
+      ],
+      AGORA,
+    );
+    expect(r).toHaveLength(2);
+  });
+
+  // 21:30 BRT é 00:30 UTC do dia seguinte, horário de metade do calendário
+  // brasileiro. Agrupar por dia UTC jogaria esse jogo pro dia errado.
+  it('jogo noturno conta no dia de Brasília, não no dia UTC', () => {
+    // 2026-08-17 21:30 BRT = 2026-08-18 00:30 UTC → é dia 17, e é passado.
+    const hist = [linha({ kickoff_utc: '2026-08-18T00:30:00', score: 41 })];
+    const board = [linha({ kickoff_utc: '2026-08-18T00:30:00', score: 99 })];
+    const r = mergeBoardAndHistory(board, hist, AGORA);
+    expect(r).toHaveLength(1);
+    expect(r[0].score).toBe(41); // tratado como passado, então veio do histórico
+  });
+
+  it('linha sem kickoff é ignorada em vez de derrubar a lista', () => {
+    const r = mergeBoardAndHistory(
+      [linha({ kickoff_utc: null as unknown as string })],
+      [linha({ kickoff_utc: '2026-08-10T20:00:00' })],
+      AGORA,
+    );
+    expect(r).toHaveLength(1);
+  });
+
+  it('duas listas vazias devolvem lista vazia', () => {
+    expect(mergeBoardAndHistory([], [], AGORA)).toEqual([]);
+  });
+});

--- a/src/utils/futebol-history.ts
+++ b/src/utils/futebol-history.ts
@@ -1,0 +1,107 @@
+// ============================================================================
+// futebol-history.ts — a costura entre o board e a foto do apito
+// ============================================================================
+// A aba Histórico de /futebol/oportunidades mostra a oportunidade COMO FOI
+// PUBLICADA, não a nota recalculada semanas depois. O passado vem da RPC
+// `get_futebol_value_history` (migrations 101 e 102), que devolve a versão do
+// snapshot viva no apito; o presente e o futuro seguem vindo do board.
+//
+// A regra da fusão mora aqui, separada da página, porque é a única parte disso
+// que dá para testar sem montar tela.
+//
+// ----------------------------------------------------------------------------
+// CRÉDITO
+// ----------------------------------------------------------------------------
+// A regra de fusão e a decisão de extrair um módulo puro vêm do PR #259 do
+// Matheus (`feat/futebol-value-history`), que implementou o mesmo A0 em
+// paralelo, sem que nenhum dos dois lados soubesse do outro. Absorvido aqui.
+//
+// O que mudou em relação ao dele: as funções de calendário (`kickoffMs`,
+// `brtDay`, `addDaysBrt`) saíram, porque `futebol-datas.ts` já tem as mesmas,
+// já testadas, e duas cópias de aritmética de fuso é como se erra fuso.
+// ============================================================================
+import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
+import { parseUtc, brtDateStr, brtDayOf, addDays } from '@/utils/futebol-datas';
+
+/** Quantos dias o Histórico navega para trás. */
+export const HISTORY_WINDOW_DAYS = 30;
+
+/** Janela padrão do Histórico: 30 dias contando hoje (hoje−29 … hoje). */
+export function historyWindow(today: string): { from: string; to: string } {
+  return { from: addDays(today, -(HISTORY_WINDOW_DAYS - 1)), to: today };
+}
+
+type KeyParts = {
+  fixture_id: number;
+  market: string | null;
+  outcome: string | null;
+  line_value: number | null;
+};
+
+/**
+ * Identidade de uma oportunidade, para casar as duas fontes.
+ *
+ * Não tenta espelhar o `opportunity_key` do snapshot: as duas listas que se
+ * cruzam aqui vêm de RPCs nossas, com as mesmas colunas, então a chave só
+ * precisa ser consistente DENTRO do front. Espelhar o formato do banco criaria
+ * um acoplamento que ninguém verifica e que quebra em silêncio.
+ */
+export function opportunityKey(o: KeyParts): string {
+  return `${o.fixture_id}|${o.market ?? ''}|${o.outcome ?? ''}|${o.line_value ?? ''}`;
+}
+
+/**
+ * Funde board (presente e futuro) com histórico point-in-time (passado).
+ *
+ *   dia passado  → só o PIT. O board do passado é a nota recalculada, e a linha
+ *                  que nasceu DEPOIS do apito não tem versão viva no apito:
+ *                  some, que é o efeito pretendido.
+ *   dia corrente → união com desempate por oportunidade:
+ *                    kickoff já passou → vence a linha do histórico (o apito)
+ *                    kickoff no futuro → vence a linha do board
+ *                  Sem isso o jogo das 16h sumiria da tela às 16h05, e a lista
+ *                  contaria história diferente da tela de detalhe, que já cai
+ *                  na foto do apito assim que o kickoff passa (migration 101).
+ *   dia futuro   → só o board. A RPC nem devolve (ela corta em `kickoff < now()`
+ *                  desde a 102), mas o front não depende disso.
+ *
+ * Segue correta depois do expurgo no mart: lá o board deixa de trazer a chave
+ * do jogo encerrado, e o lado PIT já era o vencedor.
+ */
+export function mergeBoardAndHistory(
+  board: FutebolValueBoardRow[],
+  history: FutebolValueBoardRow[],
+  nowMs: number,
+): FutebolValueBoardRow[] {
+  const today = brtDateStr(new Date(nowMs));
+  const out: FutebolValueBoardRow[] = [];
+  const hojeHist = new Map<string, FutebolValueBoardRow>();
+  const hojeBoard = new Map<string, FutebolValueBoardRow>();
+
+  for (const r of history) {
+    const d = brtDayOf(r.kickoff_utc);
+    if (!d) continue;
+    if (d < today) out.push(r);
+    else if (d === today) hojeHist.set(opportunityKey(r), r);
+    // d > today: a RPC não devolve; se um dia devolver, o board manda.
+  }
+
+  for (const r of board) {
+    const d = brtDayOf(r.kickoff_utc);
+    if (!d) continue;
+    if (d < today) continue; // passado é território do PIT, sempre
+    if (d > today) out.push(r);
+    else hojeBoard.set(opportunityKey(r), r);
+  }
+
+  for (const k of new Set([...hojeHist.keys(), ...hojeBoard.keys()])) {
+    const h = hojeHist.get(k);
+    const b = hojeBoard.get(k);
+    const ms = parseUtc((h ?? b)!.kickoff_utc)?.getTime() ?? null;
+    const comecou = ms != null && ms <= nowMs;
+    const vencedora = comecou ? (h ?? b) : (b ?? h);
+    if (vencedora) out.push(vencedora);
+  }
+
+  return out;
+}

--- a/supabase/migrations/102_futebol_historico_pit_endurecido.sql
+++ b/supabase/migrations/102_futebol_historico_pit_endurecido.sql
@@ -1,0 +1,206 @@
+-- ============================================================================
+-- 102 · Endurece a RPC de histórico point-in-time
+-- ============================================================================
+-- Absorve as melhorias do PR #259 do Matheus (`feat/futebol-value-history`),
+-- que implementou a mesma entrega em paralelo, sem que nenhum dos dois lados
+-- soubesse do outro. A base aqui é a 101 (já na develop); o que muda é o corpo
+-- da `get_futebol_value_history`, com quatro coisas que ele fez melhor.
+--
+-- A assinatura NÃO muda, então `create or replace` basta, sem `drop function`.
+--
+-- ----------------------------------------------------------------------------
+-- 1. GUARDA `kickoff < now()` — é conserto de defeito, não polimento
+-- ----------------------------------------------------------------------------
+-- A 101 filtra só pela janela de dias. O problema é que o predicado PIT
+--
+--     dbt_valid_from <= kickoff  AND  (dbt_valid_to is null OR kickoff < dbt_valid_to)
+--
+-- é satisfeito À TOA por um jogo que ainda não começou: a versão aberta tem
+-- `dbt_valid_to` nulo e nasceu antes do kickoff futuro. Medido no dev em
+-- 18/08: 7 versões abertas de jogos futuros passam no predicado.
+--
+-- O efeito seria uma chave que JÁ SAIU do board voltando à tela como
+-- oportunidade viva, servida pela função que existe justamente para mostrar o
+-- passado. Não disparou até agora por sorte de calendário.
+--
+-- ----------------------------------------------------------------------------
+-- 2. `DISTINCT ON (opportunity_key)` — blindagem, não desempate arbitrário
+-- ----------------------------------------------------------------------------
+-- A 101 confiou na medição ("zero chaves com mais de uma versão viva no apito")
+-- e deixou o grão por conta do dado. Continua verdade, e continua sendo bug de
+-- SCD se deixar de ser. Mas a blindagem é barata e o desempate é EXPLÍCITO
+-- (`dbt_valid_from desc`, a mais recente das vivas), então não é o desempate
+-- arbitrário que a 098 teve que consertar: lá o `DISTINCT ON` não tinha
+-- ordenação completa e o Postgres escolhia sozinho.
+--
+-- ----------------------------------------------------------------------------
+-- 3. JANELA BRT SARGÁVEL — a 101 impedia o índice
+-- ----------------------------------------------------------------------------
+-- A 101 filtra com `public.futebol_dia_brt(fx.kickoff_utc) between p_from and p_to`.
+-- Isso chama a função linha a linha e não usa índice nenhum. Aqui os limites do
+-- dia são convertidos UMA vez, e a comparação vira `kickoff_utc >= X and < Y`.
+--
+-- O resultado é o mesmo: a conversão de um dia BRT para o intervalo UTC
+-- correspondente é exatamente o que a `futebol_dia_brt` faz ao contrário.
+--
+-- ----------------------------------------------------------------------------
+-- 4. ÍNDICE em `fact_fixtures(kickoff_utc)`
+-- ----------------------------------------------------------------------------
+-- Não existia, e o planner varria a tabela inteira. Medido pelo Matheus: a
+-- seleção PIT de 30 dias cai de 85 ms para 6,3 ms.
+--
+-- ----------------------------------------------------------------------------
+-- ⚠️ DIVERGÊNCIA DELIBERADA COM O #259: `premissas_sem_dado` FICA
+-- ----------------------------------------------------------------------------
+-- A RPC dele não devolve a coluna, espelhando o board de PRODUÇÃO. Aqui ela
+-- fica, e o motivo é que produção é que está atrasada:
+--
+--   · a 099 (na develop, aguardando deploy) põe `premissas_sem_dado` no board
+--   · o `docs/futebol-prod-deploy.sql` já declara o board COM a coluna desde o
+--     PR #248, então o espelho do #259 contradiz a própria regra dele de
+--     "espelhar o RETURNS TABLE do board"
+--   · o deploy é das 097-103 na MESMA janela, então board e histórico nascem
+--     em produção com o mesmo contrato, no mesmo instante
+--
+-- ----------------------------------------------------------------------------
+-- ⚠️ DÍVIDA CONHECIDA, herdada e agora com três cópias
+-- ----------------------------------------------------------------------------
+-- A cascata de `evidencias` abaixo é a TERCEIRA cópia verbatim das mesmas
+-- rotulagens (as outras em `get_futebol_value_board` e
+-- `get_futebol_fixture_value`). Mercado novo agora mexe em três RPCs. Extrair
+-- para um helper exige tocar no board, que estava fora do escopo do A0; fica
+-- registrado para quem puder mexer nas três de uma vez.
+--
+-- As `evidencias` saem das tabelas de premissas CORRENTES, não de um snapshot:
+-- não existe versão PIT delas. É best-effort e pode vir vazia em jogo antigo.
+-- O que é garantidamente point-in-time aqui são os NÚMEROS.
+--
+-- ⚠️ EM PRODUÇÃO: aplicar depois da 101, e na mesma janela das 097-103.
+-- ============================================================================
+
+-- Índice primeiro: barato, idempotente, e a função abaixo depende dele para o
+-- ganho de tempo. `if not exists` porque o shape file também o declara.
+create index if not exists fact_fixtures_kickoff_utc_idx
+  on futebol.fact_fixtures using btree (kickoff_utc);
+
+-- `drop` antes do `create`, e não `create or replace`, porque a função pode
+-- existir com DOIS contratos diferentes dependendo do ambiente, e o Postgres
+-- recusa `replace` quando o `RETURNS TABLE` muda:
+--
+--   · produção e develop: a versão da 101, COM `premissas_sem_dado`
+--   · o projeto de DEV:   a versão do PR #259, SEM a coluna (o Matheus aplicou
+--     a dele lá em 18/08, por cima da nossa; os dois lados escreveram no mesmo
+--     banco de desenvolvimento sem saber)
+--
+-- Nada depende desta função além do app (é RPC folha), então o drop é seguro.
+-- O grant logo abaixo é obrigatório justamente por causa do drop: o
+-- `ALTER DEFAULT PRIVILEGES` do Supabase só vale para função nova, e uma
+-- recriada não herda o grant da que morreu.
+drop function if exists public.get_futebol_value_history(date, date);
+
+create function public.get_futebol_value_history(
+  p_from date,
+  p_to   date
+)
+returns table(
+  fixture_id bigint, home_team_id bigint, away_team_id bigint,
+  home_team_name text, away_team_name text, competition text,
+  kickoff_utc timestamp without time zone, status_short text,
+  market text, outcome text, line_value double precision,
+  edge double precision, best_odd double precision, best_book text,
+  avg_odd double precision, n_casas integer, janela_usada text,
+  prob_justa_fechamento double precision,
+  pts_valor integer, pts_premissas integer, pts_corroboracao integer,
+  penalidades integer, score integer, faixa text,
+  evidencias text[], premissas_sem_dado integer
+)
+language sql
+security definer
+set search_path to ''
+as $function$
+  with pit as (
+    select distinct on (h.opportunity_key)
+      h.fixture_id, h.market, h.outcome, h.line_value, h.edge,
+      h.best_odd, h.best_book, h.avg_odd, h.n_casas, h.janela_usada,
+      h.prob_justa_fechamento, h.pts_valor, h.pts_premissas, h.pts_corroboracao,
+      h.penalidades, h.score, h.faixa,
+      h.modelo_api_concorda, h.linha_sharp_confirma, h.premissas_sem_dado
+    from futebol.fact_value_opportunities_hist h
+    join futebol.fact_fixtures fx on fx.fixture_id = h.fixture_id
+    where fx.kickoff_utc >= ((p_from::timestamp at time zone 'America/Sao_Paulo') at time zone 'UTC')
+      and fx.kickoff_utc <  (((p_to + 1)::timestamp at time zone 'America/Sao_Paulo') at time zone 'UTC')
+      and fx.kickoff_utc <  (now() at time zone 'UTC')
+      and h.dbt_valid_from <= fx.kickoff_utc
+      and (h.dbt_valid_to is null or fx.kickoff_utc < h.dbt_valid_to)
+    order by h.opportunity_key, h.dbt_valid_from desc
+  )
+  select v.fixture_id, f.home_team_id, f.away_team_id, f.home_team_name, f.away_team_name,
+    f.competition, f.kickoff_utc, f.status_short,
+    v.market, v.outcome, v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
+    v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int, v.score::int, v.faixa,
+    array_remove(array[
+      case when p.forca_mismatch then 'Ataque forte contra defesa frágil do adversário' end,
+      case when p.superioridade_xg then 'Cria mais chances de gol do que o adversário' end,
+      case when p.mando then (case v.outcome when 'Home' then 'Manda bem em casa' when 'Away' then 'Vai bem fora de casa' else 'Mando relevante' end) end,
+      case when p.desfalque_adversario then 'Adversário com desfalque de titular importante' end,
+      case when p.superioridade_tabela then 'Bem à frente na tabela' end,
+      case when p.forma then 'Em boa fase (vitórias recentes)' end,
+      case when p.h2h_favoravel then 'Histórico favorável no confronto direto' end
+    ], null)
+    || array_remove(array[
+      case when o.ataque_combinado then 'Os dois somam muitos gols (casa + fora)' end,
+      case when o.defesas_vazaveis then 'Defesas frágeis dos dois lados' end,
+      case when o.xg_combinado_alto then 'Os dois criam muitas chances de gol' end,
+      case when o.ritmo_alto then 'Jogo de ritmo alto (muitas finalizações)' end,
+      case when o.ambos_vazam then 'Os dois sofrem gol quase todo jogo' end,
+      case when o.historico_over then 'Últimos jogos goleadores' end,
+      case when o.linha_subindo then 'Mercado puxando a linha pra cima' end,
+      case when o.defesas_firmes then 'Defesas firmes dos dois lados' end,
+      case when o.clean_sheets_altos then 'Os dois passam muitos jogos sem sofrer gol' end,
+      case when o.xg_baixo_combinado then 'Os dois criam pouca coisa na frente' end,
+      case when o.ataques_fracos then 'Ataque fraco (passam em branco com frequência)' end,
+      case when o.historico_under then 'Últimos jogos truncados' end,
+      case when o.linha_descendo then 'Mercado puxando a linha pra baixo' end
+    ], null)
+    || array_remove(array[
+      case when ah.supremacia then 'Muito superior ao adversário' end,
+      case when ah.tende_golear then 'Costuma vencer com boa diferença de gols' end,
+      case when ah.adversario_fragil_fora then 'Adversário tem defesa frágil' end,
+      case when ah.mando_forte then 'Manda muito bem em casa' end,
+      case when ah.sem_rodizio then 'Deve entrar com força máxima' end,
+      case when ah.raramente_perde_por_2 then 'Raramente perde por 2 gols ou mais' end,
+      case when ah.defesa_fora_solida then 'Defesa sólida jogando fora' end,
+      case when ah.favorito_irregular then 'O favorito não costuma golear' end
+    ], null)
+    || array_remove(array[
+      case when bt.ambos_marcam then 'Os dois quase sempre marcam' end,
+      case when bt.ataque_dos_dois then 'Os dois ataques vêm produzindo' end,
+      case when bt.defesas_vazaveis then 'As duas defesas sofrem gol com frequência' end,
+      case when bt.historico_btts then 'Nos últimos jogos, os dois marcaram' end,
+      case when bt.defesa_forte then 'Uma das defesas segura bem o placar' end,
+      case when bt.ataque_trava then 'Um dos ataques costuma passar em branco' end,
+      case when bt.historico_seco then 'Jogos recentes sem os dois marcarem' end
+    ], null)
+    || array_remove(array[
+      case when dc.lado_coberto_forte then 'O lado coberto é claramente o mais forte' end,
+      case when dc.equilibrio_defensivo then 'Defesas parelhas — empate é desfecho plausível' end,
+      case when dc.adversario_limitado then 'Adversário com campanha fraca' end,
+      case when dc.invicto_recente then 'Vem sem perder nos últimos jogos' end
+    ], null)
+    || array_remove(array[
+      case when v.modelo_api_concorda and v.linha_sharp_confirma then 'As principais casas e o modelo da API apontam o mesmo lado'
+           when v.modelo_api_concorda then 'Modelo da API concorda com esse lado'
+           when v.linha_sharp_confirma then 'As principais casas vêm baixando a odd desse lado' end
+    ], null),
+    v.premissas_sem_dado::int
+  from pit v
+  join futebol.fact_fixtures f on f.fixture_id = v.fixture_id
+  left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
+  left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
+  left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
+  order by f.kickoff_utc desc, v.score desc, v.edge desc;
+$function$;
+
+grant execute on function public.get_futebol_value_history(date, date) to anon, authenticated, service_role;

--- a/supabase/migrations/103_futebol_fase_escalacao_por_tempo.sql
+++ b/supabase/migrations/103_futebol_fase_escalacao_por_tempo.sql
@@ -1,0 +1,128 @@
+-- ============================================================================
+-- 103 · A fase da escalação é escolhida por TEMPO, não por existência
+-- ============================================================================
+-- Conserta um defeito que a 098 introduziu, e que só ficou visível agora que o
+-- Matheus entregou a C1 do lado do dbt (analytics-engineering PR #88, em draft
+-- justamente esperando esta correção).
+--
+-- ----------------------------------------------------------------------------
+-- O DEFEITO
+-- ----------------------------------------------------------------------------
+-- A 098 fez a `get_futebol_fixture_extras` devolver UMA fase de escalação, para
+-- o front não desenhar cada jogador duas vezes. Até aí certo. O erro está na
+-- regra de escolha, que é por EXISTÊNCIA:
+--
+--     se existe qualquer linha 'confirmed' -> usa 'confirmed'
+--     senão                                -> usa 'real'
+--
+-- Uma regra que vira a tela inteira com base na existência de UMA linha. E a
+-- fase `confirmed` é justamente a que chega incompleta enquanto a fonte não
+-- publicou tudo.
+--
+-- Medido no dev em 18/08, nos 154 jogos que têm as DUAS fases (todos já
+-- encerrados):
+--
+--   · `confirmed`:  306 linhas,  2,0 jogadores por jogo
+--   · `real`:     7.156 linhas, 46,5 jogadores por jogo
+--
+-- Ou seja: a regra atual desenharia um campinho com DOIS jogadores num jogo já
+-- encerrado, e esconderia os outros ~44. Pior, o bloco de estatísticas da mesma
+-- tela vem de `fact_fixture_player_stats`, que é realidade pós-jogo: a tela
+-- mostraria nota e minutagem de gente que não está no campinho.
+--
+-- Não chegou a machucar ninguém porque a 098 nunca foi promovida para produção.
+--
+-- ----------------------------------------------------------------------------
+-- A REGRA NOVA (é a que o Matheus propôs no comentário da C1)
+-- ----------------------------------------------------------------------------
+-- Por tabela, independentemente:
+--
+--   1. kickoff já passou E existe 'real'  -> 'real'      (quem entrou em campo)
+--   2. senão, existe 'confirmed'          -> 'confirmed' (o XI anunciado)
+--   3. senão                              -> 'real'
+--
+-- O corte é `kickoff <= now()`, e NÃO "jogo terminado", pelo mesmo motivo da
+-- 101: durante os 90 minutos o que interessa já é quem entrou em campo, e a
+-- linha 1 só dispara se o `real` existir de fato, então não há risco de esvaziar
+-- a tela enquanto a fonte não publicou.
+--
+-- As duas tabelas decidem SEPARADAS de propósito, como na 098: elas divergem no
+-- dado real (a fase `confirmed` aparece em contagens diferentes em cada uma), e
+-- forçar uma fase comum esvaziaria uma das duas.
+--
+-- ----------------------------------------------------------------------------
+-- ⚠️ ORDEM EM PRODUÇÃO
+-- ----------------------------------------------------------------------------
+-- Esta migration EDITA o corpo que a 098 criou. Se a 098 não tiver sido
+-- aplicada, o bloco abaixo aborta com mensagem explícita em vez de trocar
+-- pedaço errado em silêncio. Aplicar 097 -> 103 na mesma janela.
+--
+-- Depois desta chegar em produção, o Matheus tira o PR #88 do draft, mergeia e
+-- roda o build-and-push. Antes disso o gate dele continua valendo.
+-- ============================================================================
+
+do $do$
+declare
+  v_def text;
+  v_novo text;
+  -- Cada âncora é única porque difere na variável e na tabela.
+  v_ancora_times constant text :=
+    'select case when count(*) filter (where lineup_phase = ''confirmed'') > 0
+              then ''confirmed'' else ''real'' end
+    into v_fase_times
+    from futebol.fact_fixture_lineups where fixture_id = p_fixture_id;';
+  v_ancora_jog constant text :=
+    'select case when count(*) filter (where lineup_phase = ''confirmed'') > 0
+              then ''confirmed'' else ''real'' end
+    into v_fase_jogadores
+    from futebol.fact_fixture_lineups_players where fixture_id = p_fixture_id;';
+  v_novo_times constant text :=
+    'select case
+           when v_fix.kickoff_utc <= (now() at time zone ''UTC'')
+                and count(*) filter (where lineup_phase = ''real'') > 0 then ''real''
+           when count(*) filter (where lineup_phase = ''confirmed'') > 0 then ''confirmed''
+           else ''real'' end
+    into v_fase_times
+    from futebol.fact_fixture_lineups where fixture_id = p_fixture_id;';
+  v_novo_jog constant text :=
+    'select case
+           when v_fix.kickoff_utc <= (now() at time zone ''UTC'')
+                and count(*) filter (where lineup_phase = ''real'') > 0 then ''real''
+           when count(*) filter (where lineup_phase = ''confirmed'') > 0 then ''confirmed''
+           else ''real'' end
+    into v_fase_jogadores
+    from futebol.fact_fixture_lineups_players where fixture_id = p_fixture_id;';
+begin
+  select pg_get_functiondef(p.oid) into v_def
+  from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+  where n.nspname = 'public' and p.proname = 'get_futebol_fixture_extras'
+    and pg_get_function_identity_arguments(p.oid) = 'p_fixture_id bigint';
+
+  if v_def is null then
+    raise exception '103: get_futebol_fixture_extras(bigint) não existe.';
+  end if;
+
+  -- Idempotência: a marca da regra nova é o teste de kickoff.
+  if position('v_fix.kickoff_utc <= (now() at time zone ''UTC'')' in v_def) > 0 then
+    raise notice '103: a fase já é escolhida por tempo, nada a fazer.';
+    return;
+  end if;
+
+  if position(v_ancora_times in v_def) = 0 or position(v_ancora_jog in v_def) = 0 then
+    raise exception '103: não achei a regra por existência da 098 em get_futebol_fixture_extras. Aplique a 098 antes (e confira se alguém mexeu no corpo depois dela).';
+  end if;
+
+  if array_length(string_to_array(v_def, v_ancora_times), 1) - 1 <> 1
+     or array_length(string_to_array(v_def, v_ancora_jog), 1) - 1 <> 1 then
+    raise exception '103: âncora duplicada em get_futebol_fixture_extras, abortando em vez de trocar o pedaço errado.';
+  end if;
+
+  v_novo := replace(v_def, v_ancora_times, v_novo_times);
+  v_novo := replace(v_novo, v_ancora_jog, v_novo_jog);
+
+  execute v_novo;
+  raise notice '103: fase da escalação passou a ser escolhida por tempo (real depois do apito).';
+end
+$do$;
+
+grant execute on function public.get_futebol_fixture_extras(bigint) to anon, authenticated, service_role;


### PR DESCRIPTION
Funde o **#259 do Matheus** com o que já está na develop, e conserta um defeito nosso que só apareceu agora.

O A0 foi implementado duas vezes sem ninguém saber do outro: nos #254/#256 (mergeados 17/08 à noite) e no #259 (aberto 18/08 de manhã). **Decisão do Victor: absorver o melhor dos dois.** Nada é descartado.

## O que vem do #259

**Guarda `kickoff < now()` na RPC de histórico.** É conserto de defeito, não polimento. O predicado PIT é satisfeito **à toa** por jogo que ainda não começou: a versão aberta tem `dbt_valid_to` nulo e nasceu antes do kickoff futuro. Medido no dev: **7 versões abertas de jogo futuro passam**. O efeito seria uma chave que já saiu do board voltando à tela como oportunidade viva, servida justamente pela função que existe para mostrar o passado. Não disparou por sorte de calendário.

**`DISTINCT ON (opportunity_key)`** com desempate explícito. A 101 confiava na medição de zero sobreposição; continua verdade, mas blindar é barato. Não é o desempate arbitrário que a 098 consertou: lá faltava ordenação e o Postgres escolhia sozinho.

**Janela BRT sargável** e o **índice `fact_fixtures_kickoff_utc_idx`**, que não existia. Medido por ele: a seleção PIT de 30 dias cai de **85ms para 6,3ms**.

**O módulo `futebol-history.ts` com testes.** A regra de fusão dele é melhor que a nossa união inline: no dia corrente o desempate é por kickoff, e **jogo que já começou vence pelo histórico**. A nossa dava board para tudo de hoje, o que descasava da tela de detalhe, que cai na foto do apito assim que o kickoff passa. Agora lista e detalhe contam a mesma história. 17 testes.

## Duas coisas que eu não absorvi, e por quê

**As funções de calendário dele** (`kickoffMs`, `brtDay`, `addDaysBrt`) duplicam `futebol-datas.ts`, que já existe e já tem teste. Duas cópias de aritmética de fuso é como se erra fuso. O módulo importa de lá.

**`premissas_sem_dado` fica no retorno.** Ele tirou espelhando produção, mas produção é que está atrasada: a 099 põe a coluna no board e sobe na mesma janela. E o shape file já declara o board **com** a coluna desde o #248, então o espelho dele contradiz a própria regra dele de "espelhar o `RETURNS TABLE` do board".

## Conserto nosso: a fase da escalação era escolhida por existência

A 098 escolhia assim: **se existe qualquer linha `confirmed`, usa `confirmed`**. Uma regra que vira a tela inteira com base numa linha só, e a `confirmed` é justamente a que chega incompleta.

Medido no dev, nos 154 jogos que têm as duas fases (todos encerrados):

| fase | linhas | jogadores por jogo |
|---|---|---|
| `confirmed` | 306 | **2,0** |
| `real` | 7.156 | **46,5** |

Ou seja: **a regra atual desenharia um campinho com dois jogadores** num jogo encerrado, escondendo os outros ~44, enquanto o bloco de estatísticas da mesma tela mostraria nota e minutagem de quem não está no campinho.

Não machucou ninguém porque a 098 nunca foi promovida. A regra nova é por **tempo**, e é a que o Matheus propôs no comentário da C1: kickoff passou e existe `real` → `real`; senão `confirmed` se existir; senão `real`. Conferido depois: **52 jogadores, fase `real`**.

⚠️ **Isto destrava a C1 dele** (`analytics-engineering` PR #88, em draft esperando exatamente esta RPC filtrar fase).

## Bug meu, corrigido junto

O `useFutebolValueHistory` usava `toISOString()`, que dá a data em **UTC**. Depois das 21h de Brasília o "hoje" virava o dia seguinte e a janela inteira andava um dia, escondendo o jogo da noite.

## Shape file: catch-up completo, fecha a #250

O `docs/futebol-prod-deploy.sql` estava sem tudo que veio depois do #248: a janela `daily` das duas RPCs de odds (097), o `market_id` e a `janela_usada` no `DISTINCT ON` e a fase no extras (098), o `v_src` do `fixture_value` (101), a RPC de histórico e o índice (102), e a fase por tempo (103).

**Validado de verdade, não por leitura:** extraí o bloco de `get_futebol_fixture_extras` **do arquivo**, apliquei no dev por cima da versão das migrations, e rodei os testes de comportamento de novo. Mesmo resultado.

## Ordem de deploy

Produção: **097 a 103 na mesma janela**. Depois disso o Matheus liga o expurgo no mart (passo 3 do A0) **e** tira o #88 do draft para a C1.

## Testes

160 testes, 159 passando. As duas falhas (`gen-route-heads` precisa de `dist/`, e o debounce do `MatchPredictionCard`) foram conferidas na develop sem estas mudanças e já falhavam lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
