### PR TITLE
Futebol: manter linha sem cotação analisável (#280)

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -31,7 +31,7 @@ import { avisoSemDado } from '@/utils/futebol-sem-dado';
 import { valueDoCandidato, resumoDosMercados, mesmaLinha, REGUA_SCORE, type SaidaPreferida } from '@/utils/futebol-leitura';
 import { leituraDaCotacao } from '@/utils/futebol-cotacao';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
-import { isFinished } from '@/utils/futebol-datas';
+import { hasKickoffPassed, isFinished, parseUtc } from '@/utils/futebol-datas';
 import type { MatchupTendencies } from '@/utils/futebol-tendencias';
 import type { JogoInfo } from './JogoResumo';
 
@@ -55,6 +55,21 @@ const TIPO_LINHA = new Set(['goals_over_under', 'asian_handicap']);
 /** Linha em pt-BR. Sinal só no handicap: "+2,5 gols" não existe. */
 function fmtLinha(v: number, comSinal: boolean): string {
   return `${comSinal && v > 0 ? '+' : ''}${String(v).replace('.', ',')}`;
+}
+
+/** Reavalia a tela no apito, mesmo se a fonte ainda não atualizou o status. */
+function useJogoJaComecou(kickoffUtc: string | null): boolean {
+  const [agora, setAgora] = useState(() => new Date());
+
+  useEffect(() => {
+    const kickoff = parseUtc(kickoffUtc);
+    if (!kickoff || hasKickoffPassed(kickoffUtc, agora)) return;
+    const espera = Math.min(kickoff.getTime() - agora.getTime(), 2_147_483_647);
+    const timer = window.setTimeout(() => setAgora(new Date()), espera);
+    return () => window.clearTimeout(timer);
+  }, [kickoffUtc, agora]);
+
+  return hasKickoffPassed(kickoffUtc, agora);
 }
 
 /**
@@ -231,6 +246,7 @@ export function BancadaMercados({
   const { data: oddsRows } = useFutebolFixtureOdds(jogo.fixtureId);
 
   const fim = isFinished(jogo.statusShort);
+  const jogoJaComecou = useJogoJaComecou(jogo.kickoffUtc);
   const placar = fim ? { home: jogo.goalsHome, away: jogo.goalsAway } : null;
   const mercado: MercadoInfo = MERCADOS.find((m) => m.slug === mercadoAtivo) ?? MERCADOS[0];
   const ehLinha = TIPO_LINHA.has(mercado.slug);
@@ -260,10 +276,22 @@ export function BancadaMercados({
   // Sem fallback de propósito: resumoDosMercados só deixa um mercado de fora quando
   // melhorCandidato dele já é nulo, então um "?? melhorCandidato(...)" aqui nunca
   // teria o que devolver, e ainda reabriria a porta das duas verdades.
-  const melhor = useMemo(
-    () => resumos.find((r) => r.mercado.slug === mercado.slug)?.candidato ?? null,
-    [resumos, mercado.slug],
-  );
+  const candidatoInicialDoMercado = useMemo(() => {
+    const resumo = resumos.find((r) => r.mercado.slug === mercado.slug) ?? null;
+    // Primeiro, a oportunidade de maior score (ou a que veio pelo link). Sem ela,
+    // uma candidata que já tem cotação é mais útil que uma linha só analisada.
+    if (resumo?.value) return resumo.candidato;
+
+    const candidataCotada = [...doMercado]
+      .filter((c) => leituraDaCotacao(mercado.slug, c.outcome, c.line_value, valueRows, oddsRows).estado === 'cotada')
+      .sort(
+        (a, b) =>
+          contaQueValem(mercado.slug, b.acesas) - contaQueValem(mercado.slug, a.acesas) ||
+          (a.line_value ?? 0) - (b.line_value ?? 0) ||
+          a.outcome.localeCompare(b.outcome),
+      )[0];
+    return candidataCotada ?? resumo?.candidato ?? null;
+  }, [resumos, mercado.slug, doMercado, valueRows, oddsRows]);
 
   // TODAS as linhas cotadas do mercado, em ordem. Com pills a tela mostrava as 5
   // mais centrais e as outras 16 não existiam; na régua arrastável cabem todas.
@@ -274,13 +302,13 @@ export function BancadaMercados({
 
   const [linha, setLinha] = useState<number | null>(null);
   const [saida, setSaida] = useState<string | null>(null);
-  // Depende de `melhor`, não só de `rows`: premissas e preço chegam em requisições
+  // Depende do candidato inicial, não só de `rows`: premissas e preço chegam em requisições
   // separadas, e quando o preço chegava depois a régua ficava parada na linha que as
   // premissas tinham escolhido sozinhas.
   useEffect(() => {
-    setLinha(melhor?.line_value != null && paradas.includes(melhor.line_value) ? melhor.line_value : paradas[Math.floor(paradas.length / 2)] ?? null);
-    setSaida(melhor?.outcome ?? null);
-  }, [melhor, paradas]);
+    setLinha(candidatoInicialDoMercado?.line_value != null && paradas.includes(candidatoInicialDoMercado.line_value) ? candidatoInicialDoMercado.line_value : paradas[Math.floor(paradas.length / 2)] ?? null);
+    setSaida(candidatoInicialDoMercado?.outcome ?? null);
+  }, [candidatoInicialDoMercado, paradas]);
 
   // Os lados da parada atual.
   const [ladoA, ladoB] = useMemo((): [FutebolFixturePremissas | null, FutebolFixturePremissas | null] => {
@@ -289,9 +317,9 @@ export function BancadaMercados({
       const at = (o: string) => doMercado.find((r) => r.outcome === o && r.line_value != null && linha != null && mesmaLinha(r.line_value, linha)) ?? null;
       return [at(oa), at(ob)];
     }
-    const sel = doMercado.find((r) => r.outcome === saida) ?? melhor;
+    const sel = doMercado.find((r) => r.outcome === saida) ?? candidatoInicialDoMercado;
     return [sel ?? null, null];
-  }, [ehLinha, doMercado, linha, saida, melhor, mercado.slug]);
+  }, [ehLinha, doMercado, linha, saida, candidatoInicialDoMercado, mercado.slug]);
 
   // Principal = o lado analisado. Começa no que tem mais contexto e o usuário troca
   // clicando no outro card: é assim que ele vê as premissas do outro lado, em vez de
@@ -466,9 +494,14 @@ export function BancadaMercados({
   }
 
   const pickAtual = labelDe(principal);
+  const cotacaoDoDraft = cotacaoPrincipal.estado === 'oportunidade'
+    ? { bestOdd: cotacaoPrincipal.odd, oddKind: 'melhor' as const }
+    : cotacaoPrincipal.estado === 'cotada'
+      ? { bestOdd: cotacaoPrincipal.odd, oddKind: 'referencia' as const }
+      : { bestOdd: null, oddKind: 'sem_cotacao' as const };
 
   const cta =
-    principal && cotacaoPrincipal.estado !== 'sem_cotacao' && !fim && !locked ? (
+    principal && !jogoJaComecou && !locked ? (
       <RegistrarApostaCTA
         draft={{
           homeName: jogo.home,
@@ -478,8 +511,7 @@ export function BancadaMercados({
           market: principal.market,
           outcome: principal.outcome,
           lineValue: principal.line_value,
-          bestOdd: cotacaoPrincipal.odd,
-          oddKind: cotacaoPrincipal.estado === 'cotada' ? 'referencia' : 'melhor',
+          ...cotacaoDoDraft,
         }}
         variant="ambar"
         rotulo="Adicionar à gestão"
@@ -509,7 +541,7 @@ export function BancadaMercados({
         return {
           chave: o.outcome,
           rotulo: outcomeLabel(o, jogo.home, jogo.away),
-          ativa: o.outcome === (saida ?? melhor?.outcome),
+          ativa: o.outcome === (saida ?? candidatoInicialDoMercado?.outcome),
           passa: val ? val.score >= REGUA_SCORE : n >= PORTA_PREMISSAS,
           res: placar ? settleFutebol(o, placar.home, placar.away) : null,
           escolher: () => setSaida(o.outcome),
@@ -653,6 +685,14 @@ export function BancadaMercados({
                     Cotada · fora dos filtros
                   </span>
                 )}
+                {cotacaoPrincipal.estado === 'sem_cotacao' && (
+                  <span
+                    className="inline-flex items-center h-5 px-2 rounded-full text-[9px] font-bold uppercase tracking-[0.08em]"
+                    style={{ background: '#ede4ce', color: '#6b6350' }}
+                  >
+                    Sem cotação
+                  </span>
+                )}
                 {resPrincipal && <SeloRes r={resPrincipal} />}
               </div>
               <div className="mt-1.5 text-[28px] md:text-[34px] font-semibold leading-tight tracking-[-0.035em] text-white min-h-[42px] md:min-h-[46px]">
@@ -761,7 +801,7 @@ export function BancadaMercados({
                   valor={linha}
                   onEscolher={setLinha}
                   rotulo={(v) => fmtLinha(v, ehAH)}
-                  destaque={melhor?.line_value ?? null}
+                  destaque={candidatoInicialDoMercado?.line_value ?? null}
                   forca={forcaPorLinha}
                 />
               </>

--- a/src/components/futebol/FaixaPartida.tsx
+++ b/src/components/futebol/FaixaPartida.tsx
@@ -237,6 +237,7 @@ export function FaixaPartida({
                     outcome: v.outcome,
                     lineValue: v.line_value,
                     bestOdd: v.best_odd,
+                    oddKind: 'melhor',
                   }}
                   variant="ambar"
                 />

--- a/src/components/futebol/JogoResumo.tsx
+++ b/src/components/futebol/JogoResumo.tsx
@@ -415,6 +415,7 @@ export function JogoResumo({
                 outcome: top.value.outcome,
                 lineValue: top.value.line_value,
                 bestOdd: top.value.best_odd,
+                oddKind: 'melhor',
               }}
             />
           </div>

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -379,6 +379,7 @@ export function JogoResumoPanel({
                 outcome: best.outcome,
                 lineValue: best.line_value,
                 bestOdd: best.best_odd,
+                oddKind: 'melhor',
               }}
               variant="ambar"
               rotulo="Registrar"

--- a/src/components/futebol/RegistrarAposta.tsx
+++ b/src/components/futebol/RegistrarAposta.tsx
@@ -149,8 +149,10 @@ export function RegistrarApostaModal({
             </div>
             <p className="text-[11px] text-ink-3 -mt-2">
               {draft?.oddKind === 'referencia'
-                ? `Confirme a cotação na sua casa antes de registrar. A referência coletada foi ${draft.bestOdd.toFixed(2)}.`
-                : `Pegou outra odd? Ajuste acima — preenchemos com a melhor que encontramos (${draft?.bestOdd.toFixed(2)}).`}
+                ? `Confirme a cotação na sua casa antes de registrar. A referência coletada foi ${draft.bestOdd?.toFixed(2)}.`
+                : draft?.oddKind === 'sem_cotacao'
+                  ? 'Informe a odd que você encontrou para registrar a aposta.'
+                  : `Pegou outra odd? Ajuste acima — preenchemos com a melhor que encontramos (${draft?.bestOdd?.toFixed(2)}).`}
             </p>
 
             {/* Retorno potencial */}

