### PR TITLE
fix(futebol): os avisos de penalidade leem as flags do mart, nao rederivam

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -627,7 +627,13 @@ create table futebol.fact_value_opportunities (
   "pin_n_outcomes" bigint,
   "is_half_line" boolean,
   "dbt_loaded_at" timestamp,
-  "premissas_sem_dado" bigint
+  "premissas_sem_dado" bigint,
+  -- AE#87 (19/08/2026): as 4 flags de penalidade publicadas pelo mart, para a
+  -- RPC ler em vez de rederivar do int_futebol_odds_devig (issue #267)
+  "pen_odd_outlier" boolean,
+  "pen_poucas_casas" boolean,
+  "pen_odd_longshot" boolean,
+  "pen_odd_juice" boolean
 );
 
 -- ── 2a. Infra do sync: estado incremental (o Cloud Run sync lê/escreve aqui) ──
@@ -674,7 +680,13 @@ create table futebol.fact_value_opportunities_hist (
   "dbt_updated_at" timestamp,
   "dbt_valid_from" timestamp,
   "dbt_valid_to" timestamp,
-  "premissas_sem_dado" bigint
+  "premissas_sem_dado" bigint,
+  -- AE#87 (19/08/2026): as 4 flags de penalidade publicadas pelo mart, para a
+  -- RPC ler em vez de rederivar do int_futebol_odds_devig (issue #267)
+  "pen_odd_outlier" boolean,
+  "pen_poucas_casas" boolean,
+  "pen_odd_longshot" boolean,
+  "pen_odd_juice" boolean
 );
 
 -- ── 2b. Lockdown RPC-only (espelha nba_mart): acesso só via RPCs security definer
@@ -1042,12 +1054,17 @@ AS $function$
   -- kickoff já passado lê a FOTO DO APITO no snapshot. É *kickoff passado* e
   -- não *jogo terminado*, senão as ~2h de bola rolando ficariam sem linha
   -- depois que o mart passar a expurgar os status ao vivo (ADR 0009).
+  -- migration 105: os avisos de penalidade leem as colunas pen_* do proprio mart
+  -- (AE#87). O CTE sobre int_futebol_odds_devig foi removido: ele rederivava as
+  -- flags e, no prd, 76 de 126 linhas exibiam aviso de janela errada (issue #267).
+  -- No hist, pen_* pode ser NULL em versao aberta antes do AE#87: NULL nao gera aviso.
   with v_src as (
     select fixture_id, market, outcome, line_value, competition, season, edge, pts_valor,
            pts_premissas, pts_corroboracao, penalidades, score, faixa, best_odd, best_book,
            avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
            penalidades_globais_pts, penalidades_especificas_pts, modelo_api_concorda,
-           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado
+           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado,
+           pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
     from futebol.fact_value_opportunities
     where fixture_id = p_fixture_id
       and exists (select 1 from futebol.fact_fixtures fx
@@ -1057,7 +1074,8 @@ AS $function$
            pts_premissas, pts_corroboracao, penalidades, score, faixa, best_odd, best_book,
            avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
            penalidades_globais_pts, penalidades_especificas_pts, modelo_api_concorda,
-           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado
+           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado,
+           pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
     from futebol.fact_value_opportunities_hist h
     where h.fixture_id = p_fixture_id
       and exists (select 1 from futebol.fact_fixtures fx
@@ -1065,17 +1083,6 @@ AS $function$
                      and fx.kickoff_utc <= (now() at time zone 'UTC')
                      and h.dbt_valid_from <= fx.kickoff_utc
                      and (h.dbt_valid_to is null or fx.kickoff_utc < h.dbt_valid_to))
-  ),
-  -- migration 098: o DISTINCT ON ignorava `market_id` e `janela_usada`.
-  -- Sem `janela_usada`, o aviso de penalidade vinha de janela arbitrária (uma
-  -- Over 2.5 que fechou em 2,05 exibia "zebra" calculado do 5,20 do `daily`).
-  -- Sem `market_id`, Gols (5) e Gols do 1º tempo (6) colidiam na mesma linha.
-  d as (
-    select distinct on (fixture_id, market_id, outcome_side, line_value, janela_usada)
-      fixture_id, market_id, outcome_side, line_value, janela_usada,
-      pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
-    from futebol.int_futebol_odds_devig
-    order by fixture_id, market_id, outcome_side, line_value, janela_usada
   )
   select v.market, v.outcome,
     (case when v.market = 'match_winner'
@@ -1148,10 +1155,10 @@ AS $function$
            when v.linha_sharp_confirma then 'As principais casas vêm baixando a odd desse lado' end
     ], null),
     array_remove(array[
-      case when d.pen_odd_outlier then 'Só uma casa paga essa odd — pode ser linha furada' end,
-      case when d.pen_poucas_casas then 'Poucas casas cotando esse mercado' end,
-      case when d.pen_odd_longshot then 'Odd alta (zebra) — entra com cautela' end,
-      case when d.pen_odd_juice and v.market <> 'double_chance' then 'Odd baixa — retorno pequeno pro risco' end,
+      case when v.pen_odd_outlier then 'Só uma casa paga essa odd — pode ser linha furada' end,
+      case when v.pen_poucas_casas then 'Poucas casas cotando esse mercado' end,
+      case when v.pen_odd_longshot then 'Odd alta (zebra) — entra com cautela' end,
+      case when v.pen_odd_juice and v.market <> 'double_chance' then 'Odd baixa — retorno pequeno pro risco' end,
       case when p.pick_empate then 'Empate é o resultado mais difícil de prever' end,
       case when p.desfalque_proprio then 'Time apostado com desfalque de titular importante' end,
       case when o.linha_extrema then 'Linha extrema — pouco confiável' end,
@@ -1185,7 +1192,6 @@ AS $function$
   left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
   left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
   left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
-  left join d on d.fixture_id = v.fixture_id and d.outcome_side = v.outcome and d.line_value is not distinct from v.line_value and d.janela_usada is not distinct from v.janela_usada and d.market_id = (case v.market when 'match_winner' then 1 when 'asian_handicap' then 4 when 'goals_over_under' then 5 when 'btts' then 8 when 'double_chance' then 12 end)
   where v.fixture_id = p_fixture_id
   order by (case v.market when 'match_winner' then 1 when 'goals_over_under' then 2 when 'asian_handicap' then 3 when 'btts' then 4 when 'double_chance' then 5 else 9 end), 3;
 $function$

--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -1158,7 +1158,7 @@ AS $function$
       case when v.pen_odd_outlier then 'Só uma casa paga essa odd — pode ser linha furada' end,
       case when v.pen_poucas_casas then 'Poucas casas cotando esse mercado' end,
       case when v.pen_odd_longshot then 'Odd alta (zebra) — entra com cautela' end,
-      case when v.pen_odd_juice and v.market <> 'double_chance' then 'Odd baixa — retorno pequeno pro risco' end,
+      case when v.pen_odd_juice then 'Odd baixa — retorno pequeno pro risco' end,
       case when p.pick_empate then 'Empate é o resultado mais difícil de prever' end,
       case when p.desfalque_proprio then 'Time apostado com desfalque de titular importante' end,
       case when o.linha_extrema then 'Linha extrema — pouco confiável' end,

--- a/supabase/migrations/094_futebol_numeros_do_jogo.sql
+++ b/supabase/migrations/094_futebol_numeros_do_jogo.sql
@@ -29,41 +29,15 @@
 -- temporada. Essas quatro continuam sem embasamento numérico até existir o agregado.
 -- ============================================================
 
+-- v2 (01/08, aplicada na mao no dev e nunca trazida de volta pro arquivo ate
+-- 19/08, quando o primeiro `db push` real quebrou aqui): o select pulava as tres
+-- colunas de h2h que a declaracao promete, e a coluna 25 devolvia `date` onde o
+-- contrato diz `bigint`. Corpo abaixo = versao viva (shape file, mesma revisao).
 CREATE OR REPLACE FUNCTION public.get_futebol_fixture_numeros(p_fixture_id bigint)
-RETURNS TABLE(
-  side          text,
-  team_id       bigint,
-  team_name     text,
-  posicao       bigint,
-  pontos        bigint,
-  zona          text,
-  jogos         bigint,
-  jogos_casa    bigint,
-  jogos_fora    bigint,
-  v_casa        bigint,
-  e_casa        bigint,
-  d_casa        bigint,
-  v_fora        bigint,
-  e_fora        bigint,
-  d_fora        bigint,
-  gf_casa       double precision,
-  ga_casa       double precision,
-  gf_fora       double precision,
-  ga_fora       double precision,
-  gf_total      double precision,
-  ga_total      double precision,
-  clean_sheets  bigint,
-  sem_marcar    bigint,
-  forma         text,
-  -- Confronto direto, do ponto de vista DESTE lado. Existe porque
-  -- `h2h_favoravel` é uma premissa que acende e, sem número, ficava na tela como
-  -- afirmação sem lastro, que é o pior caso possível.
-  h2h_jogos     bigint,
-  h2h_vitorias  bigint,
-  h2h_empates   bigint,
-  ate           date
-)
-LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO ''
+ RETURNS TABLE(side text, team_id bigint, team_name text, posicao bigint, pontos bigint, zona text, jogos bigint, jogos_casa bigint, jogos_fora bigint, v_casa bigint, e_casa bigint, d_casa bigint, v_fora bigint, e_fora bigint, d_fora bigint, gf_casa double precision, ga_casa double precision, gf_fora double precision, ga_fora double precision, gf_total double precision, ga_total double precision, clean_sheets bigint, sem_marcar bigint, forma text, h2h_jogos bigint, h2h_vitorias bigint, h2h_empates bigint, ate date)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO ''
 AS $function$
   with jogo as (
     select f.fixture_id, f.competition, f.season, f.home_team_id, f.away_team_id
@@ -75,21 +49,19 @@ AS $function$
     union all
     select 'away'::text, j.away_team_id, j.competition, j.season from jogo j
   ),
-  -- Um time pode ter vários snapshots; interessa o mais recente.
   stats as (
     select distinct on (t.team_id, t.competition, t.season) t.*
     from futebol.fact_team_season_stats t
     join lados l on l.team_id = t.team_id and l.competition = t.competition and l.season = t.season
     order by t.team_id, t.competition, t.season, t.snapshot_date desc
   ),
-  -- Confronto direto: conta por lado quantos cada um venceu.
   h2h as (
     select l.team_id,
-           count(*)                                          as jogos,
+           count(*) as jogos,
            count(*) filter (
              where (hh.home_team_id = l.team_id and hh.goals_home > hh.goals_away)
                 or (hh.away_team_id = l.team_id and hh.goals_away > hh.goals_home)
-           )                                                 as vitorias,
+           ) as vitorias,
            count(*) filter (where hh.goals_home = hh.goals_away) as empates
     from jogo j
     join futebol.fact_h2h hh
@@ -135,10 +107,14 @@ AS $function$
          st.clean_sheet_total,
          st.failed_to_score_total,
          st.form,
+         hh.jogos,
+         hh.vitorias,
+         hh.empates,
          st.snapshot_date
   from lados l
   left join stats st on st.team_id = l.team_id
   left join tabela tb on tb.team_id = l.team_id
+  left join h2h hh on hh.team_id = l.team_id
   left join futebol.dim_teams dt on dt.team_id = l.team_id
   order by l.side desc;
 $function$;

--- a/supabase/migrations/094_futebol_numeros_do_jogo.sql
+++ b/supabase/migrations/094_futebol_numeros_do_jogo.sql
@@ -33,6 +33,13 @@
 -- 19/08, quando o primeiro `db push` real quebrou aqui): o select pulava as tres
 -- colunas de h2h que a declaracao promete, e a coluna 25 devolvia `date` onde o
 -- contrato diz `bigint`. Corpo abaixo = versao viva (shape file, mesma revisao).
+-- Rationale que a v2 nao levou pro corpo (o shape file vem do pg_get_functiondef,
+-- que nao guarda comentario de declaracao; fica aqui):
+--   * h2h_jogos/h2h_vitorias/h2h_empates existem porque `h2h_favoravel` e uma
+--     premissa que acende e, sem numero, ficava na tela como afirmacao sem
+--     lastro, que e o pior caso possivel;
+--   * stats: um time pode ter varios snapshots; interessa o mais recente;
+--   * h2h: confronto direto conta por lado quantos cada um venceu.
 CREATE OR REPLACE FUNCTION public.get_futebol_fixture_numeros(p_fixture_id bigint)
  RETURNS TABLE(side text, team_id bigint, team_name text, posicao bigint, pontos bigint, zona text, jogos bigint, jogos_casa bigint, jogos_fora bigint, v_casa bigint, e_casa bigint, d_casa bigint, v_fora bigint, e_fora bigint, d_fora bigint, gf_casa double precision, ga_casa double precision, gf_fora double precision, ga_fora double precision, gf_total double precision, ga_total double precision, clean_sheets bigint, sem_marcar bigint, forma text, h2h_jogos bigint, h2h_vitorias bigint, h2h_empates bigint, ate date)
  LANGUAGE sql

--- a/supabase/migrations/105_futebol_avisos_penalidade_do_mart.sql
+++ b/supabase/migrations/105_futebol_avisos_penalidade_do_mart.sql
@@ -1,0 +1,186 @@
+-- ============================================================================
+-- 105 · `get_futebol_fixture_value`: avisos de penalidade saem do próprio mart
+-- ============================================================================
+-- Issue #267 (Matheus, 19/08). O `analytics-engineering#87` publicou no mart as
+-- quatro flags de penalidade de odds como colunas BOOLEAN de
+-- `fact_value_opportunities` (e do `_hist`) — as MESMAS que compõem o
+-- `penalidades_globais_pts` da linha. Esta migration faz a RPC colher.
+--
+-- O que sai: o CTE `d`, que rederivava as flags do `int_futebol_odds_devig`.
+-- No prd (pré-098, sem desempate nenhum) ele sorteava a janela: 74 de 126
+-- linhas do board (18/08) e 76 (19/08) exibiam aviso de janela diferente da
+-- publicada, e 34 contradiziam o `penalidades_globais_pts` da própria linha.
+-- Aqui na develop a 098 já tinha consertado o desempate, mas o defeito de
+-- desenho fica: a tabela tem grão (fixture, mercado, saída, linha, JANELA) e
+-- é fácil de ler como se fosse única por (fixture, saída, linha). Ler as
+-- parcelas ao lado da soma remove a tentação para o próximo consumidor.
+--
+-- O que entra: as 4 colunas `pen_*` no select das duas fontes do `v_src`
+-- (board e foto do apito), e os quatro `case when` lendo `v.pen_*`.
+--
+-- No `_hist`, `pen_*` é NULL nas versões abertas antes do AE#87 (ficaram fora
+-- do check_cols de propósito, para não fabricar churn no deploy). NULL não
+-- gera aviso — "não sei" não vira alerta.
+--
+-- Conferência (0 esperado):
+--   select count(*) from futebol.fact_value_opportunities
+--   where 30*pen_odd_outlier::int + 12*pen_poucas_casas::int
+--       + 15*pen_odd_longshot::int + 10*pen_odd_juice::int
+--         is distinct from penalidades_globais_pts;
+--
+-- Assinatura não muda: `create or replace` basta, grants preservados.
+-- Corpo completo (fonte: docs/futebol-prod-deploy.sql, mesma revisão).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_value(p_fixture_id bigint)
+ RETURNS TABLE(market text, outcome text, outcome_order integer, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, penalidades_globais_pts integer, penalidades_especificas_pts integer, score integer, faixa text, modelo_api_concorda boolean, linha_sharp_confirma boolean, evidencias text[], avisos text[], contras text[], premissas_sem_dado integer)
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+  -- migration 101: a fonte deixa de ser fixa. Kickoff no futuro lê o board;
+  -- kickoff já passado lê a FOTO DO APITO no snapshot. É *kickoff passado* e
+  -- não *jogo terminado*, senão as ~2h de bola rolando ficariam sem linha
+  -- depois que o mart passar a expurgar os status ao vivo (ADR 0009).
+  -- migration 105: os avisos de penalidade leem as colunas pen_* do proprio mart
+  -- (AE#87). O CTE sobre int_futebol_odds_devig foi removido: ele rederivava as
+  -- flags e, no prd, 76 de 126 linhas exibiam aviso de janela errada (issue #267).
+  -- No hist, pen_* pode ser NULL em versao aberta antes do AE#87: NULL nao gera aviso.
+  with v_src as (
+    select fixture_id, market, outcome, line_value, competition, season, edge, pts_valor,
+           pts_premissas, pts_corroboracao, penalidades, score, faixa, best_odd, best_book,
+           avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
+           penalidades_globais_pts, penalidades_especificas_pts, modelo_api_concorda,
+           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado,
+           pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
+    from futebol.fact_value_opportunities
+    where fixture_id = p_fixture_id
+      and exists (select 1 from futebol.fact_fixtures fx
+                   where fx.fixture_id = p_fixture_id and fx.kickoff_utc > (now() at time zone 'UTC'))
+    union all
+    select fixture_id, market, outcome, line_value, competition, season, edge, pts_valor,
+           pts_premissas, pts_corroboracao, penalidades, score, faixa, best_odd, best_book,
+           avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
+           penalidades_globais_pts, penalidades_especificas_pts, modelo_api_concorda,
+           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado,
+           pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
+    from futebol.fact_value_opportunities_hist h
+    where h.fixture_id = p_fixture_id
+      and exists (select 1 from futebol.fact_fixtures fx
+                   where fx.fixture_id = p_fixture_id
+                     and fx.kickoff_utc <= (now() at time zone 'UTC')
+                     and h.dbt_valid_from <= fx.kickoff_utc
+                     and (h.dbt_valid_to is null or fx.kickoff_utc < h.dbt_valid_to))
+  )
+  select v.market, v.outcome,
+    (case when v.market = 'match_winner'
+          then (case v.outcome when 'Home' then 1 when 'Draw' then 2 else 3 end)
+          when v.market = 'goals_over_under'
+          then (coalesce(v.line_value,0)*10 + case when v.outcome='Over' then 1 else 2 end)::int
+          when v.market = 'asian_handicap'
+          then (1000 + (case v.outcome when 'Home' then 0 else 500 end) + (coalesce(v.line_value,0)*10))::int
+          when v.market = 'btts'
+          then (2000 + case when v.outcome in ('Yes') then 0 else 1 end)
+          when v.market = 'double_chance'
+          then (3000 + case v.outcome when '1X' then 1 else 2 end)
+          else 0 end),
+    v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
+    v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int,
+    v.penalidades_globais_pts::int, v.penalidades_especificas_pts::int, v.score::int, v.faixa,
+    v.modelo_api_concorda, v.linha_sharp_confirma,
+    array_remove(array[
+      case when p.forca_mismatch then 'Ataque forte contra defesa frágil do adversário' end,
+      case when p.superioridade_xg then 'Cria mais chances de gol do que o adversário' end,
+      case when p.mando then (case v.outcome when 'Home' then 'Manda bem em casa' when 'Away' then 'Vai bem fora de casa' else 'Mando relevante' end) end,
+      case when p.desfalque_adversario then 'Adversário com desfalque de titular importante' end,
+      case when p.superioridade_tabela then 'Bem à frente na tabela' end,
+      case when p.forma then 'Em boa fase (vitórias recentes)' end,
+      case when p.h2h_favoravel then 'Histórico favorável no confronto direto' end
+    ], null)
+    || array_remove(array[
+      case when o.ataque_combinado then 'Os dois somam muitos gols (casa + fora)' end,
+      case when o.defesas_vazaveis then 'Defesas frágeis dos dois lados' end,
+      case when o.xg_combinado_alto then 'Os dois criam muitas chances de gol' end,
+      case when o.ritmo_alto then 'Jogo de ritmo alto (muitas finalizações)' end,
+      case when o.ambos_vazam then 'Os dois sofrem gol quase todo jogo' end,
+      case when o.historico_over then 'Últimos jogos goleadores' end,
+      case when o.linha_subindo then 'Mercado puxando a linha pra cima' end,
+      case when o.defesas_firmes then 'Defesas firmes dos dois lados' end,
+      case when o.clean_sheets_altos then 'Os dois passam muitos jogos sem sofrer gol' end,
+      case when o.xg_baixo_combinado then 'Os dois criam pouca coisa na frente' end,
+      case when o.ataques_fracos then 'Ataque fraco (passam em branco com frequência)' end,
+      case when o.historico_under then 'Últimos jogos truncados' end,
+      case when o.linha_descendo then 'Mercado puxando a linha pra baixo' end
+    ], null)
+    || array_remove(array[
+      case when ah.supremacia then 'Muito superior ao adversário' end,
+      case when ah.tende_golear then 'Costuma vencer com boa diferença de gols' end,
+      case when ah.adversario_fragil_fora then 'Adversário tem defesa frágil' end,
+      case when ah.mando_forte then 'Manda muito bem em casa' end,
+      case when ah.sem_rodizio then 'Deve entrar com força máxima' end,
+      case when ah.raramente_perde_por_2 then 'Raramente perde por 2 gols ou mais' end,
+      case when ah.defesa_fora_solida then 'Defesa sólida jogando fora' end,
+      case when ah.favorito_irregular then 'O favorito não costuma golear' end
+    ], null)
+    || array_remove(array[
+      case when bt.ambos_marcam then 'Os dois quase sempre marcam' end,
+      case when bt.ataque_dos_dois then 'Os dois ataques vêm produzindo' end,
+      case when bt.defesas_vazaveis then 'As duas defesas sofrem gol com frequência' end,
+      case when bt.historico_btts then 'Nos últimos jogos, os dois marcaram' end,
+      case when bt.defesa_forte then 'Uma das defesas segura bem o placar' end,
+      case when bt.ataque_trava then 'Um dos ataques costuma passar em branco' end,
+      case when bt.historico_seco then 'Jogos recentes sem os dois marcarem' end
+    ], null)
+    || array_remove(array[
+      case when dc.lado_coberto_forte then 'O lado coberto é claramente o mais forte' end,
+      case when dc.equilibrio_defensivo then 'Defesas parelhas — empate é desfecho plausível' end,
+      case when dc.adversario_limitado then 'Adversário com campanha fraca' end,
+      case when dc.invicto_recente then 'Vem sem perder nos últimos jogos' end
+    ], null)
+    || array_remove(array[
+      case when v.modelo_api_concorda and v.linha_sharp_confirma then 'As principais casas e o modelo da API apontam o mesmo lado'
+           when v.modelo_api_concorda then 'Modelo da API concorda com esse lado'
+           when v.linha_sharp_confirma then 'As principais casas vêm baixando a odd desse lado' end
+    ], null),
+    array_remove(array[
+      case when v.pen_odd_outlier then 'Só uma casa paga essa odd — pode ser linha furada' end,
+      case when v.pen_poucas_casas then 'Poucas casas cotando esse mercado' end,
+      case when v.pen_odd_longshot then 'Odd alta (zebra) — entra com cautela' end,
+      case when v.pen_odd_juice and v.market <> 'double_chance' then 'Odd baixa — retorno pequeno pro risco' end,
+      case when p.pick_empate then 'Empate é o resultado mais difícil de prever' end,
+      case when p.desfalque_proprio then 'Time apostado com desfalque de titular importante' end,
+      case when o.linha_extrema then 'Linha extrema — pouco confiável' end,
+      case when ah.handicap_alto then 'Handicap alto (2,5+ gols) — raramente confiável' end
+    ], null),
+    (array_remove(array[
+      case when not coalesce(p.forca_mismatch, true) then 'Sem vantagem clara de ataque × defesa' end,
+      case when not coalesce(p.mando, true) and v.outcome <> 'Draw' then 'Mando não pesa a favor' end,
+      case when not coalesce(p.superioridade_tabela, true) then 'Times equilibrados na tabela' end,
+      case when v.outcome='Over' and not coalesce(o.ataque_combinado, true) then 'Os dois não somam tantos gols' end,
+      case when v.outcome='Over' and not coalesce(o.ritmo_alto, true) then 'Jogo não costuma ser de ritmo alto' end,
+      case when v.outcome='Over' and not coalesce(o.xg_combinado_alto, true) then 'O volume de chances não é tão alto' end,
+      case when v.outcome='Under' and not coalesce(o.defesas_firmes, true) then 'As defesas não são tão firmes' end,
+      case when v.outcome='Under' and not coalesce(o.clean_sheets_altos, true) then 'Não costumam segurar o placar zerado' end,
+      case when v.outcome='Under' and not coalesce(o.xg_baixo_combinado, true) then 'Criam chances demais pra um jogo truncado' end,
+      case when ah.is_favorito and not coalesce(ah.supremacia, true) then 'Não é tão superior assim ao adversário' end,
+      case when ah.is_favorito and not coalesce(ah.tende_golear, true) then 'Nem sempre vence com boa diferença' end,
+      case when ah.is_azarao and not coalesce(ah.raramente_perde_por_2, true) then 'Já levou goleada algumas vezes' end,
+      case when ah.is_azarao and not coalesce(ah.defesa_fora_solida, true) then 'Defesa fora não é das mais sólidas' end,
+      case when v.outcome='Yes' and not coalesce(bt.ambos_marcam, true) then 'Nem sempre os dois marcam' end,
+      case when v.outcome='Yes' and not coalesce(bt.defesas_vazaveis, true) then 'As defesas não são tão vazadas' end,
+      case when v.outcome='No' and not coalesce(bt.defesa_forte, true) then 'Nenhuma defesa é tão sólida' end,
+      case when v.outcome='No' and not coalesce(bt.ataque_trava, true) then 'Os dois ataques costumam marcar' end,
+      case when not coalesce(dc.lado_coberto_forte, true) then 'O lado coberto não é claramente o mais forte' end,
+      case when not coalesce(dc.adversario_limitado, true) then 'Adversário não é tão limitado' end
+    ], null))[1:3],
+    v.premissas_sem_dado::int
+  from v_src v
+  left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
+  left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
+  left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
+  where v.fixture_id = p_fixture_id
+  order by (case v.market when 'match_winner' then 1 when 'goals_over_under' then 2 when 'asian_handicap' then 3 when 'btts' then 4 when 'double_chance' then 5 else 9 end), 3;
+$function$
+;

--- a/supabase/migrations/105_futebol_avisos_penalidade_do_mart.sql
+++ b/supabase/migrations/105_futebol_avisos_penalidade_do_mart.sql
@@ -29,6 +29,12 @@
 --         is distinct from penalidades_globais_pts;
 --
 -- Assinatura não muda: `create or replace` basta, grants preservados.
+--
+-- O 4o case perdeu o `and v.market <> double_chance` que o ticket marcou como
+-- opcional: o mart garante pen_odd_juice = FALSE em toda linha de Dupla Chance
+-- por construcao (gate de odd proprio, sem juice). Manter a guarda nao protegia
+-- nada e armava a contradicao inversa: se o mart um dia marcasse juice numa DC,
+-- os 10 pts entrariam na soma exibida com o aviso suprimido.
 -- Corpo completo (fonte: docs/futebol-prod-deploy.sql, mesma revisão).
 -- ============================================================================
 
@@ -146,7 +152,7 @@ AS $function$
       case when v.pen_odd_outlier then 'Só uma casa paga essa odd — pode ser linha furada' end,
       case when v.pen_poucas_casas then 'Poucas casas cotando esse mercado' end,
       case when v.pen_odd_longshot then 'Odd alta (zebra) — entra com cautela' end,
-      case when v.pen_odd_juice and v.market <> 'double_chance' then 'Odd baixa — retorno pequeno pro risco' end,
+      case when v.pen_odd_juice then 'Odd baixa — retorno pequeno pro risco' end,
       case when p.pick_empate then 'Empate é o resultado mais difícil de prever' end,
       case when p.desfalque_proprio then 'Time apostado com desfalque de titular importante' end,
       case when o.linha_extrema then 'Linha extrema — pouco confiável' end,


### PR DESCRIPTION
## O que muda

A `get_futebol_fixture_value` para de **rederivar** as quatro flags de penalidade de odds do `int_futebol_odds_devig` e passa a **ler as colunas `pen_*`** que o `analytics-engineering#87` publicou no mart (19/08), as mesmas que compõem o `penalidades_globais_pts` da linha.

- sai o CTE `d` e o `left join d`
- entram as 4 colunas no select das duas fontes do `v_src` (board e foto do apito)
- os quatro `case when` do bloco de avisos leem `v.pen_*`
- assinatura não muda: `create or replace`, grants preservados

## Por quê

No prd (pré-098, sem desempate) o CTE sorteava a janela: **74 de 126 linhas do board (18/08) e 76 (19/08)** exibiam aviso de penalidade de janela diferente da publicada, e 34 contradiziam o agregado da própria linha. Na develop a 098 já desempatava, mas a armadilha de desenho ficava armada: a tabela tem grão (fixture, mercado, saída, linha, **janela**) e é fácil de ler como única por (fixture, saída, linha). Ler as parcelas ao lado da soma remove a tentação, como o ticket argumenta.

## Além do que o ticket pede

O shape file (`docs/futebol-prod-deploy.sql`) ganhou as 4 colunas no DDL de `fact_value_opportunities` e do `_hist`. Sem isso uma provisão do zero quebraria: a função é `LANGUAGE sql`, validada na criação contra as tabelas.

## Semântica do NULL no hist

Nas versões do `_hist` abertas antes do AE#87 as flags são NULL (fora do `check_cols` de propósito). `case when v.pen_odd_outlier then ...` com NULL **não gera aviso**: "não sei" não vira alerta, como o fora-de-escopo do ticket pede.

## Conferência pós-apply (0 esperado)

```sql
select count(*) from futebol.fact_value_opportunities
where 30*pen_odd_outlier::int + 12*pen_poucas_casas::int
    + 15*pen_odd_longshot::int + 10*pen_odd_juice::int
      is distinct from penalidades_globais_pts;
```

## Testes

- guarda do shape file verde (4/4)
- suíte completa: as 2 falhas existentes são pré-existentes na develop (SEO exige `dist/` buildado; debounce do bolão falha na develop limpa também)

Refs #267 — fecha quando a mudança chegar ao prd, para não repetir o padrão que a #268 aponta na #260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)