### PR TITLE
fix(futebol): abrir Oportunidades no dia atual

### DIFF
--- a/src/components/FutebolDayStepper.test.tsx
+++ b/src/components/FutebolDayStepper.test.tsx
@@ -1,0 +1,36 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import FutebolDayStepper from './FutebolDayStepper';
+
+describe('FutebolDayStepper', () => {
+  const scrollIntoView = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-26T15:00:00Z'));
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    scrollIntoView.mockReset();
+  });
+
+  it('posiciona o dia selecionado imediatamente na primeira abertura', () => {
+    render(
+      <FutebolDayStepper
+        days={['2026-07-28', '2026-08-11', '2026-08-26', '2026-08-27']}
+        value="2026-08-26"
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(scrollIntoView).toHaveBeenCalledWith(expect.objectContaining({
+      inline: 'center',
+      behavior: 'auto',
+    }));
+  });
+});

--- a/src/components/FutebolDayStepper.tsx
+++ b/src/components/FutebolDayStepper.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useLayoutEffect } from 'react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 const TZ = 'America/Sao_Paulo';
@@ -37,11 +37,20 @@ export default function FutebolDayStepper({
   days, value, onChange, counts, className = '',
 }: { days: string[]; value: string; onChange: (d: string) => void; counts?: Record<string, number>; className?: string }) {
   const activeRef = useRef<HTMLButtonElement>(null);
-  // Mantém o dia selecionado sempre visível (centralizado) — navegação fluida.
-  useEffect(() => {
+  const jaPosicionou = useRef(false);
+  // Na primeira abertura a régua pode ter dezenas de dias e começar lá no
+  // histórico. Posiciona antes da pintura para não mostrar essa janela antiga;
+  // depois disso, as trocas feitas pelo usuário continuam com animação suave.
+  useLayoutEffect(() => {
+    if (!activeRef.current) return;
     const reduce = typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
-    activeRef.current?.scrollIntoView({ inline: 'center', block: 'nearest', behavior: reduce ? 'auto' : 'smooth' });
-  }, [value]);
+    activeRef.current.scrollIntoView({
+      inline: 'center',
+      block: 'nearest',
+      behavior: reduce || !jaPosicionou.current ? 'auto' : 'smooth',
+    });
+    jaPosicionou.current = true;
+  }, [value, days.length]);
 
   if (!days.length) return null;
   const today = todayStr();

--- a/src/components/futebol/RegistrarAposta.tsx
+++ b/src/components/futebol/RegistrarAposta.tsx
@@ -152,16 +152,17 @@ export function RegistrarApostaModal({
             </div>
 
             {atalhos.length > 0 && (
-              <div className="flex flex-wrap items-center gap-2 -mt-1">
-                <span className="text-[11px] font-semibold text-ink-3 mr-0.5">Usar unidade</span>
+              <div className="flex flex-nowrap items-center gap-1.5 -mt-1">
+                <span className="shrink-0 text-[11px] font-semibold text-ink-3">Unidade</span>
                 {atalhos.map((atalho) => (
                   <button
                     key={atalho.unidades}
                     type="button"
                     onClick={() => setStake(atalho.valor.toFixed(2))}
-                    className="h-8 px-3 rounded-rebrand-sm border border-forest/20 bg-forest/5 text-[11.5px] font-semibold text-forest hover:bg-forest/10 transition"
+                    className="h-8 shrink-0 whitespace-nowrap px-2.5 rounded-rebrand-sm border border-forest/20 bg-forest/5 text-[11.5px] font-semibold text-forest hover:bg-forest/10 transition"
                   >
-                    {atalho.unidades === 1 ? '1 unidade' : '½ unidade'} · {fmtBRL(atalho.valor)}
+                    <span className="sm:hidden">{atalho.unidades === 1 ? '1 un.' : '½ un.'} · {fmtBRL(atalho.valor)}</span>
+                    <span className="hidden sm:inline">{atalho.unidades === 1 ? '1 unidade' : '½ unidade'} · {fmtBRL(atalho.valor)}</span>
                   </button>
                 ))}
               </div>


### PR DESCRIPTION
## O que muda
- A régua de datas abre já centralizada no dia selecionado, sem exibir o histórico antes de chegar em Hoje.
- Os atalhos de 1 e ½ unidade ficam em uma única linha no celular.

## Verificação
- Validação visual no localhost.
- Testes focados passaram.