### PR TITLE
feat(futebol): completar contexto da Bancada

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -34,6 +34,7 @@ import { leituraDaCotacao } from '@/utils/futebol-cotacao';
 import { separarMotivosDoContrato } from '@/utils/futebol-motivos';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { hasKickoffPassed, isFinished, parseUtc } from '@/utils/futebol-datas';
+import { linhaDaSaida } from '@/utils/futebol-saida';
 import type { MatchupTendencies } from '@/utils/futebol-tendencias';
 import type { JogoInfo } from './JogoResumo';
 
@@ -535,6 +536,11 @@ export function BancadaMercados({
   }
 
   const pickAtual = labelDe(principal);
+  const linhaExibida = linhaDaSaida({
+    market: mercado.slug,
+    outcome: principal?.outcome ?? 'Home',
+    line_value: linha,
+  });
   const cotacaoDoDraft = cotacaoPrincipal.estado === 'oportunidade'
     ? { bestOdd: cotacaoPrincipal.odd, oddKind: 'melhor' as const }
     : cotacaoPrincipal.estado === 'cotada'
@@ -726,6 +732,14 @@ export function BancadaMercados({
                     Cotada · fora dos filtros
                   </span>
                 )}
+                {cotacaoPrincipal.estado === 'oportunidade' && (
+                  <span
+                    className="inline-flex shrink-0 items-center min-h-5 px-2.5 py-1 rounded-full whitespace-nowrap text-[9px] font-bold uppercase leading-none tracking-[0.08em]"
+                    style={{ background: '#fbbf24', color: '#1a1d1a' }}
+                  >
+                    Oportunidade
+                  </span>
+                )}
                 {cotacaoPrincipal.estado === 'sem_cotacao' && (
                   <span
                     className="inline-flex shrink-0 items-center min-h-5 px-2.5 py-1 rounded-full whitespace-nowrap text-[9px] font-bold uppercase leading-none tracking-[0.08em]"
@@ -777,7 +791,6 @@ export function BancadaMercados({
                   )}
                 </div>
               </div>
-              {cotacaoPrincipal.estado !== 'cotada' && (
               <div className="text-center pl-6 min-w-[128px]" style={{ borderLeft: '1px solid rgba(255,255,255,.15)' }}>
                 <div className="tabular-nums text-[44px] font-bold leading-none tracking-[-0.04em]" style={{ color: '#fbbf24' }}>
                   {valPrincipal ? <Blur active={locked}>{String(valPrincipal.score)}</Blur> : nPrincipal}
@@ -788,7 +801,6 @@ export function BancadaMercados({
                     : 'premissas a favor'}
                 </div>
               </div>
-              )}
             </div>
           </div>
 
@@ -835,13 +847,16 @@ export function BancadaMercados({
                 {/* O número antes da trilha: com ele depois, no celular a régua
                     quebrava a linha e o valor ficava sozinho, solto embaixo. */}
                 <span className="tabular-nums text-[22px] font-bold leading-none shrink-0 min-w-[58px]" style={{ color: '#fbbf24' }}>
-                  {linha != null ? fmtLinha(linha, ehAH) : '—'}
+                  {linhaExibida != null ? fmtLinha(linhaExibida, ehAH) : '—'}
                 </span>
                 <ReguaLinhas
                   paradas={paradas}
                   valor={linha}
                   onEscolher={setLinha}
-                  rotulo={(v) => fmtLinha(v, ehAH)}
+                  rotulo={(v) => fmtLinha(
+                    linhaDaSaida({ market: mercado.slug, outcome: principal?.outcome ?? 'Home', line_value: v }) ?? v,
+                    ehAH,
+                  )}
                   destaque={candidatoInicialDoMercado?.line_value ?? null}
                   forca={forcaPorLinha}
                 />

--- a/src/components/futebol/RegistrarAposta.tsx
+++ b/src/components/futebol/RegistrarAposta.tsx
@@ -14,9 +14,10 @@ import { Receipt, Check, Loader2, ArrowRight } from 'lucide-react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { createClient } from '@/integrations/supabase/client';
 import { useAuth } from '@/hooks/use-auth';
+import { useUserUnit } from '@/hooks/use-user-unit';
 import { pickLabel, marketLabel } from '@/utils/futebol-score';
 import { competitionLabel } from '@/utils/futebol-competitions';
-import type { FutebolBetDraft } from './registrar-aposta-utils';
+import { atalhosDaUnidade, type FutebolBetDraft } from './registrar-aposta-utils';
 
 function kickoffDate(raw: string | null): string | null {
   if (!raw) return null;
@@ -32,6 +33,7 @@ export function RegistrarApostaModal({
   open, onOpenChange, draft,
 }: { open: boolean; onOpenChange: (o: boolean) => void; draft: FutebolBetDraft | null }) {
   const { user } = useAuth();
+  const { config: unidade } = useUserUnit();
   const [stake, setStake] = useState('');
   const [odd, setOdd] = useState('');
   const [saving, setSaving] = useState(false);
@@ -59,6 +61,7 @@ export function RegistrarApostaModal({
   const oddN = parseFloat(odd.replace(',', '.'));
   const valid = !isNaN(stakeN) && stakeN > 0 && !isNaN(oddN) && oddN > 1;
   const retorno = valid ? stakeN * oddN : null;
+  const atalhos = atalhosDaUnidade(unidade.unit_value);
 
   const handleSave = async () => {
     if (!draft || !user?.id || !valid) return;
@@ -147,6 +150,22 @@ export function RegistrarApostaModal({
                 />
               </label>
             </div>
+
+            {atalhos.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2 -mt-1">
+                <span className="text-[11px] font-semibold text-ink-3 mr-0.5">Usar unidade</span>
+                {atalhos.map((atalho) => (
+                  <button
+                    key={atalho.unidades}
+                    type="button"
+                    onClick={() => setStake(atalho.valor.toFixed(2))}
+                    className="h-8 px-3 rounded-rebrand-sm border border-forest/20 bg-forest/5 text-[11.5px] font-semibold text-forest hover:bg-forest/10 transition"
+                  >
+                    {atalho.unidades === 1 ? '1 unidade' : '½ unidade'} · {fmtBRL(atalho.valor)}
+                  </button>
+                ))}
+              </div>
+            )}
             <p className="text-[11px] text-ink-3 -mt-2">
               {draft?.oddKind === 'referencia'
                 ? `Confirme a cotação na sua casa antes de registrar. A referência coletada foi ${draft.bestOdd?.toFixed(2)}.`

--- a/src/components/futebol/registrar-aposta-utils.test.ts
+++ b/src/components/futebol/registrar-aposta-utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { atalhosDaUnidade } from './registrar-aposta-utils';
+
+describe('atalhosDaUnidade', () => {
+  it('oferece uma unidade e meia unidade a partir da configuração do Betinho', () => {
+    expect(atalhosDaUnidade(80)).toEqual([
+      { unidades: 1, valor: 80 },
+      { unidades: 0.5, valor: 40 },
+    ]);
+  });
+
+  it('não inventa atalhos sem uma unidade válida', () => {
+    expect(atalhosDaUnidade(null)).toEqual([]);
+    expect(atalhosDaUnidade(0)).toEqual([]);
+  });
+});

--- a/src/components/futebol/registrar-aposta-utils.ts
+++ b/src/components/futebol/registrar-aposta-utils.ts
@@ -18,6 +18,20 @@ export type FutebolBetDraft = FutebolBetDraftBase & (
   | { bestOdd: null; oddKind: 'sem_cotacao' }
 );
 
+export interface AtalhoDeUnidade {
+  unidades: 0.5 | 1;
+  valor: number;
+}
+
+/** Atalhos só existem quando a unidade efetiva do Betinho é válida. */
+export function atalhosDaUnidade(unitValue: number | null | undefined): AtalhoDeUnidade[] {
+  if (unitValue == null || !Number.isFinite(unitValue) || unitValue <= 0) return [];
+  return [
+    { unidades: 1, valor: unitValue },
+    { unidades: 0.5, valor: unitValue / 2 },
+  ];
+}
+
 /**
  * Monta o draft a partir de uma linha do board de oportunidades. Aceita
  * qualquer linha que tenha estes campos (o histórico monta linha de

--- a/src/utils/futebol-premissas.ts
+++ b/src/utils/futebol-premissas.ts
@@ -1,5 +1,5 @@
 import type { FutebolFixturePremissas } from '@/services/futebol-data.service';
-import type { Saida } from '@/utils/futebol-saida';
+import { linhaDaSaida, type Saida } from '@/utils/futebol-saida';
 
 // Catálogo das premissas do Score: rótulo, peso e agrupamento.
 //
@@ -332,7 +332,7 @@ export function outcomeLabel(s: Saida, home: string, away: string): string {
     // `line` vem na ótica do mandante (mesma convenção do pickLabel e da liquidação):
     // o handicap do visitante é o oposto, senão o card do Vasco dizia "Vasco −1,5"
     // numa linha em que ele recebe +1,5.
-    const daSaida = line != null ? (outcome === 'Away' ? -line : line) : null;
+    const daSaida = linhaDaSaida(s);
     const time = outcome === 'Home' ? home : away;
     return daSaida != null ? `${time} ${daSaida > 0 ? '+' : '−'}${fmtLinha(Math.abs(daSaida))}` : time;
   }

--- a/src/utils/futebol-saida.test.ts
+++ b/src/utils/futebol-saida.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { linhaDaSaida } from './futebol-saida';
+
+describe('linhaDaSaida', () => {
+  it('espelha o handicap para a ótica do visitante', () => {
+    expect(linhaDaSaida({ market: 'asian_handicap', outcome: 'Away', line_value: -2.5 })).toBe(2.5);
+  });
+
+  it('mantém a linha do mandante e as linhas de outros mercados', () => {
+    expect(linhaDaSaida({ market: 'asian_handicap', outcome: 'Home', line_value: -2.5 })).toBe(-2.5);
+    expect(linhaDaSaida({ market: 'goals_over_under', outcome: 'Over', line_value: 2.5 })).toBe(2.5);
+  });
+});

--- a/src/utils/futebol-saida.ts
+++ b/src/utils/futebol-saida.ts
@@ -18,3 +18,12 @@ export interface Saida {
   outcome: string;
   line_value: number | null;
 }
+
+/**
+ * Linha na ótica do time escolhido. O banco normaliza o handicap pela ótica do
+ * mandante; quem escolhe o visitante recebe o sinal oposto na tela.
+ */
+export function linhaDaSaida({ market, outcome, line_value }: Saida): number | null {
+  if (market === 'asian_handicap' && outcome === 'Away' && line_value != null) return -line_value;
+  return line_value;
+}

--- a/src/utils/futebol-score.ts
+++ b/src/utils/futebol-score.ts
@@ -1,7 +1,7 @@
 // ============================================================
 // futebol-score.ts — apresentação do Score (motor é backend)
 // ============================================================
-import type { Saida } from '@/utils/futebol-saida';
+import { linhaDaSaida, type Saida } from '@/utils/futebol-saida';
 // O Score, edge, premissas, evidências e avisos vêm prontos da
 // fact_value_opportunities (pipeline dbt no BigQuery). Aqui só ROTULAMOS
 // (mercado, pick com linha) e ajudamos a ranquear/agrupar. Nada de cálculo.
@@ -96,8 +96,7 @@ export function pickLabel(s: Saida, homeName: string, awayName: string): string 
   }
   if (market === 'asian_handicap') {
     const team = outcome === 'Home' ? homeName : awayName;
-    // line_value vem na ótica do mandante; pro visitante o handicap do próprio time é o oposto.
-    const sideLine = line != null ? (outcome === 'Away' ? -line : line) : null;
+    const sideLine = linhaDaSaida(s);
     return sideLine != null ? `${team} ${fmtHandicapLine(sideLine)}` : team;
   }
   if (market === 'btts') {


### PR DESCRIPTION
## O que mudou\n- candidata cotada mostra o número de premissas a favor, sem score, chance ou vantagem\n- oportunidade ganhou tag dourada explícita\n- modal do Betinho oferece atalhos de 1 unidade e ½ unidade, mantendo valor e odd editáveis\n- handicap do visitante mostra o mesmo sinal no título e na régua\n\n## Validação\n- 
pm run test:run -- src/utils/futebol-saida.test.ts src/components/futebol/registrar-aposta-utils.test.ts src/utils/futebol-cotacao.test.ts\n- 
px eslint nos arquivos alterados\n- 
pm run build\n\nCloses #286.