### PR TITLE
fix(futebol): a copy da premissa passa a ter uma fonte só (#272)

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -1044,6 +1044,224 @@ end $function$
 
 ;
 
+-- ── Copy das premissas (migration 106) ──────────────────────────────────────
+-- ── A copy das premissas, uma vez só ────────────────────────────────────────
+-- Antes desta tabela, o texto de cada premissa existia em DUAS fontes
+-- independentes: o catálogo do app (`src/utils/futebol-premissas.ts`), que serve a
+-- tela, e a cascata de `case when` dentro destas três RPCs, que serve a DM do
+-- Telegram. Medido em 20/08: de 36 premissas presentes nas duas, 27 tinham TEXTO
+-- DIFERENTE. Ninguém viu porque nada comparava as duas.
+--
+-- E a cascata era a TERCEIRA cópia verbatim de si mesma, como o comentário da
+-- migration 102 já registrava: "mercado novo agora mexe em três RPCs".
+--
+-- Agora o catálogo do app é a fonte, esta tabela é a projeção dele no banco, e a
+-- guarda `futebol-copy-paridade.test.ts` quebra o PR quando os dois se afastam.
+create table if not exists public.futebol_premissa_copy (
+  tipo   text    not null check (tipo in ('evidencia', 'contra', 'aviso')),
+  market text    not null,
+  slug   text    not null,
+  -- 'any' é o texto neutro; 'home'/'away' só existem onde a frase muda de verdade.
+  mando  text    not null check (mando in ('any', 'home', 'away')),
+  -- Posição na fila. É o que conserta o defeito de origem: a DM mostra o PRIMEIRO
+  -- item do array, e a ordem da cascata era a ordem em que ela foi escrita. No
+  -- azarão do handicap, 12.736 linhas mostravam a premissa de 3 pontos tendo a de
+  -- 10 pontos disponível.
+  ordem  integer not null,
+  texto  text    not null,
+  primary key (tipo, market, slug, mando)
+);
+
+-- RLS ligada e SEM policy, de propósito: nada acessa esta tabela direto. As três
+-- RPCs são SECURITY DEFINER e leem como dono, então a ausência de policy é o que
+-- garante que ninguém leia por fora.
+alter table public.futebol_premissa_copy enable row level security;
+
+-- Travessão é proibido em copy visível (régua do produto), e cinco dos oito avisos
+-- nasceram com um. A regra vira constraint porque regra que depende de alguém ler
+-- não é regra.
+alter table public.futebol_premissa_copy drop constraint if exists futebol_premissa_copy_sem_travessao;
+alter table public.futebol_premissa_copy add  constraint futebol_premissa_copy_sem_travessao
+  check (texto not like '%' || chr(8212) || '%' and texto not like '%' || chr(8211) || '%');
+
+-- Semente idempotente: a tabela é uma projeção do catálogo, então ela é reescrita
+-- inteira em vez de sofrer upsert linha por linha. Assim premissa REMOVIDA do
+-- catálogo também desaparece daqui.
+delete from public.futebol_premissa_copy;
+insert into public.futebol_premissa_copy (tipo, market, slug, mando, ordem, texto) values
+  ('evidencia', 'goals_over_under', 'defesas_firmes', 'any', 1, 'Defesas firmes dos dois lados'),
+  ('evidencia', 'goals_over_under', 'defesas_vazaveis', 'any', 2, 'Defesas frágeis dos dois lados'),
+  ('evidencia', 'goals_over_under', 'ataque_combinado', 'any', 3, 'Os dois somam muitos gols'),
+  ('evidencia', 'goals_over_under', 'xg_baixo_combinado', 'any', 4, 'Os dois criam pouca chance de gol'),
+  ('evidencia', 'goals_over_under', 'xg_combinado_alto', 'any', 5, 'Os dois criam muita chance de gol'),
+  ('evidencia', 'goals_over_under', 'clean_sheets_altos', 'any', 6, 'Os dois passam muitos jogos sem sofrer gol'),
+  ('evidencia', 'goals_over_under', 'corroboracao_ambos', 'any', 7, 'As principais casas e o modelo da API apontam o mesmo lado'),
+  ('evidencia', 'goals_over_under', 'linha_sharp_confirma', 'any', 8, 'As principais casas vêm baixando a odd desse lado'),
+  ('evidencia', 'goals_over_under', 'ataques_fracos', 'any', 9, 'Ataques fracos dos dois lados'),
+  ('evidencia', 'goals_over_under', 'historico_under', 'any', 10, 'Histórico de jogo com poucos gols'),
+  ('evidencia', 'goals_over_under', 'ambos_vazam', 'any', 11, 'Os dois sofrem gol quase todo jogo'),
+  ('evidencia', 'goals_over_under', 'ritmo_alto', 'any', 12, 'Jogo de ritmo alto'),
+  ('evidencia', 'goals_over_under', 'historico_over', 'any', 13, 'Histórico de jogo com muitos gols'),
+  ('evidencia', 'goals_over_under', 'linha_subindo', 'any', 14, 'Mercado puxando a linha pra cima'),
+  ('evidencia', 'goals_over_under', 'linha_descendo', 'any', 15, 'Mercado puxando a linha pra baixo'),
+  ('evidencia', 'goals_over_under', 'modelo_api_concorda', 'any', 16, 'Modelo da API concorda com esse lado'),
+  ('contra', 'goals_over_under', 'defesas_firmes', 'any', 1, 'As defesas não são firmes'),
+  ('contra', 'goals_over_under', 'ataque_combinado', 'any', 2, 'Os dois não somam muitos gols'),
+  ('contra', 'goals_over_under', 'xg_baixo_combinado', 'any', 3, 'Os dois criam bastante chance de gol'),
+  ('contra', 'goals_over_under', 'xg_combinado_alto', 'any', 4, 'Os dois não criam muita chance de gol'),
+  ('contra', 'goals_over_under', 'clean_sheets_altos', 'any', 5, 'Não costumam segurar o placar zerado'),
+  ('contra', 'goals_over_under', 'ritmo_alto', 'any', 6, 'O jogo não é de ritmo alto'),
+  ('aviso', 'goals_over_under', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'goals_over_under', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'goals_over_under', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'goals_over_under', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco'),
+  ('aviso', 'goals_over_under', 'linha_extrema', 'any', 5, 'Linha muito longe do normal'),
+  ('evidencia', 'match_winner', 'forma', 'any', 1, 'Em boa fase, vem ganhando'),
+  ('evidencia', 'match_winner', 'mando', 'any', 2, 'Mando relevante'),
+  ('evidencia', 'match_winner', 'mando', 'home', 2, 'Manda bem em casa'),
+  ('evidencia', 'match_winner', 'mando', 'away', 2, 'Vai bem fora de casa'),
+  ('evidencia', 'match_winner', 'superioridade_tabela', 'any', 3, 'Bem à frente na tabela'),
+  ('evidencia', 'match_winner', 'corroboracao_ambos', 'any', 4, 'As principais casas e o modelo da API apontam o mesmo lado'),
+  ('evidencia', 'match_winner', 'linha_sharp_confirma', 'any', 5, 'As principais casas vêm baixando a odd desse lado'),
+  ('evidencia', 'match_winner', 'forca_mismatch', 'any', 6, 'Ataque forte contra defesa frágil do adversário'),
+  ('evidencia', 'match_winner', 'superioridade_xg', 'any', 7, 'Cria mais chances de gol que o adversário'),
+  ('evidencia', 'match_winner', 'h2h_favoravel', 'any', 8, 'Leva vantagem no histórico do confronto'),
+  ('evidencia', 'match_winner', 'desfalque_adversario', 'any', 9, 'Adversário com desfalque de titular importante'),
+  ('evidencia', 'match_winner', 'modelo_api_concorda', 'any', 10, 'Modelo da API concorda com esse lado'),
+  ('contra', 'match_winner', 'mando', 'home', 1, 'Não manda bem em casa'),
+  ('contra', 'match_winner', 'mando', 'away', 1, 'Não vai bem fora de casa'),
+  ('contra', 'match_winner', 'superioridade_tabela', 'any', 2, 'Não está bem à frente na tabela'),
+  ('contra', 'match_winner', 'forca_mismatch', 'any', 3, 'O ataque não pega uma defesa frágil'),
+  ('aviso', 'match_winner', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'match_winner', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'match_winner', 'desfalque_proprio', 'any', 3, 'Time apostado com desfalque de titular importante'),
+  ('aviso', 'match_winner', 'pen_poucas_casas', 'any', 4, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'match_winner', 'pen_odd_juice', 'any', 5, 'Odd baixa, retorno pequeno pro risco'),
+  ('aviso', 'match_winner', 'pick_empate', 'any', 6, 'Empate é o resultado mais difícil de prever'),
+  ('evidencia', 'asian_handicap', 'tende_golear', 'any', 1, 'Costuma ganhar por muitos gols'),
+  ('evidencia', 'asian_handicap', 'supremacia', 'any', 2, 'Muito superior ao adversário'),
+  ('evidencia', 'asian_handicap', 'defesa_fora_solida', 'any', 3, 'Defesa sólida jogando fora'),
+  ('evidencia', 'asian_handicap', 'defesa_fora_solida', 'home', 3, 'Defesa sólida em casa'),
+  ('evidencia', 'asian_handicap', 'corroboracao_ambos', 'any', 4, 'As principais casas e o modelo da API apontam o mesmo lado'),
+  ('evidencia', 'asian_handicap', 'linha_sharp_confirma', 'any', 5, 'As principais casas vêm baixando a odd desse lado'),
+  ('evidencia', 'asian_handicap', 'sem_rodizio', 'any', 6, 'Deve entrar com força máxima'),
+  ('evidencia', 'asian_handicap', 'raramente_perde_por_2', 'any', 7, 'Quando perde, perde apertado'),
+  ('evidencia', 'asian_handicap', 'adversario_fragil_fora', 'any', 8, 'Adversário fraco fora de casa'),
+  ('evidencia', 'asian_handicap', 'adversario_fragil_fora', 'away', 8, 'Adversário fraco em casa'),
+  ('evidencia', 'asian_handicap', 'mando_forte', 'any', 9, 'Manda muito bem em casa'),
+  ('evidencia', 'asian_handicap', 'mando_forte', 'away', 9, 'Vai muito bem fora de casa'),
+  ('evidencia', 'asian_handicap', 'modelo_api_concorda', 'any', 10, 'Modelo da API concorda com esse lado'),
+  ('contra', 'asian_handicap', 'tende_golear', 'any', 1, 'Não costuma ganhar por muitos gols'),
+  ('contra', 'asian_handicap', 'supremacia', 'any', 2, 'Não é muito superior ao adversário'),
+  ('contra', 'asian_handicap', 'defesa_fora_solida', 'any', 3, 'A defesa não é sólida jogando fora'),
+  ('contra', 'asian_handicap', 'defesa_fora_solida', 'home', 3, 'A defesa não é sólida em casa'),
+  ('contra', 'asian_handicap', 'raramente_perde_por_2', 'any', 4, 'Costuma perder por muitos gols'),
+  ('aviso', 'asian_handicap', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'asian_handicap', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'asian_handicap', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'asian_handicap', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco'),
+  ('aviso', 'asian_handicap', 'handicap_alto', 'any', 5, 'Handicap muito alto'),
+  ('evidencia', 'btts', 'ambos_marcam', 'any', 1, 'Os dois costumam marcar'),
+  ('evidencia', 'btts', 'ataque_dos_dois', 'any', 2, 'Os dois atacam bem'),
+  ('evidencia', 'btts', 'defesas_vazaveis', 'any', 3, 'Defesas frágeis dos dois lados'),
+  ('evidencia', 'btts', 'defesa_forte', 'any', 4, 'Defesa forte de um dos lados'),
+  ('evidencia', 'btts', 'ataque_trava', 'any', 5, 'Um dos ataques costuma passar em branco'),
+  ('evidencia', 'btts', 'historico_btts', 'any', 6, 'Nos últimos jogos, os dois marcaram'),
+  ('evidencia', 'btts', 'historico_seco', 'any', 7, 'Jogos recentes sem os dois marcarem'),
+  ('evidencia', 'btts', 'corroboracao_ambos', 'any', 8, 'As principais casas e o modelo da API apontam o mesmo lado'),
+  ('evidencia', 'btts', 'linha_sharp_confirma', 'any', 9, 'As principais casas vêm baixando a odd desse lado'),
+  ('evidencia', 'btts', 'modelo_api_concorda', 'any', 10, 'Modelo da API concorda com esse lado'),
+  ('contra', 'btts', 'ambos_marcam', 'any', 1, 'Os dois não costumam marcar'),
+  ('contra', 'btts', 'defesas_vazaveis', 'any', 2, 'As defesas não são frágeis'),
+  ('contra', 'btts', 'defesa_forte', 'any', 3, 'Nenhum dos lados tem defesa forte'),
+  ('contra', 'btts', 'ataque_trava', 'any', 4, 'Os dois ataques costumam marcar'),
+  ('aviso', 'btts', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'btts', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'btts', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'btts', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco'),
+  ('evidencia', 'double_chance', 'lado_coberto_forte', 'any', 1, 'O lado coberto é forte'),
+  ('evidencia', 'double_chance', 'equilibrio_defensivo', 'any', 2, 'Equilíbrio defensivo'),
+  ('evidencia', 'double_chance', 'adversario_limitado', 'any', 3, 'Adversário com campanha fraca'),
+  ('evidencia', 'double_chance', 'invicto_recente', 'any', 4, 'Invicto nos últimos jogos'),
+  ('evidencia', 'double_chance', 'corroboracao_ambos', 'any', 5, 'As principais casas e o modelo da API apontam o mesmo lado'),
+  ('evidencia', 'double_chance', 'linha_sharp_confirma', 'any', 6, 'As principais casas vêm baixando a odd desse lado'),
+  ('evidencia', 'double_chance', 'modelo_api_concorda', 'any', 7, 'Modelo da API concorda com esse lado'),
+  ('contra', 'double_chance', 'lado_coberto_forte', 'any', 1, 'O lado coberto não é forte'),
+  ('contra', 'double_chance', 'adversario_limitado', 'any', 2, 'Adversário não é tão limitado'),
+  ('aviso', 'double_chance', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'double_chance', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'double_chance', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'double_chance', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco');
+
+-- ── Os dois helpers ─────────────────────────────────────────────────────────
+-- Junta num objeto só tudo que pode acender numa linha, e resolve a precedência da
+-- corroboração.
+--
+-- O nome da coluna booleana nas tabelas de premissa É o slug, então não existe
+-- cascata de `case when` para escrever: as chaves do jsonb já são os slugs. É por
+-- isso que a premissa nova passa a custar uma linha de semente e nada mais.
+--
+-- A corroboração é o único caso que não é "slug aceso vira texto": são dois sinais
+-- e três frases (as duas individuais e uma combinada). As três chaves saem daqui
+-- já resolvidas, e por vir DEPOIS no `||` elas vencem as do `v`.
+create or replace function public.futebol_flags(
+  p_v jsonb, p_p jsonb, p_o jsonb, p_ah jsonb, p_bt jsonb, p_dc jsonb
+) returns jsonb
+ language sql
+ immutable
+ set search_path to ''
+as $function$
+  select coalesce(p_v, '{}'::jsonb)
+      || coalesce(p_p, '{}'::jsonb)
+      || coalesce(p_o, '{}'::jsonb)
+      || coalesce(p_ah, '{}'::jsonb)
+      || coalesce(p_bt, '{}'::jsonb)
+      || coalesce(p_dc, '{}'::jsonb)
+      || jsonb_build_object(
+           'corroboracao_ambos',
+             coalesce((p_v->>'modelo_api_concorda')::boolean, false)
+             and coalesce((p_v->>'linha_sharp_confirma')::boolean, false),
+           'modelo_api_concorda',
+             coalesce((p_v->>'modelo_api_concorda')::boolean, false)
+             and not coalesce((p_v->>'linha_sharp_confirma')::boolean, false),
+           'linha_sharp_confirma',
+             coalesce((p_v->>'linha_sharp_confirma')::boolean, false)
+             and not coalesce((p_v->>'modelo_api_concorda')::boolean, false)
+         )
+$function$;
+
+-- Traduz as flags acesas para a copy, na ordem certa.
+--
+-- `contra` procura 'false' em vez de 'true', e é por isso que NULL não gera contra:
+-- em jsonb um booleano nulo vira null, que não casa com 'false'. É o mesmo
+-- comportamento do `not coalesce(x, true)` que a cascata usava, e continua honrando
+-- a ADR 0003 (dado faltante diagnostica, não elimina).
+--
+-- O `distinct on` com o desempate pelo mando escolhe a variante específica quando
+-- ela existe e cai no texto neutro quando não existe.
+create or replace function public.futebol_copy(
+  p_tipo text, p_market text, p_mando text, p_flags jsonb
+) returns text[]
+ language sql
+ stable
+ set search_path to ''
+as $function$
+  select coalesce(array_agg(t.texto order by t.ordem), array[]::text[])
+  from (
+    select distinct on (c.slug) c.ordem, c.texto
+    from public.futebol_premissa_copy c
+    join jsonb_each_text(p_flags) f on f.key = c.slug
+    where c.tipo = p_tipo
+      and c.market = p_market
+      and c.mando in ('any', coalesce(p_mando, 'any'))
+      and f.value = case when p_tipo = 'contra' then 'false' else 'true' end
+    order by c.slug, (c.mando <> 'any') desc
+  ) t
+$function$;
+
+grant execute on function public.futebol_flags(jsonb, jsonb, jsonb, jsonb, jsonb, jsonb) to anon, authenticated, service_role;
+grant execute on function public.futebol_copy(text, text, text, jsonb) to anon, authenticated, service_role;
+
 CREATE OR REPLACE FUNCTION public.get_futebol_fixture_value(p_fixture_id bigint)
  RETURNS TABLE(market text, outcome text, outcome_order integer, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, penalidades_globais_pts integer, penalidades_especificas_pts integer, score integer, faixa text, modelo_api_concorda boolean, linha_sharp_confirma boolean, evidencias text[], avisos text[], contras text[], premissas_sem_dado integer)
  LANGUAGE sql
@@ -1100,91 +1318,9 @@ AS $function$
     v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int,
     v.penalidades_globais_pts::int, v.penalidades_especificas_pts::int, v.score::int, v.faixa,
     v.modelo_api_concorda, v.linha_sharp_confirma,
-    array_remove(array[
-      case when p.forca_mismatch then 'Ataque forte contra defesa frágil do adversário' end,
-      case when p.superioridade_xg then 'Cria mais chances de gol do que o adversário' end,
-      case when p.mando then (case v.outcome when 'Home' then 'Manda bem em casa' when 'Away' then 'Vai bem fora de casa' else 'Mando relevante' end) end,
-      case when p.desfalque_adversario then 'Adversário com desfalque de titular importante' end,
-      case when p.superioridade_tabela then 'Bem à frente na tabela' end,
-      case when p.forma then 'Em boa fase (vitórias recentes)' end,
-      case when p.h2h_favoravel then 'Histórico favorável no confronto direto' end
-    ], null)
-    || array_remove(array[
-      case when o.ataque_combinado then 'Os dois somam muitos gols (casa + fora)' end,
-      case when o.defesas_vazaveis then 'Defesas frágeis dos dois lados' end,
-      case when o.xg_combinado_alto then 'Os dois criam muitas chances de gol' end,
-      case when o.ritmo_alto then 'Jogo de ritmo alto (muitas finalizações)' end,
-      case when o.ambos_vazam then 'Os dois sofrem gol quase todo jogo' end,
-      case when o.historico_over then 'Últimos jogos goleadores' end,
-      case when o.linha_subindo then 'Mercado puxando a linha pra cima' end,
-      case when o.defesas_firmes then 'Defesas firmes dos dois lados' end,
-      case when o.clean_sheets_altos then 'Os dois passam muitos jogos sem sofrer gol' end,
-      case when o.xg_baixo_combinado then 'Os dois criam pouca coisa na frente' end,
-      case when o.ataques_fracos then 'Ataque fraco (passam em branco com frequência)' end,
-      case when o.historico_under then 'Últimos jogos truncados' end,
-      case when o.linha_descendo then 'Mercado puxando a linha pra baixo' end
-    ], null)
-    || array_remove(array[
-      case when ah.supremacia then 'Muito superior ao adversário' end,
-      case when ah.tende_golear then 'Costuma vencer com boa diferença de gols' end,
-      case when ah.adversario_fragil_fora then 'Adversário tem defesa frágil' end,
-      case when ah.mando_forte then 'Manda muito bem em casa' end,
-      case when ah.sem_rodizio then 'Deve entrar com força máxima' end,
-      case when ah.raramente_perde_por_2 then 'Raramente perde por 2 gols ou mais' end,
-      case when ah.defesa_fora_solida then 'Defesa sólida jogando fora' end,
-      case when ah.favorito_irregular then 'O favorito não costuma golear' end
-    ], null)
-    || array_remove(array[
-      case when bt.ambos_marcam then 'Os dois quase sempre marcam' end,
-      case when bt.ataque_dos_dois then 'Os dois ataques vêm produzindo' end,
-      case when bt.defesas_vazaveis then 'As duas defesas sofrem gol com frequência' end,
-      case when bt.historico_btts then 'Nos últimos jogos, os dois marcaram' end,
-      case when bt.defesa_forte then 'Uma das defesas segura bem o placar' end,
-      case when bt.ataque_trava then 'Um dos ataques costuma passar em branco' end,
-      case when bt.historico_seco then 'Jogos recentes sem os dois marcarem' end
-    ], null)
-    || array_remove(array[
-      case when dc.lado_coberto_forte then 'O lado coberto é claramente o mais forte' end,
-      case when dc.equilibrio_defensivo then 'Defesas parelhas — empate é desfecho plausível' end,
-      case when dc.adversario_limitado then 'Adversário com campanha fraca' end,
-      case when dc.invicto_recente then 'Vem sem perder nos últimos jogos' end
-    ], null)
-    || array_remove(array[
-      case when v.modelo_api_concorda and v.linha_sharp_confirma then 'As principais casas e o modelo da API apontam o mesmo lado'
-           when v.modelo_api_concorda then 'Modelo da API concorda com esse lado'
-           when v.linha_sharp_confirma then 'As principais casas vêm baixando a odd desse lado' end
-    ], null),
-    array_remove(array[
-      case when v.pen_odd_outlier then 'Só uma casa paga essa odd — pode ser linha furada' end,
-      case when v.pen_poucas_casas then 'Poucas casas cotando esse mercado' end,
-      case when v.pen_odd_longshot then 'Odd alta (zebra) — entra com cautela' end,
-      case when v.pen_odd_juice then 'Odd baixa — retorno pequeno pro risco' end,
-      case when p.pick_empate then 'Empate é o resultado mais difícil de prever' end,
-      case when p.desfalque_proprio then 'Time apostado com desfalque de titular importante' end,
-      case when o.linha_extrema then 'Linha extrema — pouco confiável' end,
-      case when ah.handicap_alto then 'Handicap alto (2,5+ gols) — raramente confiável' end
-    ], null),
-    (array_remove(array[
-      case when not coalesce(p.forca_mismatch, true) then 'Sem vantagem clara de ataque × defesa' end,
-      case when not coalesce(p.mando, true) and v.outcome <> 'Draw' then 'Mando não pesa a favor' end,
-      case when not coalesce(p.superioridade_tabela, true) then 'Times equilibrados na tabela' end,
-      case when v.outcome='Over' and not coalesce(o.ataque_combinado, true) then 'Os dois não somam tantos gols' end,
-      case when v.outcome='Over' and not coalesce(o.ritmo_alto, true) then 'Jogo não costuma ser de ritmo alto' end,
-      case when v.outcome='Over' and not coalesce(o.xg_combinado_alto, true) then 'O volume de chances não é tão alto' end,
-      case when v.outcome='Under' and not coalesce(o.defesas_firmes, true) then 'As defesas não são tão firmes' end,
-      case when v.outcome='Under' and not coalesce(o.clean_sheets_altos, true) then 'Não costumam segurar o placar zerado' end,
-      case when v.outcome='Under' and not coalesce(o.xg_baixo_combinado, true) then 'Criam chances demais pra um jogo truncado' end,
-      case when ah.is_favorito and not coalesce(ah.supremacia, true) then 'Não é tão superior assim ao adversário' end,
-      case when ah.is_favorito and not coalesce(ah.tende_golear, true) then 'Nem sempre vence com boa diferença' end,
-      case when ah.is_azarao and not coalesce(ah.raramente_perde_por_2, true) then 'Já levou goleada algumas vezes' end,
-      case when ah.is_azarao and not coalesce(ah.defesa_fora_solida, true) then 'Defesa fora não é das mais sólidas' end,
-      case when v.outcome='Yes' and not coalesce(bt.ambos_marcam, true) then 'Nem sempre os dois marcam' end,
-      case when v.outcome='Yes' and not coalesce(bt.defesas_vazaveis, true) then 'As defesas não são tão vazadas' end,
-      case when v.outcome='No' and not coalesce(bt.defesa_forte, true) then 'Nenhuma defesa é tão sólida' end,
-      case when v.outcome='No' and not coalesce(bt.ataque_trava, true) then 'Os dois ataques costumam marcar' end,
-      case when not coalesce(dc.lado_coberto_forte, true) then 'O lado coberto não é claramente o mais forte' end,
-      case when not coalesce(dc.adversario_limitado, true) then 'Adversário não é tão limitado' end
-    ], null))[1:3],
+    public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
+    public.futebol_copy('aviso', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
+    (public.futebol_copy('contra', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))))[1:3],
     v.premissas_sem_dado::int
   from v_src v
   left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
@@ -1592,60 +1728,7 @@ AS $function$
     f.competition, f.kickoff_utc, f.status_short,
     v.market, v.outcome, v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
     v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int, v.score::int, v.faixa,
-    array_remove(array[
-      case when p.forca_mismatch then 'Ataque forte contra defesa frágil do adversário' end,
-      case when p.superioridade_xg then 'Cria mais chances de gol do que o adversário' end,
-      case when p.mando then (case v.outcome when 'Home' then 'Manda bem em casa' when 'Away' then 'Vai bem fora de casa' else 'Mando relevante' end) end,
-      case when p.desfalque_adversario then 'Adversário com desfalque de titular importante' end,
-      case when p.superioridade_tabela then 'Bem à frente na tabela' end,
-      case when p.forma then 'Em boa fase (vitórias recentes)' end,
-      case when p.h2h_favoravel then 'Histórico favorável no confronto direto' end
-    ], null)
-    || array_remove(array[
-      case when o.ataque_combinado then 'Os dois somam muitos gols (casa + fora)' end,
-      case when o.defesas_vazaveis then 'Defesas frágeis dos dois lados' end,
-      case when o.xg_combinado_alto then 'Os dois criam muitas chances de gol' end,
-      case when o.ritmo_alto then 'Jogo de ritmo alto (muitas finalizações)' end,
-      case when o.ambos_vazam then 'Os dois sofrem gol quase todo jogo' end,
-      case when o.historico_over then 'Últimos jogos goleadores' end,
-      case when o.linha_subindo then 'Mercado puxando a linha pra cima' end,
-      case when o.defesas_firmes then 'Defesas firmes dos dois lados' end,
-      case when o.clean_sheets_altos then 'Os dois passam muitos jogos sem sofrer gol' end,
-      case when o.xg_baixo_combinado then 'Os dois criam pouca coisa na frente' end,
-      case when o.ataques_fracos then 'Ataque fraco (passam em branco com frequência)' end,
-      case when o.historico_under then 'Últimos jogos truncados' end,
-      case when o.linha_descendo then 'Mercado puxando a linha pra baixo' end
-    ], null)
-    || array_remove(array[
-      case when ah.supremacia then 'Muito superior ao adversário' end,
-      case when ah.tende_golear then 'Costuma vencer com boa diferença de gols' end,
-      case when ah.adversario_fragil_fora then 'Adversário tem defesa frágil' end,
-      case when ah.mando_forte then 'Manda muito bem em casa' end,
-      case when ah.sem_rodizio then 'Deve entrar com força máxima' end,
-      case when ah.raramente_perde_por_2 then 'Raramente perde por 2 gols ou mais' end,
-      case when ah.defesa_fora_solida then 'Defesa sólida jogando fora' end,
-      case when ah.favorito_irregular then 'O favorito não costuma golear' end
-    ], null)
-    || array_remove(array[
-      case when bt.ambos_marcam then 'Os dois quase sempre marcam' end,
-      case when bt.ataque_dos_dois then 'Os dois ataques vêm produzindo' end,
-      case when bt.defesas_vazaveis then 'As duas defesas sofrem gol com frequência' end,
-      case when bt.historico_btts then 'Nos últimos jogos, os dois marcaram' end,
-      case when bt.defesa_forte then 'Uma das defesas segura bem o placar' end,
-      case when bt.ataque_trava then 'Um dos ataques costuma passar em branco' end,
-      case when bt.historico_seco then 'Jogos recentes sem os dois marcarem' end
-    ], null)
-    || array_remove(array[
-      case when dc.lado_coberto_forte then 'O lado coberto é claramente o mais forte' end,
-      case when dc.equilibrio_defensivo then 'Defesas parelhas — empate é desfecho plausível' end,
-      case when dc.adversario_limitado then 'Adversário com campanha fraca' end,
-      case when dc.invicto_recente then 'Vem sem perder nos últimos jogos' end
-    ], null)
-    || array_remove(array[
-      case when v.modelo_api_concorda and v.linha_sharp_confirma then 'As principais casas e o modelo da API apontam o mesmo lado'
-           when v.modelo_api_concorda then 'Modelo da API concorda com esse lado'
-           when v.linha_sharp_confirma then 'As principais casas vêm baixando a odd desse lado' end
-    ], null),
+    public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
     v.premissas_sem_dado::int
   from futebol.fact_value_opportunities v
   join futebol.fact_fixtures f on f.fixture_id = v.fixture_id
@@ -1714,60 +1797,7 @@ AS $function$
     f.competition, f.kickoff_utc, f.status_short,
     v.market, v.outcome, v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
     v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int, v.score::int, v.faixa,
-    array_remove(array[
-      case when p.forca_mismatch then 'Ataque forte contra defesa frágil do adversário' end,
-      case when p.superioridade_xg then 'Cria mais chances de gol do que o adversário' end,
-      case when p.mando then (case v.outcome when 'Home' then 'Manda bem em casa' when 'Away' then 'Vai bem fora de casa' else 'Mando relevante' end) end,
-      case when p.desfalque_adversario then 'Adversário com desfalque de titular importante' end,
-      case when p.superioridade_tabela then 'Bem à frente na tabela' end,
-      case when p.forma then 'Em boa fase (vitórias recentes)' end,
-      case when p.h2h_favoravel then 'Histórico favorável no confronto direto' end
-    ], null)
-    || array_remove(array[
-      case when o.ataque_combinado then 'Os dois somam muitos gols (casa + fora)' end,
-      case when o.defesas_vazaveis then 'Defesas frágeis dos dois lados' end,
-      case when o.xg_combinado_alto then 'Os dois criam muitas chances de gol' end,
-      case when o.ritmo_alto then 'Jogo de ritmo alto (muitas finalizações)' end,
-      case when o.ambos_vazam then 'Os dois sofrem gol quase todo jogo' end,
-      case when o.historico_over then 'Últimos jogos goleadores' end,
-      case when o.linha_subindo then 'Mercado puxando a linha pra cima' end,
-      case when o.defesas_firmes then 'Defesas firmes dos dois lados' end,
-      case when o.clean_sheets_altos then 'Os dois passam muitos jogos sem sofrer gol' end,
-      case when o.xg_baixo_combinado then 'Os dois criam pouca coisa na frente' end,
-      case when o.ataques_fracos then 'Ataque fraco (passam em branco com frequência)' end,
-      case when o.historico_under then 'Últimos jogos truncados' end,
-      case when o.linha_descendo then 'Mercado puxando a linha pra baixo' end
-    ], null)
-    || array_remove(array[
-      case when ah.supremacia then 'Muito superior ao adversário' end,
-      case when ah.tende_golear then 'Costuma vencer com boa diferença de gols' end,
-      case when ah.adversario_fragil_fora then 'Adversário tem defesa frágil' end,
-      case when ah.mando_forte then 'Manda muito bem em casa' end,
-      case when ah.sem_rodizio then 'Deve entrar com força máxima' end,
-      case when ah.raramente_perde_por_2 then 'Raramente perde por 2 gols ou mais' end,
-      case when ah.defesa_fora_solida then 'Defesa sólida jogando fora' end,
-      case when ah.favorito_irregular then 'O favorito não costuma golear' end
-    ], null)
-    || array_remove(array[
-      case when bt.ambos_marcam then 'Os dois quase sempre marcam' end,
-      case when bt.ataque_dos_dois then 'Os dois ataques vêm produzindo' end,
-      case when bt.defesas_vazaveis then 'As duas defesas sofrem gol com frequência' end,
-      case when bt.historico_btts then 'Nos últimos jogos, os dois marcaram' end,
-      case when bt.defesa_forte then 'Uma das defesas segura bem o placar' end,
-      case when bt.ataque_trava then 'Um dos ataques costuma passar em branco' end,
-      case when bt.historico_seco then 'Jogos recentes sem os dois marcarem' end
-    ], null)
-    || array_remove(array[
-      case when dc.lado_coberto_forte then 'O lado coberto é claramente o mais forte' end,
-      case when dc.equilibrio_defensivo then 'Defesas parelhas — empate é desfecho plausível' end,
-      case when dc.adversario_limitado then 'Adversário com campanha fraca' end,
-      case when dc.invicto_recente then 'Vem sem perder nos últimos jogos' end
-    ], null)
-    || array_remove(array[
-      case when v.modelo_api_concorda and v.linha_sharp_confirma then 'As principais casas e o modelo da API apontam o mesmo lado'
-           when v.modelo_api_concorda then 'Modelo da API concorda com esse lado'
-           when v.linha_sharp_confirma then 'As principais casas vêm baixando a odd desse lado' end
-    ], null),
+    public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
     v.premissas_sem_dado::int
   from pit v
   join futebol.fact_fixtures f on f.fixture_id = v.fixture_id

--- a/src/utils/futebol-copy-paridade.test.ts
+++ b/src/utils/futebol-copy-paridade.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { copyDeServing, type LinhaCopy } from './futebol-premissas';
+
+// ============================================================================
+// A guarda que impede a copy da premissa de divergir de novo (issue #272)
+// ============================================================================
+// O texto de cada premissa existia em DUAS fontes independentes: o catálogo deste
+// diretório, que serve a tela, e uma cascata de `case when` dentro de três RPCs,
+// que serve a DM do Telegram. Medido em 20/08/2026: de 36 premissas presentes nas
+// duas, 27 tinham TEXTO DIFERENTE, e ninguém tinha visto, porque:
+//
+//   · a tela e a DM são lidas por pessoas diferentes, em momentos diferentes
+//   · o SQL não é lido por ninguém depois do PR que o escreveu
+//   · a cascata era a TERCEIRA cópia verbatim de si mesma, então divergir era o
+//     comportamento esperado do sistema, não um acidente
+//
+// Agora o catálogo é a fonte e a migration semeia uma tabela de apoio a partir
+// dele. Esta guarda compara os dois em ARQUIVO contra ARQUIVO, sem banco, e roda
+// no mesmo `vitest` do resto. Mesmo padrão da guarda do shape file, que nasceu do
+// mesmo modo de falha: divergência silenciosa que só aparece quando alguém lê.
+//
+// O que ela cobra vem dos três defeitos medidos:
+//   1. TEXTO   -> as 27 divergências
+//   2. ORDEM   -> a DM mostrava a evidência mais fraca (12.736 linhas)
+//   3. AUSÊNCIA-> a `favorito_irregular` aparecia na DM e não na tela (4.268)
+//   4. TRAVESSÃO -> seis frases visíveis violavam a régua de copy
+// ============================================================================
+
+const RAIZ = resolve(__dirname, '../..');
+const MIGRATION = resolve(RAIZ, 'supabase/migrations/106_futebol_copy_das_premissas.sql');
+const SHAPE = resolve(RAIZ, 'docs/futebol-prod-deploy.sql');
+const RPCS = ['get_futebol_fixture_value', 'get_futebol_value_board', 'get_futebol_value_history'];
+
+/** As linhas do `insert` da semente, na ordem em que aparecem no arquivo. */
+function semente(sql: string): LinhaCopy[] {
+  const i = sql.indexOf('insert into public.futebol_premissa_copy');
+  expect(i, 'não achei o insert da semente').toBeGreaterThan(-1);
+  const fim = sql.indexOf(';', i);
+  const corpo = sql.slice(i, fim);
+  const re = /\('(\w+)',\s*'(\w+)',\s*'(\w+)',\s*'(\w+)',\s*(\d+),\s*'((?:[^']|'')*)'\)/g;
+  return [...corpo.matchAll(re)].map((m) => ({
+    tipo: m[1] as LinhaCopy['tipo'],
+    market: m[2],
+    slug: m[3],
+    mando: m[4] as LinhaCopy['mando'],
+    ordem: Number(m[5]),
+    texto: m[6].replace(/''/g, "'"),
+  }));
+}
+
+/** O corpo de uma função dentro de um .sql, do `create` ao `$function$` final. */
+function corpoDaFuncao(sql: string, nome: string): string {
+  const re = new RegExp(`create\\s+or\\s+replace\\s+function\\s+public\\.${nome}\\(`, 'i');
+  const m = sql.match(re);
+  expect(m, `não achei ${nome}`).not.toBeNull();
+  const i = m!.index!;
+  const j = sql.indexOf('\n$function$', i);
+  return sql.slice(i, j);
+}
+
+const chave = (l: LinhaCopy) => `${l.tipo}/${l.market}/${l.slug}/${l.mando}`;
+
+describe('a copy da serving é a copy do catálogo', () => {
+  const esperado = copyDeServing();
+
+  for (const [nome, arquivo] of [
+    ['migration 106', MIGRATION],
+    ['shape file', SHAPE],
+  ] as const) {
+    describe(nome, () => {
+      const sql = readFileSync(arquivo, 'utf8');
+      const semeado = semente(sql);
+
+      it('semeia exatamente as linhas do catálogo, na mesma ordem', () => {
+        // Comparar a lista inteira de uma vez faz o vitest mostrar o diff completo,
+        // que é o que torna o conserto óbvio sem investigação.
+        expect(semeado).toEqual(esperado);
+      });
+
+      it('não semeia premissa que a tela esconde', () => {
+        // Redundante com o teste acima e proposital: era ESTE o defeito que chegou ao
+        // usuário, então ele merece falhar com nome próprio.
+        const ocultas = semeado.filter((l) => l.slug === 'favorito_irregular');
+        expect(ocultas.map(chave)).toEqual([]);
+      });
+
+      it('não usa travessão em copy visível', () => {
+        const comTravessao = semeado.filter((l) => l.texto.includes('—') || l.texto.includes('–'));
+        expect(comTravessao.map((l) => `${chave(l)} :: ${l.texto}`)).toEqual([]);
+      });
+
+      it('não deixa cascata de rótulo voltar para dentro das RPCs', () => {
+        // A cascata é o defeito de origem: enquanto ela existir, alguém vai editar o
+        // texto lá e a tabela de apoio fica para trás.
+        for (const rpc of RPCS) {
+          const corpo = corpoDaFuncao(sql, rpc);
+          expect(corpo, `${rpc} voltou a montar array de rótulo à mão`).not.toContain('array_remove(array[');
+          expect(corpo, `${rpc} não traduz pela tabela de apoio`).toContain('public.futebol_copy(');
+        }
+      });
+    });
+  }
+
+  it('a ordem da evidência é decrescente por peso, e o handicap prova o caso', () => {
+    // O caso concreto que abriu a issue: no azarão, a premissa de 10 pontos tem que
+    // vir ANTES da de 3, porque a DM mostra só o primeiro item.
+    const ah = esperado
+      .filter((l) => l.tipo === 'evidencia' && l.market === 'asian_handicap' && l.mando === 'any')
+      .sort((a, b) => a.ordem - b.ordem)
+      .map((l) => l.slug);
+    expect(ah.indexOf('defesa_fora_solida')).toBeLessThan(ah.indexOf('raramente_perde_por_2'));
+  });
+
+  it('a frase do azarão não promete mais uma condição da aposta', () => {
+    // "Raramente perde por 2 gols ou mais" só responde a pergunta em +1 e +1,5. Num
+    // +0,5 a aposta morre em qualquer derrota. A frase nova descreve o time.
+    const linha = esperado.find(
+      (l) => l.tipo === 'evidencia' && l.market === 'asian_handicap' && l.slug === 'raramente_perde_por_2',
+    );
+    expect(linha?.texto).toBe('Quando perde, perde apertado');
+  });
+});

--- a/src/utils/futebol-premissas.ts
+++ b/src/utils/futebol-premissas.ts
@@ -106,12 +106,18 @@ export function rotuloPremissa(p: Premissa, lado: 'home' | 'away' | null, negati
 /** Resultado (1X2). Teto de premissa 51 → 30, de 7 ativas para 4. */
 const P_1X2: Premissa[] = [
   P('forma', 'Em boa fase, vem ganhando', 'Não vem em boa fase', 'decide', 10),
-  P('mando', 'Manda bem em casa', 'Não manda bem em casa', 'decide', 8, {
+  // O rótulo base é o NEUTRO, e as variantes de mando ficam explícitas. Antes o base
+  // era "Manda bem em casa" e o mandante caía nele por omissão, o que funcionava na
+  // tela mas deixava o empate sem frase própria: o SQL tinha inventado um "Mando
+  // relevante" que não existia aqui. Agora os três casos moram no mesmo lugar.
+  P('mando', 'Mando relevante', 'Mando não pesa a favor', 'decide', 8, {
+    labelCasa: 'Manda bem em casa',
+    negativoCasa: 'Não manda bem em casa',
     labelFora: 'Vai bem fora de casa',
     negativoFora: 'Não vai bem fora de casa',
   }),
   P('superioridade_tabela', 'Bem à frente na tabela', 'Não está bem à frente na tabela', 'decide', 8),
-  P('forca_mismatch', 'Ataque forte contra defesa frágil', 'O ataque não pega uma defesa frágil', 'decide', 4, {
+  P('forca_mismatch', 'Ataque forte contra defesa frágil do adversário', 'O ataque não pega uma defesa frágil', 'decide', 4, {
     motivo: 'entende o jogo, mas o preço já cobra quase tudo',
   }),
   P('superioridade_xg', 'Cria mais chances de gol que o adversário', 'Não cria mais chances de gol que o adversário', 'preco', 0, {
@@ -120,7 +126,7 @@ const P_1X2: Premissa[] = [
   P('h2h_favoravel', 'Leva vantagem no histórico do confronto', 'Não leva vantagem no histórico do confronto', 'preco', 0, {
     motivo: 'todo mundo olha, então já está na odd',
   }),
-  P('desfalque_adversario', 'Adversário desfalcado', 'Adversário sem desfalque conhecido', 'preco', 0, {
+  P('desfalque_adversario', 'Adversário com desfalque de titular importante', 'Adversário sem desfalque conhecido', 'preco', 0, {
     motivo: 'sem dado em 99,5% dos jogos futuros',
   }),
 ];
@@ -132,7 +138,7 @@ const P_OU: Premissa[] = [
   P('ataque_combinado', 'Os dois somam muitos gols', 'Os dois não somam muitos gols', 'decide', 12, { lado: 'over' }),
   P('xg_baixo_combinado', 'Os dois criam pouca chance de gol', 'Os dois criam bastante chance de gol', 'decide', 10, { lado: 'under' }),
   P('xg_combinado_alto', 'Os dois criam muita chance de gol', 'Os dois não criam muita chance de gol', 'decide', 10, { lado: 'over' }),
-  P('clean_sheets_altos', 'Os dois seguram muito jogo sem sofrer gol', 'Os dois sofrem gol na maioria dos jogos', 'decide', 10, { lado: 'under' }),
+  P('clean_sheets_altos', 'Os dois passam muitos jogos sem sofrer gol', 'Não costumam segurar o placar zerado', 'decide', 10, { lado: 'under' }),
   P('ataques_fracos', 'Ataques fracos dos dois lados', 'Os ataques não são fracos', 'decide', 3, { lado: 'under', motivo: 'o preço já cobra' }),
   P('historico_under', 'Histórico de jogo com poucos gols', 'O histórico não é de jogo com poucos gols', 'preco', 3, { lado: 'under', motivo: 'sinal fraco' }),
   P('ambos_vazam', 'Os dois sofrem gol quase todo jogo', 'Os dois não sofrem gol quase todo jogo', 'preco', 0, {
@@ -157,8 +163,17 @@ const P_AH: Premissa[] = [
     labelCasa: 'Defesa sólida em casa',
     negativoCasa: 'A defesa não é sólida em casa',
   }),
-  P('sem_rodizio', 'Não deve poupar jogadores', 'Pode poupar jogadores', 'decide', 3, { lado: 'favorito' }),
-  P('raramente_perde_por_2', 'Raramente perde por dois ou mais', 'Perde por dois ou mais com frequência', 'decide', 3, {
+  P('sem_rodizio', 'Deve entrar com força máxima', 'Pode poupar jogadores', 'decide', 3, { lado: 'favorito' }),
+  // O rótulo antigo era "Raramente perde por dois ou mais", e ele enunciava uma
+  // CONDIÇÃO DE APOSTA que só vale em duas das sete linhas do handicap: num +0,5 a
+  // aposta morre em qualquer derrota, então a margem da derrota não responde nada.
+  // Chegou ao usuário numa DM de +0,5 e não fechou a conta (issue #272).
+  //
+  // O sinal, porém, é real: gradada contra o placar dos 90 minutos no lado azarão,
+  // ela separa em TODAS as linhas de meio gol, inclusive no +0,5, e o efeito
+  // sobrevive ao controle por faixa de odd acima de 1,30. Ela funciona como atalho
+  // para solidez defensiva geral. Logo o defeito era a frase, não o cálculo.
+  P('raramente_perde_por_2', 'Quando perde, perde apertado', 'Costuma perder por muitos gols', 'decide', 3, {
     lado: 'azarao',
     motivo: 'sinal quase nulo, mas é o que abre a porta do azarão',
   }),
@@ -182,30 +197,69 @@ const P_BTTS: Premissa[] = [
   P('ataque_dos_dois', 'Os dois atacam bem', 'Os dois não atacam bem', 'decide', null, { lado: 'sim' }),
   P('defesas_vazaveis', 'Defesas frágeis dos dois lados', 'As defesas não são frágeis', 'decide', null, { lado: 'sim' }),
   P('defesa_forte', 'Defesa forte de um dos lados', 'Nenhum dos lados tem defesa forte', 'decide', null, { lado: 'nao' }),
-  P('ataque_trava', 'Ataque que trava', 'Nenhum dos ataques trava', 'decide', null, { lado: 'nao' }),
-  P('historico_btts', 'Histórico dos dois marcando', 'O histórico não é dos dois marcando', 'preco', null, { lado: 'sim', motivo: 'histórico já está na odd' }),
-  P('historico_seco', 'Histórico de jogo seco', 'O histórico não é de jogo seco', 'preco', null, { lado: 'nao', motivo: 'histórico já está na odd' }),
+  P('ataque_trava', 'Um dos ataques costuma passar em branco', 'Os dois ataques costumam marcar', 'decide', null, { lado: 'nao' }),
+  P('historico_btts', 'Nos últimos jogos, os dois marcaram', 'O histórico não é dos dois marcando', 'preco', null, { lado: 'sim', motivo: 'histórico já está na odd' }),
+  P('historico_seco', 'Jogos recentes sem os dois marcarem', 'O histórico não é de jogo seco', 'preco', null, { lado: 'nao', motivo: 'histórico já está na odd' }),
 ];
 
 /** Dupla chance. PENDENTE no doc: Score máximo simulado 39 contra régua de 40. */
 const P_DC: Premissa[] = [
   P('lado_coberto_forte', 'O lado coberto é forte', 'O lado coberto não é forte', 'decide', null),
   P('equilibrio_defensivo', 'Equilíbrio defensivo', 'Sem equilíbrio defensivo', 'decide', null),
-  P('adversario_limitado', 'Adversário limitado', 'O adversário não é limitado', 'decide', null),
+  P('adversario_limitado', 'Adversário com campanha fraca', 'Adversário não é tão limitado', 'decide', null),
   P('invicto_recente', 'Invicto nos últimos jogos', 'Não está invicto nos últimos jogos', 'preco', null, { motivo: 'histórico já está na odd' }),
 ];
 
 /** Penalidades, por mercado. Peso negativo. */
 const PEN: Record<string, Premissa[]> = {
   match_winner: [
-    P('pick_empate', 'Aposta no empate', 'Não é aposta no empate', 'decide', 0, { motivo: 'suspensa até ter amostra' }),
-    P('desfalque_proprio', 'O próprio time está desfalcado', 'O próprio time não tem desfalque', 'decide', -15),
+    P('pick_empate', 'Empate é o resultado mais difícil de prever', 'Não é aposta no empate', 'decide', 0, { motivo: 'suspensa até ter amostra' }),
+    P('desfalque_proprio', 'Time apostado com desfalque de titular importante', 'O próprio time não tem desfalque', 'decide', -15),
   ],
   goals_over_under: [P('linha_extrema', 'Linha muito longe do normal', 'A linha não está longe do normal', 'decide', -10)],
   asian_handicap: [P('handicap_alto', 'Handicap muito alto', 'O handicap não é alto', 'decide', 0, { motivo: 'efeito zero nos dois testes' })],
   btts: [],
   double_chance: [],
 };
+
+/**
+ * Avisos que não pertencem a mercado nenhum: eles falam do PREÇO, então valem para
+ * qualquer aposta.
+ *
+ * Não estavam neste catálogo porque a tela consome o array de avisos da RPC como
+ * texto cru, e por isso a copy deles nunca passou por aqui. Consequência medida na
+ * issue #272: os quatro nasceram com travessão, que a régua de copy do produto
+ * proíbe, e ninguém viu porque não havia um lugar onde eles fossem lidos.
+ *
+ * A ordem é por severidade, que é a ordem em que devem ser oferecidos.
+ */
+const AVISOS_GLOBAIS: Premissa[] = [
+  P('pen_odd_outlier', 'Só uma casa paga essa odd, pode ser linha furada', 'A odd não está fora da curva', 'decide', -30),
+  P('pen_odd_longshot', 'Odd alta de zebra, entra com cautela', 'A odd não é de zebra', 'decide', -15),
+  P('pen_poucas_casas', 'Poucas casas cotando esse mercado', 'O mercado tem casas suficientes', 'decide', -12),
+  P('pen_odd_juice', 'Odd baixa, retorno pequeno pro risco', 'A odd não é baixa demais', 'decide', -10),
+];
+
+/**
+ * Evidências que não pertencem a mercado nenhum: falam do PREÇO, então valem para
+ * qualquer aposta e competem por peso com as premissas do mercado.
+ *
+ * Mesma história dos avisos globais: o SQL publicava esta como evidência e ela não
+ * existia neste catálogo, então a tela e a DM nunca puderam concordar sobre ela.
+ * O peso 8 é o da corroboração por linha sharp, e é ele que define onde ela entra
+ * na fila de cada mercado.
+ */
+const EVIDENCIAS_GLOBAIS: Premissa[] = [
+  // A corroboração são DOIS sinais e TRÊS frases: quando os dois acendem, a frase é
+  // uma terceira, e as duas individuais somem. `corroboracao_ambos` é um slug
+  // derivado, calculado no SQL antes da tradução, para que a precedência viva num
+  // lugar só em vez de virar `case` repetido em três funções.
+  P('corroboracao_ambos', 'As principais casas e o modelo da API apontam o mesmo lado', 'Nem as casas nem o modelo apontam esse lado', 'preco', 8),
+  P('linha_sharp_confirma', 'As principais casas vêm baixando a odd desse lado', 'As casas não vêm baixando a odd desse lado', 'preco', 8),
+  // Peso 0 porque a recalibragem tirou os +7 da API da nota (o modelo troca mando por
+  // empate errando 14 pontos). Continua sendo mostrado, mas é o último da fila.
+  P('modelo_api_concorda', 'Modelo da API concorda com esse lado', 'O modelo da API não aponta esse lado', 'preco', 0),
+];
 
 export interface MercadoInfo {
   slug: string;
@@ -428,3 +482,169 @@ export function premissasDaSaida(m: MercadoInfo, s: Saida, acesas: string[] = []
 // cards e o usuário troca de lado clicando. Listar os espelhos ("defesas frágeis"
 // embaixo de uma análise de "defesas firmes") fazia a tela se contradizer, mesmo
 // sem número, porque o rótulo já é a negação do que está sendo afirmado ao lado.
+
+// ── A copy que a camada de serving publica ───────────────────────────────────
+//
+// Este bloco existe porque a copy da premissa vivia em DOIS lugares: aqui, que
+// serve a tela, e o SQL das RPCs, que serve a DM do Telegram. Eles divergiram em
+// 27 de 36 premissas, e ninguém viu, porque nada comparava os dois (issue #272).
+//
+// Agora este catálogo é a fonte única, e o SQL passa a ler de uma tabela de apoio
+// semeada a partir do que `copyDeServing()` devolve. A guarda de paridade compara
+// a semente com esta função e quebra no PR quando os dois se afastam.
+//
+// Três defeitos concretos que a ORDEM resolve, todos medidos:
+//   · a DM mostra o primeiro item do array, e a ordem do SQL era a ordem em que
+//     ele foi escrito. No azarão do handicap, 12.736 linhas mostravam a premissa
+//     de 3 pontos tendo a de 10 disponível
+//   · a `favorito_irregular` aparecia na DM em 4.268 linhas, sendo que a tela a
+//     esconde de propósito (acende em 43% das linhas e vale zero)
+//   · a `mando` do Resultado, que vale 8 pontos, não estava no array do SQL:
+//     existia a coluna no banco e a entrada aqui, e a DM nunca a mostrava
+
+/** O que a camada de serving publica: o motivo, o contra-motivo e o aviso. */
+export type TipoCopy = 'evidencia' | 'contra' | 'aviso';
+
+/**
+ * O mando da aposta a que aquele texto pertence.
+ *
+ * `any` é o texto neutro e é o que vale quando o mando não muda a frase, ou quando a
+ * saída não tem mando (empate, mais e menos gols). `home` e `away` só existem onde a
+ * frase muda de verdade, e quem decide isso é `rotuloPremissa`, para a regra não ser
+ * reescrita aqui.
+ */
+export type MandoCopy = 'any' | 'home' | 'away';
+
+export interface LinhaCopy {
+  tipo: TipoCopy;
+  market: string;
+  slug: string;
+  mando: MandoCopy;
+  /**
+   * Posição dentro do seu tipo e mercado. 1 é o primeiro a ser oferecido.
+   *
+   * As variantes de mando do MESMO slug compartilham a posição: a ordem é do slug, o
+   * mando só escolhe qual frase sai.
+   */
+  ordem: number;
+  texto: string;
+}
+
+/**
+ * Quais premissas produzem um contra quando NÃO acendem.
+ *
+ * É um subconjunto deliberado, e ele preserva exatamente o que o SQL já emitia:
+ * mostrar o contra de toda premissa apagada encheria a tela de negativas. A chave
+ * é mercado+slug porque o mesmo slug existe em dois mercados.
+ */
+const CONTRAS_ELEGIVEIS = new Set([
+  'match_winner:forca_mismatch',
+  'match_winner:mando',
+  'match_winner:superioridade_tabela',
+  'goals_over_under:ataque_combinado',
+  'goals_over_under:ritmo_alto',
+  'goals_over_under:xg_combinado_alto',
+  'goals_over_under:defesas_firmes',
+  'goals_over_under:clean_sheets_altos',
+  'goals_over_under:xg_baixo_combinado',
+  'asian_handicap:supremacia',
+  'asian_handicap:tende_golear',
+  'asian_handicap:raramente_perde_por_2',
+  'asian_handicap:defesa_fora_solida',
+  'btts:ambos_marcam',
+  'btts:defesas_vazaveis',
+  'btts:defesa_forte',
+  'btts:ataque_trava',
+  'double_chance:lado_coberto_forte',
+  'double_chance:adversario_limitado',
+]);
+
+/**
+ * Contras que só fazem sentido quando a aposta TEM mando.
+ *
+ * O SQL já fazia isso com um `and v.outcome <> 'Draw'` solto: dizer "o mando não pesa
+ * a favor" numa aposta no empate é ruído, porque não há mando de que falar. Aqui a
+ * regra vira a ausência do texto neutro, o que dispensa a exceção no SQL.
+ */
+const CONTRAS_SO_COM_MANDO = new Set(['match_winner:mando']);
+
+/**
+ * Peso para ordenar.
+ *
+ * `null` é mercado sem calibragem, e ele ordena ACIMA de qualquer peso numérico de
+ * propósito. Não é para dar prioridade a quem não foi medido: é para os itens
+ * GLOBAIS (que têm peso numérico) ficarem atrás das premissas do próprio mercado
+ * quando aquele mercado não tem escala. Sem isso, uma aposta de Ambos Marcam saía
+ * na DM justificada pelo movimento da odd em vez de pelo jogo.
+ *
+ * Nos mercados calibrados não há premissa com peso `null`, então isto não altera
+ * nada lá, e entre os `null` o `sort` estável preserva a ordem declarada.
+ */
+const chaveDeOrdem = (p: Premissa) => (p.peso == null ? Number.POSITIVE_INFINITY : p.peso);
+
+/** Numera 1..n preservando a ordem recebida. */
+function numerar(tipo: TipoCopy, market: string, itens: Premissa[], negativo = false): LinhaCopy[] {
+  const out: LinhaCopy[] = [];
+  itens.forEach((p, i) => {
+    const ordem = i + 1;
+    const neutro = negativo ? p.negativo : p.label;
+    const soComMando = tipo === 'contra' && CONTRAS_SO_COM_MANDO.has(`${market}:${p.slug}`);
+    if (!soComMando) out.push({ tipo, market, slug: p.slug, mando: 'any', ordem, texto: neutro });
+    // A variante só entra quando a frase muda mesmo. Emitir as três sempre triplicaria
+    // a tabela para repetir o mesmo texto.
+    for (const lado of ['home', 'away'] as const) {
+      const texto = rotuloPremissa(p, lado, negativo);
+      if (texto !== neutro) out.push({ tipo, market, slug: p.slug, mando: lado, ordem, texto });
+    }
+  });
+  return out;
+}
+
+/**
+ * As evidências de um mercado, na ordem em que devem ser oferecidas: peso
+ * decrescente, e sem as ocultas.
+ *
+ * Premissa de peso zero CONTINUA entrando, no fim da fila. Ela não some porque
+ * motivo fraco é melhor que motivo nenhum, e a ordem já garante que ela só apareça
+ * quando não houver nada acima dela.
+ */
+export function evidenciasDoMercado(market: string): Premissa[] {
+  const m = mercadoDe(market);
+  if (!m) return [];
+  return [...m.premissas, ...EVIDENCIAS_GLOBAIS]
+    .filter((p) => !PREMISSAS_OCULTAS.has(p.slug))
+    .sort((a, b) => chaveDeOrdem(b) - chaveDeOrdem(a));
+}
+
+/**
+ * Os avisos de um mercado, do mais severo para o menos, com os globais dentro.
+ *
+ * Os globais entram em cada mercado em vez de virar um grupo à parte porque assim a
+ * ordem de exibição é uma lista só, sem regra de "primeiro os globais" escrita em
+ * dois lugares. O preço disso é repetir quatro linhas por mercado na tabela de
+ * apoio, o que é barato.
+ */
+export function avisosDoMercado(market: string): Premissa[] {
+  const m = mercadoDe(market);
+  if (!m) return [];
+  return [...AVISOS_GLOBAIS, ...m.penalidades].sort((a, b) => chaveDeOrdem(a) - chaveDeOrdem(b));
+}
+
+/**
+ * Toda a copy que a camada de serving publica, achatada e já ordenada.
+ *
+ * É exatamente o conteúdo da tabela de apoio no banco. A migration semeia a partir
+ * desta lista e a guarda de paridade a compara com a semente.
+ */
+export function copyDeServing(): LinhaCopy[] {
+  const out: LinhaCopy[] = [];
+
+  for (const m of MERCADOS) {
+    const evidencias = evidenciasDoMercado(m.slug);
+    out.push(...numerar('evidencia', m.slug, evidencias));
+    out.push(...numerar('contra', m.slug, evidencias.filter((p) => CONTRAS_ELEGIVEIS.has(`${m.slug}:${p.slug}`)), true));
+    out.push(...numerar('aviso', m.slug, avisosDoMercado(m.slug)));
+  }
+
+  return out;
+}

--- a/supabase/migrations/106_futebol_copy_das_premissas.sql
+++ b/supabase/migrations/106_futebol_copy_das_premissas.sql
@@ -1,0 +1,400 @@
+-- ============================================================================
+-- 106 · A copy das premissas passa a ter uma fonte só
+-- ============================================================================
+-- Spec: tech-lamjav/prop-play-predictor#272
+--
+-- O QUE MOTIVOU
+-- Uma DM de oportunidade anunciou um Handicap +0,5 com o motivo "Raramente perde
+-- por 2 gols ou mais". Num +0,5 a aposta morre em QUALQUER derrota, então a margem
+-- da derrota não responde nada.
+--
+-- Medido antes de decidir: a premissa em si funciona. Gradada contra o placar dos
+-- 90 minutos, no lado azarão, ela separa em todas as linhas de meio gol (inclusive
+-- +0,5), e o efeito sobrevive ao controle por faixa de odd acima de 1,30. Ela é um
+-- atalho para solidez defensiva. Logo o defeito era a FRASE, não o cálculo.
+--
+-- Ao investigar, três defeitos de apresentação, todos medidos no dev:
+--   · 27 de 36 premissas tinham texto DIFERENTE entre a tela e a DM
+--   · a DM mostrava a evidência mais fraca: 12.736 linhas de azarão exibiam a
+--     premissa de 3 pontos tendo a de 10 disponível, porque ela imprime o primeiro
+--     item do array e a ordem era a ordem em que o SQL foi escrito
+--   · a DM mostrava a `favorito_irregular` em 4.268 linhas, e a tela esconde essa
+--     premissa de propósito (acende em 43% das linhas e vale zero ponto)
+--   · seis frases visíveis tinham travessão, que a régua de copy do produto proíbe
+--
+-- NADA DE NOTA MUDA AQUI. Nenhuma premissa é criada, removida ou repesada, e nenhum
+-- ponto se move. É tudo texto e ordem de exibição, e é essa fronteira que permite
+-- subir isto em paralelo ao redesenho do Score (task [A]).
+--
+-- O QUE MAIS ESTA MIGRATION ENCERRA
+-- Estas três funções não tinham definição verbatim em migration nenhuma: a 099, a
+-- 104 e a 105 liam a definição VIVA com `pg_get_functiondef` e a patcheavam por
+-- substituição de string. A 099 até registra o risco: "o corpo muda quando a A1 do
+-- Score mexer nele". A partir daqui as três nascem do repositório, e o corpo delas
+-- veio do `docs/futebol-prod-deploy.sql`, conferido rótulo por rótulo contra o
+-- banco de desenvolvimento em 20/08 (39 rótulos, mesma ordem, nas três).
+--
+-- `create or replace` e não `drop`: nenhuma assinatura muda, então os grants
+-- existentes sobrevivem e o front não precisa de deploy sincronizado.
+--
+-- COMO CONFERIR DEPOIS DE APLICAR (seção 8 do shape file tem o mesmo)
+--   select public.futebol_copy('evidencia', 'asian_handicap', 'away',
+--            '{"raramente_perde_por_2":"true","defesa_fora_solida":"true"}'::jsonb);
+--   -- espera: {"Defesa sólida jogando fora","Quando perde, perde apertado"}
+--   -- (a de 10 pontos primeiro; era exatamente o que estava invertido)
+--
+--   select count(*) from public.futebol_premissa_copy;  -- espera 103
+-- ============================================================================
+
+-- ── A copy das premissas, uma vez só ────────────────────────────────────────
+-- Antes desta tabela, o texto de cada premissa existia em DUAS fontes
+-- independentes: o catálogo do app (`src/utils/futebol-premissas.ts`), que serve a
+-- tela, e a cascata de `case when` dentro destas três RPCs, que serve a DM do
+-- Telegram. Medido em 20/08: de 36 premissas presentes nas duas, 27 tinham TEXTO
+-- DIFERENTE. Ninguém viu porque nada comparava as duas.
+--
+-- E a cascata era a TERCEIRA cópia verbatim de si mesma, como o comentário da
+-- migration 102 já registrava: "mercado novo agora mexe em três RPCs".
+--
+-- Agora o catálogo do app é a fonte, esta tabela é a projeção dele no banco, e a
+-- guarda `futebol-copy-paridade.test.ts` quebra o PR quando os dois se afastam.
+create table if not exists public.futebol_premissa_copy (
+  tipo   text    not null check (tipo in ('evidencia', 'contra', 'aviso')),
+  market text    not null,
+  slug   text    not null,
+  -- 'any' é o texto neutro; 'home'/'away' só existem onde a frase muda de verdade.
+  mando  text    not null check (mando in ('any', 'home', 'away')),
+  -- Posição na fila. É o que conserta o defeito de origem: a DM mostra o PRIMEIRO
+  -- item do array, e a ordem da cascata era a ordem em que ela foi escrita. No
+  -- azarão do handicap, 12.736 linhas mostravam a premissa de 3 pontos tendo a de
+  -- 10 pontos disponível.
+  ordem  integer not null,
+  texto  text    not null,
+  primary key (tipo, market, slug, mando)
+);
+
+-- RLS ligada e SEM policy, de propósito: nada acessa esta tabela direto. As três
+-- RPCs são SECURITY DEFINER e leem como dono, então a ausência de policy é o que
+-- garante que ninguém leia por fora.
+alter table public.futebol_premissa_copy enable row level security;
+
+-- Travessão é proibido em copy visível (régua do produto), e cinco dos oito avisos
+-- nasceram com um. A regra vira constraint porque regra que depende de alguém ler
+-- não é regra.
+alter table public.futebol_premissa_copy drop constraint if exists futebol_premissa_copy_sem_travessao;
+alter table public.futebol_premissa_copy add  constraint futebol_premissa_copy_sem_travessao
+  check (texto not like '%' || chr(8212) || '%' and texto not like '%' || chr(8211) || '%');
+
+-- Semente idempotente: a tabela é uma projeção do catálogo, então ela é reescrita
+-- inteira em vez de sofrer upsert linha por linha. Assim premissa REMOVIDA do
+-- catálogo também desaparece daqui.
+delete from public.futebol_premissa_copy;
+insert into public.futebol_premissa_copy (tipo, market, slug, mando, ordem, texto) values
+  ('evidencia', 'goals_over_under', 'defesas_firmes', 'any', 1, 'Defesas firmes dos dois lados'),
+  ('evidencia', 'goals_over_under', 'defesas_vazaveis', 'any', 2, 'Defesas frágeis dos dois lados'),
+  ('evidencia', 'goals_over_under', 'ataque_combinado', 'any', 3, 'Os dois somam muitos gols'),
+  ('evidencia', 'goals_over_under', 'xg_baixo_combinado', 'any', 4, 'Os dois criam pouca chance de gol'),
+  ('evidencia', 'goals_over_under', 'xg_combinado_alto', 'any', 5, 'Os dois criam muita chance de gol'),
+  ('evidencia', 'goals_over_under', 'clean_sheets_altos', 'any', 6, 'Os dois passam muitos jogos sem sofrer gol'),
+  ('evidencia', 'goals_over_under', 'corroboracao_ambos', 'any', 7, 'As principais casas e o modelo da API apontam o mesmo lado'),
+  ('evidencia', 'goals_over_under', 'linha_sharp_confirma', 'any', 8, 'As principais casas vêm baixando a odd desse lado'),
+  ('evidencia', 'goals_over_under', 'ataques_fracos', 'any', 9, 'Ataques fracos dos dois lados'),
+  ('evidencia', 'goals_over_under', 'historico_under', 'any', 10, 'Histórico de jogo com poucos gols'),
+  ('evidencia', 'goals_over_under', 'ambos_vazam', 'any', 11, 'Os dois sofrem gol quase todo jogo'),
+  ('evidencia', 'goals_over_under', 'ritmo_alto', 'any', 12, 'Jogo de ritmo alto'),
+  ('evidencia', 'goals_over_under', 'historico_over', 'any', 13, 'Histórico de jogo com muitos gols'),
+  ('evidencia', 'goals_over_under', 'linha_subindo', 'any', 14, 'Mercado puxando a linha pra cima'),
+  ('evidencia', 'goals_over_under', 'linha_descendo', 'any', 15, 'Mercado puxando a linha pra baixo'),
+  ('evidencia', 'goals_over_under', 'modelo_api_concorda', 'any', 16, 'Modelo da API concorda com esse lado'),
+  ('contra', 'goals_over_under', 'defesas_firmes', 'any', 1, 'As defesas não são firmes'),
+  ('contra', 'goals_over_under', 'ataque_combinado', 'any', 2, 'Os dois não somam muitos gols'),
+  ('contra', 'goals_over_under', 'xg_baixo_combinado', 'any', 3, 'Os dois criam bastante chance de gol'),
+  ('contra', 'goals_over_under', 'xg_combinado_alto', 'any', 4, 'Os dois não criam muita chance de gol'),
+  ('contra', 'goals_over_under', 'clean_sheets_altos', 'any', 5, 'Não costumam segurar o placar zerado'),
+  ('contra', 'goals_over_under', 'ritmo_alto', 'any', 6, 'O jogo não é de ritmo alto'),
+  ('aviso', 'goals_over_under', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'goals_over_under', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'goals_over_under', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'goals_over_under', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco'),
+  ('aviso', 'goals_over_under', 'linha_extrema', 'any', 5, 'Linha muito longe do normal'),
+  ('evidencia', 'match_winner', 'forma', 'any', 1, 'Em boa fase, vem ganhando'),
+  ('evidencia', 'match_winner', 'mando', 'any', 2, 'Mando relevante'),
+  ('evidencia', 'match_winner', 'mando', 'home', 2, 'Manda bem em casa'),
+  ('evidencia', 'match_winner', 'mando', 'away', 2, 'Vai bem fora de casa'),
+  ('evidencia', 'match_winner', 'superioridade_tabela', 'any', 3, 'Bem à frente na tabela'),
+  ('evidencia', 'match_winner', 'corroboracao_ambos', 'any', 4, 'As principais casas e o modelo da API apontam o mesmo lado'),
+  ('evidencia', 'match_winner', 'linha_sharp_confirma', 'any', 5, 'As principais casas vêm baixando a odd desse lado'),
+  ('evidencia', 'match_winner', 'forca_mismatch', 'any', 6, 'Ataque forte contra defesa frágil do adversário'),
+  ('evidencia', 'match_winner', 'superioridade_xg', 'any', 7, 'Cria mais chances de gol que o adversário'),
+  ('evidencia', 'match_winner', 'h2h_favoravel', 'any', 8, 'Leva vantagem no histórico do confronto'),
+  ('evidencia', 'match_winner', 'desfalque_adversario', 'any', 9, 'Adversário com desfalque de titular importante'),
+  ('evidencia', 'match_winner', 'modelo_api_concorda', 'any', 10, 'Modelo da API concorda com esse lado'),
+  ('contra', 'match_winner', 'mando', 'home', 1, 'Não manda bem em casa'),
+  ('contra', 'match_winner', 'mando', 'away', 1, 'Não vai bem fora de casa'),
+  ('contra', 'match_winner', 'superioridade_tabela', 'any', 2, 'Não está bem à frente na tabela'),
+  ('contra', 'match_winner', 'forca_mismatch', 'any', 3, 'O ataque não pega uma defesa frágil'),
+  ('aviso', 'match_winner', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'match_winner', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'match_winner', 'desfalque_proprio', 'any', 3, 'Time apostado com desfalque de titular importante'),
+  ('aviso', 'match_winner', 'pen_poucas_casas', 'any', 4, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'match_winner', 'pen_odd_juice', 'any', 5, 'Odd baixa, retorno pequeno pro risco'),
+  ('aviso', 'match_winner', 'pick_empate', 'any', 6, 'Empate é o resultado mais difícil de prever'),
+  ('evidencia', 'asian_handicap', 'tende_golear', 'any', 1, 'Costuma ganhar por muitos gols'),
+  ('evidencia', 'asian_handicap', 'supremacia', 'any', 2, 'Muito superior ao adversário'),
+  ('evidencia', 'asian_handicap', 'defesa_fora_solida', 'any', 3, 'Defesa sólida jogando fora'),
+  ('evidencia', 'asian_handicap', 'defesa_fora_solida', 'home', 3, 'Defesa sólida em casa'),
+  ('evidencia', 'asian_handicap', 'corroboracao_ambos', 'any', 4, 'As principais casas e o modelo da API apontam o mesmo lado'),
+  ('evidencia', 'asian_handicap', 'linha_sharp_confirma', 'any', 5, 'As principais casas vêm baixando a odd desse lado'),
+  ('evidencia', 'asian_handicap', 'sem_rodizio', 'any', 6, 'Deve entrar com força máxima'),
+  ('evidencia', 'asian_handicap', 'raramente_perde_por_2', 'any', 7, 'Quando perde, perde apertado'),
+  ('evidencia', 'asian_handicap', 'adversario_fragil_fora', 'any', 8, 'Adversário fraco fora de casa'),
+  ('evidencia', 'asian_handicap', 'adversario_fragil_fora', 'away', 8, 'Adversário fraco em casa'),
+  ('evidencia', 'asian_handicap', 'mando_forte', 'any', 9, 'Manda muito bem em casa'),
+  ('evidencia', 'asian_handicap', 'mando_forte', 'away', 9, 'Vai muito bem fora de casa'),
+  ('evidencia', 'asian_handicap', 'modelo_api_concorda', 'any', 10, 'Modelo da API concorda com esse lado'),
+  ('contra', 'asian_handicap', 'tende_golear', 'any', 1, 'Não costuma ganhar por muitos gols'),
+  ('contra', 'asian_handicap', 'supremacia', 'any', 2, 'Não é muito superior ao adversário'),
+  ('contra', 'asian_handicap', 'defesa_fora_solida', 'any', 3, 'A defesa não é sólida jogando fora'),
+  ('contra', 'asian_handicap', 'defesa_fora_solida', 'home', 3, 'A defesa não é sólida em casa'),
+  ('contra', 'asian_handicap', 'raramente_perde_por_2', 'any', 4, 'Costuma perder por muitos gols'),
+  ('aviso', 'asian_handicap', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'asian_handicap', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'asian_handicap', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'asian_handicap', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco'),
+  ('aviso', 'asian_handicap', 'handicap_alto', 'any', 5, 'Handicap muito alto'),
+  ('evidencia', 'btts', 'ambos_marcam', 'any', 1, 'Os dois costumam marcar'),
+  ('evidencia', 'btts', 'ataque_dos_dois', 'any', 2, 'Os dois atacam bem'),
+  ('evidencia', 'btts', 'defesas_vazaveis', 'any', 3, 'Defesas frágeis dos dois lados'),
+  ('evidencia', 'btts', 'defesa_forte', 'any', 4, 'Defesa forte de um dos lados'),
+  ('evidencia', 'btts', 'ataque_trava', 'any', 5, 'Um dos ataques costuma passar em branco'),
+  ('evidencia', 'btts', 'historico_btts', 'any', 6, 'Nos últimos jogos, os dois marcaram'),
+  ('evidencia', 'btts', 'historico_seco', 'any', 7, 'Jogos recentes sem os dois marcarem'),
+  ('evidencia', 'btts', 'corroboracao_ambos', 'any', 8, 'As principais casas e o modelo da API apontam o mesmo lado'),
+  ('evidencia', 'btts', 'linha_sharp_confirma', 'any', 9, 'As principais casas vêm baixando a odd desse lado'),
+  ('evidencia', 'btts', 'modelo_api_concorda', 'any', 10, 'Modelo da API concorda com esse lado'),
+  ('contra', 'btts', 'ambos_marcam', 'any', 1, 'Os dois não costumam marcar'),
+  ('contra', 'btts', 'defesas_vazaveis', 'any', 2, 'As defesas não são frágeis'),
+  ('contra', 'btts', 'defesa_forte', 'any', 3, 'Nenhum dos lados tem defesa forte'),
+  ('contra', 'btts', 'ataque_trava', 'any', 4, 'Os dois ataques costumam marcar'),
+  ('aviso', 'btts', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'btts', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'btts', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'btts', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco'),
+  ('evidencia', 'double_chance', 'lado_coberto_forte', 'any', 1, 'O lado coberto é forte'),
+  ('evidencia', 'double_chance', 'equilibrio_defensivo', 'any', 2, 'Equilíbrio defensivo'),
+  ('evidencia', 'double_chance', 'adversario_limitado', 'any', 3, 'Adversário com campanha fraca'),
+  ('evidencia', 'double_chance', 'invicto_recente', 'any', 4, 'Invicto nos últimos jogos'),
+  ('evidencia', 'double_chance', 'corroboracao_ambos', 'any', 5, 'As principais casas e o modelo da API apontam o mesmo lado'),
+  ('evidencia', 'double_chance', 'linha_sharp_confirma', 'any', 6, 'As principais casas vêm baixando a odd desse lado'),
+  ('evidencia', 'double_chance', 'modelo_api_concorda', 'any', 7, 'Modelo da API concorda com esse lado'),
+  ('contra', 'double_chance', 'lado_coberto_forte', 'any', 1, 'O lado coberto não é forte'),
+  ('contra', 'double_chance', 'adversario_limitado', 'any', 2, 'Adversário não é tão limitado'),
+  ('aviso', 'double_chance', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'double_chance', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'double_chance', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'double_chance', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco');
+
+-- ── Os dois helpers ─────────────────────────────────────────────────────────
+-- Junta num objeto só tudo que pode acender numa linha, e resolve a precedência da
+-- corroboração.
+--
+-- O nome da coluna booleana nas tabelas de premissa É o slug, então não existe
+-- cascata de `case when` para escrever: as chaves do jsonb já são os slugs. É por
+-- isso que a premissa nova passa a custar uma linha de semente e nada mais.
+--
+-- A corroboração é o único caso que não é "slug aceso vira texto": são dois sinais
+-- e três frases (as duas individuais e uma combinada). As três chaves saem daqui
+-- já resolvidas, e por vir DEPOIS no `||` elas vencem as do `v`.
+create or replace function public.futebol_flags(
+  p_v jsonb, p_p jsonb, p_o jsonb, p_ah jsonb, p_bt jsonb, p_dc jsonb
+) returns jsonb
+ language sql
+ immutable
+ set search_path to ''
+as $function$
+  select coalesce(p_v, '{}'::jsonb)
+      || coalesce(p_p, '{}'::jsonb)
+      || coalesce(p_o, '{}'::jsonb)
+      || coalesce(p_ah, '{}'::jsonb)
+      || coalesce(p_bt, '{}'::jsonb)
+      || coalesce(p_dc, '{}'::jsonb)
+      || jsonb_build_object(
+           'corroboracao_ambos',
+             coalesce((p_v->>'modelo_api_concorda')::boolean, false)
+             and coalesce((p_v->>'linha_sharp_confirma')::boolean, false),
+           'modelo_api_concorda',
+             coalesce((p_v->>'modelo_api_concorda')::boolean, false)
+             and not coalesce((p_v->>'linha_sharp_confirma')::boolean, false),
+           'linha_sharp_confirma',
+             coalesce((p_v->>'linha_sharp_confirma')::boolean, false)
+             and not coalesce((p_v->>'modelo_api_concorda')::boolean, false)
+         )
+$function$;
+
+-- Traduz as flags acesas para a copy, na ordem certa.
+--
+-- `contra` procura 'false' em vez de 'true', e é por isso que NULL não gera contra:
+-- em jsonb um booleano nulo vira null, que não casa com 'false'. É o mesmo
+-- comportamento do `not coalesce(x, true)` que a cascata usava, e continua honrando
+-- a ADR 0003 (dado faltante diagnostica, não elimina).
+--
+-- O `distinct on` com o desempate pelo mando escolhe a variante específica quando
+-- ela existe e cai no texto neutro quando não existe.
+create or replace function public.futebol_copy(
+  p_tipo text, p_market text, p_mando text, p_flags jsonb
+) returns text[]
+ language sql
+ stable
+ set search_path to ''
+as $function$
+  select coalesce(array_agg(t.texto order by t.ordem), array[]::text[])
+  from (
+    select distinct on (c.slug) c.ordem, c.texto
+    from public.futebol_premissa_copy c
+    join jsonb_each_text(p_flags) f on f.key = c.slug
+    where c.tipo = p_tipo
+      and c.market = p_market
+      and c.mando in ('any', coalesce(p_mando, 'any'))
+      and f.value = case when p_tipo = 'contra' then 'false' else 'true' end
+    order by c.slug, (c.mando <> 'any') desc
+  ) t
+$function$;
+
+grant execute on function public.futebol_flags(jsonb, jsonb, jsonb, jsonb, jsonb, jsonb) to anon, authenticated, service_role;
+grant execute on function public.futebol_copy(text, text, text, jsonb) to anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_value(p_fixture_id bigint)
+ RETURNS TABLE(market text, outcome text, outcome_order integer, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, penalidades_globais_pts integer, penalidades_especificas_pts integer, score integer, faixa text, modelo_api_concorda boolean, linha_sharp_confirma boolean, evidencias text[], avisos text[], contras text[], premissas_sem_dado integer)
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+  -- migration 101: a fonte deixa de ser fixa. Kickoff no futuro lê o board;
+  -- kickoff já passado lê a FOTO DO APITO no snapshot. É *kickoff passado* e
+  -- não *jogo terminado*, senão as ~2h de bola rolando ficariam sem linha
+  -- depois que o mart passar a expurgar os status ao vivo (ADR 0009).
+  -- migration 105: os avisos de penalidade leem as colunas pen_* do proprio mart
+  -- (AE#87). O CTE sobre int_futebol_odds_devig foi removido: ele rederivava as
+  -- flags e, no prd, 76 de 126 linhas exibiam aviso de janela errada (issue #267).
+  -- No hist, pen_* pode ser NULL em versao aberta antes do AE#87: NULL nao gera aviso.
+  with v_src as (
+    select fixture_id, market, outcome, line_value, competition, season, edge, pts_valor,
+           pts_premissas, pts_corroboracao, penalidades, score, faixa, best_odd, best_book,
+           avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
+           penalidades_globais_pts, penalidades_especificas_pts, modelo_api_concorda,
+           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado,
+           pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
+    from futebol.fact_value_opportunities
+    where fixture_id = p_fixture_id
+      and exists (select 1 from futebol.fact_fixtures fx
+                   where fx.fixture_id = p_fixture_id and fx.kickoff_utc > (now() at time zone 'UTC'))
+    union all
+    select fixture_id, market, outcome, line_value, competition, season, edge, pts_valor,
+           pts_premissas, pts_corroboracao, penalidades, score, faixa, best_odd, best_book,
+           avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
+           penalidades_globais_pts, penalidades_especificas_pts, modelo_api_concorda,
+           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado,
+           pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
+    from futebol.fact_value_opportunities_hist h
+    where h.fixture_id = p_fixture_id
+      and exists (select 1 from futebol.fact_fixtures fx
+                   where fx.fixture_id = p_fixture_id
+                     and fx.kickoff_utc <= (now() at time zone 'UTC')
+                     and h.dbt_valid_from <= fx.kickoff_utc
+                     and (h.dbt_valid_to is null or fx.kickoff_utc < h.dbt_valid_to))
+  )
+  select v.market, v.outcome,
+    (case when v.market = 'match_winner'
+          then (case v.outcome when 'Home' then 1 when 'Draw' then 2 else 3 end)
+          when v.market = 'goals_over_under'
+          then (coalesce(v.line_value,0)*10 + case when v.outcome='Over' then 1 else 2 end)::int
+          when v.market = 'asian_handicap'
+          then (1000 + (case v.outcome when 'Home' then 0 else 500 end) + (coalesce(v.line_value,0)*10))::int
+          when v.market = 'btts'
+          then (2000 + case when v.outcome in ('Yes') then 0 else 1 end)
+          when v.market = 'double_chance'
+          then (3000 + case v.outcome when '1X' then 1 else 2 end)
+          else 0 end),
+    v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
+    v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int,
+    v.penalidades_globais_pts::int, v.penalidades_especificas_pts::int, v.score::int, v.faixa,
+    v.modelo_api_concorda, v.linha_sharp_confirma,
+    public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
+    public.futebol_copy('aviso', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
+    (public.futebol_copy('contra', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))))[1:3],
+    v.premissas_sem_dado::int
+  from v_src v
+  left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
+  left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
+  left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
+  where v.fixture_id = p_fixture_id
+  order by (case v.market when 'match_winner' then 1 when 'goals_over_under' then 2 when 'asian_handicap' then 3 when 'btts' then 4 when 'double_chance' then 5 else 9 end), 3;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.get_futebol_value_board()
+ RETURNS TABLE(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, score integer, faixa text, evidencias text[], premissas_sem_dado integer)
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+  select v.fixture_id, f.home_team_id, f.away_team_id, f.home_team_name, f.away_team_name,
+    f.competition, f.kickoff_utc, f.status_short,
+    v.market, v.outcome, v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
+    v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int, v.score::int, v.faixa,
+    public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
+    v.premissas_sem_dado::int
+  from futebol.fact_value_opportunities v
+  join futebol.fact_fixtures f on f.fixture_id = v.fixture_id
+  left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
+  left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
+  left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
+  order by v.score desc, v.edge desc;
+$function$
+
+;
+
+CREATE OR REPLACE FUNCTION public.get_futebol_value_history(p_from date, p_to date)
+ RETURNS TABLE(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, score integer, faixa text, evidencias text[], premissas_sem_dado integer)
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+  with pit as (
+    select distinct on (h.opportunity_key)
+      h.fixture_id, h.market, h.outcome, h.line_value, h.edge,
+      h.best_odd, h.best_book, h.avg_odd, h.n_casas, h.janela_usada,
+      h.prob_justa_fechamento, h.pts_valor, h.pts_premissas, h.pts_corroboracao,
+      h.penalidades, h.score, h.faixa,
+      h.modelo_api_concorda, h.linha_sharp_confirma, h.premissas_sem_dado
+    from futebol.fact_value_opportunities_hist h
+    join futebol.fact_fixtures fx on fx.fixture_id = h.fixture_id
+    where fx.kickoff_utc >= ((p_from::timestamp at time zone 'America/Sao_Paulo') at time zone 'UTC')
+      and fx.kickoff_utc <  (((p_to + 1)::timestamp at time zone 'America/Sao_Paulo') at time zone 'UTC')
+      and fx.kickoff_utc <  (now() at time zone 'UTC')
+      and h.dbt_valid_from <= fx.kickoff_utc
+      and (h.dbt_valid_to is null or fx.kickoff_utc < h.dbt_valid_to)
+    order by h.opportunity_key, h.dbt_valid_from desc
+  )
+  select v.fixture_id, f.home_team_id, f.away_team_id, f.home_team_name, f.away_team_name,
+    f.competition, f.kickoff_utc, f.status_short,
+    v.market, v.outcome, v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
+    v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int, v.score::int, v.faixa,
+    public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
+    v.premissas_sem_dado::int
+  from pit v
+  join futebol.fact_fixtures f on f.fixture_id = v.fixture_id
+  left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
+  left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
+  left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
+  order by f.kickoff_utc desc, v.score desc, v.edge desc;
+$function$
+
+;


### PR DESCRIPTION
Fecha #272.

## O que motivou

Uma DM de oportunidade anunciou um Handicap **+0,5** com o motivo *"Raramente perde por 2 gols ou mais"*. Num +0,5 a aposta morre em qualquer derrota, então a margem da derrota não responde nada.

**Medi antes de tratar como defeito de modelo, e a premissa funciona.** Gradada contra o placar dos 90 minutos, no lado azarão, ela separa em todas as linhas de meio gol, inclusive no +0,5, e o efeito sobrevive ao controle por faixa de odd acima de 1,30:

| Faixa de odd | ROI com a premissa | ROI sem |
|---|---|---|
| até 1,30 | +0,3 (636) | +1,2 (280) |
| 1,30 a 1,60 | +4,6 (180) | +1,2 (103) |
| 1,60 a 2,20 | +3,2 (135) | −11,8 (81) |
| 2,20 ou mais | −0,4 (45) | −34,6 (92) |

Ela é um atalho para solidez defensiva geral. **Logo o defeito era a frase, não o cálculo**, e por isso este PR não toca em nota nenhuma.

## Os três defeitos de apresentação, medidos no dev

1. **27 de 36 premissas tinham texto diferente** entre o catálogo do app (que serve a tela) e a cascata de `case when` das RPCs (que serve a DM). Duas fontes independentes, e nada comparava as duas.
2. **A DM mostrava a evidência mais fraca.** Ela imprime o primeiro item do array e a ordem era a ordem em que o SQL foi escrito. No azarão do handicap, **12.736 linhas** exibiam a premissa de 3 pontos tendo a de 10 disponível.
3. **A DM mostrava a `favorito_irregular`** em **4.268 linhas**, e a tela esconde essa premissa de propósito (acende em 43% das linhas e vale zero ponto).

Mais **seis frases visíveis com travessão**, que a régua de copy do produto proíbe.

## O que muda

O catálogo do app passa a ser a fonte única do texto, da ordem e das exclusões. A migration semeia uma tabela de apoio a partir dele, as três RPCs traduzem por ela, e uma guarda arquivo contra arquivo quebra quando os dois se afastam.

A frase do azarão vira **"Quando perde, perde apertado"**: descreve o time em vez de prometer uma condição da aposta. O número exato continua na linha de evidência da tela.

## E paga duas dívidas registradas no próprio código

**A corrente de patches acabou.** Estas três funções não tinham definição verbatim em migration nenhuma: a 099, a 104 e a 105 liam a definição viva com `pg_get_functiondef` e a patcheavam por substituição de string. A própria 099 avisava: *"o corpo muda quando a A1 do Score mexer nele"*. Agora as três nascem do repositório.

**A terceira cópia morreu.** O comentário da 102 registrava: *"a cascata é a TERCEIRA cópia verbatim das mesmas rotulagens. Mercado novo agora mexe em três RPCs. Extrair exige tocar nas três de uma vez."* Este PR toca nas três. Premissa nova passa a custar uma linha de semente.

## Como eu reduzi o risco de transcrição

O corpo das três funções **não foi digitado à mão**. Um script leu o `docs/futebol-prod-deploy.sql`, trocou só as cadeias de rótulo pela chamada do tradutor e preservou todo o resto, incluindo o recorte `[1:3]` dos contras.

E o shape file foi conferido antes: os **39 rótulos de evidência, na mesma ordem, batem exatamente** com `pg_get_functiondef` do banco de desenvolvimento, nas três funções.

Conferido nos dois artefatos depois de gerar: zero cascatas restantes, os seis aliases que a expressão nova usa presentes nas três, e as chamadas na conta certa (3 na folha do jogo, 1 no board, 1 no histórico).

## O que NÃO muda

Nenhuma premissa criada, removida ou repesada. Nenhum ponto se move. Nenhuma assinatura de função muda, então é `create or replace`, os grants sobrevivem e o front não precisa de deploy sincronizado.

## ⚠️ Duas coisas que o revisor precisa saber

**1. O SQL nunca foi executado.** Não apliquei em banco nenhum de propósito: quem aplica é o CI. O `deploy-staging` só dispara em push na `develop`, então a sintaxe e o comportamento só ficam provados no merge.

Depois de aplicar, a sonda que prova o conserto:

```sql
select public.futebol_copy('evidencia', 'asian_handicap', 'away',
         '{"raramente_perde_por_2":"true","defesa_fora_solida":"true"}'::jsonb);
-- espera: {"Defesa sólida jogando fora","Quando perde, perde apertado"}
-- (a de 10 pontos primeiro; era exatamente o que estava invertido)

select count(*) from public.futebol_premissa_copy;  -- espera 103
```

**2. Mudança visível de comportamento.** A corroboração entra na tabela e passa a competir por peso (8), então sai da última posição do array para o meio da fila. Em alguns picks a DM vai mostrar "As principais casas vêm baixando a odd desse lado" onde antes mostrava uma premissa fraca do jogo. Se preferirmos ela sempre por último, é trocar o peso para 0 no catálogo e a guarda se reajusta sozinha.

## Nota de fora do escopo

Descobri ao fechar isto que **nenhum workflow roda o vitest**: o `ci.yml` roda só `lint` e `build`. Ou seja, esta guarda e a do shape file (#262) não são executadas em CI hoje. Ligar está bloqueado por um teste do bolão que falha na `develop`, e isso vai em trabalho separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
