### PR TITLE
Futebol: exibir candidata cotada com odd de referência

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,33 @@
+# Futebol — leitura de mercados
+
+Este contexto descreve como o produto transforma linhas de aposta analisadas e preços coletados em oportunidades publicadas.
+
+## Language
+
+**Linha analisada**:
+Uma linha para a qual o modelo calcula premissas, mesmo quando nenhuma casa ofereceu cotação.
+_Avoid_: Linha disponível, mercado aberto
+
+**Linha cotada**:
+Uma linha analisada que teve ao menos uma odd coletada.
+_Avoid_: Linha com preço disponível, oportunidade
+
+**Candidata**:
+Uma linha cotada que foi avaliada pelo funil, independentemente de ter sido aprovada ou rejeitada.
+_Avoid_: Oportunidade rejeitada, aposta possível
+
+**Oportunidade**:
+Uma candidata aprovada pelas regras de publicação vigentes.
+_Avoid_: Candidata, linha cotada
+
+**Publicação no painel**:
+O momento em que uma oportunidade passa a estar disponível no painel para o usuário. Não significa envio de notificação.
+_Avoid_: Alerta, envio, publicação no Telegram
+
+**Disponível desde**:
+O início do período contínuo atual de publicação de uma oportunidade. Se ela deixa de ser oportunidade e depois volta, o horário reinicia na reativação.
+_Avoid_: Primeira aparição histórica, última atualização da odd
+
+**Odd de referência**:
+A odd efetivamente coletada que ocupa a posição central entre as cotações de uma candidata que não virou oportunidade. Representa o mercado sem inventar uma cotação intermediária.
+_Avoid_: Melhor odd, odd da oportunidade

--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -2245,6 +2245,114 @@ $function$
 
 ;
 