--- a/src/components/futebol/registrar-aposta-utils.ts
+++ b/src/components/futebol/registrar-aposta-utils.ts
@@ -2,7 +2,7 @@
 // pra manter o Fast Refresh feliz: o .tsx exporta só componentes).
 import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
 
-export interface FutebolBetDraft {
+interface FutebolBetDraftBase {
   homeName: string;
   awayName: string;
   competition: string;
@@ -10,9 +10,13 @@ export interface FutebolBetDraft {
   market: string;
   outcome: string;
   lineValue: number | null;
-  bestOdd: number;
-  oddKind?: 'melhor' | 'referencia';
 }
+
+/** A origem da odd determina se o formulário começa preenchido. */
+export type FutebolBetDraft = FutebolBetDraftBase & (
+  | { bestOdd: number; oddKind: 'melhor' | 'referencia' }
+  | { bestOdd: null; oddKind: 'sem_cotacao' }
+);
 
 /**
  * Monta o draft a partir de uma linha do board de oportunidades. Aceita

--- a/src/utils/futebol-datas.test.ts
+++ b/src/utils/futebol-datas.test.ts
@@ -11,6 +11,7 @@ import {
   yearOf,
   isFinished,
   isLive,
+  hasKickoffPassed,
 } from './futebol-datas';
 
 // Os testes não dependem do fuso da máquina: todo formatador recebe
@@ -165,5 +166,17 @@ describe('isFinished / isLive', () => {
     expect(isLive('NS')).toBe(false);
     expect(isFinished(null)).toBe(false);
     expect(isLive(null)).toBe(false);
+  });
+});
+
+describe('hasKickoffPassed', () => {
+  const now = new Date('2026-08-26T19:30:00Z');
+
+  it('fecha a gestão no horário do apito, mesmo que o status ainda não tenha mudado', () => {
+    expect(hasKickoffPassed('2026-08-26T19:30:00', now)).toBe(true);
+  });
+
+  it('mantém a gestão disponível antes do início', () => {
+    expect(hasKickoffPassed('2026-08-26T19:31:00', now)).toBe(false);
   });
 });

--- a/src/utils/futebol-datas.ts
+++ b/src/utils/futebol-datas.ts
@@ -133,3 +133,13 @@ export function isFinished(status: string | null | undefined): boolean {
 export function isLive(status: string | null | undefined): boolean {
   return status === '1H' || status === '2H' || status === 'HT' || status === 'ET' || status === 'BT' || status === 'P' || status === 'LIVE';
 }
+
+/**
+ * O momento real do início vence o status recebido da fonte. Ela pode demorar a
+ * trocar de "NS" para "1H", mas não devemos continuar oferecendo registro de
+ * aposta depois do apito inicial.
+ */
+export function hasKickoffPassed(kickoffUtc: string | null | undefined, now = new Date()): boolean {
+  const kickoff = parseUtc(kickoffUtc);
+  return kickoff != null && kickoff.getTime() <= now.getTime();
+}


### PR DESCRIPTION
## O que muda
- Mostra “Sem cotação” em tom neutro, mantendo a análise de premissas.
- Permite adicionar uma linha sem cotação à gestão antes do jogo, com a odd em branco.
- Oculta a ação no horário real do início, mesmo que o status da fonte ainda não tenha atualizado.
- Ao abrir um mercado, prioriza oportunidade, depois candidata cotada e por fim linha apenas analisada.

## Validação
- 46 testes direcionados passaram.
- Lint dos arquivos alterados passou.
- Build de produção passou.