### PR TITLE
fix(futebol): a 098 checa 'ja aplicada' antes de checar divergencia

### DIFF
--- a/supabase/migrations/098_futebol_rpc_desempate_e_fase.sql
+++ b/supabase/migrations/098_futebol_rpc_desempate_e_fase.sql
@@ -132,16 +132,20 @@ BEGIN
     RAISE EXCEPTION 'get_futebol_fixture_value nao existe';
   END IF;
 
+  -- Guarda de idempotencia PRIMEIRO (aprendido no db push de 19/08: num banco
+  -- que ja recebeu esta migration na mao e depois evoluiu com as 099-105, a
+  -- ancora antiga nao existe mais; checar divergencia antes de checar "ja
+  -- aplicada" fazia a migration abortar exatamente onde deveria sair quieta).
+  IF position('d.janela_usada is not distinct from v.janela_usada' in v) > 0
+     OR position('left join d on' in v) = 0 THEN
+    RAISE NOTICE 'get_futebol_fixture_value ja tem o desempate (ou foi superada pela 105). Nada a fazer.';
+    RETURN;
+  END IF;
+
   -- Guarda: se a definicao viva nao for a esperada, aborta sem tocar em nada.
   IF position('distinct on (fixture_id, outcome_side, line_value)' in v) = 0
      OR position('left join d on d.fixture_id = v.fixture_id and d.outcome_side = v.outcome and d.line_value is not distinct from v.line_value' in v) = 0 THEN
     RAISE EXCEPTION 'get_futebol_fixture_value: definicao viva divergente do esperado. Revisar antes de aplicar.';
-  END IF;
-
-  -- Guarda de idempotencia: se ja tem o desempate, nao faz nada.
-  IF position('d.janela_usada is not distinct from v.janela_usada' in v) > 0 THEN
-    RAISE NOTICE 'get_futebol_fixture_value ja tem o desempate. Nada a fazer.';
-    RETURN;
   END IF;
 
   v := replace(v,


### PR DESCRIPTION
O primeiro `db push` real dessas migrations (staging, hoje, depois do reparo das 13 versões órfãs) aplicou **094 a 097** e abortou na 098 com a exceção da própria guarda: `definicao viva divergente do esperado`.

Diagnóstico: no staging a função já tinha recebido a 098 **na mão** e depois evoluído com as 099-104. A âncora antiga não existe mais no corpo vivo, e a 098 checava **divergência antes de idempotência**, então abortava exatamente no caso em que deveria sair quieta. As 099-104 já checam na ordem certa (conferido arquivo a arquivo); a 098 era a única invertida.

A saída silenciosa nova também cobre o corpo pós-105 (sem CTE `d` nenhum), então a 098 continua aplicável em qualquer ordem de chegada.

Em banco onde a 098 nunca rodou (produção), nada muda: nenhum marcador presente, cai nas âncoras e aplica como desenhado.

Sem mudança de comportamento de produto; é migration-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)