### PR TITLE
fix(futebol): alinhar motivos de Gols ao backend

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -2353,6 +2353,101 @@ AS $function$
   order by 1, 5 nulls first, 4;
 $function$;
 
+-- ── 5d. Contrato de motivos da leitura de Gols (migration 108) ───────────────
+-- O banco escolhe o grupo de cada motivo. A tela apenas renderiza o contrato,
+-- sem converter uma premissa do lado oposto em uma frase "contra".
+create or replace function public.get_futebol_fixture_reason_contract(p_fixture_id bigint)
+returns table(
+  market text,
+  outcome text,
+  line_value double precision,
+  score integer,
+  componentes_score jsonb,
+  favor jsonb,
+  contra jsonb
+)
+language sql
+stable
+security definer
+set search_path to ''
+as $function$
+  with base as (
+    select
+      v.market, v.outcome, v.line_value, v.score, v.pts_valor, v.pts_premissas,
+      v.pts_corroboracao, v.penalidades as penalidades_score,
+      v.modelo_api_concorda, v.linha_sharp_confirma, v.avisos,
+      p.acesas, p.apagadas, p.penalidades as penalidades_ativas,
+      case v.outcome
+        when 'Over' then array[
+          'defesas_vazaveis', 'ataque_combinado', 'xg_combinado_alto',
+          'ambos_vazam', 'ritmo_alto', 'historico_over', 'linha_subindo'
+        ]::text[]
+        when 'Under' then array[
+          'defesas_firmes', 'xg_baixo_combinado', 'clean_sheets_altos',
+          'ataques_fracos', 'historico_under', 'linha_descendo'
+        ]::text[]
+        else array[]::text[]
+      end as aplicaveis
+    from public.get_futebol_fixture_value(p_fixture_id) v
+    join public.get_futebol_fixture_premissas(p_fixture_id) p
+      on p.market = v.market
+     and p.outcome = v.outcome
+     and p.line_value is not distinct from v.line_value
+    where v.market = 'goals_over_under'
+  )
+  select
+    b.market,
+    b.outcome,
+    b.line_value,
+    b.score,
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', id, 'texto', texto, 'pontos', pontos) order by ordem)
+      from (values
+        (1, 'premissas', 'Premissas', b.pts_premissas),
+        (2, 'valor_de_mercado', 'Valor de mercado', b.pts_valor),
+        (3, 'corroboracao', 'Corroboração', b.pts_corroboracao),
+        (4, 'penalidades', 'Penalidades', b.penalidades_score)
+      ) as componente(ordem, id, texto, pontos)
+      where pontos <> 0
+    ), '[]'::jsonb),
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'premissa') order by slug)
+      from unnest(b.acesas) slug
+      where slug = any(b.aplicaveis) and b.pts_premissas > 0
+    ), '[]'::jsonb)
+    || case when b.pts_valor > 0
+      then jsonb_build_array(jsonb_build_object(
+        'id', 'valor_de_mercado', 'tipo', 'componente_score',
+        'texto', 'A cotação oferece valor', 'pontos', b.pts_valor
+      ))
+      else '[]'::jsonb end
+    || case when b.pts_corroboracao > 0
+      then jsonb_build_array(jsonb_build_object(
+        'id', 'corroboracao', 'tipo', 'componente_score', 'pontos', b.pts_corroboracao,
+        'texto', case
+          when b.modelo_api_concorda and b.linha_sharp_confirma then 'Modelo e movimento de mercado confirmam a leitura'
+          when b.modelo_api_concorda then 'Modelo confirma a leitura'
+          when b.linha_sharp_confirma then 'Movimento de mercado confirma a leitura'
+          else 'Corroboração confirma a leitura'
+        end
+      ))
+      else '[]'::jsonb end,
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'premissa') order by slug)
+      from unnest(b.apagadas) slug
+      where slug = any(b.aplicaveis)
+    ), '[]'::jsonb)
+    || coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'penalidade') order by slug)
+      from unnest(b.penalidades_ativas) slug
+    ), '[]'::jsonb)
+    || coalesce((
+      select jsonb_agg(jsonb_build_object('id', 'aviso_' || ord, 'tipo', 'penalidade', 'texto', texto) order by ord)
+      from unnest(b.avisos) with ordinality as a(texto, ord)
+    ), '[]'::jsonb)
+  from base b;
+$function$;
+
 -- ── 6. Grants de execução (anon / authenticated / service_role) ──────────────
 grant execute on function public._futebol_team_form(p_team_id bigint, p_competition text, p_season bigint, p_before date) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_access() to anon, authenticated, service_role;
