### PR TITLE
Futebol: levar contrato de motivos aos outros mercados

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -2353,7 +2353,7 @@ AS $function$
   order by 1, 5 nulls first, 4;
 $function$;
 
--- ── 5d. Contrato de motivos da leitura de Gols (migration 108) ───────────────
+-- ── 5d. Contrato de motivos da leitura dos cinco mercados (migration 109) ────
 -- O banco escolhe o grupo de cada motivo. A tela apenas renderiza o contrato,
 -- sem converter uma premissa do lado oposto em uma frase "contra".
 create or replace function public.get_futebol_fixture_reason_contract(p_fixture_id bigint)
@@ -2377,14 +2377,54 @@ as $function$
       v.pts_corroboracao, v.penalidades as penalidades_score,
       v.modelo_api_concorda, v.linha_sharp_confirma, v.avisos,
       p.acesas, p.apagadas, p.penalidades as penalidades_ativas,
-      case v.outcome
-        when 'Over' then array[
-          'defesas_vazaveis', 'ataque_combinado', 'xg_combinado_alto',
-          'ambos_vazam', 'ritmo_alto', 'historico_over', 'linha_subindo'
-        ]::text[]
-        when 'Under' then array[
-          'defesas_firmes', 'xg_baixo_combinado', 'clean_sheets_altos',
-          'ataques_fracos', 'historico_under', 'linha_descendo'
+      case v.market
+        when 'goals_over_under' then case v.outcome
+          when 'Over' then array[
+            'defesas_vazaveis', 'ataque_combinado', 'xg_combinado_alto',
+            'ambos_vazam', 'ritmo_alto', 'historico_over', 'linha_subindo'
+          ]::text[]
+          when 'Under' then array[
+            'defesas_firmes', 'xg_baixo_combinado', 'clean_sheets_altos',
+            'ataques_fracos', 'historico_under', 'linha_descendo'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'match_winner' then case v.outcome
+          when 'Home' then array[
+            'forma', 'mando', 'superioridade_tabela', 'forca_mismatch',
+            'superioridade_xg', 'h2h_favoravel', 'desfalque_adversario'
+          ]::text[]
+          when 'Away' then array[
+            'forma', 'mando', 'superioridade_tabela', 'forca_mismatch',
+            'superioridade_xg', 'h2h_favoravel', 'desfalque_adversario'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'asian_handicap' then case
+          -- A linha é guardada na ótica do mandante. Para o visitante, o
+          -- sinal representa a saída espelhada e precisa ser lido ao contrário.
+          when (v.outcome = 'Home' and v.line_value < 0)
+            or (v.outcome = 'Away' and v.line_value > 0) then array[
+            'tende_golear', 'supremacia', 'sem_rodizio',
+            'adversario_fragil_fora', 'mando_forte'
+          ]::text[]
+          when v.line_value <> 0 then array[
+            'defesa_fora_solida', 'raramente_perde_por_2'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'btts' then case v.outcome
+          when 'Yes' then array[
+            'ambos_marcam', 'ataque_dos_dois', 'defesas_vazaveis', 'historico_btts'
+          ]::text[]
+          when 'No' then array[
+            'defesa_forte', 'ataque_trava', 'historico_seco'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'double_chance' then array[
+          'lado_coberto_forte', 'equilibrio_defensivo',
+          'adversario_limitado', 'invicto_recente'
         ]::text[]
         else array[]::text[]
       end as aplicaveis
@@ -2393,7 +2433,6 @@ as $function$
       on p.market = v.market
      and p.outcome = v.outcome
      and p.line_value is not distinct from v.line_value
-    where v.market = 'goals_over_under'
   )
   select
     b.market,
@@ -2440,6 +2479,7 @@ as $function$
     || coalesce((
       select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'penalidade') order by slug)
       from unnest(b.penalidades_ativas) slug
+      where slug <> 'favorito_irregular'
     ), '[]'::jsonb)
     || coalesce((
       select jsonb_agg(jsonb_build_object('id', 'aviso_' || ord, 'tipo', 'penalidade', 'texto', texto) order by ord)

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -354,17 +354,18 @@ export function BancadaMercados({
     ? leituraDaCotacao(mercado.slug, principal.outcome, principal.line_value, valueRows, oddsRows)
     : { estado: 'sem_cotacao' as const, odd: null };
 
-  // Em Gols, o banco é a fonte do grupo de cada motivo. Ele evita transformar uma
-  // premissa do lado oposto em frase negativa e mantém contador e detalhe iguais.
+  // Nas saídas cotadas, o banco é a fonte do grupo de cada motivo. Ele evita
+  // transformar uma premissa do lado oposto em frase negativa e mantém contador
+  // e detalhe iguais nos cinco mercados.
   const contratoMotivos = useMemo((): FutebolFixtureReasonContractRow | null => {
-    if (!principal || mercado.slug !== 'goals_over_under') return null;
+    if (!principal) return null;
     return reasonContractRows?.find((r) =>
       r.market === principal.market &&
       r.outcome === principal.outcome &&
       mesmaLinha(r.line_value, principal.line_value),
     ) ?? null;
-  }, [reasonContractRows, principal, mercado.slug]);
-  const requerContratoMotivos = mercado.slug === 'goals_over_under' && valPrincipal != null;
+  }, [reasonContractRows, principal]);
+  const requerContratoMotivos = valPrincipal != null;
   const contratoMotivosIndisponivel = requerContratoMotivos && !contratoMotivos;
 
 

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -103,7 +103,7 @@ export function useFutebolFixturePremissas(fixtureId: number | undefined) {
   });
 }
 
-/** Motivos já agrupados pelo backend. Hoje cobre as saídas cotadas de Gols. */
+/** Motivos já agrupados pelo backend para qualquer saída cotada da Bancada. */
 export function useFutebolFixtureReasonContract(fixtureId: number | undefined) {
   return useQuery<FutebolFixtureReasonContractRow[]>({
     queryKey: ['futebol', 'fixture-reason-contract', fixtureId],

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -98,7 +98,7 @@ export interface FutebolFixtureScoreComponent {
 }
 
 /**
- * Motivos da saída cotada em Gols (RPC get_futebol_fixture_reason_contract).
+ * Motivos de qualquer saída cotada da Bancada (RPC get_futebol_fixture_reason_contract).
  * A separação favor/contra é autoridade do backend; não derive o lado pelo slug.
  */
 export interface FutebolFixtureReasonContractRow {
@@ -683,7 +683,7 @@ export const futebolDataService = {
     });
   },
 
-  /** Contrato de motivos da saída cotada. Hoje cobre apenas Gols (migration 108). */
+  /** Contrato de motivos da saída cotada nos cinco mercados (migration 109). */
   async getFixtureReasonContract(fixtureId: number): Promise<FutebolFixtureReasonContractRow[]> {
     return withRetry(async () => {
       const { data, error } = await supabaseClient.rpc('get_futebol_fixture_reason_contract', {

--- a/src/utils/futebol-motivos.test.ts
+++ b/src/utils/futebol-motivos.test.ts
@@ -49,4 +49,58 @@ describe('separarMotivosDoContrato', () => {
     expect(contratoJuventudeCrbOver15.componentes_score.reduce((total, componente) => total + componente.pontos, 0))
       .toBe(contratoJuventudeCrbOver15.score);
   });
+
+  it('declara o lado aplicável dos outros quatro mercados no contrato do backend', () => {
+    const migration = readFileSync(resolve(__dirname, '../../supabase/migrations/20260826113000_109_futebol_motivos_outros_mercados.sql'), 'utf8');
+
+    expect(migration).toMatch(/when 'match_winner' then case v\.outcome[\s\S]*when 'Home' then array\[[\s\S]*when 'Away' then array\[[\s\S]*else array\[\]::text\[\]/);
+    expect(migration).toMatch(/when 'asian_handicap' then case[\s\S]*v\.outcome = 'Home' and v\.line_value < 0[\s\S]*v\.outcome = 'Away' and v\.line_value > 0[\s\S]*when v\.line_value <> 0 then array\[/);
+    expect(migration).toMatch(/when 'btts' then case v\.outcome[\s\S]*when 'Yes' then array\[[\s\S]*when 'No' then array\[/);
+    expect(migration).toContain("when 'double_chance' then array[");
+    expect(migration).toContain("where slug <> 'favorito_irregular'");
+    expect(migration).not.toContain("where v.market = 'goals_over_under'");
+  });
+
+  it.each([
+    {
+      mercado: 'Resultado',
+      favor: [{ id: 'mando', tipo: 'premissa' }],
+      contra: [
+        { id: 'forma', tipo: 'premissa' },
+        { id: 'aviso_1', tipo: 'penalidade', texto: 'A escalação reduz a confiança' },
+      ],
+    },
+    {
+      mercado: 'Handicap asiático',
+      favor: [{ id: 'mando_forte', tipo: 'premissa' }],
+      contra: [
+        { id: 'supremacia', tipo: 'premissa' },
+        { id: 'handicap_alto', tipo: 'penalidade' },
+      ],
+    },
+    {
+      mercado: 'Ambos marcam',
+      favor: [{ id: 'defesa_forte', tipo: 'premissa' }],
+      contra: [
+        { id: 'ataque_trava', tipo: 'premissa' },
+        { id: 'aviso_1', tipo: 'penalidade', texto: 'Dado de mercado pede cautela' },
+      ],
+    },
+    {
+      mercado: 'Dupla chance',
+      favor: [{ id: 'equilibrio_defensivo', tipo: 'premissa' }],
+      contra: [
+        { id: 'lado_coberto_forte', tipo: 'premissa' },
+        { id: 'aviso_1', tipo: 'penalidade', texto: 'Mercado com liquidez reduzida' },
+      ],
+    },
+  ] as const)('$mercado mantém favor, contra e alerta separados', ({ favor, contra }) => {
+    const motivosFavor = separarMotivosDoContrato(favor);
+    const motivosContra = separarMotivosDoContrato(contra);
+
+    expect(motivosFavor.slugsDePremissas).toEqual([favor[0].id]);
+    expect(motivosContra.slugsDePremissas).toContain(contra[0].id);
+    expect(motivosContra.slugsDePremissas.length + motivosContra.motivosSemDrilldown.length)
+      .toBe(contra.length);
+  });
 });

--- a/supabase/migrations/20260826113000_109_futebol_motivos_outros_mercados.sql
+++ b/supabase/migrations/20260826113000_109_futebol_motivos_outros_mercados.sql
@@ -1,0 +1,136 @@
+-- 20260826113000_109_futebol_motivos_outros_mercados
+-- Estende o contrato de motivos para os cinco mercados da Bancada.
+-- O backend escolhe as razões aplicáveis à saída; o front não reconstrói direção.
+create or replace function public.get_futebol_fixture_reason_contract(p_fixture_id bigint)
+returns table(
+  market text,
+  outcome text,
+  line_value double precision,
+  score integer,
+  componentes_score jsonb,
+  favor jsonb,
+  contra jsonb
+)
+language sql
+stable
+security definer
+set search_path to ''
+as $function$
+  with base as (
+    select
+      v.market, v.outcome, v.line_value, v.score, v.pts_valor, v.pts_premissas,
+      v.pts_corroboracao, v.penalidades as penalidades_score,
+      v.modelo_api_concorda, v.linha_sharp_confirma, v.avisos,
+      p.acesas, p.apagadas, p.penalidades as penalidades_ativas,
+      case v.market
+        when 'goals_over_under' then case v.outcome
+          when 'Over' then array[
+            'defesas_vazaveis', 'ataque_combinado', 'xg_combinado_alto',
+            'ambos_vazam', 'ritmo_alto', 'historico_over', 'linha_subindo'
+          ]::text[]
+          when 'Under' then array[
+            'defesas_firmes', 'xg_baixo_combinado', 'clean_sheets_altos',
+            'ataques_fracos', 'historico_under', 'linha_descendo'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'match_winner' then case v.outcome
+          when 'Home' then array[
+            'forma', 'mando', 'superioridade_tabela', 'forca_mismatch',
+            'superioridade_xg', 'h2h_favoravel', 'desfalque_adversario'
+          ]::text[]
+          when 'Away' then array[
+            'forma', 'mando', 'superioridade_tabela', 'forca_mismatch',
+            'superioridade_xg', 'h2h_favoravel', 'desfalque_adversario'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'asian_handicap' then case
+          -- A linha é guardada na ótica do mandante. Para o visitante, o
+          -- sinal representa a saída espelhada e precisa ser lido ao contrário.
+          when (v.outcome = 'Home' and v.line_value < 0)
+            or (v.outcome = 'Away' and v.line_value > 0) then array[
+            'tende_golear', 'supremacia', 'sem_rodizio',
+            'adversario_fragil_fora', 'mando_forte'
+          ]::text[]
+          when v.line_value <> 0 then array[
+            'defesa_fora_solida', 'raramente_perde_por_2'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'btts' then case v.outcome
+          when 'Yes' then array[
+            'ambos_marcam', 'ataque_dos_dois', 'defesas_vazaveis', 'historico_btts'
+          ]::text[]
+          when 'No' then array[
+            'defesa_forte', 'ataque_trava', 'historico_seco'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'double_chance' then array[
+          'lado_coberto_forte', 'equilibrio_defensivo',
+          'adversario_limitado', 'invicto_recente'
+        ]::text[]
+        else array[]::text[]
+      end as aplicaveis
+    from public.get_futebol_fixture_value(p_fixture_id) v
+    join public.get_futebol_fixture_premissas(p_fixture_id) p
+      on p.market = v.market
+     and p.outcome = v.outcome
+     and p.line_value is not distinct from v.line_value
+  )
+  select
+    b.market,
+    b.outcome,
+    b.line_value,
+    b.score,
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', id, 'texto', texto, 'pontos', pontos) order by ordem)
+      from (values
+        (1, 'premissas', 'Premissas', b.pts_premissas),
+        (2, 'valor_de_mercado', 'Valor de mercado', b.pts_valor),
+        (3, 'corroboracao', 'Corroboração', b.pts_corroboracao),
+        (4, 'penalidades', 'Penalidades', b.penalidades_score)
+      ) as componente(ordem, id, texto, pontos)
+      where pontos <> 0
+    ), '[]'::jsonb),
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'premissa') order by slug)
+      from unnest(b.acesas) slug
+      where slug = any(b.aplicaveis) and b.pts_premissas > 0
+    ), '[]'::jsonb)
+    || case when b.pts_valor > 0
+      then jsonb_build_array(jsonb_build_object(
+        'id', 'valor_de_mercado', 'tipo', 'componente_score',
+        'texto', 'A cotação oferece valor', 'pontos', b.pts_valor
+      ))
+      else '[]'::jsonb end
+    || case when b.pts_corroboracao > 0
+      then jsonb_build_array(jsonb_build_object(
+        'id', 'corroboracao', 'tipo', 'componente_score', 'pontos', b.pts_corroboracao,
+        'texto', case
+          when b.modelo_api_concorda and b.linha_sharp_confirma then 'Modelo e movimento de mercado confirmam a leitura'
+          when b.modelo_api_concorda then 'Modelo confirma a leitura'
+          when b.linha_sharp_confirma then 'Movimento de mercado confirma a leitura'
+          else 'Corroboração confirma a leitura'
+        end
+      ))
+      else '[]'::jsonb end,
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'premissa') order by slug)
+      from unnest(b.apagadas) slug
+      where slug = any(b.aplicaveis)
+    ), '[]'::jsonb)
+    || coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'penalidade') order by slug)
+      from unnest(b.penalidades_ativas) slug
+      where slug <> 'favorito_irregular'
+    ), '[]'::jsonb)
+    || coalesce((
+      select jsonb_agg(jsonb_build_object('id', 'aviso_' || ord, 'tipo', 'penalidade', 'texto', texto) order by ord)
+      from unnest(b.avisos) with ordinality as a(texto, ord)
+    ), '[]'::jsonb)
+  from base b;
+$function$;
+
+grant execute on function public.get_futebol_fixture_reason_contract(bigint) to anon, authenticated, service_role;


### PR DESCRIPTION
Closes #279. Estende o contrato de motivos para Resultado, Handicap asiático, Ambos Marcam e Dupla Chance; a tela usa o backend em toda saída cotada. Validações: 208 testes passaram; build de staging passou; migração verificada no ambiente de testes com Resultado (fixture 1575475), Handicap favorito (1575475) e visitante (1552745). Ambos Marcam e Dupla Chance ainda não têm saída cotada nesse ambiente, mas o contrato já cobre as regras.