### PR TITLE
refactor(futebol): a saida da aposta vira um tipo, em vez de tres campos soltos

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -286,8 +286,8 @@ export function BancadaMercados({
   // contradiziam na mesma tela.
   const nA = ladoA ? contaQueValem(mercado.slug, ladoA.acesas) : 0;
   const nB = ladoB ? contaQueValem(mercado.slug, ladoB.acesas) : 0;
-  const valA = ladoA ? valueDoCandidato(valueRows, mercado.slug, ladoA.outcome, ladoA.line_value) : null;
-  const valB = ladoB ? valueDoCandidato(valueRows, mercado.slug, ladoB.outcome, ladoB.line_value) : null;
+  const valA = ladoA ? valueDoCandidato(valueRows, ladoA) : null;
+  const valB = ladoB ? valueDoCandidato(valueRows, ladoB) : null;
 
   const [ladoSel, setLadoSel] = useState<'a' | 'b' | null>(null);
   useEffect(() => setLadoSel(null), [mercado.slug, linha, saida]);
@@ -306,13 +306,13 @@ export function BancadaMercados({
 
 
   const labelDe = (c: FutebolFixturePremissas | null) =>
-    c ? outcomeLabel(mercado.slug, c.outcome, jogo.home, jogo.away, c.line_value) : '';
+    c ? outcomeLabel(c, jogo.home, jogo.away) : '';
 
   // Favor / apagadas do lado principal. Só as premissas DAQUELE lado: as do outro
   // medem o mesmo número ao contrário ("defesas frágeis" × "defesas firmes"), então
   // listá-las aqui como "não aconteceu" fazia a tela se contradizer.
   const visiveis = principal
-    ? premissasDaSaida(mercado, principal.outcome, principal.line_value, principal.acesas)
+    ? premissasDaSaida(mercado, principal, principal.acesas)
     : mercado.premissas.filter((p) => !PREMISSAS_OCULTAS.has(p.slug));
   const acesasSet = new Set(principal?.acesas ?? []);
   const favor = visiveis.filter((p) => acesasSet.has(p.slug)).sort((a, b) => (b.peso ?? 0) - (a.peso ?? 0));
@@ -408,7 +408,7 @@ export function BancadaMercados({
   const veredito = useMemo(() => {
     const lbl = labelDe(principal);
     if (fim) {
-      const r = placar && principal ? settleFutebol(mercado.slug, principal.outcome, principal.line_value, placar.home, placar.away) : null;
+      const r = placar && principal ? settleFutebol(principal, placar.home, placar.away) : null;
       return r ? `O mapa apontava ${lbl}: ${resultBadge(r).label.toLowerCase()}.` : `Jogo encerrado.`;
     }
     if (valPrincipal) {
@@ -485,21 +485,21 @@ export function BancadaMercados({
   const paradasUI = ehLinha
     ? []
     : doMercado.map((o) => {
-        const val = valueDoCandidato(valueRows, mercado.slug, o.outcome, o.line_value);
+        const val = valueDoCandidato(valueRows, o);
         const n = contaQueValem(mercado.slug, o.acesas);
         return {
           chave: o.outcome,
-          rotulo: outcomeLabel(mercado.slug, o.outcome, jogo.home, jogo.away, o.line_value),
+          rotulo: outcomeLabel(o, jogo.home, jogo.away),
           ativa: o.outcome === (saida ?? melhor?.outcome),
           passa: val ? val.score >= REGUA_SCORE : n >= PORTA_PREMISSAS,
-          res: placar ? settleFutebol(mercado.slug, o.outcome, o.line_value, placar.home, placar.away) : null,
+          res: placar ? settleFutebol(o, placar.home, placar.away) : null,
           escolher: () => setSaida(o.outcome),
         };
       });
 
   const resPrincipal =
     placar && principal
-      ? settleFutebol(mercado.slug, principal.outcome, principal.line_value, placar.home, placar.away)
+      ? settleFutebol(principal, placar.home, placar.away)
       : null;
 
   return (
@@ -537,7 +537,7 @@ export function BancadaMercados({
             const larg = temScore ? `${s}%` : `${Math.min(100, (r.nValem / Math.max(r.totalQueValem, 1)) * 100)}%`;
             const regua = temScore ? `${REGUA_SCORE}%` : `${(PORTA_PREMISSAS / Math.max(r.totalQueValem, 1)) * 100}%`;
             const cor = on ? '#fbbf24' : r.passa ? (temScore && s >= 60 ? '#0a3d2e' : '#d4a017') : '#c4bda8';
-            const pick = outcomeLabel(r.mercado.slug, r.candidato.outcome, jogo.home, jogo.away, r.candidato.line_value);
+            const pick = outcomeLabel(r.candidato, jogo.home, jogo.away);
             return (
               <button
                 key={r.mercado.slug}

--- a/src/components/futebol/FaixaPartida.tsx
+++ b/src/components/futebol/FaixaPartida.tsx
@@ -161,12 +161,25 @@ export function FaixaPartida({
 
         {/* A melhor leitura, na mesma faixa. Sem preço coletado, o número grande é
             quantas premissas sustentam, que é o que existe para afirmar. */}
-        <button
-          type="button"
-          onClick={() => top && onAbrirMercado(top.mercado.slug)}
-          className="flex items-center gap-5 text-left bg-transparent border-0 p-0 cursor-pointer min-w-0"
-        >
-          <div className="flex-1 min-w-0">
+        {/* A área clicável é o TEXTO da leitura, não a faixa inteira.
+
+            Era um <button> só, envolvendo tudo, com o botão de registrar dentro:
+            HTML não permite botão dentro de botão, e o navegador não recusa, ele
+            reescreve a árvore sozinho na hora de ler a página, tirando o de dentro
+            de dentro do de fora. Ou seja, o que ia para a tela não era o que estava
+            escrito aqui, e cada navegador reescrevia do seu jeito. Para leitor de
+            tela e teclado, dois controles um dentro do outro não têm resposta: não
+            dá para dizer qual deles está em foco.
+
+            Funcionava por acaso, porque o CTA chama stopPropagation. O Score ficou
+            fora da área clicável de propósito: ele é leitura, não controle, e é o
+            vizinho do botão de registrar. */}
+        <div className="flex items-center gap-5 min-w-0">
+          <button
+            type="button"
+            onClick={() => top && onAbrirMercado(top.mercado.slug)}
+            className="flex-1 min-w-0 text-left bg-transparent border-0 p-0 cursor-pointer rounded-md outline-none focus-visible:ring-2 focus-visible:ring-[#fbbf24] focus-visible:ring-offset-2 focus-visible:ring-offset-[#08321f]"
+          >
             <div className="text-[10px] uppercase tracking-[0.16em] text-white/45">Melhor leitura do jogo</div>
             {/* Sem truncate: "Mais de 1,75 g…" escondia justamente a linha da
                 leitura. Aqui ela quebra em duas linhas. */}
@@ -203,7 +216,7 @@ export function FaixaPartida({
                 perto do jogo
               </div>
             )}
-          </div>
+          </button>
 
           <div className="text-center shrink-0">
             <div className="tabular-nums font-bold leading-none tracking-[-0.04em] text-[44px]" style={{ color: '#fbbf24' }}>
@@ -233,7 +246,7 @@ export function FaixaPartida({
               <div className="mt-2 text-[10px] text-white/45 max-w-[130px] mx-auto leading-snug">sem preço coletado</div>
             )}
           </div>
-        </button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/futebol/FaixaPartida.tsx
+++ b/src/components/futebol/FaixaPartida.tsx
@@ -85,7 +85,7 @@ export function FaixaPartida({
   const rolando = isLive(jogo.statusShort);
 
   const pick = top
-    ? outcomeLabel(top.mercado.slug, top.candidato.outcome, jogo.home, jogo.away, top.candidato.line_value)
+    ? outcomeLabel(top.candidato, jogo.home, jogo.away)
     : null;
   const v = top?.value ?? null;
   const nValem = top ? contaQueValem(top.mercado.slug, top.candidato.acesas) : 0;

--- a/src/components/futebol/FixtureRow.tsx
+++ b/src/components/futebol/FixtureRow.tsx
@@ -54,7 +54,7 @@ export function FixtureRow({
   // Jogo encerrado não precisa mais do Score, que é uma previsão: o que importa
   // ali é se a leitura bateu. O selo vira ✓ ou ✕ pelo placar.
   const liquidacao =
-    fim && best ? settleFutebol(best.market, best.outcome, best.line_value, gh, ga) : null;
+    fim && best ? settleFutebol(best, gh, ga) : null;
   const bateu = liquidacao != null ? isHit(liquidacao) : null;
 
   return (
@@ -101,7 +101,7 @@ export function FixtureRow({
         {best ? (
           <>
             <span className="block sm:mt-0.5 text-[11.5px] sm:text-[12.5px] font-semibold text-ink truncate">
-              {pickLabel(best.market, best.outcome, best.line_value, fixture.home_team_name, fixture.away_team_name)}
+              {pickLabel(best, fixture.home_team_name, fixture.away_team_name)}
             </span>
             <span className="block mt-px text-[10.5px] sm:text-[11px] tabular-nums truncate" style={{ color: '#8d8672' }}>
               odd {best.best_odd.toFixed(2)}

--- a/src/components/futebol/JogoResumo.tsx
+++ b/src/components/futebol/JogoResumo.tsx
@@ -74,7 +74,7 @@ export function HeroLeitura({
   const { data: numeros } = useFutebolFixtureNumeros(jogo.fixtureId);
   if (!top) return null;
   const lado = ladoDaSaida(top.mercado.slug, top.candidato.outcome);
-  const pick = outcomeLabel(top.mercado.slug, top.candidato.outcome, jogo.home, jogo.away, top.candidato.line_value);
+  const pick = outcomeLabel(top.candidato, jogo.home, jogo.away);
 
   // Os porquês: a evidência das acesas de maior peso, no máximo 3.
   const porques = top.candidato.acesas
@@ -88,7 +88,7 @@ export function HeroLeitura({
     });
 
   const fim = isFinished(jogo.statusShort);
-  const res = fim ? settleFutebol(top.mercado.slug, top.candidato.outcome, top.candidato.line_value, jogo.goalsHome, jogo.goalsAway) : null;
+  const res = fim ? settleFutebol(top.candidato, jogo.goalsHome, jogo.goalsAway) : null;
 
   return (
     <div
@@ -230,7 +230,7 @@ export function JogoResumo({
     if (!placar || !resumos.length) return null;
     const apontados = resumos.filter((r) => r.passa);
     const liq = apontados
-      .map((r) => settleFutebol(r.mercado.slug, r.candidato.outcome, r.candidato.line_value, placar.home, placar.away))
+      .map((r) => settleFutebol(r.candidato, placar.home, placar.away))
       .filter((x): x is NonNullable<typeof x> => x != null);
     if (!liq.length) return null;
     const hits = liq.filter(isHit).length;
@@ -314,10 +314,10 @@ export function JogoResumo({
             <span className="text-[11.5px] text-ink-3">clique para abrir a bancada</span>
           </div>
           {resumos.map((r) => {
-            const pick = outcomeLabel(r.mercado.slug, r.candidato.outcome, jogo.home, jogo.away, r.candidato.line_value);
+            const pick = outcomeLabel(r.candidato, jogo.home, jogo.away);
             const badge = scoreBadge(r);
             const res = placar
-              ? settleFutebol(r.mercado.slug, r.candidato.outcome, r.candidato.line_value, placar.home, placar.away)
+              ? settleFutebol(r.candidato, placar.home, placar.away)
               : null;
             return (
               <button

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -112,15 +112,9 @@ export function JogoResumoPanel({
           )
         : null) ?? resumos.find((r) => r.mercado.slug === mercadoLeitura)?.candidato ?? null;
   const pick = best
-    ? pickLabel(best.market, best.outcome, best.line_value, fixture.home_team_name, fixture.away_team_name)
+    ? pickLabel(best, fixture.home_team_name, fixture.away_team_name)
     : topo
-      ? pickLabel(
-          topo.mercado.slug,
-          topo.candidato.outcome,
-          topo.candidato.line_value,
-          fixture.home_team_name,
-          fixture.away_team_name,
-        )
+      ? pickLabel(topo.candidato, fixture.home_team_name, fixture.away_team_name)
       : null;
 
   const temLeitura = !!best || (topo != null && topo.nValem > 0);
@@ -172,7 +166,7 @@ export function JogoResumoPanel({
 
   const desfecho =
     fim && cand && mercadoLeitura
-      ? settleFutebol(mercadoLeitura, cand.outcome, cand.line_value, fixture.goals_home, fixture.goals_away)
+      ? settleFutebol(cand, fixture.goals_home, fixture.goals_away)
       : null;
 
   const chance = best ? chancePct(best.prob_justa_fechamento) : null;

--- a/src/components/futebol/MapaPremissas.tsx
+++ b/src/components/futebol/MapaPremissas.tsx
@@ -3,6 +3,7 @@ import { Check, ChevronDown, Minus } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useFutebolFixturePremissas, useFutebolFixtureNumeros } from '@/hooks/use-futebol-data';
 import type { FutebolFixturePremissas, FutebolFixtureNumeros } from '@/services/futebol-data.service';
+import type { Saida } from '@/utils/futebol-saida';
 import {
   MERCADOS,
   PREMISSAS_OCULTAS,
@@ -63,8 +64,8 @@ function GoalDistChart({ lh, la }: { lh: number; la: number }) {
   );
 }
 
-function SeloResultado({ market, outcome, line, placar }: { market: string; outcome: string; line: number | null; placar: PlacarFinal }) {
-  const r = settleFutebol(market, outcome, line, placar.home, placar.away);
+function SeloResultado({ saida, placar }: { saida: Saida; placar: PlacarFinal }) {
+  const r = settleFutebol(saida, placar.home, placar.away);
   if (!r) return null;
   const b = resultBadge(r);
   const cls =
@@ -283,11 +284,11 @@ function PainelMercado({
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-[10px] uppercase tracking-[0.18em] font-semibold text-ink-3">
-              {outcomeLabel(mercado.slug, atual.outcome, home, away, atual.line_value)}
+              {outcomeLabel(atual, home, away)}
             </span>
             {/* Jogo encerrado: o que o mapa apontava, liquidado contra o placar. */}
             {placar && (
-              <SeloResultado market={mercado.slug} outcome={atual.outcome} line={atual.line_value} placar={placar} />
+              <SeloResultado saida={atual} placar={placar} />
             )}
           </div>
           <p
@@ -336,7 +337,7 @@ function PainelMercado({
             const ativo = chave(atual) === k;
             const n = contaQueValem(mercado.slug, r.acesas);
             // Jogo encerrado: cada saída ganha o ponto do que aconteceu.
-            const res = placar ? settleFutebol(mercado.slug, r.outcome, r.line_value, placar.home, placar.away) : null;
+            const res = placar ? settleFutebol(r, placar.home, placar.away) : null;
             return (
               <button
                 key={k}
@@ -357,7 +358,7 @@ function PainelMercado({
                     }}
                   />
                 )}
-                {outcomeLabel(mercado.slug, r.outcome, home, away, r.line_value)}
+                {outcomeLabel(r, home, away)}
                 {n > 0 && <span className={ativo ? 'text-canvas/70' : 'text-forest'}> · {n}</span>}
               </button>
             );
@@ -494,7 +495,7 @@ export function MapaPremissas({
         x.c != null && contaQueValem(x.slug, x.c.acesas) >= PORTA_PREMISSAS,
       );
     const liquidados = apontados
-      .map((x) => settleFutebol(x.slug, x.c.outcome, x.c.line_value, placar.home, placar.away))
+      .map((x) => settleFutebol(x.c, placar.home, placar.away))
       .filter((r): r is NonNullable<typeof r> => r != null);
     if (!liquidados.length) return null;
     return { total: liquidados.length, hits: liquidados.filter(isHit).length };

--- a/src/components/futebol/RegistrarAposta.tsx
+++ b/src/components/futebol/RegistrarAposta.tsx
@@ -46,7 +46,11 @@ export function RegistrarApostaModal({
     }
   }, [open, draft]);
 
-  const pick = draft ? pickLabel(draft.market, draft.outcome, draft.lineValue, draft.homeName, draft.awayName) : '';
+  // O draft veio do formulario com `lineValue` em camelCase, entao a saida se monta
+  // aqui. E o unico lugar em que ela nao chega pronta da RPC.
+  const pick = draft
+    ? pickLabel({ market: draft.market, outcome: draft.outcome, line_value: draft.lineValue }, draft.homeName, draft.awayName)
+    : '';
   const match = draft ? `${draft.homeName} x ${draft.awayName}` : '';
   const mkt = draft ? marketLabel(draft.market) : '';
   const league = draft ? competitionLabel(draft.competition) : '';

--- a/src/pages/FutebolCampeonato.tsx
+++ b/src/pages/FutebolCampeonato.tsx
@@ -220,7 +220,7 @@ export default function FutebolCampeonato() {
     if (encerrada) {
       const bateram = comLeitura.filter((f) => {
         const b = bestByFixture.get(f.fixture_id)!;
-        const r = settleFutebol(b.market, b.outcome, b.line_value, f.goals_home, f.goals_away);
+        const r = settleFutebol(b, f.goals_home, f.goals_away);
         return r != null && isHit(r);
       }).length;
       return { rotulo, valor: `${bateram}/${comLeitura.length}`, texto: 'leituras bateram' };

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -93,7 +93,7 @@ function HeroStat({ label, value, dark, locked }: { label: string; value: string
 // ── Hero: melhor valor do dia — 3 colunas (pick · por quê · confiab). ────────
 // Alta = gradiente forest (texto branco); Média = card claro com acento âmbar.
 function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow; onClick: () => void; atencao?: string | null; locked?: boolean }) {
-  const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
+  const pick = pickLabel(o, o.home_team_name, o.away_team_name);
   const ev = topEvidencia(o.evidencias);
   const d = true; // hero sempre no fundo forest (mockup); a faixa vai no selo, não na cor do card
   const chance = chancePct(o.prob_justa_fechamento);
@@ -175,7 +175,7 @@ function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow
 
 // ── Card de oportunidade ───────────────────────────────────
 function OppCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClick: () => void; locked?: boolean }) {
-  const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
+  const pick = pickLabel(o, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
   return (
     <button onClick={onClick} className={`${CARD} p-4 text-left hover:shadow-sm hover:border-line-2 transition w-full`}>

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -281,7 +281,7 @@ export default function FutebolJogo() {
     if (!market || !outcome) return null;
     const linha = params.get('linha');
     const n = linha != null ? Number(linha) : NaN;
-    return { market, outcome, line: Number.isFinite(n) ? n : null };
+    return { market, outcome, line_value: Number.isFinite(n) ? n : null };
   }, [params]);
   const fid = fixtureId ? Number(fixtureId) : undefined;
   const { data, isLoading, isError } = useFutebolFixtureDetail(fid);

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -212,7 +212,7 @@ function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
   o: OppLike; onClick: () => void; muted?: boolean; locked?: boolean;
   result?: BetResult | null; homeGoals?: number | null; awayGoals?: number | null;
 }) {
-  const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
+  const pick = pickLabel(o, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
   const showLock = !!locked && !result; // histórico (com resultado) é sempre visível
   const hasScore = homeGoals != null && awayGoals != null;
@@ -257,7 +257,7 @@ function OppMobileCard({ o, onClick, locked, result, homeGoals, awayGoals }: {
   o: OppLike; onClick: () => void; locked?: boolean;
   result?: BetResult | null; homeGoals?: number | null; awayGoals?: number | null;
 }) {
-  const pick = pickLabel(o.market, o.outcome, o.line_value, o.home_team_name, o.away_team_name);
+  const pick = pickLabel(o, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
   const showLock = !!locked && !result;
   const hasScore = homeGoals != null && awayGoals != null;
@@ -383,7 +383,7 @@ export default function FutebolOportunidades() {
   const resultOf = (o: OppLike): BetResult | null => {
     if (!FINISHED_STATUS.has(o.status_short ?? '')) return null;
     const g = goalsMap.get(o.fixture_id);
-    return g ? settleFutebol(o.market, o.outcome, o.line_value, g.gh, g.ga) : null;
+    return g ? settleFutebol(o, g.gh, g.ga) : null;
   };
 
   // ── Oportunidades REGISTRADAS ─────────────────────────────────────────────

--- a/src/utils/futebol-leitura.test.ts
+++ b/src/utils/futebol-leitura.test.ts
@@ -133,7 +133,7 @@ describe('resumoDosMercados com a saída clicada', () => {
   const doisPrecos = [value('Over', 1.5, 54), value('Under', 4.5, 61)];
 
   it('a saída clicada ganha do maior Score do mercado', () => {
-    const g = gols(resumoDosMercados(rows, doisPrecos, { market: 'goals_over_under', outcome: 'Over', line: 1.5 }));
+    const g = gols(resumoDosMercados(rows, doisPrecos, { market: 'goals_over_under', outcome: 'Over', line_value: 1.5 }));
     expect(g.candidato.outcome).toBe('Over');
     expect(g.value?.score).toBe(54);
   });
@@ -145,12 +145,12 @@ describe('resumoDosMercados com a saída clicada', () => {
   });
 
   it('saída clicada de OUTRO mercado não mexe neste', () => {
-    const g = gols(resumoDosMercados(rows, doisPrecos, { market: 'match_winner', outcome: 'Home', line: null }));
+    const g = gols(resumoDosMercados(rows, doisPrecos, { market: 'match_winner', outcome: 'Home', line_value: null }));
     expect(g.candidato.outcome).toBe('Under');
   });
 
   it('link apontando para saída que não existe mais cai no maior Score, não em nada', () => {
-    const g = gols(resumoDosMercados(rows, doisPrecos, { market: 'goals_over_under', outcome: 'Over', line: 9.5 }));
+    const g = gols(resumoDosMercados(rows, doisPrecos, { market: 'goals_over_under', outcome: 'Over', line_value: 9.5 }));
     expect(g.candidato.outcome).toBe('Under');
     expect(g.value?.score).toBe(61);
   });

--- a/src/utils/futebol-leitura.ts
+++ b/src/utils/futebol-leitura.ts
@@ -1,4 +1,5 @@
 import type { FutebolFixturePremissas, FutebolFixtureValueRow } from '@/services/futebol-data.service';
+import type { Saida } from '@/utils/futebol-saida';
 import {
   MERCADOS,
   PORTA_PREMISSAS,
@@ -27,12 +28,13 @@ export function mesmaLinha(a: number | null, b: number | null): boolean {
 /** Casa uma linha de valor (odds reais) com um candidato de premissas. */
 export function valueDoCandidato(
   valueRows: FutebolFixtureValueRow[] | null | undefined,
-  market: string,
-  outcome: string,
-  line: number | null,
+  s: Saida,
 ): FutebolFixtureValueRow | null {
   if (!valueRows?.length) return null;
-  return valueRows.find((v) => v.market === market && v.outcome === outcome && mesmaLinha(v.line_value, line)) ?? null;
+  return (
+    valueRows.find((v) => v.market === s.market && v.outcome === s.outcome && mesmaLinha(v.line_value, s.line_value)) ??
+    null
+  );
 }
 
 /** O caminho inverso: a linha de premissas da saída que tem preço. */
@@ -51,12 +53,11 @@ export function candidatoDaValue(
  * SAÍDA, não por mercado, e 18 dos 104 pares (jogo, mercado) do board têm duas ou
  * mais saídas cotadas: sem carregar qual foi clicada, abrir o card da segunda caía
  * na primeira, que é o mesmo susto de ver um pick virar outro.
+ *
+ * É uma `Saida` como qualquer outra; o apelido existe só para o parâmetro dizer
+ * de onde ela vem.
  */
-export interface SaidaPreferida {
-  market: string;
-  outcome: string;
-  line: number | null;
-}
+export type SaidaPreferida = Saida;
 
 /**
  * Quem representa o mercado quando HÁ preço coletado: a saída que o usuário clicou,
@@ -83,7 +84,7 @@ function saidaComPreco(
   if (!pares.length) return null;
   if (preferida?.market === market) {
     const clicada = pares.find(
-      (x) => x.value.outcome === preferida.outcome && mesmaLinha(x.value.line_value, preferida.line),
+      (x) => x.value.outcome === preferida.outcome && mesmaLinha(x.value.line_value, preferida.line_value),
     );
     if (clicada) return clicada;
   }
@@ -142,7 +143,7 @@ export function resumoDosMercados(
     // Denominador só do lado da saída: para um Over, "defesas firmes" e as outras do
     // Under nunca poderiam acender, então contá-las fazia "2 de 8" onde o certo é
     // "2 de 3".
-    const totalQueValem = premissasDaSaida(m, c.outcome, c.line_value, c.acesas).filter(
+    const totalQueValem = premissasDaSaida(m, c, c.acesas).filter(
       (p) => p.peso == null || p.peso > 0,
     ).length;
     const value = comPreco?.value ?? null;

--- a/src/utils/futebol-premissas.ts
+++ b/src/utils/futebol-premissas.ts
@@ -1,4 +1,5 @@
 import type { FutebolFixturePremissas } from '@/services/futebol-data.service';
+import type { Saida } from '@/utils/futebol-saida';
 
 // Catálogo das premissas do Score: rótulo, peso e agrupamento.
 //
@@ -263,7 +264,8 @@ function fmtLinha(line: number): string {
 }
 
 /** Rótulo da saída da aposta, na linguagem do apostador. */
-export function outcomeLabel(market: string, outcome: string, home: string, away: string, line: number | null): string {
+export function outcomeLabel(s: Saida, home: string, away: string): string {
+  const { market, outcome, line_value: line } = s;
   if (market === 'match_winner') {
     if (outcome === 'Home') return `Vitória do ${home}`;
     if (outcome === 'Away') return `Vitória do ${away}`;
@@ -394,7 +396,7 @@ export function contextoDoMercado(acesasFortes: number, semCalibragem: boolean):
  * oposto: quem dá gol de vantagem (handicap negativo) é o favorito. Conferido na
  * base: Home −1,5 acende premissa de favorito, Home +0,5 acende de azarão.
  */
-export function ladoDaSaidaNoMercado(market: string, outcome: string, line: number | null): LadoPremissa | null {
+export function ladoDaSaidaNoMercado({ market, outcome, line_value: line }: Saida): LadoPremissa | null {
   if (market === 'goals_over_under') return outcome === 'Over' ? 'over' : 'under';
   if (market === 'btts') return outcome === 'Yes' ? 'sim' : 'nao';
   if (market === 'asian_handicap') {
@@ -412,13 +414,8 @@ export function ladoDaSaidaNoMercado(market: string, outcome: string, line: numb
  * `acesas` entra como rede de segurança: se o mart algum dia acender uma premissa do
  * outro lado, ela continua aparecendo em vez de sumir da tela em silêncio.
  */
-export function premissasDaSaida(
-  m: MercadoInfo,
-  outcome: string,
-  line: number | null,
-  acesas: string[] = [],
-): Premissa[] {
-  const lado = ladoDaSaidaNoMercado(m.slug, outcome, line);
+export function premissasDaSaida(m: MercadoInfo, s: Saida, acesas: string[] = []): Premissa[] {
+  const lado = ladoDaSaidaNoMercado(s);
   const acesasSet = new Set(acesas);
   return m.premissas.filter(
     (p) =>

--- a/src/utils/futebol-saida.ts
+++ b/src/utils/futebol-saida.ts
@@ -1,0 +1,20 @@
+/**
+ * A SAÍDA de uma aposta: qual mercado, qual lado, e em que linha.
+ *
+ * Existe porque esses três andavam sempre juntos e sempre soltos, de função em
+ * função (`outcomeLabel`, `pickLabel`, `settleFutebol`, `premissasDaSaida`,
+ * `valueDoCandidato`). Nada impedia passar o mercado de uma aposta com a linha de
+ * outra, e foi exatamente esse o bug do #264: o rótulo saía de uma saída e a
+ * chance, a odd e o Score saíam de outra, dentro do mesmo card. Para o compilador
+ * eram só duas strings e um número, então ele não tinha como reclamar.
+ *
+ * O campo se chama `line_value`, e não `line`, de propósito: é o nome que as duas
+ * RPCs usam, então `FutebolFixturePremissas` e `FutebolFixtureValueRow` casam com
+ * este tipo por estrutura. Na prática dá para passar A LINHA INTEIRA que veio do
+ * banco, em vez de desmontá-la em três argumentos e arriscar remontar errado.
+ */
+export interface Saida {
+  market: string;
+  outcome: string;
+  line_value: number | null;
+}

--- a/src/utils/futebol-score.ts
+++ b/src/utils/futebol-score.ts
@@ -1,6 +1,7 @@
 // ============================================================
 // futebol-score.ts — apresentação do Score (motor é backend)
 // ============================================================
+import type { Saida } from '@/utils/futebol-saida';
 // O Score, edge, premissas, evidências e avisos vêm prontos da
 // fact_value_opportunities (pipeline dbt no BigQuery). Aqui só ROTULAMOS
 // (mercado, pick com linha) e ajudamos a ranquear/agrupar. Nada de cálculo.
@@ -87,7 +88,8 @@ export function outcomePt(outcome: string, homeName: string, awayName: string): 
 }
 
 /** Rótulo da aposta (pick), por mercado — inclui a linha no Over/Under. */
-export function pickLabel(market: string, outcome: string, line: number | null, homeName: string, awayName: string): string {
+export function pickLabel(s: Saida, homeName: string, awayName: string): string {
+  const { market, outcome, line_value: line } = s;
   if (market === 'goals_over_under') {
     const n = line != null ? String(line).replace('.', ',') : '';
     return outcome === 'Over' ? `Mais de ${n} gols` : `Menos de ${n} gols`;

--- a/src/utils/futebol-settlement.ts
+++ b/src/utils/futebol-settlement.ts
@@ -1,6 +1,7 @@
 // ============================================================
 // futebol-settlement.ts — liquida uma oportunidade pelo placar final
 // ============================================================
+import type { Saida } from '@/utils/futebol-saida';
 // Usado no histórico da tela de Oportunidades ("bateu / não bateu"). O placar
 // vem de fact_fixtures (goals_home/goals_away). Convenções (espelham pickLabel):
 //  - asian_handicap / goals_over_under: line_value na ótica do MANDANTE.
@@ -25,12 +26,11 @@ function mapAsian(dRaw: number): BetResult {
  * mercado é desconhecido.
  */
 export function settleFutebol(
-  market: string,
-  outcome: string,
-  line: number | null,
+  s: Saida,
   goalsHome: number | null | undefined,
   goalsAway: number | null | undefined,
 ): BetResult | null {
+  const { market, outcome, line_value: line } = s;
   if (goalsHome == null || goalsAway == null) return null;
   const diff = goalsHome - goalsAway; // ótica do mandante
   const total = goalsHome + goalsAway;


### PR DESCRIPTION
> Empilhado no #265. Revisar depois dele; os dois tocam `FaixaPartida.tsx`.

## O problema

"De qual aposta estamos falando" nunca era **uma** coisa no código. Eram sempre três valores soltos, na mesma ordem, de função em função:

```ts
outcomeLabel(market, outcome, home, away, line)
pickLabel(market, outcome, line, homeName, awayName)
settleFutebol(market, outcome, line, golsCasa, golsFora)
premissasDaSaida(mercado, outcome, line, acesas)
valueDoCandidato(valueRows, market, outcome, line)
ladoDaSaidaNoMercado(market, outcome, line)
```

Com três soltos, nada impedia passar o mercado de uma aposta junto com a linha de outra, e para o compilador eram só duas strings e um número. **Foi exatamente esse o bug do #264**: o rótulo saía de uma saída e a chance, a odd e o Score saíam de outra, dentro do mesmo card, e nem o typecheck nem os testes viram.

## O tipo

```ts
interface Saida { market: string; outcome: string; line_value: number | null }
```

O campo se chama `line_value`, e não `line`, de propósito: é o nome que as duas RPCs usam, então `FutebolFixturePremissas` e `FutebolFixtureValueRow` casam com ele por estrutura. O ganho de verdade é esse, as chamadas passaram a entregar **a linha inteira que veio do banco** em vez de desmontá-la em três argumentos e arriscar remontar errado:

```diff
- outcomeLabel(mercado.slug, c.outcome, home, away, c.line_value)
+ outcomeLabel(c, home, away)
```

Em 33 dos 34 pontos de chamada o objeto já estava ali, do lado. O único que monta a saída na mão é o `RegistrarApostaModal`, porque o draft do formulário usa `lineValue` em camelCase.

O `SaidaPreferida` que o #264 criou virou apelido de `Saida`: era o mesmo tipo, nascido no lugar certo pelo motivo errado.

## O que não muda

Nenhum comportamento. Trocar cinco parâmetros posicionais por `(objeto, string, string)` faz o typecheck acusar **todos** os pontos de chamada, então não há como sobrar um sítio antigo em silêncio.

`pickLabel` e `outcomeLabel` continuam duas funções. Elas parecem duplicadas mas têm copy divergente de propósito ("Os dois marcam" na tela do jogo, "Sim" no registro), e juntar as duas seria decisão de copy, não refactor. Vale registrar como pergunta em aberto: hoje o Betinho grava `pickLabel`, então uma aposta de ambos marcam lida como "Os dois marcam" seria salva como "Sim". Não dispara hoje porque esse mercado nunca tem preço.

## Verificação

Typecheck sem erro novo (sobram os 2 pré-existentes: `FutebolHoje.tsx:218` e `FutebolOportunidades.tsx:63`). Lint limpo. Suíte 178 de 179, com as mesmas 2 falhas pré-existentes.

Conferido na tela, porque refactor de rótulo só se confia vendo: Oportunidades (linha e card), `/futebol`, e a tela do jogo com partida encerrada, onde o selo **Green** e a frase "O mapa apontava Mais de 1,5 gols: green" exercitam `settleFutebol` e `outcomeLabel` juntos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
