### PR TITLE
fix(futebol): o rotulo e o numero da leitura saem sempre da MESMA saida

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -27,7 +27,7 @@ import { evidenciaDe, ladoDaSaida } from '@/utils/futebol-evidencias';
 import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 import { MotivosJogoPorJogo } from './MotivosJogoPorJogo';
 import { avisoSemDado } from '@/utils/futebol-sem-dado';
-import { valueDoCandidato, resumoDosMercados, REGUA_SCORE } from '@/utils/futebol-leitura';
+import { valueDoCandidato, resumoDosMercados, mesmaLinha, REGUA_SCORE, type SaidaPreferida } from '@/utils/futebol-leitura';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { isFinished } from '@/utils/futebol-datas';
 import type { MatchupTendencies } from '@/utils/futebol-tendencias';
@@ -85,15 +85,20 @@ function ReguaLinhas({
   forca: Map<number, number>;
 }) {
   const trilha = useRef<HTMLDivElement | null>(null);
+  // A medida da trilha é tirada UMA vez, no pointerdown, e vale o arrasto inteiro.
+  // Medindo a cada movimento, qualquer mudança de largura no meio do caminho
+  // reposicionava a mão do usuário: a parada com preço faz aparecer o botão de
+  // registrar, a trilha encolhia, e o mesmo X do cursor virava outra parada.
+  const medidaDaTrilha = useRef<DOMRect | null>(null);
   const [arrastando, setArrastando] = useState(false);
-  const i = valor != null ? paradas.findIndex((p) => Math.abs(p - valor) < 0.001) : -1;
+  const soltar = () => { setArrastando(false); medidaDaTrilha.current = null; };
+  const i = valor != null ? paradas.findIndex((p) => mesmaLinha(p, valor)) : -1;
   const idx = i < 0 ? 0 : i;
   const pos = paradas.length > 1 ? (idx / (paradas.length - 1)) * 100 : 0;
 
   const escolherPorX = (clientX: number) => {
-    const el = trilha.current;
-    if (!el || paradas.length < 2) return;
-    const r = el.getBoundingClientRect();
+    const r = medidaDaTrilha.current ?? trilha.current?.getBoundingClientRect();
+    if (!r || !r.width || paradas.length < 2) return;
     const t = Math.min(1, Math.max(0, (clientX - r.left) / r.width));
     onEscolher(paradas[Math.round(t * (paradas.length - 1))]);
   };
@@ -109,15 +114,20 @@ function ReguaLinhas({
         aria-valuemax={paradas[paradas.length - 1]}
         aria-valuenow={valor ?? undefined}
         aria-valuetext={valor != null ? rotulo(valor) : undefined}
-        className="relative h-8 cursor-pointer select-none touch-none"
+        className="relative h-8 cursor-pointer select-none touch-none rounded-md outline-none focus-visible:ring-2 focus-visible:ring-[#fbbf24] focus-visible:ring-offset-2 focus-visible:ring-offset-[#08321f]"
         onPointerDown={(e) => {
           (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+          medidaDaTrilha.current = e.currentTarget.getBoundingClientRect();
           setArrastando(true);
           escolherPorX(e.clientX);
         }}
         onPointerMove={(e) => arrastando && escolherPorX(e.clientX)}
-        onPointerUp={() => setArrastando(false)}
-        onPointerCancel={() => setArrastando(false)}
+        onPointerUp={soltar}
+        onPointerCancel={soltar}
+        // Fecha o caminho em que o navegador não tem captura de ponteiro: sem ela o
+        // pointerup cai fora do elemento, "arrastando" ficava travado em true e a
+        // trilha seguia respondendo ao mouse depois de solta.
+        onLostPointerCapture={soltar}
         onKeyDown={(e) => {
           if (e.key === 'ArrowLeft' || e.key === 'ArrowDown') {
             e.preventDefault();
@@ -201,6 +211,7 @@ export function BancadaMercados({
   locked,
   mercadoAtivo,
   onMercado,
+  preferida,
 }: {
   jogo: JogoInfo;
   valueRows: FutebolFixtureValueRow[] | null | undefined;
@@ -208,6 +219,8 @@ export function BancadaMercados({
   locked: boolean;
   mercadoAtivo: string;
   onMercado: (slug: string) => void;
+  /** A saída que o usuário clicou em Oportunidades, quando ele veio de lá. */
+  preferida?: SaidaPreferida | null;
 }) {
   const { data: rows, isLoading } = useFutebolFixturePremissas(jogo.fixtureId);
   const { data: numeros } = useFutebolFixtureNumeros(jogo.fixtureId);
@@ -220,14 +233,24 @@ export function BancadaMercados({
   const ehLinha = TIPO_LINHA.has(mercado.slug);
   const ehAH = mercado.slug === 'asian_handicap';
 
-  const resumos = useMemo(() => resumoDosMercados(rows, valueRows), [rows, valueRows]);
+  const resumos = useMemo(() => resumoDosMercados(rows, valueRows, preferida), [rows, valueRows, preferida]);
 
   const doMercado = useMemo(
     () => (rows ?? []).filter((r) => r.market === mercado.slug).filter((r) => !(mercado.slug === 'asian_handicap' && r.line_value === 0)),
     [rows, mercado.slug],
   );
 
-  const melhor = useMemo(() => melhorCandidato(rows ?? [], mercado.slug), [rows, mercado.slug]);
+  // O candidato que abre a folha é o MESMO do card do mercado e do hero: com preço
+  // coletado, a saída do melhor Score. Vinha só das premissas, então clicar num card
+  // que dizia "Mais de 1,5 gols" abria a régua em 4,5.
+  //
+  // Sem fallback de propósito: resumoDosMercados só deixa um mercado de fora quando
+  // melhorCandidato dele já é nulo, então um "?? melhorCandidato(...)" aqui nunca
+  // teria o que devolver, e ainda reabriria a porta das duas verdades.
+  const melhor = useMemo(
+    () => resumos.find((r) => r.mercado.slug === mercado.slug)?.candidato ?? null,
+    [resumos, mercado.slug],
+  );
 
   // TODAS as linhas cotadas do mercado, em ordem. Com pills a tela mostrava as 5
   // mais centrais e as outras 16 não existiam; na régua arrastável cabem todas.
@@ -238,17 +261,19 @@ export function BancadaMercados({
 
   const [linha, setLinha] = useState<number | null>(null);
   const [saida, setSaida] = useState<string | null>(null);
+  // Depende de `melhor`, não só de `rows`: premissas e preço chegam em requisições
+  // separadas, e quando o preço chegava depois a régua ficava parada na linha que as
+  // premissas tinham escolhido sozinhas.
   useEffect(() => {
     setLinha(melhor?.line_value != null && paradas.includes(melhor.line_value) ? melhor.line_value : paradas[Math.floor(paradas.length / 2)] ?? null);
     setSaida(melhor?.outcome ?? null);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mercado.slug, rows]);
+  }, [melhor, paradas]);
 
   // Os lados da parada atual.
   const [ladoA, ladoB] = useMemo((): [FutebolFixturePremissas | null, FutebolFixturePremissas | null] => {
     if (ehLinha) {
       const [oa, ob] = mercado.slug === 'goals_over_under' ? ['Under', 'Over'] : ['Home', 'Away'];
-      const at = (o: string) => doMercado.find((r) => r.outcome === o && r.line_value != null && Math.abs((r.line_value ?? 0) - (linha ?? NaN)) < 0.001) ?? null;
+      const at = (o: string) => doMercado.find((r) => r.outcome === o && r.line_value != null && linha != null && mesmaLinha(r.line_value, linha)) ?? null;
       return [at(oa), at(ob)];
     }
     const sel = doMercado.find((r) => r.outcome === saida) ?? melhor;
@@ -261,14 +286,22 @@ export function BancadaMercados({
   // contradiziam na mesma tela.
   const nA = ladoA ? contaQueValem(mercado.slug, ladoA.acesas) : 0;
   const nB = ladoB ? contaQueValem(mercado.slug, ladoB.acesas) : 0;
+  const valA = ladoA ? valueDoCandidato(valueRows, mercado.slug, ladoA.outcome, ladoA.line_value) : null;
+  const valB = ladoB ? valueDoCandidato(valueRows, mercado.slug, ladoB.outcome, ladoB.line_value) : null;
+
   const [ladoSel, setLadoSel] = useState<'a' | 'b' | null>(null);
   useEffect(() => setLadoSel(null), [mercado.slug, linha, saida]);
   // Sub-abas da folha: a favor e contra, as duas jogo a jogo (é onde mora a auditoria).
   const [abaMotivo, setAbaMotivo] = useState<'favor' | 'contra'>('favor');
-  const principal = ladoSel === 'a' ? ladoA : ladoSel === 'b' ? ladoB : ladoB && nB > nA ? ladoB : ladoA;
-
-  const valA = ladoA ? valueDoCandidato(valueRows, mercado.slug, ladoA.outcome, ladoA.line_value) : null;
-  const valB = ladoB ? valueDoCandidato(valueRows, mercado.slug, ladoB.outcome, ladoB.line_value) : null;
+  // O lado que abre por padrão. Onde a linha tem preço é o lado que TEM preço, que é
+  // o que o card do mercado está anunciando; sem preço nenhum, o de mais premissas.
+  const ladoPadrao = (() => {
+    if (valA && valB) return valB.score > valA.score ? ladoB : ladoA;
+    if (valA) return ladoA;
+    if (valB) return ladoB;
+    return ladoB && nB > nA ? ladoB : ladoA;
+  })();
+  const principal = ladoSel === 'a' ? ladoA : ladoSel === 'b' ? ladoB : ladoPadrao;
   const valPrincipal = principal === ladoB ? valB : valA;
 
 
@@ -415,6 +448,24 @@ export function BancadaMercados({
   }
 
   const pickAtual = labelDe(principal);
+
+  const cta =
+    valPrincipal && !fim && !locked ? (
+      <RegistrarApostaCTA
+        draft={{
+          homeName: jogo.home,
+          awayName: jogo.away,
+          competition: jogo.competition,
+          kickoffUtc: jogo.kickoffUtc,
+          market: valPrincipal.market,
+          outcome: valPrincipal.outcome,
+          lineValue: valPrincipal.line_value,
+          bestOdd: valPrincipal.best_odd,
+        }}
+        variant="ambar"
+        rotulo={`Registrar ${pickAtual}`}
+      />
+    ) : null;
 
   /**
    * Quantas premissas sustentam cada linha, no lado escolhido. É o que a régua
@@ -692,22 +743,15 @@ export function BancadaMercados({
                 ))}
               </div>
             )}
-            {valPrincipal && !fim && !locked && (
-              <RegistrarApostaCTA
-                draft={{
-                  homeName: jogo.home,
-                  awayName: jogo.away,
-                  competition: jogo.competition,
-                  kickoffUtc: jogo.kickoffUtc,
-                  market: valPrincipal.market,
-                  outcome: valPrincipal.outcome,
-                  lineValue: valPrincipal.line_value,
-                  bestOdd: valPrincipal.best_odd,
-                }}
-                variant="ambar"
-                rotulo={`Registrar ${pickAtual}`}
-              />
-            )}
+            {/* Na régua o botão desce para uma fileira só dele (`basis-full`). Ele só
+                existe na parada que tem preço, e dividindo a fileira com a trilha,
+                entrar nessa parada encolhia a trilha e sair dela esticava de volta:
+                no meio do arrasto a parada debaixo do cursor mudava sozinha. Embaixo
+                ele pode aparecer e sumir à vontade, porque a largura da trilha não
+                depende dele. Reservar a altura custaria uma faixa vazia nas outras
+                17 paradas, que é pior do que a fileira entrar e sair.
+                Sem régua (1X2, ambos marcam, dupla chance) não há o que proteger. */}
+            {ehLinha && paradas.length > 1 ? cta && <div className="basis-full mt-1">{cta}</div> : cta}
           </div>
         </div>
 

--- a/src/components/futebol/FaixaPartida.tsx
+++ b/src/components/futebol/FaixaPartida.tsx
@@ -5,7 +5,7 @@ import { Crest } from '@/components/futebol/Crest';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
 import { useFutebolFixturePremissas } from '@/hooks/use-futebol-data';
 import type { FutebolFixtureValueRow, FutebolFormResult } from '@/services/futebol-data.service';
-import { melhorLeitura, resumoDosMercados, REGUA_SCORE } from '@/utils/futebol-leitura';
+import { melhorLeitura, resumoDosMercados, REGUA_SCORE, type SaidaPreferida } from '@/utils/futebol-leitura';
 import { outcomeLabel, contaQueValem, PORTA_PREMISSAS } from '@/utils/futebol-premissas';
 import { isFinished, isLive } from '@/utils/futebol-datas';
 import type { JogoInfo } from './JogoResumo';
@@ -56,6 +56,7 @@ export function FaixaPartida({
   homeTeamId,
   awayTeamId,
   onAbrirMercado,
+  preferida,
 }: {
   jogo: JogoInfo;
   valueRows: FutebolFixtureValueRow[] | null | undefined;
@@ -69,9 +70,11 @@ export function FaixaPartida({
   homeTeamId: number;
   awayTeamId: number;
   onAbrirMercado: (slug: string) => void;
+  /** A saída que o usuário clicou em Oportunidades, quando ele veio de lá. */
+  preferida?: SaidaPreferida | null;
 }) {
   const { data: rows } = useFutebolFixturePremissas(jogo.fixtureId);
-  const resumos = useMemo(() => resumoDosMercados(rows, valueRows), [rows, valueRows]);
+  const resumos = useMemo(() => resumoDosMercados(rows, valueRows, preferida), [rows, valueRows, preferida]);
   const top = useMemo(() => melhorLeitura(resumos), [resumos]);
   const fim = isFinished(jogo.statusShort);
   // A faixa conhecia dois estados, encerrado e "não começou", então o jogo EM

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo, type ReactNode } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import { MapPin } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
@@ -13,6 +13,7 @@ import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
 import {
   computeMatchupTendencies,
 } from '@/utils/futebol-tendencias';
+import { type SaidaPreferida } from '@/utils/futebol-leitura';
 import {
   pickLabel, marketLabel, valorVerdict, fmtEdgeScore,
   faixaWord, faixaBadgeCls, chancePct, SCORE_MEDIA,
@@ -271,6 +272,17 @@ function StatsCompare({ home, away }: { home?: FutebolTeamProfile; away?: Futebo
 export default function FutebolJogo() {
   const { fixtureId } = useParams<{ fixtureId: string }>();
   const navigate = useNavigate();
+  const [params] = useSearchParams();
+  // A saída que o usuário clicou em Oportunidades. Sem ela, a tela escolhia sozinha
+  // a de maior Score do mercado, que nem sempre é a do card clicado.
+  const preferida = useMemo((): SaidaPreferida | null => {
+    const market = params.get('mercado');
+    const outcome = params.get('saida');
+    if (!market || !outcome) return null;
+    const linha = params.get('linha');
+    const n = linha != null ? Number(linha) : NaN;
+    return { market, outcome, line: Number.isFinite(n) ? n : null };
+  }, [params]);
   const fid = fixtureId ? Number(fixtureId) : undefined;
   const { data, isLoading, isError } = useFutebolFixtureDetail(fid);
   const { data: extras, isLoading: extrasLoading } = useFutebolFixtureExtras(fid);
@@ -344,7 +356,8 @@ export default function FutebolJogo() {
   // Duas abas (Leitura & mercados · Times) e o mercado aberto na bancada.
   const [aba, setAba] = useState<'mercados' | 'times'>('mercados');
   const bancadaLadoALado = useBancadaLadoALado();
-  const [mercadoAtivo, setMercadoAtivo] = useState('goals_over_under');
+  // Abre já no mercado do card clicado; sem link, no de gols, como sempre foi.
+  const [mercadoAtivo, setMercadoAtivo] = useState(() => preferida?.market ?? 'goals_over_under');
   const jogoInfo: JogoInfo | null = fixture
     ? {
         fixtureId: fid!,
@@ -525,6 +538,7 @@ export default function FutebolJogo() {
                   formAway={extrasLoading ? [] : extras?.form_away || []}
                   homeTeamId={fixture.home_team_id}
                   awayTeamId={fixture.away_team_id}
+                  preferida={preferida}
                   onAbrirMercado={(slug) => {
                     setMercadoAtivo(slug);
                     setAba('mercados');
@@ -575,6 +589,7 @@ export default function FutebolJogo() {
                   locked={locked}
                   mercadoAtivo={mercadoAtivo}
                   onMercado={setMercadoAtivo}
+                  preferida={preferida}
                 />
               )}
 

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -538,7 +538,15 @@ export default function FutebolOportunidades() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPastDay, comValor, goalsMap]);
 
-  const go = (id: number) => navigate(`/futebol/jogo/${id}`);
+  // Esta tela lista uma linha por SAÍDA, não por mercado, e há jogos com duas
+  // saídas cotadas no mesmo mercado. Navegando só com o id do jogo, clicar no card
+  // da segunda abria a tela na primeira, e o pick que o usuário leu aqui virava
+  // outro lá. O link carrega qual card foi clicado.
+  const go = (o: OppLike) => {
+    const q = new URLSearchParams({ mercado: o.market, saida: o.outcome });
+    if (o.line_value != null) q.set('linha', String(o.line_value));
+    navigate(`/futebol/jogo/${o.fixture_id}?${q}`);
+  };
   const key = (o: OppLike) => `${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`;
 
   const oppSteps = useMemo(
@@ -631,7 +639,7 @@ export default function FutebolOportunidades() {
                 const g = goalsMap.get(o.fixture_id);
                 return (
                   <div key={key(o)}>
-                    <OppRow o={o} onClick={() => go(o.fixture_id)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
+                    <OppRow o={o} onClick={() => go(o)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
                     {!isPastDay && !locked && !res && (
                       <div className="px-5 pb-2 -mt-0.5">
                         <RegistrarApostaCTA variant="text" draft={draftFromBoardRow(o)} />
@@ -649,7 +657,7 @@ export default function FutebolOportunidades() {
                 const g = goalsMap.get(o.fixture_id);
                 return (
                   <div key={key(o)}>
-                    <OppMobileCard o={o} onClick={() => go(o.fixture_id)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
+                    <OppMobileCard o={o} onClick={() => go(o)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
                     {!isPastDay && !locked && !res && <div className="px-1 pt-1.5"><RegistrarApostaCTA variant="text" draft={draftFromBoardRow(o)} /></div>}
                   </div>
                 );

--- a/src/utils/futebol-leitura.test.ts
+++ b/src/utils/futebol-leitura.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { resumoDosMercados, melhorLeitura } from './futebol-leitura';
+import type { FutebolFixturePremissas, FutebolFixtureValueRow } from '@/services/futebol-data.service';
+
+// O caso é o Independ. Rivadavia x Fluminense (fixture 1547770, staging): o mart
+// cotou UMA saída de gols, Mais de 1,5, Score 54 — e é ela que Oportunidades
+// mostra. Nas premissas, quem tem mais linhas acesas é Menos de 4,5.
+//
+// A tela do jogo tirava o RÓTULO das premissas e os NÚMEROS do preço, então dizia
+// "Menos de 4,5 gols" com a chance, a odd e o Score do "Mais de 1,5 gols" — e o
+// botão de registrar gravava o Mais de 1,5 que o usuário nunca leu.
+
+const prem = (outcome: string, line: number | null, acesas: string[]): FutebolFixturePremissas => ({
+  market: 'goals_over_under',
+  outcome,
+  line_value: line,
+  pts_premissas: 0,
+  penalidades_pts: 0,
+  acesas,
+  apagadas: [],
+  penalidades: [],
+});
+
+// Tipado de verdade, sem `as`: assim, campo novo obrigatório na RPC quebra o teste
+// aqui em vez de chegar `undefined` na tela.
+const VALUE_BASE: FutebolFixtureValueRow = {
+  market: 'goals_over_under',
+  outcome: 'Over',
+  outcome_order: 1,
+  line_value: 1.5,
+  edge: 0.0088,
+  best_odd: 1.65,
+  best_book: 'bet365',
+  avg_odd: 1.6,
+  n_casas: 5,
+  janela_usada: 'fechamento',
+  prob_justa_fechamento: 0.6114,
+  pts_valor: 20,
+  pts_premissas: 34,
+  pts_corroboracao: 0,
+  penalidades: 0,
+  penalidades_globais_pts: 0,
+  penalidades_especificas_pts: 0,
+  score: 54,
+  faixa: 'media',
+  modelo_api_concorda: true,
+  linha_sharp_confirma: false,
+  evidencias: [],
+  avisos: [],
+  contras: [],
+  premissas_sem_dado: 0,
+};
+
+const value = (outcome: string, line: number | null, score: number): FutebolFixtureValueRow => ({
+  ...VALUE_BASE,
+  outcome,
+  line_value: line,
+  score,
+});
+
+const OVER_15 = ['defesas_vazaveis', 'ataque_combinado', 'xg_combinado_alto'];
+const UNDER_45 = ['defesas_firmes', 'xg_baixo_combinado', 'ataques_fracos', 'historico_under'];
+
+const rows = [prem('Over', 1.5, OVER_15), prem('Under', 4.5, UNDER_45)];
+
+const gols = (r: ReturnType<typeof resumoDosMercados>) => r.find((x) => x.mercado.slug === 'goals_over_under')!;
+
+describe('resumoDosMercados', () => {
+  it('com preço, quem representa o mercado é a saída que tem preço', () => {
+    const g = gols(resumoDosMercados(rows, [value('Over', 1.5, 54)]));
+    expect(g.candidato.outcome).toBe('Over');
+    expect(g.candidato.line_value).toBe(1.5);
+    expect(g.value?.score).toBe(54);
+  });
+
+  it('as premissas contadas são as da saída que tem preço', () => {
+    const g = gols(resumoDosMercados(rows, [value('Over', 1.5, 54)]));
+    expect(g.nValem).toBe(OVER_15.length);
+  });
+
+  it('entre duas saídas com preço, vale a de maior Score', () => {
+    const g = gols(resumoDosMercados(rows, [value('Over', 1.5, 54), value('Under', 4.5, 61)]));
+    expect(g.candidato.outcome).toBe('Under');
+    expect(g.value?.score).toBe(61);
+  });
+
+  it('empate de Score não troca a saída no meio do caminho', () => {
+    const a = gols(resumoDosMercados(rows, [value('Over', 1.5, 50), value('Under', 4.5, 50)]));
+    const b = gols(resumoDosMercados(rows, [value('Under', 4.5, 50), value('Over', 1.5, 50)]));
+    expect(a.candidato.outcome).toBe(b.candidato.outcome);
+  });
+
+  it('sem preço nenhum, volta a mandar a saída com mais premissas', () => {
+    const g = gols(resumoDosMercados(rows, []));
+    expect(g.candidato.outcome).toBe('Under');
+    expect(g.candidato.line_value).toBe(4.5);
+    expect(g.value).toBeNull();
+  });
+
+  it('preço de uma saída sem premissa não empresta o número para outra saída', () => {
+    const g = gols(resumoDosMercados(rows, [value('Over', 2.5, 71)]));
+    expect(g.candidato.outcome).toBe('Under');
+    expect(g.value).toBeNull();
+  });
+
+  it('casa a linha mesmo com a folga de float entre as duas RPCs', () => {
+    const g = gols(resumoDosMercados(rows, [value('Over', 1.5000001, 54)]));
+    expect(g.value?.score).toBe(54);
+    expect(g.candidato.outcome).toBe('Over');
+  });
+
+  it('mercado sem linha (1X2) casa por saída, com line_value nulo', () => {
+    const semLinha = [
+      { ...prem('Home', null, ['forma', 'mando']), market: 'match_winner' },
+      { ...prem('Away', null, ['superioridade_xg']), market: 'match_winner' },
+    ];
+    const v: FutebolFixtureValueRow = { ...VALUE_BASE, market: 'match_winner', outcome: 'Away', line_value: null, score: 58 };
+    const r = resumoDosMercados(semLinha, [v]).find((x) => x.mercado.slug === 'match_winner')!;
+    expect(r.candidato.outcome).toBe('Away');
+    expect(r.value?.score).toBe(58);
+  });
+
+  it('passa a régua pelo Score da própria saída', () => {
+    expect(gols(resumoDosMercados(rows, [value('Over', 1.5, 54)])).passa).toBe(true);
+    expect(gols(resumoDosMercados(rows, [value('Over', 1.5, 31)])).passa).toBe(false);
+  });
+});
+
+// Oportunidades lista uma linha por SAÍDA, não por mercado: no board de staging,
+// 18 dos 104 pares (jogo, mercado) têm duas ou mais saídas cotadas. Sem levar qual
+// card foi clicado, abrir o de Score menor caía no de Score maior.
+describe('resumoDosMercados com a saída clicada', () => {
+  const doisPrecos = [value('Over', 1.5, 54), value('Under', 4.5, 61)];
+
+  it('a saída clicada ganha do maior Score do mercado', () => {
+    const g = gols(resumoDosMercados(rows, doisPrecos, { market: 'goals_over_under', outcome: 'Over', line: 1.5 }));
+    expect(g.candidato.outcome).toBe('Over');
+    expect(g.value?.score).toBe(54);
+  });
+
+  it('sem a saída clicada, segue mandando o maior Score', () => {
+    const g = gols(resumoDosMercados(rows, doisPrecos, null));
+    expect(g.candidato.outcome).toBe('Under');
+    expect(g.value?.score).toBe(61);
+  });
+
+  it('saída clicada de OUTRO mercado não mexe neste', () => {
+    const g = gols(resumoDosMercados(rows, doisPrecos, { market: 'match_winner', outcome: 'Home', line: null }));
+    expect(g.candidato.outcome).toBe('Under');
+  });
+
+  it('link apontando para saída que não existe mais cai no maior Score, não em nada', () => {
+    const g = gols(resumoDosMercados(rows, doisPrecos, { market: 'goals_over_under', outcome: 'Over', line: 9.5 }));
+    expect(g.candidato.outcome).toBe('Under');
+    expect(g.value?.score).toBe(61);
+  });
+});
+
+// Handicap zero nunca acende premissa, e a régua da folha não lista essa parada. Um
+// handicap zero COTADO virava o representante do mercado e a folha abria fora da
+// régua: o mesmo bug de linha errada, por outra porta.
+describe('handicap zero', () => {
+  const ah = (outcome: string, line: number | null, acesas: string[]) => ({
+    ...prem(outcome, line, acesas),
+    market: 'asian_handicap',
+  });
+  const ahValue = (outcome: string, line: number | null, score: number): FutebolFixtureValueRow => ({
+    ...VALUE_BASE,
+    market: 'asian_handicap',
+    outcome,
+    line_value: line,
+    score,
+  });
+
+  it('linha zero não representa o mercado, mesmo tendo o maior Score', () => {
+    const linhas = [ah('Home', 0, []), ah('Home', -0.5, ['supremacia', 'tende_golear'])];
+    const r = resumoDosMercados(linhas, [ahValue('Home', 0, 70), ahValue('Home', -0.5, 44)])
+      .find((x) => x.mercado.slug === 'asian_handicap')!;
+    expect(r.candidato.line_value).toBe(-0.5);
+    expect(r.value?.score).toBe(44);
+  });
+});
+
+describe('melhorLeitura', () => {
+  it('o rótulo do hero e o Score do hero saem da MESMA saída', () => {
+    const top = melhorLeitura(resumoDosMercados(rows, [value('Over', 1.5, 54)]))!;
+    expect(top.candidato.outcome).toBe('Over');
+    expect(top.candidato.line_value).toBe(top.value!.line_value);
+    expect(top.candidato.outcome).toBe(top.value!.outcome);
+  });
+});

--- a/src/utils/futebol-leitura.ts
+++ b/src/utils/futebol-leitura.ts
@@ -3,6 +3,7 @@ import {
   MERCADOS,
   PORTA_PREMISSAS,
   contaQueValem,
+  linhaNegociavel,
   melhorCandidato,
   premissasDaSaida,
   type MercadoInfo,
@@ -16,6 +17,13 @@ import {
 // (get_futebol_fixture_value). Sem odds, a leitura vive das premissas — o próprio
 // protótipo tem esse padrão no "sem preço" do BTTS.
 
+/** Mesma parada da régua? Compara com folga porque a linha vem em float. */
+export function mesmaLinha(a: number | null, b: number | null): boolean {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  return Math.abs(a - b) < 0.011;
+}
+
 /** Casa uma linha de valor (odds reais) com um candidato de premissas. */
 export function valueDoCandidato(
   valueRows: FutebolFixtureValueRow[] | null | undefined,
@@ -24,20 +32,80 @@ export function valueDoCandidato(
   line: number | null,
 ): FutebolFixtureValueRow | null {
   if (!valueRows?.length) return null;
+  return valueRows.find((v) => v.market === market && v.outcome === outcome && mesmaLinha(v.line_value, line)) ?? null;
+}
+
+/** O caminho inverso: a linha de premissas da saída que tem preço. */
+export function candidatoDaValue(
+  rows: FutebolFixturePremissas[] | null | undefined,
+  v: FutebolFixtureValueRow,
+): FutebolFixturePremissas | null {
   return (
-    valueRows.find(
-      (v) =>
-        v.market === market &&
-        v.outcome === outcome &&
-        ((v.line_value == null && line == null) ||
-          (v.line_value != null && line != null && Math.abs(v.line_value - line) < 0.011)),
-    ) ?? null
+    (rows ?? []).find((r) => r.market === v.market && r.outcome === v.outcome && mesmaLinha(r.line_value, v.line_value)) ??
+    null
   );
+}
+
+/**
+ * A saída que o usuário clicou em Oportunidades. Aquela tela lista uma linha por
+ * SAÍDA, não por mercado, e 18 dos 104 pares (jogo, mercado) do board têm duas ou
+ * mais saídas cotadas: sem carregar qual foi clicada, abrir o card da segunda caía
+ * na primeira, que é o mesmo susto de ver um pick virar outro.
+ */
+export interface SaidaPreferida {
+  market: string;
+  outcome: string;
+  line: number | null;
+}
+
+/**
+ * Quem representa o mercado quando HÁ preço coletado: a saída que o usuário clicou,
+ * se ele veio de Oportunidades, senão a de maior Score. Sempre junto das premissas
+ * DELA.
+ *
+ * Só entram saídas que existem dos dois lados (preço e premissas). Uma saída com
+ * preço e sem premissa pegaria carona no rótulo de outra saída, que é justamente o
+ * bug que isto fecha.
+ */
+function saidaComPreco(
+  rows: FutebolFixturePremissas[],
+  valueRows: FutebolFixtureValueRow[] | null | undefined,
+  market: string,
+  preferida: SaidaPreferida | null | undefined,
+): { value: FutebolFixtureValueRow; candidato: FutebolFixturePremissas } | null {
+  if (!valueRows?.length) return null;
+  const pares = valueRows
+    .filter((v) => v.market === market && linhaNegociavel(market, v.line_value))
+    .flatMap((v) => {
+      const c = candidatoDaValue(rows, v);
+      return c ? [{ value: v, candidato: c }] : [];
+    });
+  if (!pares.length) return null;
+  if (preferida?.market === market) {
+    const clicada = pares.find(
+      (x) => x.value.outcome === preferida.outcome && mesmaLinha(x.value.line_value, preferida.line),
+    );
+    if (clicada) return clicada;
+  }
+  // Desempate EXPLÍCITO. Ordenando só por Score, duas saídas empatadas ficavam na
+  // ordem em que a RPC devolveu as linhas, e o hero podia nomear uma ou outra sem
+  // regra nenhuma. Empatado no preço, ganha quem tem mais premissas atrás, que é o
+  // mesmo critério que vale quando não há preço; persistindo o empate, a ordem de
+  // saída do próprio mercado, que é estável.
+  return [...pares].sort(
+    (a, b) =>
+      b.value.score - a.value.score ||
+      contaQueValem(market, b.candidato.acesas) - contaQueValem(market, a.candidato.acesas) ||
+      a.value.outcome_order - b.value.outcome_order,
+  )[0];
 }
 
 export interface MercadoResumo {
   mercado: MercadoInfo;
-  /** O candidato que representa o mercado (saída/linha com mais premissas). */
+  /**
+   * A saída/linha que representa o mercado: a de melhor Score quando há preço, a de
+   * mais premissas quando não há. É ela que dá o rótulo, as premissas e o `value`.
+   */
   candidato: FutebolFixturePremissas;
   nValem: number;
   totalQueValem: number;
@@ -55,10 +123,20 @@ export const REGUA_SCORE = 40;
 export function resumoDosMercados(
   rows: FutebolFixturePremissas[] | null | undefined,
   valueRows: FutebolFixtureValueRow[] | null | undefined,
+  preferida?: SaidaPreferida | null,
 ): MercadoResumo[] {
   if (!rows?.length) return [];
   return MERCADOS.flatMap((m) => {
-    const c = melhorCandidato(rows, m.slug);
+    // Com preço coletado quem representa o mercado é a saída do melhor Score; sem
+    // preço, a saída com mais premissas. Rótulo e números na MESMA saída, sempre.
+    //
+    // Antes o candidato saía sempre das premissas e o número saía do melhor Score do
+    // mercado, e os dois podiam ser saídas diferentes: a tela escrevia "Menos de 4,5
+    // gols" exibindo a chance, a odd e o Score de "Mais de 1,5 gols", enquanto
+    // Oportunidades mostrava o segundo. Pior: o botão de registrar gravava a aposta
+    // do preço, não a do rótulo que o usuário leu.
+    const comPreco = saidaComPreco(rows, valueRows, m.slug, preferida);
+    const c = comPreco?.candidato ?? melhorCandidato(rows, m.slug);
     if (!c) return [];
     const nValem = contaQueValem(m.slug, c.acesas);
     // Denominador só do lado da saída: para um Over, "defesas firmes" e as outras do
@@ -67,14 +145,7 @@ export function resumoDosMercados(
     const totalQueValem = premissasDaSaida(m, c.outcome, c.line_value, c.acesas).filter(
       (p) => p.peso == null || p.peso > 0,
     ).length;
-    // O valor pode estar em qualquer saída do mercado; o candidato de contexto e o
-    // de preço podem divergir. Preferimos o do próprio candidato; se não houver,
-    // olhamos o melhor Score do mercado inteiro.
-    const doCandidato = valueDoCandidato(valueRows, m.slug, c.outcome, c.line_value);
-    const doMercado = (valueRows ?? [])
-      .filter((v) => v.market === m.slug)
-      .sort((a, b) => b.score - a.score)[0] ?? null;
-    const value = doCandidato ?? doMercado;
+    const value = comPreco?.value ?? null;
     const passa = value ? value.score >= REGUA_SCORE : nValem >= PORTA_PREMISSAS;
     return [{ mercado: m, candidato: c, nValem, totalQueValem, value, passa }];
   });

--- a/src/utils/futebol-premissas.ts
+++ b/src/utils/futebol-premissas.ts
@@ -301,15 +301,26 @@ export const PORTA_PREMISSAS = 2;
  * valem). Vive aqui, e não no componente do mapa, porque o painel da agenda também
  * resume o jogo por ele.
  */
+/**
+ * A linha entra como candidata? Handicap zero nunca acende premissa (as 7 são de
+ * favorito ou de azarão) e o doc manda excluir explicitamente em vez de deixar
+ * sumir em silêncio.
+ *
+ * Mora aqui, e não dentro de `melhorCandidato`, porque o candidato de PREÇO precisa
+ * do mesmo corte: aplicado só de um lado, um handicap zero cotado viraria o
+ * representante do mercado e a folha abriria numa linha que a régua nem lista.
+ */
+export function linhaNegociavel(market: string, line: number | null): boolean {
+  return !(market === 'asian_handicap' && line === 0);
+}
+
 export function melhorCandidato(
   rows: FutebolFixturePremissas[],
   market: string,
 ): FutebolFixturePremissas | null {
   const doMercado = rows
     .filter((r) => r.market === market)
-    // Handicap zero nunca acende premissa (as 7 são de favorito ou de azarão) e o doc
-    // manda excluir explicitamente em vez de deixar sumir em silêncio.
-    .filter((r) => !(market === 'asian_handicap' && r.line_value === 0));
+    .filter((r) => linhaNegociavel(market, r.line_value));
   if (!doMercado.length) return null;
   const nota = (r: FutebolFixturePremissas) => contaQueValem(market, r.acesas);
   const nPen = (r: FutebolFixturePremissas) => (r.penalidades ?? []).length;


### PR DESCRIPTION
## O bug

Na tela do jogo, o hero dizia **"Menos de 4,5 gols"** exibindo a chance, a odd e o Score de **"Mais de 1,5 gols"**, que era o pick que Oportunidades mostrava. Clicar em Gols na lista de mercados abria a régua em 4,5 em vez de 1,5. E o botão Registrar gravava a aposta do preço, não a do rótulo que o usuário leu.

`resumoDosMercados` montava cada mercado com duas fontes que podiam divergir: o **rótulo** saía do candidato de premissas (a saída com mais premissas acesas) e o **número** caía num fallback que pegava o melhor Score do mercado inteiro, de qualquer saída. No Independ. Rivadavia × Fluminense (1547770) o mart cotou uma saída só, Mais de 1,5 com Score 54, e as premissas apontavam Menos de 4,5: um pick em cada metade do mesmo card.

## O que muda

Com preço coletado, quem representa o mercado é a saída **que tem preço**, junto das premissas dela. Sem preço, segue a saída com mais premissas. Rótulo, contagem de premissas, Score e o draft do Registrar passam a sair sempre da mesma saída.

Só entram saídas que existem dos dois lados. Medido no staging: 126 de 126 linhas de valor têm premissa casada, então o caminho sem casamento é defensivo, não rotina.

### A saída clicada viaja no link

Oportunidades lista uma linha por **saída**, não por mercado, e 18 dos 104 pares (jogo, mercado) do board têm duas ou mais saídas cotadas. Navegando só com o id do jogo, clicar no card da segunda abria a tela na primeira. O link agora leva `?mercado=&saida=&linha=`, a tela do jogo já abre no mercado certo e a saída clicada tem prioridade sobre o maior Score.

O hero segue sendo "melhor leitura do jogo", o maior Score entre os cinco mercados, independente de como se chegou. São duas afirmações verdadeiras e diferentes: o hero fala do jogo, a folha fala da aposta clicada. Fazer o hero depender do referrer criaria o problema inverso, o mesmo jogo com heros diferentes conforme o link.

### O desempate de Score virou explícito

Ordenando só por Score, duas saídas empatadas ficavam na ordem em que a RPC devolveu as linhas. Agora é Score, depois premissas, depois `outcome_order`. Foi o teste de empate que pegou isso.

### Handicap zero

O corte de handicap zero (nunca acende premissa, e a régua não lista essa parada) existia só no candidato de premissas. Virou `linhaNegociavel` e vale para os dois: aplicado de um lado só, um handicap zero cotado viraria o representante do mercado e a folha abriria fora da régua.

### A régua parava de acompanhar o cursor

O botão Registrar dividia a fileira flex com a trilha e só existe na parada que tem preço. Entrar nessa parada encolhia a trilha ~185px e sair esticava de volta, então a parada debaixo do cursor mudava sozinha no meio do arrasto: clicar em 1,5 levava para 2,0.

O botão desceu para uma fileira própria, e a trilha passou a medir a si mesma uma vez, no `pointerdown`, valendo o arrasto inteiro. Mais o release em `onLostPointerCapture`, que fechava o caso do navegador sem captura de ponteiro deixando `arrastando` travado, e um anel de foco na trilha, que já respondia às setas sem sinal visual nenhum.

## Como testar

1. `/futebol/oportunidades`, clicar em qualquer card. A URL leva `?mercado=&saida=&linha=`, e o hero, o card do mercado e a régua têm que dizer a mesma coisa que o card clicado.
2. `/futebol/jogo/<id>` sem parâmetro nenhum: abre em Gols, na saída de maior Score, como sempre foi.
3. Na régua, arrastar devagar de 0,5 até 3,5 passando pela parada que tem preço. A bolinha tem que acompanhar o cursor sem pular.

## Verificação

15 testes novos em `futebol-leitura.test.ts`, cobrindo a saída clicada, o handicap zero, a folga de float entre as duas RPCs, mercado sem linha, empate de Score e o caso original. Suíte 178 de 179; a falha (`MatchPredictionCard`) e o arquivo que quebra (`gen-route-heads`) já falhavam na develop limpa. Typecheck sem erro novo, confirmado rodando na develop sem o diff e comparando.

## Fora de escopo, achado no caminho

`<button>` dentro de `<button>` em `FaixaPartida.tsx`: o bloco da melhor leitura é um botão e o CTA de registrar mora dentro dele. HTML inválido, o navegador reescreve a árvore sozinho, e leitor de tela fica ambíguo. Pré-existente, não mexi porque muda a área clicável do hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