+-- ── Cotações de referência (migration 20260826010945) ───────────────────────
+-- Distingue linha sem cotação de candidata cotada que não passou pelo funil.
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_quotes(p_fixture_id bigint)
+RETURNS TABLE(
+  market_key text, market_label text, outcome_label text, outcome_order integer,
+  line double precision, pinnacle_odd double precision, avg_odd double precision,
+  reference_odd double precision, best_odd double precision, best_book text,
+  n_books integer, pin_open double precision, pin_close double precision
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+  with base as (
+    select o.market_name, o.outcome_label, o.bookmaker_name, o.collection_window,
+           o.odd_decimal, o.line_value, f.kickoff_utc
+    from futebol.fact_odds_snapshot o
+    join futebol.fact_fixtures f on f.fixture_id = o.fixture_id
+    where o.fixture_id = p_fixture_id
+      and ( o.market_name = 'Match Winner'
+         or o.market_name = 'Both Teams Score'
+         or o.market_name = 'Double Chance'
+         or (o.market_name = 'Goals Over/Under' and o.outcome_label in
+             ('Over 0.5','Under 0.5','Over 1.5','Under 1.5','Over 2.5','Under 2.5',
+              'Over 3.5','Under 3.5','Over 4.5','Under 4.5'))
+         or (o.market_name = 'Asian Handicap'
+             and abs(o.line_value - trunc(o.line_value)) = 0.5
+             and abs(o.line_value) <= 2.5))
+  ),
+  ranked as (
+    select b.*,
+      case b.collection_window
+        when 't15m' then 4 when 't1h' then 3 when 't24h' then 2
+        when 'daily' then 1 else 0
+      end as window_rank
+    from base b
+  ),
+  chosen_window as (
+    select market_name, outcome_label,
+      case
+        when max(kickoff_utc) <= (now() at time zone 'UTC') then coalesce(
+          max(window_rank) filter (where collection_window = 't15m'),
+          max(window_rank) filter (where collection_window = 't1h'),
+          max(window_rank) filter (where collection_window = 't24h'),
+          max(window_rank) filter (where collection_window = 'daily')
+        )
+        else max(window_rank)
+      end as window_rank
+    from ranked
+    group by market_name, outcome_label
+  ),
+  current_quotes as (
+    select distinct on (r.market_name, r.outcome_label, r.bookmaker_name)
+      r.market_name, r.outcome_label, r.bookmaker_name, r.odd_decimal, r.line_value
+    from ranked r
+    join chosen_window w using (market_name, outcome_label, window_rank)
+    order by r.market_name, r.outcome_label, r.bookmaker_name
+  ),
+  agg as (
+    select c.market_name, c.outcome_label, max(c.line_value) as line_value,
+      count(distinct c.bookmaker_name)::int as n_books,
+      avg(c.odd_decimal) as avg_odd,
+      percentile_disc(0.5) within group (order by c.odd_decimal) as reference_odd
+    from current_quotes c
+    group by c.market_name, c.outcome_label
+  ),
+  best_book as (
+    select distinct on (c.market_name, c.outcome_label)
+      c.market_name, c.outcome_label, c.bookmaker_name, c.odd_decimal
+    from current_quotes c
+    order by c.market_name, c.outcome_label, c.odd_decimal desc
+  ),
+  pinnacle as (
+    select b.market_name, b.outcome_label,
+      max(b.odd_decimal) filter (where b.collection_window='t24h') as t24,
+      max(b.odd_decimal) filter (where b.collection_window='t1h') as t1,
+      max(b.odd_decimal) filter (where b.collection_window='t15m') as t15
+    from base b
+    where b.bookmaker_name = 'Pinnacle'
+    group by b.market_name, b.outcome_label
+  )
+  select
+    case a.market_name
+      when 'Match Winner' then 'match_winner'
+      when 'Goals Over/Under' then 'over_under'
+      when 'Both Teams Score' then 'btts'
+      when 'Double Chance' then 'double_chance'
+      when 'Asian Handicap' then 'asian_handicap'
+    end,
+    a.market_name,
+    a.outcome_label,
+    case
+      when a.outcome_label in ('Home','Yes','Home/Draw')
+        or a.outcome_label like 'Over %' or a.outcome_label like 'Home %' then 1
+      when a.outcome_label in ('Draw','No','Home/Away')
+        or a.outcome_label like 'Under %' or a.outcome_label like 'Away %' then 2
+      else 3
+    end,
+    case when a.market_name in ('Goals Over/Under','Asian Handicap') then a.line_value end,
+    coalesce(p.t15, p.t1, p.t24), a.avg_odd, a.reference_odd,
+    bb.odd_decimal, bb.bookmaker_name, a.n_books, p.t24, coalesce(p.t15, p.t1)
+  from agg a
+  join best_book bb using (market_name, outcome_label)
+  left join pinnacle p using (market_name, outcome_label)
+  where a.market_name <> 'Asian Handicap' or a.n_books >= 3
+  order by 1, 5 nulls first, 4;
+$function$;
+
 -- ── 6. Grants de execução (anon / authenticated / service_role) ──────────────
 grant execute on function public._futebol_team_form(p_team_id bigint, p_competition text, p_season bigint, p_before date) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_access() to anon, authenticated, service_role;
@@ -2252,6 +2360,7 @@ grant execute on function public.get_futebol_fixture_detail(p_fixture_id bigint)
 grant execute on function public.get_futebol_fixture_extras(p_fixture_id bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_injuries(p_fixture_id bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_odds(p_fixture_id bigint) to anon, authenticated, service_role;
+grant execute on function public.get_futebol_fixture_quotes(p_fixture_id bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_prediction(p_fixture_id bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_value(p_fixture_id bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixtures(p_competition text, p_season bigint, p_round text) to anon, authenticated, service_role;

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -7,6 +7,7 @@ import {
   useFutebolFixtureNumeros,
   useFutebolFixtureHistorico,
   useFutebolFixtureInjuries,
+  useFutebolFixtureOdds,
 } from '@/hooks/use-futebol-data';
 import type { FutebolFixturePremissas, FutebolFixtureValueRow } from '@/services/futebol-data.service';
 import {
@@ -28,6 +29,7 @@ import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 import { MotivosJogoPorJogo } from './MotivosJogoPorJogo';
 import { avisoSemDado } from '@/utils/futebol-sem-dado';
 import { valueDoCandidato, resumoDosMercados, mesmaLinha, REGUA_SCORE, type SaidaPreferida } from '@/utils/futebol-leitura';
+import { leituraDaCotacao } from '@/utils/futebol-cotacao';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { isFinished } from '@/utils/futebol-datas';
 import type { MatchupTendencies } from '@/utils/futebol-tendencias';
@@ -226,6 +228,7 @@ export function BancadaMercados({
   const { data: numeros } = useFutebolFixtureNumeros(jogo.fixtureId);
   const { data: historico } = useFutebolFixtureHistorico(jogo.fixtureId);
   const { data: injuries } = useFutebolFixtureInjuries(jogo.fixtureId);
+  const { data: oddsRows } = useFutebolFixtureOdds(jogo.fixtureId);
 
   const fim = isFinished(jogo.statusShort);
   const placar = fim ? { home: jogo.goalsHome, away: jogo.goalsAway } : null;
@@ -234,6 +237,16 @@ export function BancadaMercados({
   const ehAH = mercado.slug === 'asian_handicap';
 
   const resumos = useMemo(() => resumoDosMercados(rows, valueRows, preferida), [rows, valueRows, preferida]);
+  const mercadosCotados = useMemo(
+    () => resumos.filter((r) => leituraDaCotacao(
+      r.mercado.slug,
+      r.candidato.outcome,
+      r.candidato.line_value,
+      valueRows,
+      oddsRows,
+    ).estado !== 'sem_cotacao').length,
+    [resumos, valueRows, oddsRows],
+  );
 
   const doMercado = useMemo(
     () => (rows ?? []).filter((r) => r.market === mercado.slug).filter((r) => !(mercado.slug === 'asian_handicap' && r.line_value === 0)),
@@ -288,7 +301,6 @@ export function BancadaMercados({
   const nB = ladoB ? contaQueValem(mercado.slug, ladoB.acesas) : 0;
   const valA = ladoA ? valueDoCandidato(valueRows, ladoA) : null;
   const valB = ladoB ? valueDoCandidato(valueRows, ladoB) : null;
-
   const [ladoSel, setLadoSel] = useState<'a' | 'b' | null>(null);
   useEffect(() => setLadoSel(null), [mercado.slug, linha, saida]);
   // Sub-abas da folha: a favor e contra, as duas jogo a jogo (é onde mora a auditoria).
@@ -303,6 +315,9 @@ export function BancadaMercados({
   })();
   const principal = ladoSel === 'a' ? ladoA : ladoSel === 'b' ? ladoB : ladoPadrao;
   const valPrincipal = principal === ladoB ? valB : valA;
+  const cotacaoPrincipal = principal
+    ? leituraDaCotacao(mercado.slug, principal.outcome, principal.line_value, valueRows, oddsRows)
+    : { estado: 'sem_cotacao' as const, odd: null };
 
 
   const labelDe = (c: FutebolFixturePremissas | null) =>
@@ -416,11 +431,14 @@ export function BancadaMercados({
       if (valPrincipal.score >= REGUA_SCORE) return `${lbl} passa a régua, em faixa média: leitura razoável e algum valor.`;
       return `Abaixo da régua de ${REGUA_SCORE}: ${lbl} entra como consulta, não como aposta.`;
     }
+    if (cotacaoPrincipal.estado === 'cotada') {
+      return `${lbl} tem cotação, mas ficou fora dos filtros de oportunidade.`;
+    }
     const n = principal ? contaQueValem(mercado.slug, principal.acesas) : 0;
     if (n >= PORTA_PREMISSAS) return `O jogo aponta para ${lbl}, mas falta o preço: as odds entram perto do jogo.`;
     return `O jogo não sustenta esta saída.`;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [principal, valPrincipal, fim, mercado.slug, placar]);
+  }, [principal, valPrincipal, cotacaoPrincipal.estado, fim, mercado.slug, placar]);
 
   // Distribuição de gols: só no mercado de gols, cortada pela linha selecionada.
   const dist = useMemo(() => {
@@ -450,20 +468,21 @@ export function BancadaMercados({
   const pickAtual = labelDe(principal);
 
   const cta =
-    valPrincipal && !fim && !locked ? (
+    principal && cotacaoPrincipal.estado !== 'sem_cotacao' && !fim && !locked ? (
       <RegistrarApostaCTA
         draft={{
           homeName: jogo.home,
           awayName: jogo.away,
           competition: jogo.competition,
           kickoffUtc: jogo.kickoffUtc,
-          market: valPrincipal.market,
-          outcome: valPrincipal.outcome,
-          lineValue: valPrincipal.line_value,
-          bestOdd: valPrincipal.best_odd,
+          market: principal.market,
+          outcome: principal.outcome,
+          lineValue: principal.line_value,
+          bestOdd: cotacaoPrincipal.odd,
+          oddKind: cotacaoPrincipal.estado === 'cotada' ? 'referencia' : 'melhor',
         }}
         variant="ambar"
-        rotulo={`Registrar ${pickAtual}`}
+        rotulo="Adicionar à gestão"
       />
     ) : null;
 
@@ -523,6 +542,8 @@ export function BancadaMercados({
           <div className="mt-1 text-[11.5px] leading-relaxed" style={{ color: '#6b6350' }}>
             {resumos.some((r) => r.value)
               ? `${resumos.filter((r) => r.passa).length} de ${resumos.length} passam a régua de ${REGUA_SCORE}. A barra é o Score; o tracinho é a régua.`
+              : mercadosCotados > 0
+                ? `${mercadosCotados} de ${resumos.length} mercados têm cotação. Os demais continuam analisados pelas premissas.`
               : `Sem preço ainda: a barra conta as premissas e o tracinho é a porta de ${PORTA_PREMISSAS}.`}
           </div>
         </div>
@@ -533,6 +554,14 @@ export function BancadaMercados({
           {resumos.map((r) => {
             const on = r.mercado.slug === mercado.slug;
             const temScore = r.value != null;
+            const leituraCotacao = leituraDaCotacao(
+              r.mercado.slug,
+              r.candidato.outcome,
+              r.candidato.line_value,
+              valueRows,
+              oddsRows,
+            );
+            const candidataCotada = leituraCotacao.estado === 'cotada';
             const s = temScore ? r.value!.score : r.nValem;
             const larg = temScore ? `${s}%` : `${Math.min(100, (r.nValem / Math.max(r.totalQueValem, 1)) * 100)}%`;
             const regua = temScore ? `${REGUA_SCORE}%` : `${(PORTA_PREMISSAS / Math.max(r.totalQueValem, 1)) * 100}%`;
@@ -555,12 +584,14 @@ export function BancadaMercados({
                   >
                     {r.mercado.label}
                   </span>
-                  <span
-                    className="tabular-nums text-[18px] font-bold shrink-0"
-                    style={{ color: on ? '#fbbf24' : r.passa ? (temScore && s >= 60 ? '#0a3d2e' : '#b8870f') : '#8d8672' }}
-                  >
-                    <Blur active={locked && temScore}>{String(s)}</Blur>
-                  </span>
+                  {!candidataCotada && (
+                    <span
+                      className="tabular-nums text-[18px] font-bold shrink-0"
+                      style={{ color: on ? '#fbbf24' : r.passa ? (temScore && s >= 60 ? '#0a3d2e' : '#b8870f') : '#8d8672' }}
+                    >
+                      <Blur active={locked && temScore}>{String(s)}</Blur>
+                    </span>
+                  )}
                 </div>
                 <div className="mt-1 text-[11.5px] truncate" style={{ color: on ? 'rgba(255,255,255,.6)' : '#8d8672' }}>
                   {pick}
@@ -572,19 +603,23 @@ export function BancadaMercados({
                       <Blur active={locked}>{r.value!.best_odd.toFixed(2)}</Blur>
                     </>
                   ) : (
-                    ' · sem preço'
+                    leituraCotacao.estado === 'cotada'
+                      ? ` · cotada @ ${leituraCotacao.odd.toFixed(2)}`
+                      : ' · sem cotação'
                   )}
                 </div>
-                <div
-                  className="relative mt-2.5 h-1.5 rounded-full"
-                  style={{ background: on ? 'rgba(255,255,255,.16)' : '#f1e9d6' }}
-                >
-                  <div className="absolute left-0 top-0 bottom-0 rounded-full" style={{ width: larg, background: cor }} />
+                {!candidataCotada && (
                   <div
-                    className="absolute -top-[3px] -bottom-[3px] w-0"
-                    style={{ left: regua, borderLeft: `1px dashed ${on ? 'rgba(255,255,255,.6)' : '#8d8672'}` }}
-                  />
-                </div>
+                    className="relative mt-2.5 h-1.5 rounded-full"
+                    style={{ background: on ? 'rgba(255,255,255,.16)' : '#f1e9d6' }}
+                  >
+                    <div className="absolute left-0 top-0 bottom-0 rounded-full" style={{ width: larg, background: cor }} />
+                    <div
+                      className="absolute -top-[3px] -bottom-[3px] w-0"
+                      style={{ left: regua, borderLeft: `1px dashed ${on ? 'rgba(255,255,255,.6)' : '#8d8672'}` }}
+                    />
+                  </div>
+                )}
               </button>
             );
           })}
@@ -610,6 +645,14 @@ export function BancadaMercados({
                 <span className="text-[10px] uppercase tracking-[0.16em]" style={{ color: 'rgba(255,255,255,.45)' }}>
                   Mercado aberto · {mercado.label}
                 </span>
+                {cotacaoPrincipal.estado === 'cotada' && (
+                  <span
+                    className="inline-flex items-center h-5 px-2 rounded-full text-[9px] font-bold uppercase tracking-[0.08em]"
+                    style={{ background: '#dcefe2', color: '#0a3d2e' }}
+                  >
+                    Cotada · fora dos filtros
+                  </span>
+                )}
                 {resPrincipal && <SeloRes r={resPrincipal} />}
               </div>
               <div className="mt-1.5 text-[28px] md:text-[34px] font-semibold leading-tight tracking-[-0.035em] text-white min-h-[42px] md:min-h-[46px]">
@@ -635,7 +678,9 @@ export function BancadaMercados({
               <div className="min-w-[52px]">
                 <div className="text-[9px] uppercase tracking-[0.14em]" style={{ color: 'rgba(255,255,255,.45)' }}>Odd</div>
                 <div className="tabular-nums text-[22px] font-semibold leading-none mt-1 text-white">
-                  {valPrincipal ? <Blur active={locked}>{valPrincipal.best_odd.toFixed(2)}</Blur> : '—'}
+                  {cotacaoPrincipal.odd != null
+                    ? <Blur active={locked}>{cotacaoPrincipal.odd.toFixed(2)}</Blur>
+                    : '—'}
                 </div>
               </div>
               <div className="min-w-[76px]">
@@ -651,6 +696,7 @@ export function BancadaMercados({
                   )}
                 </div>
               </div>
+              {cotacaoPrincipal.estado !== 'cotada' && (
               <div className="text-center pl-6 min-w-[128px]" style={{ borderLeft: '1px solid rgba(255,255,255,.15)' }}>
                 <div className="tabular-nums text-[44px] font-bold leading-none tracking-[-0.04em]" style={{ color: '#fbbf24' }}>
                   {valPrincipal ? <Blur active={locked}>{String(valPrincipal.score)}</Blur> : nPrincipal}
@@ -661,6 +707,7 @@ export function BancadaMercados({
                     : 'premissas a favor'}
                 </div>
               </div>
+              )}
             </div>
           </div>
 
@@ -754,6 +801,15 @@ export function BancadaMercados({
             {ehLinha && paradas.length > 1 ? cta && <div className="basis-full mt-1">{cta}</div> : cta}
           </div>
         </div>
+
+        {cotacaoPrincipal.estado === 'cotada' && (
+          <div
+            className="px-6 md:px-8 py-3 text-[12px] leading-relaxed"
+            style={{ background: '#edf5ef', borderBottom: '1px solid #cfe4d5', color: '#0a3d2e' }}
+          >
+            Confirme a cotação na sua casa antes de registrar.
+          </div>
+        )}
 
         {mercado.aviso && (
           <div className="px-6 md:px-8 py-3 text-[12px] leading-relaxed" style={{ background: '#fef7df', borderBottom: '1px solid #fde68a', color: '#5a3c00' }}>

--- a/src/components/futebol/RegistrarAposta.tsx
+++ b/src/components/futebol/RegistrarAposta.tsx
@@ -147,7 +147,11 @@ export function RegistrarApostaModal({
                 />
               </label>
             </div>
-            <p className="text-[11px] text-ink-3 -mt-2">Pegou outra odd? Ajuste acima — preenchemos com a melhor que encontramos ({draft?.bestOdd.toFixed(2)}).</p>
+            <p className="text-[11px] text-ink-3 -mt-2">
+              {draft?.oddKind === 'referencia'
+                ? `Confirme a cotação na sua casa antes de registrar. A referência coletada foi ${draft.bestOdd.toFixed(2)}.`
+                : `Pegou outra odd? Ajuste acima — preenchemos com a melhor que encontramos (${draft?.bestOdd.toFixed(2)}).`}
+            </p>
 
             {/* Retorno potencial */}
             <div className="flex items-center justify-between rounded-rebrand-sm bg-forest/5 border border-forest/15 px-3.5 py-2.5">

--- a/src/components/futebol/registrar-aposta-utils.ts
+++ b/src/components/futebol/registrar-aposta-utils.ts
@@ -11,6 +11,7 @@ export interface FutebolBetDraft {
   outcome: string;
   lineValue: number | null;
   bestOdd: number;
+  oddKind?: 'melhor' | 'referencia';
 }
 
 /**
@@ -33,5 +34,6 @@ export function draftFromBoardRow(o: DraftSource): FutebolBetDraft {
     outcome: o.outcome,
     lineValue: o.line_value,
     bestOdd: o.best_odd,
+    oddKind: 'melhor',
   };
 }

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -426,6 +426,8 @@ export interface FutebolOddsRow {
   line: number | null;
   pinnacle_odd: number | null;
   avg_odd: number | null;
+  /** Mediana discreta das odds observadas na janela usada pela consulta. */
+  reference_odd: number | null;
   best_odd: number;
   best_book: string;
   n_books: number;
@@ -805,7 +807,7 @@ export const futebolDataService = {
 
   async getFixtureOdds(fixtureId: number): Promise<FutebolOddsRow[]> {
     return withRetry(async () => {
-      const { data, error } = await supabaseClient.rpc('get_futebol_fixture_odds', {
+      const { data, error } = await supabaseClient.rpc('get_futebol_fixture_quotes', {
         p_fixture_id: fixtureId,
       });
       if (error) throw error;

--- a/src/utils/futebol-cotacao.test.ts
+++ b/src/utils/futebol-cotacao.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { FutebolFixtureValueRow, FutebolOddsRow } from '@/services/futebol-data.service';
+import { leituraDaCotacao } from './futebol-cotacao';
+
+const odd: FutebolOddsRow = {
+  market_key: 'over_under',
+  market_label: 'Goals Over/Under',
+  outcome_label: 'Over 1.5',
+  outcome_order: 1,
+  line: 1.5,
+  pinnacle_odd: null,
+  avg_odd: 1.63,
+  reference_odd: 1.6,
+  best_odd: 1.72,
+  best_book: 'Casa A',
+  n_books: 4,
+  pin_open: null,
+  pin_close: null,
+};
+
+describe('leituraDaCotacao', () => {
+  it('classifica como cotada a linha rejeitada pelos filtros e usa a odd de referência', () => {
+    expect(leituraDaCotacao('goals_over_under', 'Over', 1.5, [], [odd])).toEqual({
+      estado: 'cotada',
+      odd: 1.6,
+    });
+  });
+
+  it('mantém a oportunidade publicada acima da cotação bruta', () => {
+    const oportunidade = {
+      market: 'goals_over_under',
+      outcome: 'Over',
+      line_value: 1.5,
+      best_odd: 1.72,
+    } as FutebolFixtureValueRow;
+
+    expect(leituraDaCotacao('goals_over_under', 'Over', 1.5, [oportunidade], [odd])).toEqual({
+      estado: 'oportunidade',
+      odd: 1.72,
+      oportunidade,
+    });
+  });
+
+  it('não confunde outra linha cotada com a linha selecionada', () => {
+    expect(leituraDaCotacao('goals_over_under', 'Over', 2.5, [], [odd])).toEqual({
+      estado: 'sem_cotacao',
+      odd: null,
+    });
+  });
+});

--- a/src/utils/futebol-cotacao.ts
+++ b/src/utils/futebol-cotacao.ts
@@ -1,0 +1,52 @@
+import type {
+  FutebolFixtureValueRow,
+  FutebolOddsRow,
+} from '@/services/futebol-data.service';
+
+export type LeituraCotacao =
+  | { estado: 'oportunidade'; odd: number; oportunidade: FutebolFixtureValueRow }
+  | { estado: 'cotada'; odd: number }
+  | { estado: 'sem_cotacao'; odd: null };
+
+const ODDS_MARKET: Record<string, FutebolOddsRow['market_key']> = {
+  match_winner: 'match_winner',
+  goals_over_under: 'over_under',
+  btts: 'btts',
+  double_chance: 'double_chance',
+  asian_handicap: 'asian_handicap',
+};
+
+function mesmaLinha(a: number | null, b: number | null): boolean {
+  return a == null && b == null || a != null && b != null && Math.abs(a - b) < 0.001;
+}
+
+function outcomeDaOdd(row: FutebolOddsRow): string {
+  if (row.market_key === 'over_under') return row.outcome_label.split(' ')[0];
+  if (row.market_key === 'asian_handicap') return row.outcome_label.split(' ')[0];
+  return row.outcome_label;
+}
+
+export function leituraDaCotacao(
+  market: string,
+  outcome: string,
+  line: number | null,
+  oportunidades: FutebolFixtureValueRow[] | null | undefined,
+  odds: FutebolOddsRow[] | null | undefined,
+): LeituraCotacao {
+  const oportunidade = (oportunidades ?? []).find(
+    (row) => row.market === market && row.outcome === outcome && mesmaLinha(row.line_value, line),
+  );
+  if (oportunidade) {
+    return { estado: 'oportunidade', odd: oportunidade.best_odd, oportunidade };
+  }
+
+  const marketKey = ODDS_MARKET[market];
+  const cotacao = (odds ?? []).find(
+    (row) => row.market_key === marketKey && outcomeDaOdd(row) === outcome && mesmaLinha(row.line, line),
+  );
+  if (cotacao?.reference_odd != null) {
+    return { estado: 'cotada', odd: cotacao.reference_odd };
+  }
+
+  return { estado: 'sem_cotacao', odd: null };
+}

--- a/supabase/migrations/20260826010945_107_futebol_cotacao_referencia.sql
+++ b/supabase/migrations/20260826010945_107_futebol_cotacao_referencia.sql
@@ -1,0 +1,121 @@
+-- 20260826010945_107_futebol_cotacao_referencia
+--
+-- A tela de detalhe precisa distinguir uma linha sem cotacao de uma candidata
+-- que tem preco, mas foi rejeitada pelos filtros de oportunidade. A odd de
+-- referencia e a mediana DISCRETA: sempre uma cotacao observada; em amostra par,
+-- a menor das duas observacoes centrais.
+
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_quotes(p_fixture_id bigint)
+RETURNS TABLE(
+  market_key text, market_label text, outcome_label text, outcome_order integer,
+  line double precision, pinnacle_odd double precision, avg_odd double precision,
+  reference_odd double precision, best_odd double precision, best_book text,
+  n_books integer, pin_open double precision, pin_close double precision
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+  with base as (
+    select o.market_name, o.outcome_label, o.bookmaker_name, o.collection_window,
+           o.odd_decimal, o.line_value, f.kickoff_utc
+    from futebol.fact_odds_snapshot o
+    join futebol.fact_fixtures f on f.fixture_id = o.fixture_id
+    where o.fixture_id = p_fixture_id
+      and ( o.market_name = 'Match Winner'
+         or o.market_name = 'Both Teams Score'
+         or o.market_name = 'Double Chance'
+         or (o.market_name = 'Goals Over/Under' and o.outcome_label in
+             ('Over 0.5','Under 0.5','Over 1.5','Under 1.5','Over 2.5','Under 2.5',
+              'Over 3.5','Under 3.5','Over 4.5','Under 4.5'))
+         or (o.market_name = 'Asian Handicap'
+             and abs(o.line_value - trunc(o.line_value)) = 0.5
+             and abs(o.line_value) <= 2.5))
+  ),
+  ranked as (
+    select b.*,
+      case b.collection_window
+        when 't15m' then 4 when 't1h' then 3 when 't24h' then 2
+        when 'daily' then 1 else 0
+      end as window_rank
+    from base b
+  ),
+  chosen_window as (
+    select market_name, outcome_label,
+      case
+        -- Jogo passado: a foto PIT e a janela mais proxima disponivel antes do
+        -- apito (t15m, com fallback para t1h, t24h e daily).
+        when max(kickoff_utc) <= (now() at time zone 'UTC') then coalesce(
+          max(window_rank) filter (where collection_window = 't15m'),
+          max(window_rank) filter (where collection_window = 't1h'),
+          max(window_rank) filter (where collection_window = 't24h'),
+          max(window_rank) filter (where collection_window = 'daily')
+        )
+        -- Jogo futuro: a coleta mais recente que ja existe para a selecao.
+        else max(window_rank)
+      end as window_rank
+    from ranked
+    group by market_name, outcome_label
+  ),
+  current_quotes as (
+    select distinct on (r.market_name, r.outcome_label, r.bookmaker_name)
+      r.market_name, r.outcome_label, r.bookmaker_name, r.odd_decimal, r.line_value
+    from ranked r
+    join chosen_window w using (market_name, outcome_label, window_rank)
+    order by r.market_name, r.outcome_label, r.bookmaker_name
+  ),
+  agg as (
+    select c.market_name, c.outcome_label, max(c.line_value) as line_value,
+      count(distinct c.bookmaker_name)::int as n_books,
+      avg(c.odd_decimal) as avg_odd,
+      percentile_disc(0.5) within group (order by c.odd_decimal) as reference_odd
+    from current_quotes c
+    group by c.market_name, c.outcome_label
+  ),
+  best_book as (
+    select distinct on (c.market_name, c.outcome_label)
+      c.market_name, c.outcome_label, c.bookmaker_name, c.odd_decimal
+    from current_quotes c
+    order by c.market_name, c.outcome_label, c.odd_decimal desc
+  ),
+  pinnacle as (
+    select b.market_name, b.outcome_label,
+      max(b.odd_decimal) filter (where b.collection_window='t24h') as t24,
+      max(b.odd_decimal) filter (where b.collection_window='t1h') as t1,
+      max(b.odd_decimal) filter (where b.collection_window='t15m') as t15
+    from base b
+    where b.bookmaker_name = 'Pinnacle'
+    group by b.market_name, b.outcome_label
+  )
+  select
+    case a.market_name
+      when 'Match Winner' then 'match_winner'
+      when 'Goals Over/Under' then 'over_under'
+      when 'Both Teams Score' then 'btts'
+      when 'Double Chance' then 'double_chance'
+      when 'Asian Handicap' then 'asian_handicap'
+    end,
+    a.market_name,
+    a.outcome_label,
+    case
+      when a.outcome_label in ('Home','Yes','Home/Draw')
+        or a.outcome_label like 'Over %' or a.outcome_label like 'Home %' then 1
+      when a.outcome_label in ('Draw','No','Home/Away')
+        or a.outcome_label like 'Under %' or a.outcome_label like 'Away %' then 2
+      else 3
+    end,
+    case when a.market_name in ('Goals Over/Under','Asian Handicap') then a.line_value end,
+    coalesce(p.t15, p.t1, p.t24), a.avg_odd, a.reference_odd,
+    bb.odd_decimal, bb.bookmaker_name, a.n_books, p.t24, coalesce(p.t15, p.t1)
+  from agg a
+  join best_book bb using (market_name, outcome_label)
+  left join pinnacle p using (market_name, outcome_label)
+  where a.market_name <> 'Asian Handicap' or a.n_books >= 3
+  order by 1, 5 nulls first, 4;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_fixture_quotes(bigint)
+TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.get_futebol_fixture_quotes(bigint) IS
+  'Cotacoes do detalhe do jogo na janela mais recente comum a cada selecao, incluindo mediana discreta como odd de referencia.';


### PR DESCRIPTION
Closes #277

## O que muda

- A Bancada diferencia oportunidade publicada, candidata cotada e linha sem cotação.
- Candidata cotada mostra a odd de referência: mediana discreta das cotações observadas.
- A candidata não exibe Score, chance ou vantagem; oportunidade continua tendo prioridade.
- “Adicionar à gestão” pré-preenche a odd de referência e orienta o usuário a confirmá-la na própria casa.
- A consulta usa a janela mais recente antes do jogo e a foto PIT para jogo passado.

## Validação

- Testes unitários da regra de classificação e da prioridade da oportunidade.
- Lint dos arquivos alterados: sem erros (somente dois avisos antigos no serviço Supabase).
- Build de produção concluído.

## Observação

O repositório já tinha arquivos locais não rastreados; eles não fazem parte deste PR.