@@ -2384,6 +2479,7 @@ grant execute on function public.get_futebol_fixtures_by_day(p_day date, p_compe
 grant execute on function public.get_futebol_fixture_premissas(p_fixture_id bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_numeros(p_fixture_id bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_historico(p_fixture_id bigint, p_max integer) to anon, authenticated, service_role;
+grant execute on function public.get_futebol_fixture_reason_contract(p_fixture_id bigint) to anon, authenticated, service_role;
 
 -- ── 7. Reverse trial (7 dias, sem cartão) — colunas no public.users ──────────
 alter table public.users add column if not exists futebol_trial_started_at timestamptz;

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -487,7 +487,6 @@ export function BancadaMercados({
     : requerContratoMotivos
       ? { premissas: [], extras: [] }
       : { premissas: naoAconteceu, extras: contras };
-  const componentesScore = contratoMotivos?.componentes_score ?? [];
 
   // O veredito em uma frase, sem inventar número.
   const veredito = useMemo(() => {
@@ -896,20 +895,6 @@ export function BancadaMercados({
         {mercado.aviso && (
           <div className="px-6 md:px-8 py-3 text-[12px] leading-relaxed" style={{ background: '#fef7df', borderBottom: '1px solid #fde68a', color: '#5a3c00' }}>
             {mercado.aviso}
-          </div>
-        )}
-
-        {contratoMotivos && componentesScore.length > 0 && (
-          <div className="px-6 md:px-8 py-3 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-[11.5px]" style={{ borderBottom: '1px solid #f1e9d6', background: '#fdfbf6', color: '#5a625a' }}>
-            <span className="font-semibold" style={{ color: '#0a3d2e' }}>Score {contratoMotivos.score}</span>
-            <span>=</span>
-            {componentesScore.map((componente, index) => (
-              <span key={componente.id} className="inline-flex items-baseline gap-1">
-                {index > 0 && <span>{componente.pontos < 0 ? '−' : '+'}</span>}
-                <strong className="tabular-nums" style={{ color: '#0a3d2e' }}>{Math.abs(componente.pontos)}</strong>
-                <span>{componente.texto.toLowerCase()}</span>
-              </span>
-            ))}
           </div>
         )}
 

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -8,8 +8,9 @@ import {
   useFutebolFixtureHistorico,
   useFutebolFixtureInjuries,
   useFutebolFixtureOdds,
+  useFutebolFixtureReasonContract,
 } from '@/hooks/use-futebol-data';
-import type { FutebolFixturePremissas, FutebolFixtureValueRow } from '@/services/futebol-data.service';
+import type { FutebolFixturePremissas, FutebolFixtureReasonContractRow, FutebolFixtureValueRow } from '@/services/futebol-data.service';
 import {
   MERCADOS,
   PORTA_PREMISSAS,
@@ -30,6 +31,7 @@ import { MotivosJogoPorJogo } from './MotivosJogoPorJogo';
 import { avisoSemDado } from '@/utils/futebol-sem-dado';
 import { valueDoCandidato, resumoDosMercados, mesmaLinha, REGUA_SCORE, type SaidaPreferida } from '@/utils/futebol-leitura';
 import { leituraDaCotacao } from '@/utils/futebol-cotacao';
+import { separarMotivosDoContrato } from '@/utils/futebol-motivos';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { hasKickoffPassed, isFinished, parseUtc } from '@/utils/futebol-datas';
 import type { MatchupTendencies } from '@/utils/futebol-tendencias';
@@ -244,6 +246,11 @@ export function BancadaMercados({
   const { data: historico } = useFutebolFixtureHistorico(jogo.fixtureId);
   const { data: injuries } = useFutebolFixtureInjuries(jogo.fixtureId);
   const { data: oddsRows } = useFutebolFixtureOdds(jogo.fixtureId);
+  const {
+    data: reasonContractRows,
+    isLoading: carregandoContratoMotivos,
+    isError: falhaContratoMotivos,
+  } = useFutebolFixtureReasonContract(jogo.fixtureId);
 
   const fim = isFinished(jogo.statusShort);
   const jogoJaComecou = useJogoJaComecou(jogo.kickoffUtc);
@@ -347,6 +354,19 @@ export function BancadaMercados({
     ? leituraDaCotacao(mercado.slug, principal.outcome, principal.line_value, valueRows, oddsRows)
     : { estado: 'sem_cotacao' as const, odd: null };
 
+  // Em Gols, o banco é a fonte do grupo de cada motivo. Ele evita transformar uma
+  // premissa do lado oposto em frase negativa e mantém contador e detalhe iguais.
+  const contratoMotivos = useMemo((): FutebolFixtureReasonContractRow | null => {
+    if (!principal || mercado.slug !== 'goals_over_under') return null;
+    return reasonContractRows?.find((r) =>
+      r.market === principal.market &&
+      r.outcome === principal.outcome &&
+      mesmaLinha(r.line_value, principal.line_value),
+    ) ?? null;
+  }, [reasonContractRows, principal, mercado.slug]);
+  const requerContratoMotivos = mercado.slug === 'goals_over_under' && valPrincipal != null;
+  const contratoMotivosIndisponivel = requerContratoMotivos && !contratoMotivos;
+
 
   const labelDe = (c: FutebolFixturePremissas | null) =>
     c ? outcomeLabel(c, jogo.home, jogo.away) : '';
@@ -412,12 +432,28 @@ export function BancadaMercados({
   // modelos dbt, não aqui.
   const favorVisivel = favor.filter((p) => p.peso !== 0 || evDe(p.slug) != null);
 
+  const motivosDoContrato = (itens: FutebolFixtureReasonContractRow['favor']) => {
+    const separados = separarMotivosDoContrato(itens);
+    return {
+      premissas: separados.slugsDePremissas
+        .map((slug) => premissaDe(mercado.slug, slug))
+        .filter((p): p is Premissa => p != null),
+      extras: separados.motivosSemDrilldown,
+    };
+  };
+  const motivosFavor = contratoMotivos
+    ? motivosDoContrato(contratoMotivos.favor)
+    : requerContratoMotivos
+      ? { premissas: [], extras: [] }
+      : { premissas: favorVisivel, extras: [] };
+
   // Contras: os do backend (quando há preço) + penalidades ativas.
   //
   // A penalidade de desfalque aparecia como título solto, sem dizer QUEM está fora.
   // Aqui ela puxa a lista de desfalques do lado certo; quando a lista ainda não
   // saiu, a tela diz isso em vez de deixar a linha muda.
   const contras = useMemo(() => {
+    if (requerContratoMotivos) return [];
     const out: { t: string; sub?: string }[] = [];
     (valPrincipal?.contras ?? []).forEach((t) => out.push({ t }));
     (valPrincipal?.avisos ?? []).forEach((t) => out.push({ t }));
@@ -445,7 +481,13 @@ export function BancadaMercados({
       out.push({ t: `Penalidade: ${p.label.toLowerCase()}`, sub });
     });
     return out;
-  }, [valPrincipal, penAtivas, injuries, ladoPrincipal, jogo.homeId, jogo.awayId]);
+  }, [requerContratoMotivos, valPrincipal, penAtivas, injuries, ladoPrincipal, jogo.homeId, jogo.awayId]);
+  const motivosContra = contratoMotivos
+    ? motivosDoContrato(contratoMotivos.contra)
+    : requerContratoMotivos
+      ? { premissas: [], extras: [] }
+      : { premissas: naoAconteceu, extras: contras };
+  const componentesScore = contratoMotivos?.componentes_score ?? [];
 
   // O veredito em uma frase, sem inventar número.
   const veredito = useMemo(() => {
@@ -857,12 +899,26 @@ export function BancadaMercados({
           </div>
         )}
 
+        {contratoMotivos && componentesScore.length > 0 && (
+          <div className="px-6 md:px-8 py-3 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-[11.5px]" style={{ borderBottom: '1px solid #f1e9d6', background: '#fdfbf6', color: '#5a625a' }}>
+            <span className="font-semibold" style={{ color: '#0a3d2e' }}>Score {contratoMotivos.score}</span>
+            <span>=</span>
+            {componentesScore.map((componente, index) => (
+              <span key={componente.id} className="inline-flex items-baseline gap-1">
+                {index > 0 && <span>{componente.pontos < 0 ? '−' : '+'}</span>}
+                <strong className="tabular-nums" style={{ color: '#0a3d2e' }}>{Math.abs(componente.pontos)}</strong>
+                <span>{componente.texto.toLowerCase()}</span>
+              </span>
+            ))}
+          </div>
+        )}
+
         {/* Sub-abas em forma de pasta: A favor · Contra. */}
         <div data-tour="fut-jogo-premissas" className="px-6 md:px-8 pt-4 flex items-center gap-2" style={{ borderBottom: '1px solid #f1e9d6' }}>
           {(
             [
-              ['favor', 'A favor', favorVisivel.length],
-              ['contra', 'Contra', naoAconteceu.length + contras.length],
+              ['favor', 'A favor', contratoMotivosIndisponivel ? null : motivosFavor.premissas.length + motivosFavor.extras.length],
+              ['contra', 'Contra', contratoMotivosIndisponivel ? null : motivosContra.premissas.length + motivosContra.extras.length],
             ] as const
           ).map(([k, rot, n]) => {
             const on = abaMotivo === k;
@@ -887,7 +943,7 @@ export function BancadaMercados({
               >
                 {rot}
                 <span className="tabular-nums text-[11px] font-bold" style={{ color: on ? '#0a3d2e' : '#8d8672' }}>
-                  {n}
+                  {n ?? '—'}
                 </span>
               </button>
             );
@@ -897,10 +953,19 @@ export function BancadaMercados({
           </span>
         </div>
 
-        {abaMotivo === 'favor' ? (
+        {contratoMotivosIndisponivel ? (
+          <div className="p-6 md:p-8 text-[13px]" style={{ color: '#8d8672' }}>
+            {carregandoContratoMotivos
+              ? 'Carregando os motivos desta leitura.'
+              : falhaContratoMotivos
+                ? 'Os motivos desta leitura estão sendo atualizados. Tente novamente em instantes.'
+                : 'Os motivos desta leitura ainda não estão disponíveis.'}
+          </div>
+        ) : abaMotivo === 'favor' ? (
           <MotivosJogoPorJogo
-            premissas={favorVisivel}
+            premissas={motivosFavor.premissas}
             modo="favor"
+            extras={motivosFavor.extras}
             historico={historico}
             numeros={numeros}
             lado={ladoPrincipal}
@@ -909,9 +974,9 @@ export function BancadaMercados({
           />
         ) : (
           <MotivosJogoPorJogo
-            premissas={naoAconteceu}
+            premissas={motivosContra.premissas}
             modo="contra"
-            contras={contras}
+            extras={motivosContra.extras}
             historico={historico}
             numeros={numeros}
             lado={ladoPrincipal}

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -714,13 +714,13 @@ export function BancadaMercados({
               veredito ganharam altura mínima. */}
           <div className="relative flex items-end justify-between gap-7 flex-wrap">
             <div className="min-w-0">
-              <div className="flex items-center gap-2.5 h-6">
+              <div className="flex items-center gap-2.5 min-h-6 md:h-6">
                 <span className="text-[10px] uppercase tracking-[0.16em]" style={{ color: 'rgba(255,255,255,.45)' }}>
                   Mercado aberto · {mercado.label}
                 </span>
                 {cotacaoPrincipal.estado === 'cotada' && (
                   <span
-                    className="inline-flex items-center h-5 px-2 rounded-full text-[9px] font-bold uppercase tracking-[0.08em]"
+                    className="inline-flex shrink-0 items-center min-h-5 px-2.5 py-1 rounded-full whitespace-nowrap text-[9px] font-bold uppercase leading-none tracking-[0.08em]"
                     style={{ background: '#dcefe2', color: '#0a3d2e' }}
                   >
                     Cotada · fora dos filtros
@@ -728,7 +728,7 @@ export function BancadaMercados({
                 )}
                 {cotacaoPrincipal.estado === 'sem_cotacao' && (
                   <span
-                    className="inline-flex items-center h-5 px-2 rounded-full text-[9px] font-bold uppercase tracking-[0.08em]"
+                    className="inline-flex shrink-0 items-center min-h-5 px-2.5 py-1 rounded-full whitespace-nowrap text-[9px] font-bold uppercase leading-none tracking-[0.08em]"
                     style={{ background: '#ede4ce', color: '#6b6350' }}
                   >
                     Sem cotação

--- a/src/components/futebol/MotivosJogoPorJogo.tsx
+++ b/src/components/futebol/MotivosJogoPorJogo.tsx
@@ -432,7 +432,7 @@ function LinhaPremissa({
 export function MotivosJogoPorJogo({
   premissas,
   modo,
-  contras,
+  extras,
   historico,
   numeros,
   lado,
@@ -441,8 +441,8 @@ export function MotivosJogoPorJogo({
 }: {
   premissas: Premissa[];
   modo: 'favor' | 'contra';
-  /** Só no modo contra: o que o preço e as penalidades pesam. */
-  contras?: { t: string; sub?: string }[];
+  /** Componentes que o backend já descreveu e não têm drilldown jogo a jogo. */
+  extras?: { t: string; sub?: string }[];
   historico: FutebolFixtureHistorico[] | undefined;
   numeros: FutebolFixtureNumeros[] | undefined;
   lado: 'home' | 'away' | null;
@@ -472,15 +472,17 @@ export function MotivosJogoPorJogo({
     return <div className="p-6 md:p-8 text-[13px]" style={{ color: '#8d8672' }}>Carregando os jogos anteriores.</div>;
   }
 
+  const total = itens.length + (extras?.length ?? 0);
+
   return (
     <div className="p-5 md:p-7">
       <div className="flex items-center justify-between gap-4 mb-3.5 flex-wrap">
         <div className="text-[12.5px]" style={{ color: '#8d8672' }}>
           {modo === 'favor'
-            ? itens.length > 0
-              ? `${itens.length} ${itens.length === 1 ? 'premissa sustenta' : 'premissas sustentam'} ${saidaLabel.toLowerCase()}. Clique numa linha para ver os jogos que produziram o número.`
-              : 'Nenhuma premissa a favor desta saída.'
-            : itens.length > 0 || (contras?.length ?? 0) > 0
+            ? total > 0
+              ? `${total} ${total === 1 ? 'motivo sustenta' : 'motivos sustentam'} ${saidaLabel.toLowerCase()}. Clique numa premissa para ver os jogos que produziram o número.`
+              : 'Nenhum motivo a favor desta saída.'
+            : total > 0
               ? 'O que o jogo e o preço colocam contra esta saída.'
               : 'Nada pesando contra esta saída: todas as premissas que valem aconteceram.'}
         </div>
@@ -498,9 +500,9 @@ export function MotivosJogoPorJogo({
         )}
       </div>
 
-      {modo === 'contra' && (contras?.length ?? 0) > 0 && (
+      {(extras?.length ?? 0) > 0 && (
         <div className="flex flex-col gap-2.5 mb-2.5">
-          {contras!.map((c, i) => (
+          {extras!.map((c, i) => (
             <div
               key={i}
               className="flex gap-3 items-start p-4 rounded-[14px]"
@@ -508,9 +510,11 @@ export function MotivosJogoPorJogo({
             >
               <span
                 className="shrink-0 w-[22px] h-[22px] rounded-md grid place-items-center text-[13px] font-bold"
-                style={{ background: '#fdf3d9', color: '#b8870f' }}
+                style={modo === 'favor'
+                  ? { background: '#e7f1e9', color: '#0a6549' }
+                  : { background: '#fdf3d9', color: '#b8870f' }}
               >
-                −
+                {modo === 'favor' ? '+' : '−'}
               </span>
               <div>
                 <div className="text-[13px] font-semibold leading-snug text-ink">{c.t}</div>

--- a/src/components/futebol/MotivosJogoPorJogo.tsx
+++ b/src/components/futebol/MotivosJogoPorJogo.tsx
@@ -442,7 +442,7 @@ export function MotivosJogoPorJogo({
   premissas: Premissa[];
   modo: 'favor' | 'contra';
   /** Componentes que o backend já descreveu e não têm drilldown jogo a jogo. */
-  extras?: { t: string; sub?: string }[];
+  extras?: { t: string; sub?: string; pontos?: number }[];
   historico: FutebolFixtureHistorico[] | undefined;
   numeros: FutebolFixtureNumeros[] | undefined;
   lado: 'home' | 'away' | null;
@@ -468,11 +468,18 @@ export function MotivosJogoPorJogo({
   const chave = itens.map((x) => x.p.slug).join('|');
   useEffect(() => setAberta(primeira), [chave, primeira]);
 
+  const total = itens.length + (extras?.length ?? 0);
+  const blocosOrdenados = useMemo(
+    () => [
+      ...itens.map((item) => ({ tipo: 'premissa' as const, peso: item.p.peso ?? 0, item })),
+      ...(extras ?? []).map((extra) => ({ tipo: 'extra' as const, peso: extra.pontos ?? 0, extra })),
+    ].sort((a, b) => b.peso - a.peso),
+    [itens, extras],
+  );
+
   if (!historico) {
     return <div className="p-6 md:p-8 text-[13px]" style={{ color: '#8d8672' }}>Carregando os jogos anteriores.</div>;
   }
-
-  const total = itens.length + (extras?.length ?? 0);
 
   return (
     <div className="p-5 md:p-7">
@@ -500,11 +507,13 @@ export function MotivosJogoPorJogo({
         )}
       </div>
 
-      {(extras?.length ?? 0) > 0 && (
-        <div className="flex flex-col gap-2.5 mb-2.5">
-          {extras!.map((c, i) => (
+      <div className="flex flex-col gap-2.5">
+        {blocosOrdenados.map((bloco) => {
+          if (bloco.tipo === 'extra') {
+            const c = bloco.extra;
+            return (
             <div
-              key={i}
+              key={`extra-${c.t}`}
               className="flex gap-3 items-start p-4 rounded-[14px]"
               style={{ border: '1px solid #ded2b6', background: '#fdfbf6' }}
             >
@@ -521,24 +530,24 @@ export function MotivosJogoPorJogo({
                 {c.sub && <div className="text-[12px] leading-relaxed mt-0.5" style={{ color: '#8d8672' }}>{c.sub}</div>}
               </div>
             </div>
-          ))}
-        </div>
-      )}
+            );
+          }
 
-      <div className="flex flex-col gap-2.5">
-        {itens.map(({ p, ev, story }) => (
-          <LinhaPremissa
-            key={p.slug}
-            p={p}
-            modo={modo}
-            lado={lado}
-            ev={ev}
-            story={story}
-            aberta={aberta === p.slug}
-            onAlternar={() => setAberta(aberta === p.slug ? null : p.slug)}
-            saidaLabel={saidaLabel}
-          />
-        ))}
+          const { p, ev, story } = bloco.item;
+          return (
+            <LinhaPremissa
+              key={p.slug}
+              p={p}
+              modo={modo}
+              lado={lado}
+              ev={ev}
+              story={story}
+              aberta={aberta === p.slug}
+              onAlternar={() => setAberta(aberta === p.slug ? null : p.slug)}
+              saidaLabel={saidaLabel}
+            />
+          );
+        })}
       </div>
 
       {itens.some((x) => x.story == null) && (

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -11,6 +11,7 @@ import {
   type FutebolFixtureByDay,
   type FutebolFixtureDay,
   type FutebolFixturePremissas,
+  type FutebolFixtureReasonContractRow,
   type FutebolFixtureNumeros,
   type FutebolFixtureHistorico,
   type FutebolCompetitionInfo,
@@ -98,6 +99,18 @@ export function useFutebolFixturePremissas(fixtureId: number | undefined) {
     enabled: !!fixtureId,
     staleTime: 10 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/** Motivos já agrupados pelo backend. Hoje cobre as saídas cotadas de Gols. */
+export function useFutebolFixtureReasonContract(fixtureId: number | undefined) {
+  return useQuery<FutebolFixtureReasonContractRow[]>({
+    queryKey: ['futebol', 'fixture-reason-contract', fixtureId],
+    queryFn: () => futebolDataService.getFixtureReasonContract(fixtureId as number),
+    enabled: !!fixtureId,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 }

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -82,6 +82,35 @@ export interface FutebolFixturePremissas {
   penalidades: string[];
 }
 
+/** Um motivo do contrato de leitura: o banco define o grupo e o front apenas o exibe. */
+export interface FutebolFixtureReasonItem {
+  id: string;
+  tipo: 'premissa' | 'componente_score' | 'penalidade';
+  texto?: string;
+  pontos?: number;
+}
+
+/** Parcela do score, devolvida pelo backend para a tela não recalcular o total. */
+export interface FutebolFixtureScoreComponent {
+  id: 'premissas' | 'valor_de_mercado' | 'corroboracao' | 'penalidades';
+  texto: string;
+  pontos: number;
+}
+
+/**
+ * Motivos da saída cotada em Gols (RPC get_futebol_fixture_reason_contract).
+ * A separação favor/contra é autoridade do backend; não derive o lado pelo slug.
+ */
+export interface FutebolFixtureReasonContractRow {
+  market: string;
+  outcome: string;
+  line_value: number | null;
+  score: number;
+  componentes_score: FutebolFixtureScoreComponent[];
+  favor: FutebolFixtureReasonItem[];
+  contra: FutebolFixtureReasonItem[];
+}
+
 /**
  * Números de temporada de um lado do confronto (RPC get_futebol_fixture_numeros).
  * Serve para EMBASAR as premissas: sem o número, "em boa fase" é adjetivo.
@@ -651,6 +680,17 @@ export const futebolDataService = {
       });
       if (error) throw error;
       return (data || []) as FutebolFixturePremissas[];
+    });
+  },
+
+  /** Contrato de motivos da saída cotada. Hoje cobre apenas Gols (migration 108). */
+  async getFixtureReasonContract(fixtureId: number): Promise<FutebolFixtureReasonContractRow[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_futebol_fixture_reason_contract', {
+        p_fixture_id: fixtureId,
+      });
+      if (error) throw error;
+      return (data || []) as FutebolFixtureReasonContractRow[];
     });
   },
 

--- a/src/utils/futebol-motivos.test.ts
+++ b/src/utils/futebol-motivos.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { separarMotivosDoContrato } from './futebol-motivos';
+
+describe('separarMotivosDoContrato', () => {
+  it('mantém na migration a seleção direta das premissas de Over, sem usar a cópia genérica de contra', () => {
+    const migration = readFileSync(resolve(__dirname, '../../supabase/migrations/20260826103000_108_futebol_motivos_gols.sql'), 'utf8');
+
+    expect(migration).toMatch(/when 'Over' then array\[[\s\S]*'xg_combinado_alto'[\s\S]*'ritmo_alto'[\s\S]*'linha_subindo'/);
+    expect(migration).toContain('from unnest(b.acesas) slug');
+    expect(migration).toContain('from unnest(b.apagadas) slug');
+    expect(migration).not.toContain("futebol_copy('contra'");
+  });
+
+  it('mantém Juventude × CRB · Mais de 1,5 no agrupamento devolvido pelo backend', () => {
+    const contratoJuventudeCrbOver15 = {
+      score: 46,
+      componentes_score: [
+        { id: 'premissas', texto: 'Premissas', pontos: 22 },
+        { id: 'valor_de_mercado', texto: 'Valor de mercado', pontos: 16 },
+        { id: 'corroboracao', texto: 'Corroboração', pontos: 8 },
+      ],
+      favor: [
+      { id: 'xg_combinado_alto', tipo: 'premissa' },
+      { id: 'ritmo_alto', tipo: 'premissa' },
+      { id: 'linha_subindo', tipo: 'premissa' },
+      { id: 'valor_de_mercado', tipo: 'componente_score', texto: 'A cotação oferece valor' },
+        { id: 'corroboracao', tipo: 'componente_score', texto: 'Movimento de mercado confirma a leitura' },
+      ],
+      contra: [
+      { id: 'defesas_vazaveis', tipo: 'premissa' },
+      { id: 'ataque_combinado', tipo: 'premissa' },
+        { id: 'ambos_vazam', tipo: 'premissa' },
+        { id: 'historico_over', tipo: 'premissa' },
+      ],
+    } as const;
+    const favor = separarMotivosDoContrato(contratoJuventudeCrbOver15.favor);
+    const contra = separarMotivosDoContrato(contratoJuventudeCrbOver15.contra);
+
+    expect(favor.slugsDePremissas).toEqual(['xg_combinado_alto', 'ritmo_alto', 'linha_subindo']);
+    expect(favor.motivosSemDrilldown).toEqual([
+      { t: 'A cotação oferece valor' },
+      { t: 'Movimento de mercado confirma a leitura' },
+    ]);
+    expect(contra.slugsDePremissas).toEqual(['defesas_vazaveis', 'ataque_combinado', 'ambos_vazam', 'historico_over']);
+    expect(contra.slugsDePremissas).not.toContain('defesas_firmes');
+    expect(contra.slugsDePremissas).not.toContain('xg_baixo_combinado');
+    expect(contratoJuventudeCrbOver15.componentes_score.reduce((total, componente) => total + componente.pontos, 0))
+      .toBe(contratoJuventudeCrbOver15.score);
+  });
+});

--- a/src/utils/futebol-motivos.test.ts
+++ b/src/utils/futebol-motivos.test.ts
@@ -25,8 +25,8 @@ describe('separarMotivosDoContrato', () => {
       { id: 'xg_combinado_alto', tipo: 'premissa' },
       { id: 'ritmo_alto', tipo: 'premissa' },
       { id: 'linha_subindo', tipo: 'premissa' },
-      { id: 'valor_de_mercado', tipo: 'componente_score', texto: 'A cotação oferece valor' },
-        { id: 'corroboracao', tipo: 'componente_score', texto: 'Movimento de mercado confirma a leitura' },
+        { id: 'valor_de_mercado', tipo: 'componente_score', texto: 'A cotação oferece valor', pontos: 16 },
+        { id: 'corroboracao', tipo: 'componente_score', texto: 'Movimento de mercado confirma a leitura', pontos: 8 },
       ],
       contra: [
       { id: 'defesas_vazaveis', tipo: 'premissa' },
@@ -40,8 +40,8 @@ describe('separarMotivosDoContrato', () => {
 
     expect(favor.slugsDePremissas).toEqual(['xg_combinado_alto', 'ritmo_alto', 'linha_subindo']);
     expect(favor.motivosSemDrilldown).toEqual([
-      { t: 'A cotação oferece valor' },
-      { t: 'Movimento de mercado confirma a leitura' },
+      { t: 'A cotação oferece valor', pontos: 16 },
+      { t: 'Movimento de mercado confirma a leitura', pontos: 8 },
     ]);
     expect(contra.slugsDePremissas).toEqual(['defesas_vazaveis', 'ataque_combinado', 'ambos_vazam', 'historico_over']);
     expect(contra.slugsDePremissas).not.toContain('defesas_firmes');

--- a/src/utils/futebol-motivos.ts
+++ b/src/utils/futebol-motivos.ts
@@ -1,0 +1,15 @@
+import type { FutebolFixtureReasonItem } from '@/services/futebol-data.service';
+
+/**
+ * Separa apenas a forma de apresentar o contrato já decidido pelo backend.
+ * Slugs seguem para o catálogo visual; itens com texto são componentes explícitos
+ * do score e não têm drilldown jogo a jogo.
+ */
+export function separarMotivosDoContrato(itens: readonly FutebolFixtureReasonItem[]) {
+  return {
+    slugsDePremissas: itens.filter((item) => !item.texto).map((item) => item.id),
+    motivosSemDrilldown: itens
+      .filter((item) => item.texto)
+      .map((item) => ({ t: item.texto as string })),
+  };
+}

--- a/src/utils/futebol-motivos.ts
+++ b/src/utils/futebol-motivos.ts
@@ -10,6 +10,6 @@ export function separarMotivosDoContrato(itens: readonly FutebolFixtureReasonIte
     slugsDePremissas: itens.filter((item) => !item.texto).map((item) => item.id),
     motivosSemDrilldown: itens
       .filter((item) => item.texto)
-      .map((item) => ({ t: item.texto as string })),
+      .map((item) => ({ t: item.texto as string, pontos: item.pontos })),
   };
 }

--- a/supabase/migrations/20260826103000_108_futebol_motivos_gols.sql
+++ b/supabase/migrations/20260826103000_108_futebol_motivos_gols.sql
@@ -1,0 +1,95 @@
+-- 20260826103000_108_futebol_motivos_gols
+-- Contrato de motivos para a tela: o backend escolhe o lado e o front apenas renderiza.
+create or replace function public.get_futebol_fixture_reason_contract(p_fixture_id bigint)
+returns table(
+  market text,
+  outcome text,
+  line_value double precision,
+  score integer,
+  componentes_score jsonb,
+  favor jsonb,
+  contra jsonb
+)
+language sql
+stable
+security definer
+set search_path to ''
+as $function$
+  with base as (
+    select
+      v.market, v.outcome, v.line_value, v.score, v.pts_valor, v.pts_premissas,
+      v.pts_corroboracao, v.penalidades as penalidades_score,
+      v.modelo_api_concorda, v.linha_sharp_confirma, v.avisos,
+      p.acesas, p.apagadas, p.penalidades as penalidades_ativas,
+      case v.outcome
+        when 'Over' then array[
+          'defesas_vazaveis', 'ataque_combinado', 'xg_combinado_alto',
+          'ambos_vazam', 'ritmo_alto', 'historico_over', 'linha_subindo'
+        ]::text[]
+        when 'Under' then array[
+          'defesas_firmes', 'xg_baixo_combinado', 'clean_sheets_altos',
+          'ataques_fracos', 'historico_under', 'linha_descendo'
+        ]::text[]
+        else array[]::text[]
+      end as aplicaveis
+    from public.get_futebol_fixture_value(p_fixture_id) v
+    join public.get_futebol_fixture_premissas(p_fixture_id) p
+      on p.market = v.market
+     and p.outcome = v.outcome
+     and p.line_value is not distinct from v.line_value
+    where v.market = 'goals_over_under'
+  )
+  select
+    b.market,
+    b.outcome,
+    b.line_value,
+    b.score,
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', id, 'texto', texto, 'pontos', pontos) order by ordem)
+      from (values
+        (1, 'premissas', 'Premissas', b.pts_premissas),
+        (2, 'valor_de_mercado', 'Valor de mercado', b.pts_valor),
+        (3, 'corroboracao', 'Corroboração', b.pts_corroboracao),
+        (4, 'penalidades', 'Penalidades', b.penalidades_score)
+      ) as componente(ordem, id, texto, pontos)
+      where pontos <> 0
+    ), '[]'::jsonb),
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'premissa') order by slug)
+      from unnest(b.acesas) slug
+      where slug = any(b.aplicaveis) and b.pts_premissas > 0
+    ), '[]'::jsonb)
+    || case when b.pts_valor > 0
+      then jsonb_build_array(jsonb_build_object(
+        'id', 'valor_de_mercado', 'tipo', 'componente_score',
+        'texto', 'A cotação oferece valor', 'pontos', b.pts_valor
+      ))
+      else '[]'::jsonb end
+    || case when b.pts_corroboracao > 0
+      then jsonb_build_array(jsonb_build_object(
+        'id', 'corroboracao', 'tipo', 'componente_score', 'pontos', b.pts_corroboracao,
+        'texto', case
+          when b.modelo_api_concorda and b.linha_sharp_confirma then 'Modelo e movimento de mercado confirmam a leitura'
+          when b.modelo_api_concorda then 'Modelo confirma a leitura'
+          when b.linha_sharp_confirma then 'Movimento de mercado confirma a leitura'
+          else 'Corroboração confirma a leitura'
+        end
+      ))
+      else '[]'::jsonb end,
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'premissa') order by slug)
+      from unnest(b.apagadas) slug
+      where slug = any(b.aplicaveis)
+    ), '[]'::jsonb)
+    || coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'penalidade') order by slug)
+      from unnest(b.penalidades_ativas) slug
+    ), '[]'::jsonb)
+    || coalesce((
+      select jsonb_agg(jsonb_build_object('id', 'aviso_' || ord, 'tipo', 'penalidade', 'texto', texto) order by ord)
+      from unnest(b.avisos) with ordinality as a(texto, ord)
+    ), '[]'::jsonb)
+  from base b;
+$function$;
+
+grant execute on function public.get_futebol_fixture_reason_contract(bigint) to anon, authenticated, service_role;


### PR DESCRIPTION
Closes #278

## O que muda
- cria um contrato de backend para os motivos de Gols, separando A favor e Contra sem inverter o lado oposto;
- usa o mesmo contrato nos contadores e nos detalhes da tela;
- explica a composição do score atual (por exemplo, 46 = 22 premissas + 16 valor + 8 corroboração);
- distingue confirmação por modelo de movimento de mercado;
- não recorre ao cálculo antigo do front se o contrato estiver indisponível.

## Validação
- Juventude × CRB / Mais de 1,5: consulta validada contra o banco de staging;
- suíte completa: 202 testes passaram (1 ignorado);
- build de staging concluído.