### PR TITLE
feat(futebol): alertar oportunidades publicadas

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -55,6 +55,7 @@ jobs:
           supabase functions deploy winback-backfill --no-verify-jwt
           supabase functions deploy notify-handoff --no-verify-jwt
           supabase functions deploy notify-opportunities --no-verify-jwt
+          supabase functions deploy notify-published-opportunities --no-verify-jwt
           supabase functions deploy go --no-verify-jwt
           supabase functions deploy mirror-futebol-team-logos --no-verify-jwt
           supabase functions deploy mirror-futebol-player-photos --no-verify-jwt

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -55,6 +55,7 @@ jobs:
           supabase functions deploy winback-backfill --no-verify-jwt
           supabase functions deploy notify-handoff --no-verify-jwt
           supabase functions deploy notify-opportunities --no-verify-jwt
+          supabase functions deploy notify-published-opportunities --no-verify-jwt
           supabase functions deploy go --no-verify-jwt
           supabase functions deploy mirror-futebol-team-logos --no-verify-jwt
           supabase functions deploy mirror-futebol-player-photos --no-verify-jwt

--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -2488,6 +2488,131 @@ as $function$
   from base b;
 $function$;
 
+-- ── 5e. Alertas de publicação no Telegram (migration 111) ───────────────────
+-- São RPCs internas da Edge Function; não expor a anon/autenticated.
+CREATE OR REPLACE FUNCTION public.claim_futebol_publication_alert_batch(
+  p_sync_at timestamptz,
+  p_opportunities jsonb
+)
+RETURNS TABLE(batch_id uuid, alert_id uuid, opportunity_key text)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_batch_id uuid;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('futebol-publication-alerts'));
+
+  WITH incoming AS (
+    SELECT * FROM jsonb_to_recordset(p_opportunities) AS x(
+      opportunity_key text, fixture_id bigint, home_team_name text,
+      away_team_name text, competition text, kickoff_utc timestamptz,
+      market text, outcome text, line_value double precision, best_odd numeric,
+      score integer, faixa text, janela_usada text, edge double precision,
+      prob_justa_fechamento double precision, evidencias text[]
+    )
+  )
+  INSERT INTO public.futebol_publication_alert_batches (sync_at)
+  SELECT p_sync_at WHERE EXISTS (
+    SELECT 1 FROM incoming i WHERE NOT EXISTS (
+      SELECT 1 FROM public.futebol_publication_alerts a
+      WHERE a.opportunity_key = i.opportunity_key
+    )
+  )
+  RETURNING id INTO v_batch_id;
+
+  IF v_batch_id IS NULL THEN RETURN; END IF;
+
+  RETURN QUERY
+  WITH incoming AS (
+    SELECT * FROM jsonb_to_recordset(p_opportunities) AS x(
+      opportunity_key text, fixture_id bigint, home_team_name text,
+      away_team_name text, competition text, kickoff_utc timestamptz,
+      market text, outcome text, line_value double precision, best_odd numeric,
+      score integer, faixa text, janela_usada text, edge double precision,
+      prob_justa_fechamento double precision, evidencias text[]
+    )
+  ), inserted AS (
+    INSERT INTO public.futebol_publication_alerts (
+      batch_id, opportunity_key, fixture_id, home_team_name, away_team_name,
+      competition, kickoff_utc, market, outcome, line_value, best_odd, score,
+      faixa, janela_usada, edge, prob_justa_fechamento, evidencias
+    )
+    SELECT v_batch_id, i.opportunity_key, i.fixture_id, i.home_team_name,
+      i.away_team_name, i.competition, i.kickoff_utc, i.market, i.outcome,
+      i.line_value, i.best_odd, i.score, i.faixa, i.janela_usada, i.edge,
+      i.prob_justa_fechamento, i.evidencias
+    FROM incoming i ON CONFLICT (opportunity_key) DO NOTHING
+    RETURNING id, opportunity_key
+  )
+  SELECT v_batch_id, i.id, i.opportunity_key FROM inserted i;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.get_futebol_publication_alert_recipients()
+RETURNS TABLE(user_id uuid, chat_id text, user_name text)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  SELECT u.id, u.telegram_chat_id::text, u.name::text
+  FROM public.users u
+  WHERE u.telegram_chat_id IS NOT NULL
+    AND (
+      coalesce(u.futebol_subscription_status, 'free') = 'premium'
+      OR (
+        u.futebol_trial_started_at IS NOT NULL
+        AND u.futebol_trial_started_at + interval '7 days' > now()
+      )
+    );
+$function$;
+
+CREATE OR REPLACE FUNCTION public.claim_futebol_publication_alert_deliveries()
+RETURNS TABLE(batch_id uuid, user_id uuid, chat_id text, attempt_id uuid, opportunities jsonb)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+BEGIN
+  UPDATE public.futebol_publication_alert_deliveries d
+  SET status = 'expired', attempt_id = NULL, claimed_at = NULL
+  WHERE d.status IN ('pending', 'failed', 'processing')
+    AND NOT EXISTS (
+      SELECT 1 FROM public.futebol_publication_alerts a
+      WHERE a.batch_id = d.batch_id AND a.kickoff_utc > now()
+    );
+
+  RETURN QUERY
+  WITH claimed AS (
+    UPDATE public.futebol_publication_alert_deliveries d
+    SET status = 'processing', attempts = d.attempts + 1,
+        attempt_id = gen_random_uuid(), claimed_at = now(), last_attempt_at = now()
+    FROM public.users u
+    WHERE d.user_id = u.id
+      AND d.status IN ('pending', 'failed')
+      AND u.telegram_chat_id IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM public.futebol_publication_alerts a
+        WHERE a.batch_id = d.batch_id AND a.kickoff_utc > now()
+      )
+      AND (
+        coalesce(u.futebol_subscription_status, 'free') = 'premium'
+        OR (u.futebol_trial_started_at IS NOT NULL
+          AND u.futebol_trial_started_at + interval '7 days' > now())
+      )
+    RETURNING d.batch_id, d.user_id, u.telegram_chat_id::text, d.attempt_id
+  )
+  SELECT c.batch_id, c.user_id, c.telegram_chat_id, c.attempt_id,
+    jsonb_agg(jsonb_build_object(
+      'alert_id', a.id, 'fixture_id', a.fixture_id,
+      'home_team_name', a.home_team_name, 'away_team_name', a.away_team_name,
+      'competition', a.competition, 'kickoff_utc', a.kickoff_utc,
+      'market', a.market, 'outcome', a.outcome, 'line_value', a.line_value,
+      'best_odd', a.best_odd, 'score', a.score, 'faixa', a.faixa,
+      'evidencias', a.evidencias
+    ) ORDER BY a.score DESC)
+  FROM claimed c
+  JOIN public.futebol_publication_alerts a ON a.batch_id = c.batch_id
+  WHERE a.kickoff_utc > now()
+  GROUP BY c.batch_id, c.user_id, c.telegram_chat_id, c.attempt_id;
+END;
+$function$;
+
 -- ── 6. Grants de execução (anon / authenticated / service_role) ──────────────
 grant execute on function public._futebol_team_form(p_team_id bigint, p_competition text, p_season bigint, p_before date) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_access() to anon, authenticated, service_role;
@@ -2520,6 +2645,12 @@ grant execute on function public.get_futebol_fixture_premissas(p_fixture_id bigi
 grant execute on function public.get_futebol_fixture_numeros(p_fixture_id bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_historico(p_fixture_id bigint, p_max integer) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_reason_contract(p_fixture_id bigint) to anon, authenticated, service_role;
+revoke all on function public.claim_futebol_publication_alert_batch(timestamptz, jsonb) from public, anon, authenticated;
+grant execute on function public.claim_futebol_publication_alert_batch(timestamptz, jsonb) to service_role;
+revoke all on function public.get_futebol_publication_alert_recipients() from public, anon, authenticated;
+grant execute on function public.get_futebol_publication_alert_recipients() to service_role;
+revoke all on function public.claim_futebol_publication_alert_deliveries() from public, anon, authenticated;
+grant execute on function public.claim_futebol_publication_alert_deliveries() to service_role;
 
 -- ── 7. Reverse trial (7 dias, sem cartão) — colunas no public.users ──────────
 alter table public.users add column if not exists futebol_trial_started_at timestamptz;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -27,6 +27,10 @@ verify_jwt = false
 # Job de cron (aviso de kickoff no Telegram do dono) — header x-cron-secret (CRON_SECRET).
 verify_jwt = false
 
+[functions.notify-published-opportunities]
+# Job de cron: alerta uma Oportunidade recém-publicada no painel.
+verify_jwt = false
+
 [functions.ingest-wc-squads]
 # Ingestão de elencos sob demanda — protegida pelo header x-cron-secret (CRON_SECRET).
 verify_jwt = false

--- a/supabase/functions/go/index.ts
+++ b/supabase/functions/go/index.ts
@@ -8,6 +8,7 @@
 //
 // URL: /go?u=<user_id>&d=<dest>&s=<hmac>&c=<campanha?>
 //   dest permitidos: "board" → /futebol · "jogo-<id>" → /futebol/jogo/<id>
+//                    · "jogo-<id>|mercado|saída|linha" → leitura exata
 //                    · "bank" → /bets (resumo semanal, item 04)
 //   c = campanha (default "daily_opportunities" p/ retrocompat). Só a campanha
 //       do daily zera a régua de reativação (opportunity_dispatch_state).
@@ -25,22 +26,45 @@ import { generateTraceId, trackEvent } from "../shared/posthog.ts";
 const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
 const SITE = "https://www.smartbetting.app";
 const DAILY_CAMPAIGN = "daily_opportunities";
+const PUBLISHED_CAMPAIGN = "published_opportunities";
 
 function destUrl(dest: string, campaign: string): string {
-  const utm = `utm_source=telegram&utm_campaign=${encodeURIComponent(campaign)}`;
+  const utm = `utm_source=telegram&utm_campaign=${
+    encodeURIComponent(campaign)
+  }`;
   if (dest === "board") return `${SITE}/futebol?${utm}`;
   if (dest === "bank") return `${SITE}/bets?${utm}`;
-  const jogo = dest.match(/^jogo-(\d+)$/);
-  if (jogo) return `${SITE}/futebol/jogo/${jogo[1]}?${utm}`;
+  const jogo = dest.match(/^jogo-(\d+)(?:\|([^|]+)\|([^|]+)\|([^|]*))?$/);
+  if (jogo) {
+    const params = new URLSearchParams({
+      utm_source: "telegram",
+      utm_campaign: campaign,
+    });
+    if (jogo[2] && jogo[3]) {
+      params.set("mercado", jogo[2]);
+      params.set("saida", jogo[3]);
+      if (jogo[4]) params.set("linha", jogo[4]);
+    }
+    return `${SITE}/futebol/jogo/${jogo[1]}?${params.toString()}`;
+  }
   return SITE; // destino desconhecido → home (nunca mostrar erro pro usuário)
 }
 
 async function hmacHex(msg: string): Promise<string> {
   const key = await crypto.subtle.importKey(
-    "raw", new TextEncoder().encode(CRON_SECRET), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]
+    "raw",
+    new TextEncoder().encode(CRON_SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
   );
-  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(msg));
-  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0")).join("").slice(0, 16);
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(msg),
+  );
+  return [...new Uint8Array(sig)].map((b) => b.toString(16).padStart(2, "0"))
+    .join("").slice(0, 16);
 }
 
 serve(async (req) => {
@@ -56,20 +80,33 @@ serve(async (req) => {
     if (u && d && s && CRON_SECRET && s === (await hmacHex(`${u}:${d}`))) {
       const supabase = createClient(
         Deno.env.get("SUPABASE_URL") || "",
-        Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || ""
+        Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "",
       );
-      await supabase.from("notification_clicks").insert({ user_id: u, campaign, destination: d });
+      await supabase.from("notification_clicks").insert({
+        user_id: u,
+        campaign,
+        destination: d,
+      });
       // clique no daily = engajou → zera a régua da reativação (só p/ o daily)
       if (campaign === DAILY_CAMPAIGN) {
         await supabase
           .from("opportunity_dispatch_state")
-          .update({ sends_without_click: 0, last_click_at: new Date().toISOString() })
+          .update({
+            sends_without_click: 0,
+            last_click_at: new Date().toISOString(),
+          })
           .eq("user_id", u);
       }
+      const event = campaign === DAILY_CAMPAIGN
+        ? "daily_opportunities_click"
+        : campaign === PUBLISHED_CAMPAIGN
+        ? "published_opportunities_click"
+        : "weekly_summary_clicked";
       await trackEvent(
-        campaign === DAILY_CAMPAIGN ? "daily_opportunities_click" : "weekly_summary_clicked",
+        event,
         { destination: d, campaign, channel: "telegram" },
-        u, generateTraceId()
+        u,
+        generateTraceId(),
       ).catch(() => {});
     }
   } catch (e) {

--- a/supabase/functions/notify-published-opportunities/index.ts
+++ b/supabase/functions/notify-published-opportunities/index.ts
@@ -1,0 +1,477 @@
+// ============================================================
+// notify-published-opportunities — alerta quando uma Oportunidade entra no painel
+// ============================================================
+// O daily de oportunidades continua sendo o resumo editorial das 10h. Esta
+// função observa o mesmo board do produto e avisa somente a PRIMEIRA publicação
+// de cada Oportunidade. O primeiro run em cada ambiente só cria a linha de base
+// para não notificar o que já estava publicado antes do lançamento.
+//
+// ?mode=report não grava nem envia; serve para validar o próximo lote.
+// Proteção: header x-cron-secret == CRON_SECRET.
+// ============================================================
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { trackedUrl } from "../shared/links.ts";
+import { generateTraceId, trackEvent } from "../shared/posthog.ts";
+import { logMessageRun } from "../shared/runs.ts";
+import { planPublicationBatch, type PublicationBoardRow } from "./planner.ts";
+import {
+  type PublishedMessageOpportunity,
+  publishedMessageText,
+  publishedPickLabel,
+} from "./message.ts";
+
+const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
+const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
+const CAMPAIGN = "published_opportunities";
+
+interface BoardRow extends PublicationBoardRow {
+  home_team_name: string;
+  away_team_name: string;
+  competition: string;
+  status_short: string;
+  best_odd: number;
+  faixa: string;
+  janela_usada: string | null;
+  edge: number | null;
+  prob_justa_fechamento: number | null;
+  evidencias: string[] | null;
+}
+
+interface Recipient {
+  user_id: string;
+  chat_id: string;
+  user_name: string | null;
+}
+
+interface ClaimedAlert {
+  batch_id: string;
+  alert_id: string;
+  opportunity_key: string;
+}
+
+type DeliveryOpportunity = PublishedMessageOpportunity;
+
+interface Delivery {
+  batch_id: string;
+  user_id: string;
+  chat_id: string;
+  attempt_id: string;
+  opportunities: DeliveryOpportunity[];
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function kickoffDate(value: string): Date {
+  return new Date(value.includes("T") ? value : value.replace(" ", "T") + "Z");
+}
+
+function marketPt(market: string): string {
+  if (market === "match_winner") return "Money Line";
+  if (market === "goals_over_under") return "Over/Under";
+  if (market === "asian_handicap") return "Handicap";
+  if (market === "btts") return "Ambas marcam";
+  if (market === "double_chance") return "Dupla chance";
+  return market;
+}
+
+async function buildMessage(
+  opportunities: DeliveryOpportunity[],
+  userId: string,
+): Promise<string> {
+  const urls = new Map<string, string>();
+  for (const opportunity of opportunities) {
+    urls.set(
+      opportunity.alert_id,
+      await trackedUrl(userId, opportunityDestination(opportunity), CAMPAIGN),
+    );
+  }
+  return publishedMessageText(opportunities, urls);
+}
+
+function opportunityDestination(opportunity: DeliveryOpportunity): string {
+  return [
+    `jogo-${opportunity.fixture_id}`,
+    opportunity.market,
+    opportunity.outcome,
+    opportunity.line_value == null ? "" : String(opportunity.line_value),
+  ].join("|");
+}
+
+function registerButtons(
+  opportunities: DeliveryOpportunity[],
+  pickByAlertId: Map<string, string>,
+): unknown[][] {
+  return [...opportunities]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .flatMap((opportunity) => {
+      const pickId = pickByAlertId.get(opportunity.alert_id);
+      if (!pickId) return [];
+      const label = publishedPickLabel(opportunity);
+      return [[{
+        text: `📋 Registrar: ${
+          label.length > 34 ? `${label.slice(0, 33)}…` : label
+        }`,
+        callback_data: `regpub:${pickId}`,
+      }]];
+    });
+}
+
+async function sendTelegram(
+  chatId: string,
+  text: string,
+  cta: { label: string; url: string },
+  registerRows: unknown[][],
+): Promise<void> {
+  const response = await fetch(
+    `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        parse_mode: "HTML",
+        disable_web_page_preview: true,
+        reply_markup: {
+          inline_keyboard: [...registerRows, [{
+            text: cta.label,
+            url: cta.url,
+          }]],
+        },
+      }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`telegram ${response.status}: ${await response.text()}`);
+  }
+}
+
+function payload(row: BoardRow & { key: string }) {
+  return {
+    opportunity_key: row.key,
+    fixture_id: row.fixture_id,
+    home_team_name: row.home_team_name,
+    away_team_name: row.away_team_name,
+    competition: row.competition,
+    kickoff_utc: kickoffDate(row.kickoff_utc).toISOString(),
+    market: row.market,
+    outcome: row.outcome,
+    line_value: row.line_value,
+    best_odd: row.best_odd,
+    score: row.score,
+    faixa: row.faixa,
+    janela_usada: row.janela_usada,
+    edge: row.edge,
+    prob_justa_fechamento: row.prob_justa_fechamento,
+    evidencias: row.evidencias ?? [],
+  };
+}
+
+async function persistRegistrationPicks(
+  supabase: any,
+  claimed: ClaimedAlert[],
+  byKey: Map<string, BoardRow & { key: string }>,
+): Promise<void> {
+  const rows = claimed.map((claim) => {
+    const row = byKey.get(claim.opportunity_key);
+    if (!row) {
+      throw new Error(`alerta sem oportunidade: ${claim.opportunity_key}`);
+    }
+    const asDelivery: DeliveryOpportunity = {
+      ...row,
+      alert_id: claim.alert_id,
+    };
+    return {
+      fixture_id: row.fixture_id,
+      sport: "Futebol",
+      league: row.competition,
+      betting_market: marketPt(row.market),
+      match_description: `${row.home_team_name} × ${row.away_team_name}`,
+      bet_description: publishedPickLabel(asDelivery),
+      odds: row.best_odd,
+      match_date: kickoffDate(row.kickoff_utc).toISOString(),
+      market: row.market,
+      outcome: row.outcome,
+      line_value: row.line_value,
+      janela_usada: row.janela_usada,
+      score: row.score,
+      faixa: row.faixa,
+      edge: row.edge,
+      prob_justa_fechamento: row.prob_justa_fechamento,
+    };
+  });
+  if (rows.length === 0) return;
+  const { data: picks, error } = await supabase.from("daily_opportunity_picks")
+    .upsert(rows, { onConflict: "sent_date,fixture_id,bet_description" })
+    .select("id, fixture_id, bet_description");
+  if (error) throw error;
+
+  const pickByIdentity = new Map<string, string>(
+    (picks ?? []).map((pick: any) => [
+      `${pick.fixture_id}:${pick.bet_description}`,
+      pick.id,
+    ]),
+  );
+  const refs = claimed.map((claim) => {
+    const row = byKey.get(claim.opportunity_key)!;
+    const label = publishedPickLabel(row);
+    const pickId = pickByIdentity.get(`${row.fixture_id}:${label}`);
+    if (!pickId) {
+      throw new Error(
+        `pick de registro não retornou para ${claim.opportunity_key}`,
+      );
+    }
+    return { alert_id: claim.alert_id, pick_id: pickId };
+  });
+  const { error: refError } = await supabase
+    .from("futebol_publication_alert_pick_refs")
+    .upsert(refs, { onConflict: "alert_id" });
+  if (refError) throw refError;
+}
+
+async function deliverPending(
+  supabase: any,
+  traceId: string,
+): Promise<{ sent: number; errors: string[] }> {
+  const { data, error } = await supabase.rpc(
+    "claim_futebol_publication_alert_deliveries",
+  );
+  if (error) throw error;
+  const deliveries = (data ?? []) as Delivery[];
+  let sent = 0;
+  const errors: string[] = [];
+
+  for (const delivery of deliveries) {
+    let telegramAccepted = false;
+    try {
+      const alertIds = delivery.opportunities.map((opportunity) =>
+        opportunity.alert_id
+      );
+      const { data: picks, error: picksError } = await supabase
+        .from("futebol_publication_alert_pick_refs")
+        .select("alert_id, pick_id")
+        .in("alert_id", alertIds);
+      if (picksError) throw picksError;
+      const pickByAlertId = new Map<string, string>(
+        (picks ?? []).map((pick: any) => [pick.alert_id, pick.pick_id]),
+      );
+      const text = await buildMessage(delivery.opportunities, delivery.user_id);
+      const cta = delivery.opportunities.length === 1
+        ? {
+          label: "Ver o porquê dessa pick →",
+          url: await trackedUrl(
+            delivery.user_id,
+            opportunityDestination(delivery.opportunities[0]),
+            CAMPAIGN,
+          ),
+        }
+        : {
+          label: "Ver oportunidades no painel →",
+          url: await trackedUrl(delivery.user_id, "board", CAMPAIGN),
+        };
+      await sendTelegram(
+        delivery.chat_id,
+        text,
+        cta,
+        registerButtons(delivery.opportunities, pickByAlertId),
+      );
+      telegramAccepted = true;
+
+      const { error: updateError } = await supabase
+        .from("futebol_publication_alert_deliveries")
+        .update({
+          status: "sent",
+          sent_at: new Date().toISOString(),
+          last_error: null,
+        })
+        .eq("batch_id", delivery.batch_id)
+        .eq("user_id", delivery.user_id)
+        .eq("attempt_id", delivery.attempt_id)
+        .eq("status", "processing");
+      if (updateError) throw updateError;
+      sent++;
+      await trackEvent(
+        "published_opportunities_sent",
+        {
+          picks_count: delivery.opportunities.length,
+          top_score: Math.max(
+            ...delivery.opportunities.map((opportunity) => opportunity.score),
+          ),
+          channel: "telegram",
+        },
+        delivery.user_id,
+        traceId,
+      ).catch(() => {});
+    } catch (cause) {
+      const message = `${delivery.user_id}: ${
+        (cause as Error)?.message ?? "erro no envio"
+      }`;
+      errors.push(message);
+      if (telegramAccepted) {
+        // O Telegram confirmou o envio, mas o banco não confirmou o estado.
+        // Mantemos a reserva auditável em vez de arriscar uma mensagem duplicada.
+        continue;
+      }
+      await supabase
+        .from("futebol_publication_alert_deliveries")
+        .update({
+          status: "failed",
+          last_error: message,
+        })
+        .eq("batch_id", delivery.batch_id)
+        .eq("user_id", delivery.user_id)
+        .eq("attempt_id", delivery.attempt_id)
+        .eq("status", "processing");
+    }
+  }
+  return { sent, errors };
+}
+
+serve(async (req) => {
+  if (!CRON_SECRET || req.headers.get("x-cron-secret") !== CRON_SECRET) {
+    return json({ error: "Unauthorized" }, 401);
+  }
+  const mode = new URL(req.url).searchParams.get("mode") || "send";
+  if (mode === "send" && !TELEGRAM_BOT_TOKEN) {
+    return json({ error: "TELEGRAM_BOT_TOKEN not set" }, 500);
+  }
+
+  const supabase = createClient(
+    SUPABASE_URL,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "",
+  );
+  const traceId = generateTraceId();
+  try {
+    const { data: board, error: boardError } = await supabase.rpc(
+      "get_futebol_value_board",
+    );
+    if (boardError) throw boardError;
+    const now = new Date();
+    const { data: existing, error: existingError } = await supabase
+      .from("futebol_publication_alerts")
+      .select("opportunity_key");
+    if (existingError) throw existingError;
+    const plan = planPublicationBatch({
+      now,
+      alreadyAlerted: new Set(
+        (existing ?? []).map((row: any) => row.opportunity_key as string),
+      ),
+      board: (board ?? []) as BoardRow[],
+    });
+
+    const { data: recipients, error: recipientsError } = await supabase.rpc(
+      "get_futebol_publication_alert_recipients",
+    );
+    if (recipientsError) throw recipientsError;
+    if (mode === "report") {
+      return json({
+        ok: true,
+        mode,
+        new_opportunities: plan.newOpportunities.map((row) => ({
+          key: row.key,
+          jogo: `${row.home_team_name} × ${row.away_team_name}`,
+          pick: publishedPickLabel(row),
+          odd: row.best_odd,
+          score: row.score,
+        })),
+        detailed_count: plan.detailedOpportunities.length,
+        recipients: (recipients ?? []).length,
+      });
+    }
+
+    const { data: runtime, error: runtimeError } = await supabase
+      .from("futebol_publication_alert_runtime")
+      .select("initialized_at")
+      .eq("singleton", true)
+      .maybeSingle();
+    if (runtimeError) throw runtimeError;
+
+    const byKey = new Map(plan.newOpportunities.map((row) => [row.key, row]));
+    const { data: claimedData, error: claimError } = await supabase.rpc(
+      "claim_futebol_publication_alert_batch",
+      {
+        p_sync_at: now.toISOString(),
+        p_opportunities: plan.newOpportunities.map(payload),
+      },
+    );
+    if (claimError) throw claimError;
+    const claimed = (claimedData ?? []) as ClaimedAlert[];
+
+    if (!runtime) {
+      const { error: initializeError } = await supabase
+        .from("futebol_publication_alert_runtime")
+        .insert({
+          singleton: true,
+          initialized_at: now.toISOString(),
+          last_sync_at: now.toISOString(),
+        });
+      if (initializeError) throw initializeError;
+      await logMessageRun(supabase, "notify-published-opportunities", {
+        candidates: claimed.length,
+        sent: 0,
+        ok: true,
+      });
+      return json({
+        ok: true,
+        mode,
+        baseline: true,
+        recorded: claimed.length,
+        sent: 0,
+      });
+    }
+
+    if (claimed.length > 0) {
+      await persistRegistrationPicks(supabase, claimed, byKey);
+      const batchId = claimed[0].batch_id;
+      const deliveryRows = ((recipients ?? []) as Recipient[]).map((
+        recipient,
+      ) => ({
+        batch_id: batchId,
+        user_id: recipient.user_id,
+        chat_id: recipient.chat_id,
+      }));
+      if (deliveryRows.length > 0) {
+        const { error: deliveryError } = await supabase
+          .from("futebol_publication_alert_deliveries")
+          .upsert(deliveryRows, {
+            onConflict: "batch_id,user_id",
+            ignoreDuplicates: true,
+          });
+        if (deliveryError) throw deliveryError;
+      }
+    }
+
+    const result = await deliverPending(supabase, traceId);
+    await logMessageRun(supabase, "notify-published-opportunities", {
+      candidates: claimed.length,
+      sent: result.sent,
+      errors: result.errors,
+      ok: true,
+    });
+    return json({
+      ok: true,
+      mode,
+      published: claimed.length,
+      sent: result.sent,
+      errors: result.errors,
+    });
+  } catch (cause) {
+    const message = (cause as Error)?.message ?? "Internal error";
+    console.error("notify-published-opportunities error:", message);
+    if (mode === "send") {
+      await logMessageRun(supabase, "notify-published-opportunities", {
+        errors: [message],
+        ok: false,
+      });
+    }
+    return json({ error: message }, 500);
+  }
+});

--- a/supabase/functions/notify-published-opportunities/message.ts
+++ b/supabase/functions/notify-published-opportunities/message.ts
@@ -1,0 +1,129 @@
+import { esc } from "../shared/format.ts";
+
+export interface PublishedMessageOpportunity {
+  alert_id: string;
+  fixture_id: number;
+  home_team_name: string;
+  away_team_name: string;
+  competition: string | null;
+  kickoff_utc: string;
+  market: string;
+  outcome: string;
+  line_value: number | null;
+  best_odd: number;
+  score: number;
+  faixa: string;
+  evidencias: string[] | null;
+}
+
+function kickoffDate(value: string): Date {
+  return new Date(value.includes("T") ? value : value.replace(" ", "T") + "Z");
+}
+
+function brtHourMin(value: string): string {
+  return new Intl.DateTimeFormat("pt-BR", {
+    timeZone: "America/Sao_Paulo",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(kickoffDate(value));
+}
+
+function fmtHandicapLine(line: number): string {
+  const sign = line > 0 ? "+" : line < 0 ? "−" : "";
+  return `${sign}${String(Math.abs(line)).replace(".", ",")}`;
+}
+
+function outcomePt(
+  outcome: string,
+  homeName: string,
+  awayName: string,
+): string {
+  if (outcome === "Home") return homeName;
+  if (outcome === "Away") return awayName;
+  if (outcome === "Draw") return "Empate";
+  return outcome;
+}
+
+export function publishedPickLabel(
+  row: Pick<
+    PublishedMessageOpportunity,
+    "market" | "outcome" | "line_value" | "home_team_name" | "away_team_name"
+  >,
+): string {
+  if (row.market === "goals_over_under") {
+    const line = row.line_value == null
+      ? ""
+      : String(row.line_value).replace(".", ",");
+    return row.outcome === "Over"
+      ? `Mais de ${line} gols`
+      : `Menos de ${line} gols`;
+  }
+  if (row.market === "asian_handicap") {
+    const team = row.outcome === "Home"
+      ? row.home_team_name
+      : row.away_team_name;
+    const line = row.line_value == null
+      ? null
+      : (row.outcome === "Away" ? -row.line_value : row.line_value);
+    return line == null ? team : `${team} ${fmtHandicapLine(line)}`;
+  }
+  if (row.market === "btts") {
+    return row.outcome === "Yes" ? "Ambos marcam: Sim" : "Ambos marcam: Não";
+  }
+  if (row.market === "double_chance") {
+    return row.outcome === "1X"
+      ? `${row.home_team_name} ou empate`
+      : `Empate ou ${row.away_team_name}`;
+  }
+  if (row.market === "match_winner") {
+    return `Vitória: ${
+      outcomePt(row.outcome, row.home_team_name, row.away_team_name)
+    }`;
+  }
+  return outcomePt(row.outcome, row.home_team_name, row.away_team_name);
+}
+
+export function publishedMessageText(
+  opportunities: PublishedMessageOpportunity[],
+  opportunityUrls: ReadonlyMap<string, string>,
+): string {
+  const detailed = [...opportunities].sort((a, b) => b.score - a.score).slice(
+    0,
+    3,
+  );
+  const title = opportunities.length === 1
+    ? "⚽ <b>Nova oportunidade mapeada</b>"
+    : `⚽ <b>Novas oportunidades mapeadas</b> · ${opportunities.length} no painel`;
+  const lines = [title, ""];
+
+  for (const opportunity of detailed) {
+    const gameUrl = opportunityUrls.get(opportunity.alert_id) ??
+      "https://www.smartbetting.app/futebol/oportunidades";
+    const evidence = opportunity.evidencias?.[0]
+      ? `\n✓ ${esc(opportunity.evidencias[0])}`
+      : "";
+    lines.push(
+      `<a href="${gameUrl}"><b>${esc(opportunity.home_team_name)} × ${
+        esc(opportunity.away_team_name)
+      }</b></a> · ${brtHourMin(opportunity.kickoff_utc)}`,
+      `${
+        esc(publishedPickLabel(opportunity))
+      } · odd ${opportunity.best_odd} · Score <b>${opportunity.score} · ${
+        esc(opportunity.faixa)
+      }</b>${evidence}`,
+      "",
+    );
+  }
+
+  const extra = opportunities.length - detailed.length;
+  if (extra > 0) {
+    lines.push(
+      `<i>+ ${extra} ${
+        extra === 1 ? "oportunidade no painel" : "oportunidades no painel"
+      }.</i>`,
+      "",
+    );
+  }
+  lines.push("<i>Leitura de risco, não recomendação de aposta.</i>");
+  return lines.join("\n");
+}

--- a/supabase/functions/notify-published-opportunities/planner.ts
+++ b/supabase/functions/notify-published-opportunities/planner.ts
@@ -1,0 +1,60 @@
+export interface PublicationBoardRow {
+  fixture_id: number;
+  market: string;
+  outcome: string;
+  line_value: number | null;
+  kickoff_utc: string;
+  score: number;
+}
+
+// O painel só publica oportunidades a partir da faixa Média. O detector deve
+// receber exatamente o mesmo conjunto, nunca candidatas de score inferior.
+export const MIN_PUBLICATION_SCORE = 40;
+
+function kickoffDate(kickoffUtc: string): Date {
+  return new Date(
+    kickoffUtc.includes("T") ? kickoffUtc : `${kickoffUtc.replace(" ", "T")}Z`,
+  );
+}
+
+function normalizedLine(line: number | null): string {
+  return line == null ? "none" : String(line);
+}
+
+export function opportunityKey(
+  row: Pick<
+    PublicationBoardRow,
+    "fixture_id" | "market" | "outcome" | "line_value"
+  >,
+): string {
+  return `${row.fixture_id}:${row.market}:${row.outcome}:${
+    normalizedLine(row.line_value)
+  }`;
+}
+
+export function planPublicationBatch<T extends PublicationBoardRow>({
+  now,
+  alreadyAlerted,
+  board,
+}: {
+  now: Date;
+  alreadyAlerted: ReadonlySet<string>;
+  board: T[];
+}): {
+  newOpportunities: Array<T & { key: string }>;
+  detailedOpportunities: Array<T & { key: string }>;
+} {
+  const newOpportunities = board
+    .filter((row) =>
+      row.score >= MIN_PUBLICATION_SCORE &&
+      kickoffDate(row.kickoff_utc).getTime() > now.getTime()
+    )
+    .map((row) => ({ ...row, key: opportunityKey(row) }))
+    .filter((row) => !alreadyAlerted.has(row.key));
+
+  const detailedOpportunities = [...newOpportunities]
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3);
+
+  return { newOpportunities, detailedOpportunities };
+}

--- a/supabase/functions/telegram-webhook/callbacks.ts
+++ b/supabase/functions/telegram-webhook/callbacks.ts
@@ -2,52 +2,67 @@
 // callbacks.ts — todos os botões inline (settle/mute/fix/regbet/stk/prefs)
 // ============================================================
 // Extraído de index.ts na Onda 6b da revisão (split mecânico, move-only).
-import { BETS_DASHBOARD_URL } from "./config.ts"
-import type { TelegramCallbackQuery } from "./types.ts"
+import { BETS_DASHBOARD_URL } from "./config.ts";
+import type { TelegramCallbackQuery } from "./types.ts";
 import {
-  telegramCall, escHtml, formatBRL, answerCallbackQuery, editSettledMessage, settledHtml,
-} from "./telegram-api.ts"
-import { effectiveUnit, registerPickBet, pickReceiptHtml, sendStakePrompt } from "./picks.ts"
-import { findUserByTelegram } from "./users.ts"
-import { prefsKeyboard, prefsText } from "./prefs.ts"
-import { trackEvent } from "../shared/posthog.ts"
-import { receiptStreakLineFor } from "../shared/streak.ts"
+  answerCallbackQuery,
+  editSettledMessage,
+  escHtml,
+  formatBRL,
+  settledHtml,
+  telegramCall,
+} from "./telegram-api.ts";
+import {
+  effectiveUnit,
+  pickReceiptHtml,
+  type PickSource,
+  registerPickBet,
+  sendStakePrompt,
+} from "./picks.ts";
+import { findUserByTelegram } from "./users.ts";
+import { prefsKeyboard, prefsText } from "./prefs.ts";
+import { trackEvent } from "../shared/posthog.ts";
+import { receiptStreakLineFor } from "../shared/streak.ts";
 
 async function handleCallbackQuery(
   supabase: any,
   cq: TelegramCallbackQuery,
-  traceId: string
+  traceId: string,
 ): Promise<Response> {
   const ok = (msg: string) =>
     new Response(JSON.stringify({ success: true, message: msg }), {
       headers: { "Content-Type": "application/json" },
-      status: 200
-    })
+      status: 200,
+    });
 
-  const data = cq.data || ""
-  const chatId = cq.message?.chat?.id
-  const messageId = cq.message?.message_id
+  const data = cq.data || "";
+  const chatId = cq.message?.chat?.id;
+  const messageId = cq.message?.message_id;
 
   if (!chatId || !messageId) {
-    await answerCallbackQuery(cq.id).catch(() => {})
-    return ok("callback without message")
+    await answerCallbackQuery(cq.id).catch(() => {});
+    return ok("callback without message");
   }
 
   const user = await findUserByTelegram(
     supabase,
     cq.from?.id ? String(cq.from.id) : undefined,
     String(chatId),
-    traceId
-  )
+    traceId,
+  );
   if (!user) {
-    await answerCallbackQuery(cq.id, "Não achei sua conta. Manda /start pra sincronizar.")
-    return ok("callback user not found")
+    await answerCallbackQuery(
+      cq.id,
+      "Não achei sua conta. Manda /start pra sincronizar.",
+    );
+    return ok("callback user not found");
   }
 
   // 🔕 mute:<bet_id> — para os lembretes; mantém os botões de liquidar desta aposta
   if (data.startsWith("mute:")) {
-    const betId = data.slice("mute:".length)
-    await supabase.from("users").update({ settlement_reminders_muted: true }).eq("id", user.id)
+    const betId = data.slice("mute:".length);
+    await supabase.from("users").update({ settlement_reminders_muted: true })
+      .eq("id", user.id);
     await telegramCall("editMessageReplyMarkup", {
       chat_id: chatId,
       message_id: messageId,
@@ -55,70 +70,97 @@ async function handleCallbackQuery(
         inline_keyboard: [
           [
             { text: "✅ Green", callback_data: `settle:${betId}:won` },
-            { text: "❌ Red", callback_data: `settle:${betId}:lost` }
+            { text: "❌ Red", callback_data: `settle:${betId}:lost` },
           ],
-          [{ text: "Outras opções ↗", url: BETS_DASHBOARD_URL }]
-        ]
-      }
-    })
-    await answerCallbackQuery(cq.id, "🔕 Ok, sem mais lembretes. Reative mandando /lembretes.")
+          [{ text: "Outras opções ↗", url: BETS_DASHBOARD_URL }],
+        ],
+      },
+    });
+    await answerCallbackQuery(
+      cq.id,
+      "🔕 Ok, sem mais lembretes. Reative mandando /lembretes.",
+    );
     await trackEvent(
       "settlement_reminders_muted",
       { via: "button", channel: "telegram" },
       user.id,
-      traceId
-    ).catch(() => {})
-    return ok("reminders muted")
+      traceId,
+    ).catch(() => {});
+    return ok("reminders muted");
   }
 
   // mutew — botão "Silenciar resumo" da DM do resumo semanal (item 04).
   // Opt-out independente da liquidação; /resumo reativa.
   if (data === "mutew") {
-    await supabase.from("users").update({ weekly_summary_muted: true }).eq("id", user.id)
+    await supabase.from("users").update({ weekly_summary_muted: true }).eq(
+      "id",
+      user.id,
+    );
     // remove só a linha do silenciar; "Ver minha banca" continua útil
     await telegramCall("editMessageReplyMarkup", {
       chat_id: chatId,
       message_id: messageId,
       reply_markup: {
-        inline_keyboard: [[{ text: "Ver minha banca", url: BETS_DASHBOARD_URL }]]
-      }
-    })
-    await answerCallbackQuery(cq.id, "Ok, sem mais resumos semanais. Pra voltar: /resumo")
+        inline_keyboard: [[{
+          text: "Ver minha banca",
+          url: BETS_DASHBOARD_URL,
+        }]],
+      },
+    });
+    await answerCallbackQuery(
+      cq.id,
+      "Ok, sem mais resumos semanais. Pra voltar: /resumo",
+    );
     await trackEvent(
       "weekly_summary_muted",
       { via: "button", channel: "telegram" },
       user.id,
-      traceId
-    ).catch(() => {})
-    return ok("weekly summary muted")
+      traceId,
+    ).catch(() => {});
+    return ok("weekly summary muted");
   }
 
   // prefliq / prefres — toggles do centro de controle /mensagens (Onda 6).
   // Alterna a preferência e REESCREVE a própria mensagem com o estado novo.
   if (data === "prefliq" || data === "prefres") {
     const { data: cur } = await supabase
-      .from("users").select("settlement_reminders_muted, weekly_summary_muted").eq("id", user.id).maybeSingle()
+      .from("users").select("settlement_reminders_muted, weekly_summary_muted")
+      .eq("id", user.id).maybeSingle();
     const p = {
       settlementMuted: cur?.settlement_reminders_muted ?? false,
       weeklyMuted: cur?.weekly_summary_muted ?? false,
-    }
-    let toast: string
+    };
+    let toast: string;
     if (data === "prefliq") {
-      p.settlementMuted = !p.settlementMuted
-      await supabase.from("users").update({ settlement_reminders_muted: p.settlementMuted }).eq("id", user.id)
-      toast = p.settlementMuted ? "🔕 Liquidação silenciada." : "🔔 Liquidação reativada."
+      p.settlementMuted = !p.settlementMuted;
+      await supabase.from("users").update({
+        settlement_reminders_muted: p.settlementMuted,
+      }).eq("id", user.id);
+      toast = p.settlementMuted
+        ? "🔕 Liquidação silenciada."
+        : "🔔 Liquidação reativada.";
       await trackEvent(
-        p.settlementMuted ? "settlement_reminders_muted" : "settlement_reminders_unmuted",
-        { via: "prefs", channel: "telegram" }, user.id, traceId
-      ).catch(() => {})
+        p.settlementMuted
+          ? "settlement_reminders_muted"
+          : "settlement_reminders_unmuted",
+        { via: "prefs", channel: "telegram" },
+        user.id,
+        traceId,
+      ).catch(() => {});
     } else {
-      p.weeklyMuted = !p.weeklyMuted
-      await supabase.from("users").update({ weekly_summary_muted: p.weeklyMuted }).eq("id", user.id)
-      toast = p.weeklyMuted ? "Resumo semanal silenciado." : "📊 Resumo semanal reativado."
+      p.weeklyMuted = !p.weeklyMuted;
+      await supabase.from("users").update({
+        weekly_summary_muted: p.weeklyMuted,
+      }).eq("id", user.id);
+      toast = p.weeklyMuted
+        ? "Resumo semanal silenciado."
+        : "📊 Resumo semanal reativado.";
       await trackEvent(
         p.weeklyMuted ? "weekly_summary_muted" : "weekly_summary_unmuted",
-        { via: "prefs", channel: "telegram" }, user.id, traceId
-      ).catch(() => {})
+        { via: "prefs", channel: "telegram" },
+        user.id,
+        traceId,
+      ).catch(() => {});
     }
     await telegramCall("editMessageText", {
       chat_id: chatId,
@@ -127,175 +169,266 @@ async function handleCallbackQuery(
       parse_mode: "HTML",
       disable_web_page_preview: true,
       reply_markup: { inline_keyboard: prefsKeyboard(p) },
-    })
-    await answerCallbackQuery(cq.id, toast)
-    return ok("prefs toggled")
+    });
+    await answerCallbackQuery(cq.id, toast);
+    return ok("prefs toggled");
   }
 
-  // 📋 regbet:<pick_id> — tocou "Registrar no Betinho" no daily
-  if (data.startsWith("regbet:")) {
-    const pickId = data.slice("regbet:".length)
+  // 📋 regbet:<pick_id> / regpub:<pick_id> — registro vindo do daily ou
+  // de uma publicação em tempo real. A origem acompanha toda a jornada.
+  if (data.startsWith("regbet:") || data.startsWith("regpub:")) {
+    const source: PickSource = data.startsWith("regpub:")
+      ? "published_opportunities"
+      : "daily_opportunities";
+    const pickId = data.slice(
+      source === "published_opportunities"
+        ? "regpub:".length
+        : "regbet:".length,
+    );
     const { data: pick } = await supabase
-      .from("daily_opportunity_picks").select("id, bet_description, odds").eq("id", pickId).maybeSingle()
+      .from("daily_opportunity_picks").select("id, bet_description, odds").eq(
+        "id",
+        pickId,
+      ).maybeSingle();
     if (!pick) {
-      await answerCallbackQuery(cq.id, "Essa oportunidade expirou 🕑")
-      return ok("regbet: pick not found")
+      await answerCallbackQuery(cq.id, "Essa oportunidade expirou 🕑");
+      return ok("regbet: pick not found");
     }
-    const unit = await effectiveUnit(supabase, user.id)
+    const unit = await effectiveUnit(supabase, user.id);
     if (unit) {
       // COM unidade: atalhos de valor + "Outro valor" (que aí faz sentido)
       await telegramCall("sendMessage", {
         chat_id: chatId,
-        text: `📋 Registrar <b>${escHtml(pick.bet_description)}</b> (odd ${Number(pick.odds)})\nQuanto você vai colocar?`,
+        text: `📋 Registrar <b>${escHtml(pick.bet_description)}</b> (odd ${
+          Number(pick.odds)
+        })\nQuanto você vai colocar?`,
         parse_mode: "HTML",
-        reply_markup: { inline_keyboard: [
-          [
-            { text: `1 unidade · ${formatBRL(unit)}`, callback_data: `stk:${pickId}:u1` },
-            { text: `½ unidade · ${formatBRL(unit / 2)}`, callback_data: `stk:${pickId}:uh` }
+        reply_markup: {
+          inline_keyboard: [
+            [
+              {
+                text: `1 unidade · ${formatBRL(unit)}`,
+                callback_data: `${
+                  source === "published_opportunities" ? "stkpub" : "stk"
+                }:${pickId}:u1`,
+              },
+              {
+                text: `½ unidade · ${formatBRL(unit / 2)}`,
+                callback_data: `${
+                  source === "published_opportunities" ? "stkpub" : "stk"
+                }:${pickId}:uh`,
+              },
+            ],
+            [{
+              text: "Outro valor",
+              callback_data: `${
+                source === "published_opportunities" ? "stkpub" : "stk"
+              }:${pickId}:ot`,
+            }],
           ],
-          [{ text: "Outro valor", callback_data: `stk:${pickId}:ot` }]
-        ] }
-      })
+        },
+      });
     } else {
       // SEM unidade: vai DIRETO pra pergunta (sem botão órfão, sem pergunta dupla)
-      await sendStakePrompt(supabase, chatId, user.id, pickId,
-        `📋 Registrar <b>${escHtml(pick.bet_description)}</b> (odd ${Number(pick.odds)})\nQuanto você colocou? Responde com o valor aqui 👇`)
+      await sendStakePrompt(
+        supabase,
+        chatId,
+        user.id,
+        pickId,
+        `📋 Registrar <b>${escHtml(pick.bet_description)}</b> (odd ${
+          Number(pick.odds)
+        })\nQuanto você colocou? Responde com o valor aqui 👇`,
+        source,
+      );
     }
-    await answerCallbackQuery(cq.id)
-    return ok("regbet: asked stake")
+    await answerCallbackQuery(cq.id);
+    return ok("regbet: asked stake");
   }
 
   // 💰 stk:<pick_id>:<u1|uh|ot> — escolha do valor
-  if (data.startsWith("stk:")) {
-    const [, pickId, code] = data.split(":")
+  if (data.startsWith("stk:") || data.startsWith("stkpub:")) {
+    const source: PickSource = data.startsWith("stkpub:")
+      ? "published_opportunities"
+      : "daily_opportunities";
+    const [, pickId, code] = data.split(":");
     const { data: pick } = await supabase
-      .from("daily_opportunity_picks").select("*").eq("id", pickId).maybeSingle()
+      .from("daily_opportunity_picks").select("*").eq("id", pickId)
+      .maybeSingle();
     if (!pick) {
-      await answerCallbackQuery(cq.id, "Essa oportunidade expirou 🕑")
-      return ok("stk: pick not found")
+      await answerCallbackQuery(cq.id, "Essa oportunidade expirou 🕑");
+      return ok("stk: pick not found");
     }
 
     // "Outro valor" → pergunta curta por force_reply (o "Registrar X — quanto?"
     // já foi mostrado com os botões; aqui não repete)
     if (code === "ot") {
-      await sendStakePrompt(supabase, chatId, user.id, pickId, `Qual valor? Responde com o número aqui 👇`)
-      await answerCallbackQuery(cq.id)
-      return ok("stk: force reply")
+      await sendStakePrompt(
+        supabase,
+        chatId,
+        user.id,
+        pickId,
+        `Qual valor? Responde com o número aqui 👇`,
+        source,
+      );
+      await answerCallbackQuery(cq.id);
+      return ok("stk: force reply");
     }
 
-    const unit = await effectiveUnit(supabase, user.id)
+    const unit = await effectiveUnit(supabase, user.id);
     if (!unit) {
-      await answerCallbackQuery(cq.id, "Configure sua unidade no site ou toque em Outro valor.")
-      return ok("stk: no unit")
+      await answerCallbackQuery(
+        cq.id,
+        "Configure sua unidade no site ou toque em Outro valor.",
+      );
+      return ok("stk: no unit");
     }
-    const stake = code === "uh" ? Math.round((unit / 2) * 100) / 100 : unit
-    const { data: bet, error } = await registerPickBet(supabase, user.id, pick, stake)
+    const stake = code === "uh" ? Math.round((unit / 2) * 100) / 100 : unit;
+    const { data: bet, error } = await registerPickBet(
+      supabase,
+      user.id,
+      pick,
+      stake,
+      source,
+    );
     if (error || !bet) {
-      await answerCallbackQuery(cq.id, "Deu ruim ao registrar — tenta de novo.")
-      return ok("stk: insert failed")
+      await answerCallbackQuery(
+        cq.id,
+        "Deu ruim ao registrar — tenta de novo.",
+      );
+      return ok("stk: insert failed");
     }
-    const streakLine = await receiptStreakLineFor(supabase, user.id) // item 18 (flag-gated)
-    await editSettledMessage(chatId, messageId, pickReceiptHtml(pick, stake, streakLine))
-    await answerCallbackQuery(cq.id, "✅ Registrado!")
+    const streakLine = await receiptStreakLineFor(supabase, user.id); // item 18 (flag-gated)
+    await editSettledMessage(
+      chatId,
+      messageId,
+      pickReceiptHtml(pick, stake, streakLine),
+    );
+    await answerCallbackQuery(cq.id, "✅ Registrado!");
     await trackEvent(
-      "opportunity_bet_registered",
-      { bet_id: bet.id, pick_id: pickId, stake, via: "unit_button", channel: "telegram" },
-      user.id, traceId
-    ).catch(() => {})
-    return ok("stk: registered")
+      source === "published_opportunities"
+        ? "published_opportunity_bet_registered"
+        : "opportunity_bet_registered",
+      {
+        bet_id: bet.id,
+        pick_id: pickId,
+        stake,
+        via: "unit_button",
+        channel: "telegram",
+        source,
+      },
+      user.id,
+      traceId,
+    ).catch(() => {});
+    return ok("stk: registered");
   }
 
   // ↩️ fix:<bet_id> — desfaz a AUTO-liquidação (notify-settlement): volta pra
   // pendente e devolve os botões clássicos pro usuário dizer o resultado certo
   if (data.startsWith("fix:")) {
-    const betId = data.slice("fix:".length)
+    const betId = data.slice("fix:".length);
 
     const { data: bet } = await supabase
       .from("bets")
-      .select("id, user_id, status, bet_description, match_description, stake_amount, potential_return, processed_data")
+      .select(
+        "id, user_id, status, bet_description, match_description, stake_amount, potential_return, processed_data",
+      )
       .eq("id", betId)
-      .maybeSingle()
+      .maybeSingle();
 
     if (!bet || bet.user_id !== user.id) {
-      await answerCallbackQuery(cq.id, "Não achei essa aposta na sua conta.")
-      return ok("fix: bet not found or not owner")
+      await answerCallbackQuery(cq.id, "Não achei essa aposta na sua conta.");
+      return ok("fix: bet not found or not owner");
     }
-    const REVERTIBLE = ["won", "lost", "void", "half_won", "half_lost"] // nunca cashout
+    const REVERTIBLE = ["won", "lost", "void", "half_won", "half_lost"]; // nunca cashout
     if (!REVERTIBLE.includes(bet.status)) {
-      await answerCallbackQuery(cq.id, "Essa aposta não está mais liquidada 👍")
-      return ok("fix: invalid status")
+      await answerCallbackQuery(
+        cq.id,
+        "Essa aposta não está mais liquidada 👍",
+      );
+      return ok("fix: invalid status");
     }
 
-    const pd = bet.processed_data && typeof bet.processed_data === "object" && !Array.isArray(bet.processed_data)
+    const pd = bet.processed_data && typeof bet.processed_data === "object" &&
+        !Array.isArray(bet.processed_data)
       ? bet.processed_data
-      : {}
+      : {};
     const { error: fixErr } = await supabase
       .from("bets")
       .update({
         status: "pending",
         processed_data: {
           ...pd,
-          auto_settle: { ...((pd as any).auto_settle ?? {}), corrected_at: new Date().toISOString() },
+          auto_settle: {
+            ...((pd as any).auto_settle ?? {}),
+            corrected_at: new Date().toISOString(),
+          },
         },
       })
       .eq("id", betId)
-      .in("status", ["won", "lost", "void", "half_won", "half_lost"]) // nunca reverte cashout
+      .in("status", ["won", "lost", "void", "half_won", "half_lost"]); // nunca reverte cashout
 
     if (fixErr) {
-      await answerCallbackQuery(cq.id, "Deu ruim ao desfazer — tenta de novo.")
-      return ok("fix: update failed")
+      await answerCallbackQuery(cq.id, "Deu ruim ao desfazer — tenta de novo.");
+      return ok("fix: update failed");
     }
 
     await telegramCall("editMessageText", {
       chat_id: chatId,
       message_id: messageId,
-      text: `↩️ Desfeito — voltou pra pendente.\n\n<b>${escHtml(bet.bet_description)}</b>${bet.match_description ? `\n${escHtml(bet.match_description)}` : ""}\n\nComo foi essa?`,
+      text: `↩️ Desfeito — voltou pra pendente.\n\n<b>${
+        escHtml(bet.bet_description)
+      }</b>${
+        bet.match_description ? `\n${escHtml(bet.match_description)}` : ""
+      }\n\nComo foi essa?`,
       parse_mode: "HTML",
       disable_web_page_preview: true,
       reply_markup: {
         inline_keyboard: [
           [
             { text: "✅ Green", callback_data: `settle:${betId}:won` },
-            { text: "❌ Red", callback_data: `settle:${betId}:lost` }
+            { text: "❌ Red", callback_data: `settle:${betId}:lost` },
           ],
-          [{ text: "Outras opções ↗", url: BETS_DASHBOARD_URL }]
-        ]
-      }
-    })
-    await answerCallbackQuery(cq.id, "↩️ Desfeito.")
+          [{ text: "Outras opções ↗", url: BETS_DASHBOARD_URL }],
+        ],
+      },
+    });
+    await answerCallbackQuery(cq.id, "↩️ Desfeito.");
     await trackEvent(
       "auto_settle_corrected",
       { bet_id: betId, previous_status: bet.status, channel: "telegram" },
       user.id,
-      traceId
-    ).catch(() => {})
-    return ok("auto settle corrected")
+      traceId,
+    ).catch(() => {});
+    return ok("auto settle corrected");
   }
 
   // ✅/❌ settle:<bet_id>:<won|lost>
   if (data.startsWith("settle:")) {
-    const [, betId, outcome] = data.split(":")
+    const [, betId, outcome] = data.split(":");
     if (!betId || (outcome !== "won" && outcome !== "lost")) {
-      await answerCallbackQuery(cq.id, "Não entendi esse toque 🤔")
-      return ok("bad callback data")
+      await answerCallbackQuery(cq.id, "Não entendi esse toque 🤔");
+      return ok("bad callback data");
     }
 
     const { data: bet } = await supabase
       .from("bets")
-      .select("id, user_id, status, bet_description, match_description, stake_amount, potential_return, odds, created_at, channel")
+      .select(
+        "id, user_id, status, bet_description, match_description, stake_amount, potential_return, odds, created_at, channel",
+      )
       .eq("id", betId)
-      .maybeSingle()
+      .maybeSingle();
 
     // dono confere? (callback vem do Telegram; a aposta TEM que ser deste usuário)
     if (!bet || bet.user_id !== user.id) {
-      await answerCallbackQuery(cq.id, "Não achei essa aposta na sua conta.")
-      return ok("bet not found or not owner")
+      await answerCallbackQuery(cq.id, "Não achei essa aposta na sua conta.");
+      return ok("bet not found or not owner");
     }
 
     if (bet.status !== "pending") {
-      await answerCallbackQuery(cq.id, "Essa já estava registrada 👍")
-      await editSettledMessage(chatId, messageId, settledHtml(bet, bet.status)).catch(() => {})
-      return ok("already settled")
+      await answerCallbackQuery(cq.id, "Essa já estava registrada 👍");
+      await editSettledMessage(chatId, messageId, settledHtml(bet, bet.status))
+        .catch(() => {});
+      return ok("already settled");
     }
 
     const { data: updated, error: updErr } = await supabase
@@ -304,21 +437,28 @@ async function handleCallbackQuery(
       .eq("id", betId)
       .eq("status", "pending") // guarda otimista: dois toques ≠ duas liquidações
       .select()
-      .maybeSingle()
+      .maybeSingle();
 
     if (updErr || !updated) {
-      await answerCallbackQuery(cq.id, "Deu ruim ao registrar — tenta de novo.")
-      return ok("settle update failed")
+      await answerCallbackQuery(
+        cq.id,
+        "Deu ruim ao registrar — tenta de novo.",
+      );
+      return ok("settle update failed");
     }
 
-    await editSettledMessage(chatId, messageId, settledHtml(updated, outcome)).catch(() => {})
-    await answerCallbackQuery(cq.id, outcome === "won" ? "✅ Green registrado!" : "❌ Red registrado.")
+    await editSettledMessage(chatId, messageId, settledHtml(updated, outcome))
+      .catch(() => {});
+    await answerCallbackQuery(
+      cq.id,
+      outcome === "won" ? "✅ Green registrado!" : "❌ Red registrado.",
+    );
     await trackEvent(
       "settlement_settled_via_bot",
       { bet_id: betId, outcome, channel: "telegram" },
       user.id,
-      traceId
-    ).catch(() => {})
+      traceId,
+    ).catch(() => {});
     // Evento canônico da métrica central de retenção (mesmo schema dos 4 caminhos da web em
     // Bets.tsx). O settlement_settled_via_bot acima fica por continuidade de histórico.
     await trackEvent(
@@ -328,7 +468,9 @@ async function handleCallbackQuery(
         channel: bet.channel ?? "telegram",
         status: outcome,
         days_to_settle: bet.created_at
-          ? Math.round((Date.now() - new Date(bet.created_at).getTime()) / 86400000)
+          ? Math.round(
+            (Date.now() - new Date(bet.created_at).getTime()) / 86400000,
+          )
           : null,
         settled_by: "user_manual",
         via: "bot_reminder",
@@ -336,13 +478,13 @@ async function handleCallbackQuery(
         count: 1,
       },
       user.id,
-      traceId
-    ).catch(() => {})
-    return ok("bet settled")
+      traceId,
+    ).catch(() => {});
+    return ok("bet settled");
   }
 
-  await answerCallbackQuery(cq.id).catch(() => {})
-  return ok("unknown callback")
+  await answerCallbackQuery(cq.id).catch(() => {});
+  return ok("unknown callback");
 }
 
-export { handleCallbackQuery }
+export { handleCallbackQuery };

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -7,82 +7,106 @@
 //   config.ts (env/constantes) · types.ts · telegram-api.ts (chamadas/copy)
 //   callbacks.ts (todos os botões) · picks.ts (item 15) · extraction.ts
 //   (pipeline LLM + limites) · users.ts (vínculo) · stake.ts/prefs.ts (puros)
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
-import { createClient } from "npm:@supabase/supabase-js@2"
-import { maskPhone } from "../shared/phone.ts"
-import { generateTraceId, identifyUser, trackEvent } from "../shared/posthog.ts"
-import { isBareNumber, parseStake } from "./stake.ts"
-import { prefsKeyboard, prefsText } from "./prefs.ts"
-import { TELEGRAM_BOT_TOKEN, TELEGRAM_WEBHOOK_SECRET } from "./config.ts"
-import type { TelegramMessage, TelegramCallbackQuery } from "./types.ts"
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import { maskPhone } from "../shared/phone.ts";
 import {
-  sendTelegramMessage, getTelegramFileUrl, sendContactRequest, sendWelcomeMessageTelegram,
-} from "./telegram-api.ts"
-import { registerPickBet, pickReceiptHtml } from "./picks.ts"
-import { receiptStreakLineFor } from "../shared/streak.ts"
-import { handleCallbackQuery } from "./callbacks.ts"
-import { transcribeAudio, processImage, processMessage } from "./extraction.ts"
-import { findUserByTelegram, findUserByPhone } from "./users.ts"
-
+  generateTraceId,
+  identifyUser,
+  trackEvent,
+} from "../shared/posthog.ts";
+import { isBareNumber, parseStake } from "./stake.ts";
+import { prefsKeyboard, prefsText } from "./prefs.ts";
+import { TELEGRAM_BOT_TOKEN, TELEGRAM_WEBHOOK_SECRET } from "./config.ts";
+import type { TelegramCallbackQuery, TelegramMessage } from "./types.ts";
+import {
+  getTelegramFileUrl,
+  sendContactRequest,
+  sendTelegramMessage,
+  sendWelcomeMessageTelegram,
+} from "./telegram-api.ts";
+import { pickReceiptHtml, type PickSource, registerPickBet } from "./picks.ts";
+import { receiptStreakLineFor } from "../shared/streak.ts";
+import { handleCallbackQuery } from "./callbacks.ts";
+import { processImage, processMessage, transcribeAudio } from "./extraction.ts";
+import { findUserByPhone, findUserByTelegram } from "./users.ts";
 
 // Simple in-memory guard to avoid reprocessing the same update_id on retries
-const processedUpdateIds = new Set<number>()
+const processedUpdateIds = new Set<number>();
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Headers": "content-type" } })
+    return new Response("ok", {
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "content-type",
+      },
+    });
   }
 
   if (!TELEGRAM_BOT_TOKEN) {
-    return new Response("Missing TELEGRAM_BOT_TOKEN", { status: 500 })
+    return new Response("Missing TELEGRAM_BOT_TOKEN", { status: 500 });
   }
 
   if (TELEGRAM_WEBHOOK_SECRET) {
-    const provided = req.headers.get("x-telegram-bot-api-secret-token")
+    const provided = req.headers.get("x-telegram-bot-api-secret-token");
     if (provided !== TELEGRAM_WEBHOOK_SECRET) {
-      return new Response("Unauthorized", { status: 401 })
+      return new Response("Unauthorized", { status: 401 });
     }
   }
 
   try {
-    const payload = await req.json()
-    const updateId: number | undefined = payload.update_id
+    const payload = await req.json();
+    const updateId: number | undefined = payload.update_id;
 
     // Idempotency: if we already handled this update_id in this process, skip
     if (typeof updateId === "number") {
       if (processedUpdateIds.has(updateId)) {
-        return new Response(JSON.stringify({ success: true, message: "Duplicate update ignored" }), { headers: { "Content-Type": "application/json" }, status: 200 })
+        return new Response(
+          JSON.stringify({
+            success: true,
+            message: "Duplicate update ignored",
+          }),
+          { headers: { "Content-Type": "application/json" }, status: 200 },
+        );
       }
-      processedUpdateIds.add(updateId)
+      processedUpdateIds.add(updateId);
     }
 
     // Toque em botão inline (lembrete de liquidação) — trata e sai antes do fluxo
     // de mensagem. Requer setWebhook com allowed_updates incluindo callback_query.
     if (payload.callback_query) {
-      const cbSupabaseUrl = Deno.env.get("SUPABASE_URL")
-      const cbServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")
+      const cbSupabaseUrl = Deno.env.get("SUPABASE_URL");
+      const cbServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
       if (!cbSupabaseUrl || !cbServiceKey) {
-        console.error("Missing Supabase configuration (callback_query)")
+        console.error("Missing Supabase configuration (callback_query)");
         return new Response(
-          JSON.stringify({ success: false, error: "Server configuration error" }),
-          { headers: { "Content-Type": "application/json" }, status: 500 }
-        )
+          JSON.stringify({
+            success: false,
+            error: "Server configuration error",
+          }),
+          { headers: { "Content-Type": "application/json" }, status: 500 },
+        );
       }
       return await handleCallbackQuery(
         createClient(cbSupabaseUrl, cbServiceKey),
         payload.callback_query as TelegramCallbackQuery,
-        generateTraceId()
-      )
+        generateTraceId(),
+      );
     }
 
-    const updateMessage: TelegramMessage | undefined = payload.message || payload.edited_message || payload.channel_post
+    const updateMessage: TelegramMessage | undefined = payload.message ||
+      payload.edited_message || payload.channel_post;
 
     // Log raw payload (truncate to avoid huge logs)
     try {
-      const raw = JSON.stringify(payload)
-      console.log("telegram_raw_payload", raw.length > 4000 ? raw.slice(0, 4000) + "...(truncated)" : raw)
+      const raw = JSON.stringify(payload);
+      console.log(
+        "telegram_raw_payload",
+        raw.length > 4000 ? raw.slice(0, 4000) + "...(truncated)" : raw,
+      );
     } catch (_) {
-      console.log("telegram_raw_payload_unstringifiable")
+      console.log("telegram_raw_payload_unstringifiable");
     }
 
     // Log summary
@@ -91,31 +115,37 @@ serve(async (req) => {
       has_message: !!payload.message,
       has_edited_message: !!payload.edited_message,
       has_channel_post: !!payload.channel_post,
-      contact: payload.message?.contact ? { phone: maskPhone(payload.message.contact.phone_number) } : undefined,
-      text_preview: (payload.message?.text || payload.message?.caption || "").slice(0, 100)
-    })
+      contact: payload.message?.contact
+        ? { phone: maskPhone(payload.message.contact.phone_number) }
+        : undefined,
+      text_preview: (payload.message?.text || payload.message?.caption || "")
+        .slice(0, 100),
+    });
 
     if (!updateMessage) {
-      return new Response(JSON.stringify({ success: true, message: "No message to process" }), { headers: { "Content-Type": "application/json" }, status: 200 })
+      return new Response(
+        JSON.stringify({ success: true, message: "No message to process" }),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      );
     }
 
-    const chatId = updateMessage.chat.id
-    const fromUser = updateMessage.from
-    const text = updateMessage.text || updateMessage.caption || ""
-    const traceId = generateTraceId()
+    const chatId = updateMessage.chat.id;
+    const fromUser = updateMessage.from;
+    const text = updateMessage.text || updateMessage.caption || "";
+    const traceId = generateTraceId();
 
-    const supabaseUrl = Deno.env.get("SUPABASE_URL")
-    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 
     if (!supabaseUrl || !supabaseServiceKey) {
-      console.error("Missing Supabase configuration")
+      console.error("Missing Supabase configuration");
       return new Response(
         JSON.stringify({ success: false, error: "Server configuration error" }),
-        { headers: { "Content-Type": "application/json" }, status: 500 }
-      )
+        { headers: { "Content-Type": "application/json" }, status: 500 },
+      );
     }
 
-    const supabase = createClient(supabaseUrl, supabaseServiceKey)
+    const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
     // Debug info about message content fields
     console.log("telegram_message_debug", {
@@ -128,26 +158,33 @@ serve(async (req) => {
       has_voice: !!updateMessage?.voice,
       has_audio: !!updateMessage?.audio,
       has_document: !!updateMessage?.document,
-      document_mime: updateMessage?.document?.mime_type
-    })
+      document_mime: updateMessage?.document?.mime_type,
+    });
 
     // Handle /start force_contact (explicit resync flow from Settings)
     if (text.startsWith("/start")) {
-      const parts = text.split(/\s+/)
-      const param = parts[1]
+      const parts = text.split(/\s+/);
+      const param = parts[1];
       if (param === "force_contact") {
-        await sendContactRequest(chatId)
-        const telegramUserId = fromUser?.id ? String(fromUser.id) : undefined
+        await sendContactRequest(chatId);
+        const telegramUserId = fromUser?.id ? String(fromUser.id) : undefined;
         await trackEvent(
           "telegram_start_force_contact",
-          { chat_id: String(chatId), telegram_user_id: telegramUserId, channel: "telegram" },
+          {
+            chat_id: String(chatId),
+            telegram_user_id: telegramUserId,
+            channel: "telegram",
+          },
           telegramUserId || "unknown",
-          traceId
-        ).catch(() => {})
+          traceId,
+        ).catch(() => {});
         return new Response(
-          JSON.stringify({ success: true, message: "Contact requested via /start" }),
-          { headers: { "Content-Type": "application/json" }, status: 200 }
-        )
+          JSON.stringify({
+            success: true,
+            message: "Contact requested via /start",
+          }),
+          { headers: { "Content-Type": "application/json" }, status: 200 },
+        );
       }
 
       // Deep-link de vínculo (onboarding redesign): /start link_<token>.
@@ -155,20 +192,28 @@ serve(async (req) => {
       // que gerava beco quando o nº do Telegram ≠ nº do cadastro.
       // O fluxo de contato logo abaixo permanece como fallback.
       if (param && param.startsWith("link_")) {
-        const token = param.slice("link_".length)
+        const token = param.slice("link_".length);
         const { data: tok } = await supabase
           .from("telegram_link_tokens")
           .select("token, user_id, expires_at, used_at")
           .eq("token", token)
-          .maybeSingle()
+          .maybeSingle();
 
-        if (!tok || tok.used_at || new Date(tok.expires_at).getTime() < Date.now()) {
-          await sendTelegramMessage(chatId, "Esse link de conexão expirou. Volte ao site e clique em *Conectar meu Telegram* de novo — ou vincule pelo número abaixo.")
-          await sendContactRequest(chatId)
+        if (
+          !tok || tok.used_at || new Date(tok.expires_at).getTime() < Date.now()
+        ) {
+          await sendTelegramMessage(
+            chatId,
+            "Esse link de conexão expirou. Volte ao site e clique em *Conectar meu Telegram* de novo — ou vincule pelo número abaixo.",
+          );
+          await sendContactRequest(chatId);
           return new Response(
-            JSON.stringify({ success: true, message: "Link token invalid or expired" }),
-            { headers: { "Content-Type": "application/json" }, status: 200 }
-          )
+            JSON.stringify({
+              success: true,
+              message: "Link token invalid or expired",
+            }),
+            { headers: { "Content-Type": "application/json" }, status: 200 },
+          );
         }
 
         const { error: linkErr } = await supabase
@@ -177,137 +222,186 @@ serve(async (req) => {
             telegram_chat_id: String(chatId),
             telegram_user_id: fromUser?.id ? String(fromUser.id) : null,
             telegram_synced_at: new Date().toISOString(),
-            telegram_sync_source: "deep_link"
+            telegram_sync_source: "deep_link",
           })
-          .eq("id", tok.user_id)
+          .eq("id", tok.user_id);
 
         if (linkErr) {
-          console.error("deep_link_sync_failed", { user_id: tok.user_id, error: linkErr.message })
-          await sendTelegramMessage(chatId, "Não consegui vincular sua conta agora — volte ao site e tente de novo.")
+          console.error("deep_link_sync_failed", {
+            user_id: tok.user_id,
+            error: linkErr.message,
+          });
+          await sendTelegramMessage(
+            chatId,
+            "Não consegui vincular sua conta agora — volte ao site e tente de novo.",
+          );
           return new Response(
             JSON.stringify({ success: true, error: "Deep link update failed" }),
-            { headers: { "Content-Type": "application/json" }, status: 200 }
-          )
+            { headers: { "Content-Type": "application/json" }, status: 200 },
+          );
         }
 
         await supabase
           .from("telegram_link_tokens")
           .update({ used_at: new Date().toISOString() })
-          .eq("token", token)
+          .eq("token", token);
 
         await identifyUser(tok.user_id, {
-          name: fromUser?.first_name || undefined
-        }).catch(() => {})
+          name: fromUser?.first_name || undefined,
+        }).catch(() => {});
 
-        await sendWelcomeMessageTelegram(chatId, fromUser?.first_name || undefined)
+        await sendWelcomeMessageTelegram(
+          chatId,
+          fromUser?.first_name || undefined,
+        );
         await trackEvent(
           "telegram_sync_success",
-          { user_id: tok.user_id, chat_id: String(chatId), channel: "telegram", sync_source: "deep_link" },
+          {
+            user_id: tok.user_id,
+            chat_id: String(chatId),
+            channel: "telegram",
+            sync_source: "deep_link",
+          },
           tok.user_id,
-          traceId
-        ).catch(() => {})
+          traceId,
+        ).catch(() => {});
 
         return new Response(
-          JSON.stringify({ success: true, message: "Telegram linked via deep link" }),
-          { headers: { "Content-Type": "application/json" }, status: 200 }
-        )
+          JSON.stringify({
+            success: true,
+            message: "Telegram linked via deep link",
+          }),
+          { headers: { "Content-Type": "application/json" }, status: 200 },
+        );
       }
     }
 
     // Handle contact sync first
     if (updateMessage.contact) {
-      const contactPhone = updateMessage.contact.phone_number
+      const contactPhone = updateMessage.contact.phone_number;
       if (!contactPhone) {
-        console.log('contact_received_no_phone', { chat_id: chatId })
-        await sendTelegramMessage(chatId, "Não consegui identificar seu número de telefone. Tente novamente.")
+        console.log("contact_received_no_phone", { chat_id: chatId });
+        await sendTelegramMessage(
+          chatId,
+          "Não consegui identificar seu número de telefone. Tente novamente.",
+        );
         return new Response(
           JSON.stringify({ success: true, error: "Contact without phone" }),
-          { headers: { "Content-Type": "application/json" }, status: 200 }
-        )
+          { headers: { "Content-Type": "application/json" }, status: 200 },
+        );
       }
-      console.log('contact_received', {
+      console.log("contact_received", {
         chat_id: chatId,
         from_user_id: fromUser?.id,
         contact_phone: maskPhone(contactPhone),
-        raw_contact: contactPhone
-      })
-      const userMatch = await findUserByPhone(supabase, contactPhone)
+        raw_contact: contactPhone,
+      });
+      const userMatch = await findUserByPhone(supabase, contactPhone);
 
       if (userMatch) {
         const { error: updateError } = await supabase
           .from("users")
           .update({
-            telegram_user_id: fromUser?.id ? String(fromUser.id) : String(updateMessage.contact.user_id || ""),
+            telegram_user_id: fromUser?.id
+              ? String(fromUser.id)
+              : String(updateMessage.contact.user_id || ""),
             telegram_chat_id: String(chatId),
             telegram_username: fromUser?.username || null,
             telegram_phone: contactPhone,
             telegram_synced: true,
             telegram_synced_at: new Date().toISOString(),
-            telegram_sync_source: "contact_share"
+            telegram_sync_source: "contact_share",
           })
-          .eq("id", userMatch.id)
+          .eq("id", userMatch.id);
 
         if (!updateError) {
           await identifyUser(userMatch.id, {
             name: fromUser?.first_name || userMatch.name || undefined,
             phone: contactPhone,
             conversation_id: undefined,
-            whatsapp_number: userMatch.whatsapp_number || undefined
-          }).catch(() => {})
+            whatsapp_number: userMatch.whatsapp_number || undefined,
+          }).catch(() => {});
 
-          await sendWelcomeMessageTelegram(chatId, fromUser?.first_name || userMatch.name || undefined)
+          await sendWelcomeMessageTelegram(
+            chatId,
+            fromUser?.first_name || userMatch.name || undefined,
+          );
           await trackEvent(
             "telegram_sync_success",
-            { user_id: userMatch.id, chat_id: chatId, phone: contactPhone, channel: "telegram", sync_source: "contact_share" },
+            {
+              user_id: userMatch.id,
+              chat_id: chatId,
+              phone: contactPhone,
+              channel: "telegram",
+              sync_source: "contact_share",
+            },
             userMatch.id,
-            traceId
-          ).catch(() => {})
+            traceId,
+          ).catch(() => {});
 
-          return new Response(JSON.stringify({ success: true, message: "Telegram synced" }), { headers: { "Content-Type": "application/json" }, status: 200 })
+          return new Response(
+            JSON.stringify({ success: true, message: "Telegram synced" }),
+            { headers: { "Content-Type": "application/json" }, status: 200 },
+          );
         }
       }
 
-      await sendTelegramMessage(chatId, "Não encontrei sua conta com esse número. Responda com o contato novamente ou fale com o suporte.")
+      await sendTelegramMessage(
+        chatId,
+        "Não encontrei sua conta com esse número. Responda com o contato novamente ou fale com o suporte.",
+      );
       // Return 200 to avoid Telegram retrying the same contact message indefinitely
       return new Response(
-        JSON.stringify({ success: true, error: "User not found for provided phone" }),
-        { headers: { "Content-Type": "application/json" }, status: 200 }
-      )
+        JSON.stringify({
+          success: true,
+          error: "User not found for provided phone",
+        }),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      );
     }
 
     // Find user by telegram ids
-    const telegramUserId = fromUser?.id ? String(fromUser.id) : undefined
-    const user = await findUserByTelegram(supabase, telegramUserId, String(chatId), traceId)
+    const telegramUserId = fromUser?.id ? String(fromUser.id) : undefined;
+    const user = await findUserByTelegram(
+      supabase,
+      telegramUserId,
+      String(chatId),
+      traceId,
+    );
 
     if (!user) {
       await trackEvent(
         "telegram_user_missing",
-        { chat_id: chatId, telegram_user_id: telegramUserId, channel: "telegram" },
+        {
+          chat_id: chatId,
+          telegram_user_id: telegramUserId,
+          channel: "telegram",
+        },
         telegramUserId || "unknown",
-        traceId
-      ).catch(() => {})
+        traceId,
+      ).catch(() => {});
 
-      await sendContactRequest(chatId)
+      await sendContactRequest(chatId);
       // Return 200 to avoid Telegram retry loops that would resend the same message
       return new Response(
         JSON.stringify({ success: true, message: "Contact requested" }),
-        { headers: { "Content-Type": "application/json" }, status: 200 }
-      )
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      );
     }
 
     console.log("daily_limit_user_mapped", {
       telegram_user_id: telegramUserId,
       chat_id: String(chatId),
       resolved_user_id: user.id,
-      trace_id: traceId
-    })
+      trace_id: traceId,
+    });
 
     await identifyUser(user.id, {
       name: fromUser?.first_name || user.name || undefined,
       phone: undefined,
       conversation_id: undefined,
-      whatsapp_number: undefined
-    }).catch(() => {})
+      whatsapp_number: undefined,
+    }).catch(() => {});
 
     await trackEvent(
       "telegram_message_received",
@@ -317,78 +411,96 @@ serve(async (req) => {
         has_photo: !!updateMessage.photo,
         has_voice: !!updateMessage.voice,
         content_length: text.length,
-        channel: "telegram"
+        channel: "telegram",
       },
       user.id,
-      traceId
-    ).catch(() => {})
+      traceId,
+    ).catch(() => {});
 
     // Preferência dos lembretes de liquidação (par do botão 🔕 do notify-settlement)
-    const command = text.trim().toLowerCase()
+    const command = text.trim().toLowerCase();
     if (command === "/silenciar" || command === "/lembretes") {
-      const mute = command === "/silenciar"
-      await supabase.from("users").update({ settlement_reminders_muted: mute }).eq("id", user.id)
+      const mute = command === "/silenciar";
+      await supabase.from("users").update({ settlement_reminders_muted: mute })
+        .eq("id", user.id);
       await sendTelegramMessage(
         chatId,
         mute
           ? "🔕 Beleza — parei com os lembretes de liquidação. Pra voltar, é só mandar /lembretes."
-          : "🔔 Lembretes reativados! Quando um jogo seu terminar, eu te chamo aqui pra fechar a aposta."
-      )
+          : "🔔 Lembretes reativados! Quando um jogo seu terminar, eu te chamo aqui pra fechar a aposta.",
+      );
       await trackEvent(
         mute ? "settlement_reminders_muted" : "settlement_reminders_unmuted",
         { via: "command", channel: "telegram" },
         user.id,
-        traceId
-      ).catch(() => {})
+        traceId,
+      ).catch(() => {});
       return new Response(
-        JSON.stringify({ success: true, message: "Reminder preference updated" }),
-        { headers: { "Content-Type": "application/json" }, status: 200 }
-      )
+        JSON.stringify({
+          success: true,
+          message: "Reminder preference updated",
+        }),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      );
     }
 
     // /resumo — toggle do resumo semanal (par do botão "Silenciar resumo")
     if (command === "/resumo") {
       const { data: pref } = await supabase
-        .from("users").select("weekly_summary_muted").eq("id", user.id).maybeSingle()
-      const mute = !(pref?.weekly_summary_muted ?? false)
-      await supabase.from("users").update({ weekly_summary_muted: mute }).eq("id", user.id)
+        .from("users").select("weekly_summary_muted").eq("id", user.id)
+        .maybeSingle();
+      const mute = !(pref?.weekly_summary_muted ?? false);
+      await supabase.from("users").update({ weekly_summary_muted: mute }).eq(
+        "id",
+        user.id,
+      );
       await sendTelegramMessage(
         chatId,
         mute
           ? "Ok — parei com o resumo semanal. Pra voltar, é só mandar /resumo de novo."
-          : "📊 Resumo semanal reativado! Toda segunda de manhã eu te mando como fecharam seus últimos 7 dias."
-      )
+          : "📊 Resumo semanal reativado! Toda segunda de manhã eu te mando como fecharam seus últimos 7 dias.",
+      );
       await trackEvent(
         mute ? "weekly_summary_muted" : "weekly_summary_unmuted",
         { via: "command", channel: "telegram" },
         user.id,
-        traceId
-      ).catch(() => {})
+        traceId,
+      ).catch(() => {});
       return new Response(
-        JSON.stringify({ success: true, message: "Weekly summary preference updated" }),
-        { headers: { "Content-Type": "application/json" }, status: 200 }
-      )
+        JSON.stringify({
+          success: true,
+          message: "Weekly summary preference updated",
+        }),
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      );
     }
 
     // /mensagens — centro de controle: o que o Betinho manda + toggles num
     // lugar só (Onda 6 da revisão; embrião do item 17 do Marco 2)
     if (command === "/mensagens") {
       const { data: pref } = await supabase
-        .from("users").select("settlement_reminders_muted, weekly_summary_muted").eq("id", user.id).maybeSingle()
+        .from("users").select(
+          "settlement_reminders_muted, weekly_summary_muted",
+        ).eq("id", user.id).maybeSingle();
       const p = {
         settlementMuted: pref?.settlement_reminders_muted ?? false,
         weeklyMuted: pref?.weekly_summary_muted ?? false,
-      }
+      };
       await sendTelegramMessage(chatId, prefsText(p), {
         parse_mode: "HTML",
         disable_web_page_preview: true,
         reply_markup: { inline_keyboard: prefsKeyboard(p) },
-      })
-      await trackEvent("message_prefs_viewed", { channel: "telegram" }, user.id, traceId).catch(() => {})
+      });
+      await trackEvent(
+        "message_prefs_viewed",
+        { channel: "telegram" },
+        user.id,
+        traceId,
+      ).catch(() => {});
       return new Response(
         JSON.stringify({ success: true, message: "Prefs shown" }),
-        { headers: { "Content-Type": "application/json" }, status: 200 }
-      )
+        { headers: { "Content-Type": "application/json" }, status: 200 },
+      );
     }
 
     // Resposta ao "Outro valor" (force_reply do registrar-oportunidade).
@@ -399,84 +511,167 @@ serve(async (req) => {
     {
       const { data: prompt } = await supabase
         .from("stake_prompts")
-        .select("pick_id, message_id, created_at")
+        .select("pick_id, message_id, created_at, source")
         .eq("chat_id", String(chatId))
         .order("created_at", { ascending: false })
         .limit(1)
-        .maybeSingle()
+        .maybeSingle();
       if (prompt) {
-        const replyToId = updateMessage.reply_to_message?.message_id
-        const isReply = replyToId != null && Number(replyToId) === Number(prompt.message_id)
-        const bareNumber = isBareNumber(text)
-        const fresh = Date.now() - new Date(prompt.created_at).getTime() < 30 * 60_000
+        const replyToId = updateMessage.reply_to_message?.message_id;
+        const isReply = replyToId != null &&
+          Number(replyToId) === Number(prompt.message_id);
+        const bareNumber = isBareNumber(text);
+        const fresh =
+          Date.now() - new Date(prompt.created_at).getTime() < 30 * 60_000;
         if (isReply || (bareNumber && fresh)) {
-          const stake = parseStake(text)
+          const stake = parseStake(text);
           if (stake == null) {
-            await sendTelegramMessage(chatId, "Não entendi o valor 🤔 Manda só o número, ex: 50")
-            return new Response(JSON.stringify({ success: true, message: "stake reply invalid" }), { headers: { "Content-Type": "application/json" }, status: 200 })
+            await sendTelegramMessage(
+              chatId,
+              "Não entendi o valor 🤔 Manda só o número, ex: 50",
+            );
+            return new Response(
+              JSON.stringify({ success: true, message: "stake reply invalid" }),
+              { headers: { "Content-Type": "application/json" }, status: 200 },
+            );
           }
           // consome o prompt antes de registrar (um número não vira duas apostas)
-          await supabase.from("stake_prompts").delete().eq("chat_id", String(chatId)).eq("message_id", prompt.message_id)
+          await supabase.from("stake_prompts").delete().eq(
+            "chat_id",
+            String(chatId),
+          ).eq("message_id", prompt.message_id);
           const { data: pick } = await supabase
-            .from("daily_opportunity_picks").select("*").eq("id", prompt.pick_id).maybeSingle()
+            .from("daily_opportunity_picks").select("*").eq(
+              "id",
+              prompt.pick_id,
+            ).maybeSingle();
           if (pick) {
-            const { data: bet, error } = await registerPickBet(supabase, user.id, pick, stake)
+            const source = (prompt.source === "published_opportunities"
+              ? "published_opportunities"
+              : "daily_opportunities") as PickSource;
+            const { data: bet, error } = await registerPickBet(
+              supabase,
+              user.id,
+              pick,
+              stake,
+              source,
+            );
             if (error || !bet) {
-              await sendTelegramMessage(chatId, "Deu ruim ao registrar — tenta de novo.")
+              await sendTelegramMessage(
+                chatId,
+                "Deu ruim ao registrar — tenta de novo.",
+              );
             } else {
-              const streakLine = await receiptStreakLineFor(supabase, user.id) // item 18 (flag-gated)
-              await sendTelegramMessage(chatId, pickReceiptHtml(pick, stake, streakLine), { parse_mode: "HTML", disable_web_page_preview: true })
+              const streakLine = await receiptStreakLineFor(supabase, user.id); // item 18 (flag-gated)
+              await sendTelegramMessage(
+                chatId,
+                pickReceiptHtml(pick, stake, streakLine),
+                { parse_mode: "HTML", disable_web_page_preview: true },
+              );
               await trackEvent(
-                "opportunity_bet_registered",
-                { bet_id: bet.id, pick_id: prompt.pick_id, stake, via: isReply ? "force_reply" : "bare_number", channel: "telegram" },
-                user.id, traceId
-              ).catch(() => {})
+                source === "published_opportunities"
+                  ? "published_opportunity_bet_registered"
+                  : "opportunity_bet_registered",
+                {
+                  bet_id: bet.id,
+                  pick_id: prompt.pick_id,
+                  stake,
+                  via: isReply ? "force_reply" : "bare_number",
+                  channel: "telegram",
+                  source,
+                },
+                user.id,
+                traceId,
+              ).catch(() => {});
             }
           }
-          return new Response(JSON.stringify({ success: true, message: "stake reply handled" }), { headers: { "Content-Type": "application/json" }, status: 200 })
+          return new Response(
+            JSON.stringify({ success: true, message: "stake reply handled" }),
+            { headers: { "Content-Type": "application/json" }, status: 200 },
+          );
         }
 
         // Não foi resposta de valor válida. A pergunta pendente não pode ficar
         // "esperando" e grudar num número futuro — então limpa aqui.
-        await supabase.from("stake_prompts").delete().eq("chat_id", String(chatId))
+        await supabase.from("stake_prompts").delete().eq(
+          "chat_id",
+          String(chatId),
+        );
 
         if (bareNumber) {
           // número puro, mas o prompt esfriou (>30min): não vira aposta-lixo —
           // avisa e encerra (não segue pro fluxo de extração)
           // reaquecimento (Onda 6): reenvia o botão do pick aqui mesmo — sem
           // obrigar o usuário a rolar o histórico atrás do Registrar original
-          await sendTelegramMessage(chatId, "Essa oportunidade esfriou 🕑 Se ainda quiser registrar, toca abaixo que eu te pergunto o valor de novo.", {
-            reply_markup: { inline_keyboard: [[{ text: "📋 Registrar de novo", callback_data: `regbet:${prompt.pick_id}` }]] },
-          })
-          return new Response(JSON.stringify({ success: true, message: "stale stake prompt cleared" }), { headers: { "Content-Type": "application/json" }, status: 200 })
+          await sendTelegramMessage(
+            chatId,
+            "Essa oportunidade esfriou 🕑 Se ainda quiser registrar, toca abaixo que eu te pergunto o valor de novo.",
+            {
+              reply_markup: {
+                inline_keyboard: [[{
+                  text: "📋 Registrar de novo",
+                  callback_data: `${
+                    prompt.source === "published_opportunities"
+                      ? "regpub"
+                      : "regbet"
+                  }:${prompt.pick_id}`,
+                }]],
+              },
+            },
+          );
+          return new Response(
+            JSON.stringify({
+              success: true,
+              message: "stale stake prompt cleared",
+            }),
+            { headers: { "Content-Type": "application/json" }, status: 200 },
+          );
         }
         // qualquer outra coisa (print, aposta em texto...) → pendência limpa e
         // a mensagem SEGUE o fluxo normal de registro (sem return)
       }
     }
 
-    let actualContent = text
-    let mediaUrl: string | null = null
-    let messageType = "text"
+    let actualContent = text;
+    let mediaUrl: string | null = null;
+    let messageType = "text";
 
     if (updateMessage.photo && updateMessage.photo.length > 0) {
-      const largest = updateMessage.photo[updateMessage.photo.length - 1]
-      mediaUrl = await getTelegramFileUrl(largest.file_id)
-      messageType = "image"
-      console.log("telegram_media_detected", { type: "photo", file_id: largest.file_id, mediaUrl, photos_count: updateMessage.photo.length })
+      const largest = updateMessage.photo[updateMessage.photo.length - 1];
+      mediaUrl = await getTelegramFileUrl(largest.file_id);
+      messageType = "image";
+      console.log("telegram_media_detected", {
+        type: "photo",
+        file_id: largest.file_id,
+        mediaUrl,
+        photos_count: updateMessage.photo.length,
+      });
     } else if (updateMessage.voice) {
-      mediaUrl = await getTelegramFileUrl(updateMessage.voice.file_id)
-      messageType = "audio"
-      console.log("telegram_media_detected", { type: "voice", file_id: updateMessage.voice.file_id, mediaUrl })
+      mediaUrl = await getTelegramFileUrl(updateMessage.voice.file_id);
+      messageType = "audio";
+      console.log("telegram_media_detected", {
+        type: "voice",
+        file_id: updateMessage.voice.file_id,
+        mediaUrl,
+      });
     } else if (updateMessage.audio) {
-      mediaUrl = await getTelegramFileUrl(updateMessage.audio.file_id)
-      messageType = "audio"
-      console.log("telegram_media_detected", { type: "audio", file_id: updateMessage.audio.file_id, mediaUrl })
+      mediaUrl = await getTelegramFileUrl(updateMessage.audio.file_id);
+      messageType = "audio";
+      console.log("telegram_media_detected", {
+        type: "audio",
+        file_id: updateMessage.audio.file_id,
+        mediaUrl,
+      });
     } else if (updateMessage.document) {
       // Some clients send images as document
-      mediaUrl = await getTelegramFileUrl(updateMessage.document.file_id)
-      messageType = "image"
-      console.log("telegram_media_detected", { type: "document", mime: updateMessage.document.mime_type, file_id: updateMessage.document.file_id, mediaUrl })
+      mediaUrl = await getTelegramFileUrl(updateMessage.document.file_id);
+      messageType = "image";
+      console.log("telegram_media_detected", {
+        type: "document",
+        mime: updateMessage.document.mime_type,
+        file_id: updateMessage.document.file_id,
+        mediaUrl,
+      });
     } else if (!actualContent || actualContent.trim().length === 0) {
       console.log("telegram_empty_content", {
         text: actualContent,
@@ -484,28 +679,36 @@ serve(async (req) => {
         has_photo: !!updateMessage.photo,
         has_voice: !!updateMessage.voice,
         has_audio: !!updateMessage.audio,
-        has_document: !!updateMessage.document
-      })
-      await sendTelegramMessage(chatId, "Não encontrei conteúdo na mensagem. Envie texto, foto ou áudio.")
-      return new Response(JSON.stringify({ success: false, error: "Empty message" }), { headers: { "Content-Type": "application/json" }, status: 400 })
+        has_document: !!updateMessage.document,
+      });
+      await sendTelegramMessage(
+        chatId,
+        "Não encontrei conteúdo na mensagem. Envie texto, foto ou áudio.",
+      );
+      return new Response(
+        JSON.stringify({ success: false, error: "Empty message" }),
+        { headers: { "Content-Type": "application/json" }, status: 400 },
+      );
     }
 
     if (messageType === "audio" && mediaUrl) {
-      const transcription = await transcribeAudio(mediaUrl, user.id, traceId)
+      const transcription = await transcribeAudio(mediaUrl, user.id, traceId);
       if (actualContent && actualContent.trim()) {
-        actualContent = `Transcrição do áudio: ${transcription}\n\nTexto adicional: ${actualContent}`
+        actualContent =
+          `Transcrição do áudio: ${transcription}\n\nTexto adicional: ${actualContent}`;
       } else {
-        actualContent = transcription
+        actualContent = transcription;
       }
-      messageType = "text"
+      messageType = "text";
     } else if (messageType === "image" && mediaUrl) {
-      const imageAnalysis = await processImage(mediaUrl, user.id, traceId)
+      const imageAnalysis = await processImage(mediaUrl, user.id, traceId);
       if (actualContent && actualContent.trim()) {
-        actualContent = `Análise da imagem: ${imageAnalysis}\n\nTexto adicional do usuário: ${actualContent}`
+        actualContent =
+          `Análise da imagem: ${imageAnalysis}\n\nTexto adicional do usuário: ${actualContent}`;
       } else {
-        actualContent = imageAnalysis
+        actualContent = imageAnalysis;
       }
-      messageType = "text"
+      messageType = "text";
     }
 
     const { data: queueMessage, error: queueError } = await supabase
@@ -516,23 +719,42 @@ serve(async (req) => {
         content: actualContent,
         media_url: mediaUrl,
         status: "pending",
-        channel: "telegram"
+        channel: "telegram",
       })
       .select()
-      .single()
+      .single();
 
     if (queueError) {
-      console.error("queue_insert_error", queueError)
-      throw new Error(queueError.message)
+      console.error("queue_insert_error", queueError);
+      throw new Error(queueError.message);
     }
 
-    await processMessage(supabase, queueMessage.id, actualContent, user.id, traceId, chatId)
+    await processMessage(
+      supabase,
+      queueMessage.id,
+      actualContent,
+      user.id,
+      traceId,
+      chatId,
+    );
 
-    return new Response(JSON.stringify({ success: true, message: "Message processed successfully", queue_id: queueMessage.id }), { headers: { "Content-Type": "application/json" }, status: 200 })
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: "Message processed successfully",
+        queue_id: queueMessage.id,
+      }),
+      { headers: { "Content-Type": "application/json" }, status: 200 },
+    );
   } catch (error: any) {
-    console.error("Error in Telegram webhook:", error)
-    return new Response(JSON.stringify({ success: false, error: error.message, timestamp: new Date().toISOString() }), { headers: { "Content-Type": "application/json" }, status: 500 })
+    console.error("Error in Telegram webhook:", error);
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: error.message,
+        timestamp: new Date().toISOString(),
+      }),
+      { headers: { "Content-Type": "application/json" }, status: 500 },
+    );
   }
-})
-
-
+});

--- a/supabase/functions/telegram-webhook/picks.ts
+++ b/supabase/functions/telegram-webhook/picks.ts
@@ -2,8 +2,8 @@
 // picks.ts — registro de aposta a partir do daily (item 15)
 // ============================================================
 // Extraído de index.ts na Onda 6b da revisão (split mecânico, move-only).
-import { BETS_DASHBOARD_URL } from "./config.ts"
-import { telegramCall, escHtml, formatBRL } from "./telegram-api.ts"
+import { BETS_DASHBOARD_URL } from "./config.ts";
+import { escHtml, formatBRL, telegramCall } from "./telegram-api.ts";
 
 // ============================================================
 // Registrar aposta da "oportunidade do dia" (item 15) — botões de stake
@@ -11,26 +11,37 @@ import { telegramCall, escHtml, formatBRL } from "./telegram-api.ts"
 
 // Unidade efetiva do usuário em R$ (fixo = valor; percentual = % da banca).
 // null = não configurada → só oferece "Outro valor".
-async function effectiveUnit(supabase: any, userId: string): Promise<number | null> {
+async function effectiveUnit(
+  supabase: any,
+  userId: string,
+): Promise<number | null> {
   const { data } = await supabase
     .from("users")
     .select("unit_value, unit_calculation_method, bank_amount")
     .eq("id", userId)
-    .maybeSingle()
-  const u = Number(data?.unit_value)
-  if (!u || u <= 0) return null
+    .maybeSingle();
+  const u = Number(data?.unit_value);
+  if (!u || u <= 0) return null;
   if (data.unit_calculation_method === "percentual") {
-    const bank = Number(data.bank_amount)
-    if (!bank || bank <= 0) return null
-    return Math.round(bank * (u / 100) * 100) / 100
+    const bank = Number(data.bank_amount);
+    if (!bank || bank <= 0) return null;
+    return Math.round(bank * (u / 100) * 100) / 100;
   }
-  return u
+  return u;
 }
 
 // Cria a aposta pendente a partir de um pick do daily. channel 'futebol' marca
 // a origem (loop Análise→Betinho); processed_data guarda o pick pra auditoria.
-async function registerPickBet(supabase: any, userId: string, pick: any, stake: number) {
-  const odds = Number(pick.odds)
+type PickSource = "daily_opportunities" | "published_opportunities";
+
+async function registerPickBet(
+  supabase: any,
+  userId: string,
+  pick: any,
+  stake: number,
+  source: PickSource = "daily_opportunities",
+) {
+  const odds = Number(pick.odds);
   return await supabase
     .from("bets")
     .insert({
@@ -48,42 +59,64 @@ async function registerPickBet(supabase: any, userId: string, pick: any, stake: 
       bet_date: new Date().toISOString(),
       match_date: pick.match_date || null,
       channel: "futebol",
-      raw_input: "[oportunidade do dia]",
-      processed_data: { source: "daily_opportunity", pick_id: pick.id }
+      raw_input: source === "published_opportunities"
+        ? "[oportunidade publicada]"
+        : "[oportunidade do dia]",
+      processed_data: { source, pick_id: pick.id },
     })
     .select("id")
-    .maybeSingle()
+    .maybeSingle();
 }
 
-function pickReceiptHtml(pick: any, stake: number, streakLine?: string | null): string {
-  const odds = Number(pick.odds)
+function pickReceiptHtml(
+  pick: any,
+  stake: number,
+  streakLine?: string | null,
+): string {
+  const odds = Number(pick.odds);
   return [
     `✅ <b>Registrado no Betinho!</b>`,
     "",
     `<b>${escHtml(pick.bet_description)}</b>`,
     `${escHtml(pick.match_description)}`,
-    `${formatBRL(stake)} · odd ${odds} · retorno ${formatBRL(Math.round(stake * odds * 100) / 100)}`,
+    `${formatBRL(stake)} · odd ${odds} · retorno ${
+      formatBRL(Math.round(stake * odds * 100) / 100)
+    }`,
     ...(streakLine ? ["", streakLine] : []), // item 18: milestone da sequência (flag-gated)
     "",
-    `Tá pendente — quando o jogo acabar, eu fecho pra você. 📊 ${BETS_DASHBOARD_URL}`
-  ].join("\n")
+    `Tá pendente — quando o jogo acabar, eu fecho pra você. 📊 ${BETS_DASHBOARD_URL}`,
+  ].join("\n");
 }
 
 // pergunta o valor por force_reply e guarda o prompt (o interceptador lê depois)
-async function sendStakePrompt(supabase: any, chatId: string | number, userId: string, pickId: string, text: string): Promise<void> {
-  const sent = await telegramCall<{ result?: { message_id: number } }>("sendMessage", {
-    chat_id: chatId,
-    text,
-    parse_mode: "HTML",
-    reply_markup: { force_reply: true, input_field_placeholder: "Ex: 50" }
-  })
-  const promptId = sent?.result?.message_id
+async function sendStakePrompt(
+  supabase: any,
+  chatId: string | number,
+  userId: string,
+  pickId: string,
+  text: string,
+  source: PickSource = "daily_opportunities",
+): Promise<void> {
+  const sent = await telegramCall<{ result?: { message_id: number } }>(
+    "sendMessage",
+    {
+      chat_id: chatId,
+      text,
+      parse_mode: "HTML",
+      reply_markup: { force_reply: true, input_field_placeholder: "Ex: 50" },
+    },
+  );
+  const promptId = sent?.result?.message_id;
   if (promptId) {
     await supabase.from("stake_prompts").insert({
-      chat_id: String(chatId), message_id: promptId, pick_id: pickId, user_id: userId
-    })
+      chat_id: String(chatId),
+      message_id: promptId,
+      pick_id: pickId,
+      user_id: userId,
+      source,
+    });
   }
 }
 
-
-export { effectiveUnit, registerPickBet, pickReceiptHtml, sendStakePrompt }
+export { effectiveUnit, pickReceiptHtml, registerPickBet, sendStakePrompt };
+export type { PickSource };

--- a/supabase/functions/tests/published-opportunities-message.test.ts
+++ b/supabase/functions/tests/published-opportunities-message.test.ts
@@ -1,0 +1,63 @@
+import { assert } from "./_assert.ts";
+import {
+  type PublishedMessageOpportunity,
+  publishedMessageText,
+} from "../notify-published-opportunities/message.ts";
+
+const opportunity = (
+  fixture_id: number,
+  score: number,
+): PublishedMessageOpportunity => ({
+  alert_id: `alert-${fixture_id}`,
+  fixture_id,
+  home_team_name: `Casa ${fixture_id}`,
+  away_team_name: `Fora ${fixture_id}`,
+  competition: "Brasileirão",
+  kickoff_utc: "2026-08-27T19:30:00.000Z",
+  market: "goals_over_under",
+  outcome: "Over",
+  line_value: 1.5,
+  best_odd: 1.8,
+  score,
+  faixa: "Média",
+  evidencias: ["O jogo cria chances dos dois lados"],
+});
+
+Deno.test("mensagem de publicação: oportunidade única aponta a nova leitura", () => {
+  const text = publishedMessageText(
+    [opportunity(1, 46)],
+    new Map([["alert-1", "https://example.test/jogo-1"]]),
+  );
+
+  assert(text.includes("Nova oportunidade mapeada"), "título individual");
+  assert(text.includes("Casa 1 × Fora 1"), "jogo");
+  assert(
+    text.includes("Mais de 1,5 gols · odd 1.8 · Score <b>46 · Média</b>"),
+    "dados da oportunidade",
+  );
+});
+
+Deno.test("mensagem de publicação: lote grande detalha as três maiores e aponta o restante no painel", () => {
+  const text = publishedMessageText(
+    [
+      opportunity(1, 40),
+      opportunity(2, 64),
+      opportunity(3, 58),
+      opportunity(4, 70),
+    ],
+    new Map([
+      ["alert-1", "u1"],
+      ["alert-2", "u2"],
+      ["alert-3", "u3"],
+      ["alert-4", "u4"],
+    ]),
+  );
+
+  assert(text.includes("Novas oportunidades mapeadas"), "título consolidado");
+  assert(text.includes("4 no painel"), "quantidade consolidada");
+  assert(text.includes("Casa 4 × Fora 4"), "maior Score entra");
+  assert(text.includes("Casa 2 × Fora 2"), "segunda maior entra");
+  assert(text.includes("Casa 3 × Fora 3"), "terceira maior entra");
+  assert(!text.includes("Casa 1 × Fora 1"), "quarta não ocupa detalhe");
+  assert(text.includes("+ 1 oportunidade no painel."), "restante explícito");
+});

--- a/supabase/functions/tests/published-opportunities.test.ts
+++ b/supabase/functions/tests/published-opportunities.test.ts
@@ -1,0 +1,122 @@
+import { assertEquals } from "./_assert.ts";
+import { planPublicationBatch } from "../notify-published-opportunities/planner.ts";
+
+const now = new Date("2026-08-27T12:00:00.000Z");
+
+Deno.test("publicação: uma oportunidade pré-live nova entra no lote uma única vez", () => {
+  const batch = planPublicationBatch({
+    now,
+    alreadyAlerted: new Set<string>(),
+    board: [{
+      fixture_id: 1520835,
+      market: "goals_over_under",
+      outcome: "Over",
+      line_value: 1.5,
+      kickoff_utc: "2026-08-27 19:30:00",
+      score: 46,
+    }],
+  });
+
+  assertEquals(batch.newOpportunities.map((opportunity) => opportunity.key), [
+    "1520835:goals_over_under:Over:1.5",
+  ]);
+  assertEquals(batch.detailedOpportunities.length, 1);
+});
+
+Deno.test("publicação: a mesma oportunidade não volta ao lote quando já foi alertada", () => {
+  const batch = planPublicationBatch({
+    now,
+    alreadyAlerted: new Set(["1520835:goals_over_under:Over:1.5"]),
+    board: [{
+      fixture_id: 1520835,
+      market: "goals_over_under",
+      outcome: "Over",
+      line_value: 1.5,
+      kickoff_utc: "2026-08-27 19:30:00",
+      score: 62,
+    }],
+  });
+
+  assertEquals(batch.newOpportunities.length, 0);
+});
+
+Deno.test("publicação: não inclui oportunidade depois do kickoff", () => {
+  const batch = planPublicationBatch({
+    now,
+    alreadyAlerted: new Set<string>(),
+    board: [{
+      fixture_id: 1520835,
+      market: "goals_over_under",
+      outcome: "Over",
+      line_value: 1.5,
+      kickoff_utc: "2026-08-27 11:59:59",
+      score: 62,
+    }],
+  });
+
+  assertEquals(batch.newOpportunities.length, 0);
+});
+
+Deno.test("publicação: candidata abaixo da régua do painel não entra no lote", () => {
+  const batch = planPublicationBatch({
+    now,
+    alreadyAlerted: new Set<string>(),
+    board: [{
+      fixture_id: 1520835,
+      market: "goals_over_under",
+      outcome: "Over",
+      line_value: 1.5,
+      kickoff_utc: "2026-08-27T19:30:00Z",
+      score: 39,
+    }],
+  });
+
+  assertEquals(batch.newOpportunities.length, 0);
+});
+
+Deno.test("publicação: lote mantém todas as novas e detalha as três de maior Score", () => {
+  const batch = planPublicationBatch({
+    now,
+    alreadyAlerted: new Set<string>(),
+    board: [
+      {
+        fixture_id: 1,
+        market: "goals_over_under",
+        outcome: "Over",
+        line_value: 1.5,
+        kickoff_utc: "2026-08-27 19:30:00",
+        score: 43,
+      },
+      {
+        fixture_id: 2,
+        market: "goals_over_under",
+        outcome: "Over",
+        line_value: 1.5,
+        kickoff_utc: "2026-08-27 19:30:00",
+        score: 58,
+      },
+      {
+        fixture_id: 3,
+        market: "goals_over_under",
+        outcome: "Over",
+        line_value: 1.5,
+        kickoff_utc: "2026-08-27 19:30:00",
+        score: 70,
+      },
+      {
+        fixture_id: 4,
+        market: "goals_over_under",
+        outcome: "Over",
+        line_value: 1.5,
+        kickoff_utc: "2026-08-27 19:30:00",
+        score: 51,
+      },
+    ],
+  });
+
+  assertEquals(batch.newOpportunities.length, 4);
+  assertEquals(
+    batch.detailedOpportunities.map((opportunity) => opportunity.fixture_id),
+    [3, 2, 4],
+  );
+});

--- a/supabase/migrations/20260827120000_111_futebol_alertas_publicacao.sql
+++ b/supabase/migrations/20260827120000_111_futebol_alertas_publicacao.sql
@@ -1,0 +1,293 @@
+-- ============================================================
+-- 111_futebol_alertas_publicacao — alertas Telegram ao publicar oportunidade
+-- ============================================================
+-- O daily (081) é um resumo editorial às 10h. Este fluxo é diferente: guarda
+-- a PRIMEIRA publicação de cada Oportunidade e entrega um lote após o sync.
+-- A identidade é fixture + mercado + saída + linha; mudança de odd/Score não
+-- cria outro alerta, e reativação da mesma oportunidade também não.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.futebol_publication_alert_runtime (
+  singleton     boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+  initialized_at timestamptz NOT NULL DEFAULT now(),
+  last_sync_at   timestamptz
+);
+COMMENT ON TABLE public.futebol_publication_alert_runtime IS
+  'Estado do detector de publicações. O primeiro run só cria a base histórica para não disparar oportunidades que já estavam no painel.';
+ALTER TABLE public.futebol_publication_alert_runtime ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE IF NOT EXISTS public.futebol_publication_alert_batches (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sync_at    timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_futebol_publication_alert_batches_sync
+  ON public.futebol_publication_alert_batches (sync_at DESC);
+ALTER TABLE public.futebol_publication_alert_batches ENABLE ROW LEVEL SECURITY;
+
+CREATE TABLE IF NOT EXISTS public.futebol_publication_alerts (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  batch_id                 uuid NOT NULL REFERENCES public.futebol_publication_alert_batches(id) ON DELETE CASCADE,
+  opportunity_key          text NOT NULL UNIQUE,
+  fixture_id               bigint NOT NULL,
+  home_team_name           text NOT NULL,
+  away_team_name           text NOT NULL,
+  competition              text,
+  kickoff_utc              timestamptz NOT NULL,
+  market                   text NOT NULL,
+  outcome                  text NOT NULL,
+  line_value               double precision,
+  best_odd                 numeric NOT NULL,
+  score                    integer NOT NULL,
+  faixa                    text NOT NULL,
+  janela_usada             text,
+  edge                     double precision,
+  prob_justa_fechamento    double precision,
+  evidencias               text[],
+  detected_at              timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_futebol_publication_alerts_batch
+  ON public.futebol_publication_alerts (batch_id, score DESC);
+COMMENT ON TABLE public.futebol_publication_alerts IS
+  'Registro imutável da primeira publicação de cada Oportunidade no painel; fonte do alerta em tempo real e da fotografia dos números enviados.';
+ALTER TABLE public.futebol_publication_alerts ENABLE ROW LEVEL SECURITY;
+
+-- Um alerta pode reutilizar o mesmo pick criado pelo daily no mesmo dia. A
+-- referência mantém o callback regbet existente sem criar outra família dele.
+CREATE TABLE IF NOT EXISTS public.futebol_publication_alert_pick_refs (
+  alert_id uuid PRIMARY KEY REFERENCES public.futebol_publication_alerts(id) ON DELETE CASCADE,
+  pick_id  uuid NOT NULL REFERENCES public.daily_opportunity_picks(id) ON DELETE CASCADE
+);
+ALTER TABLE public.futebol_publication_alert_pick_refs ENABLE ROW LEVEL SECURITY;
+
+-- O mesmo pick pode aparecer no resumo diário e no alerta em tempo real. A
+-- origem acompanha o registro no Betinho para manter o funil mensurável.
+ALTER TABLE public.stake_prompts
+  ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'daily_opportunities'
+  CHECK (source IN ('daily_opportunities', 'published_opportunities'));
+
+CREATE TABLE IF NOT EXISTS public.futebol_publication_alert_deliveries (
+  batch_id        uuid NOT NULL REFERENCES public.futebol_publication_alert_batches(id) ON DELETE CASCADE,
+  user_id         uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  chat_id         text NOT NULL,
+  status          text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'failed', 'sent', 'expired')),
+  attempts        integer NOT NULL DEFAULT 0,
+  attempt_id      uuid,
+  claimed_at      timestamptz,
+  last_attempt_at timestamptz,
+  sent_at         timestamptz,
+  last_error      text,
+  PRIMARY KEY (batch_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_futebol_publication_alert_deliveries_pending
+  ON public.futebol_publication_alert_deliveries (status, last_attempt_at);
+COMMENT ON TABLE public.futebol_publication_alert_deliveries IS
+  'Entrega por pessoa dos lotes de publicação. Uma reserva atômica impede dois crons de reenviar a mesma linha; falhas podem ser retomadas enquanto houver jogo pré-live.';
+ALTER TABLE public.futebol_publication_alert_deliveries ENABLE ROW LEVEL SECURITY;
+
+-- Cria um lote somente para oportunidades que ainda não estavam no ledger.
+-- O advisory lock torna o polling idempotente mesmo se dois crons coincidirem.
+CREATE OR REPLACE FUNCTION public.claim_futebol_publication_alert_batch(
+  p_sync_at timestamptz,
+  p_opportunities jsonb
+)
+RETURNS TABLE(batch_id uuid, alert_id uuid, opportunity_key text)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_batch_id uuid;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('futebol-publication-alerts'));
+
+  WITH incoming AS (
+    SELECT *
+    FROM jsonb_to_recordset(p_opportunities) AS x(
+      opportunity_key text,
+      fixture_id bigint,
+      home_team_name text,
+      away_team_name text,
+      competition text,
+      kickoff_utc timestamptz,
+      market text,
+      outcome text,
+      line_value double precision,
+      best_odd numeric,
+      score integer,
+      faixa text,
+      janela_usada text,
+      edge double precision,
+      prob_justa_fechamento double precision,
+      evidencias text[]
+    )
+  )
+  INSERT INTO public.futebol_publication_alert_batches (sync_at)
+  SELECT p_sync_at
+  WHERE EXISTS (
+    SELECT 1 FROM incoming i
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.futebol_publication_alerts a
+      WHERE a.opportunity_key = i.opportunity_key
+    )
+  )
+  RETURNING id INTO v_batch_id;
+
+  IF v_batch_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH incoming AS (
+    SELECT *
+    FROM jsonb_to_recordset(p_opportunities) AS x(
+      opportunity_key text,
+      fixture_id bigint,
+      home_team_name text,
+      away_team_name text,
+      competition text,
+      kickoff_utc timestamptz,
+      market text,
+      outcome text,
+      line_value double precision,
+      best_odd numeric,
+      score integer,
+      faixa text,
+      janela_usada text,
+      edge double precision,
+      prob_justa_fechamento double precision,
+      evidencias text[]
+    )
+  ), inserted AS (
+    INSERT INTO public.futebol_publication_alerts (
+      batch_id, opportunity_key, fixture_id, home_team_name, away_team_name,
+      competition, kickoff_utc, market, outcome, line_value, best_odd, score,
+      faixa, janela_usada, edge, prob_justa_fechamento, evidencias
+    )
+    SELECT v_batch_id, i.opportunity_key, i.fixture_id, i.home_team_name,
+           i.away_team_name, i.competition, i.kickoff_utc, i.market,
+           i.outcome, i.line_value, i.best_odd, i.score, i.faixa,
+           i.janela_usada, i.edge, i.prob_justa_fechamento, i.evidencias
+    FROM incoming i
+    ON CONFLICT (opportunity_key) DO NOTHING
+    RETURNING id, opportunity_key
+  )
+  SELECT v_batch_id, i.id, i.opportunity_key FROM inserted i;
+END;
+$function$;
+REVOKE ALL ON FUNCTION public.claim_futebol_publication_alert_batch(timestamptz, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_futebol_publication_alert_batch(timestamptz, jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.get_futebol_publication_alert_recipients()
+RETURNS TABLE(user_id uuid, chat_id text, user_name text)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  SELECT u.id, u.telegram_chat_id::text, u.name::text
+  FROM public.users u
+  WHERE u.telegram_chat_id IS NOT NULL
+    AND (
+      coalesce(u.futebol_subscription_status, 'free') = 'premium'
+      OR (
+        u.futebol_trial_started_at IS NOT NULL
+        AND u.futebol_trial_started_at + interval '7 days' > now()
+  )
+    );
+$function$;
+REVOKE ALL ON FUNCTION public.get_futebol_publication_alert_recipients() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_futebol_publication_alert_recipients() TO service_role;
+
+-- Reserva somente entregas que ainda podem ocorrer. O filtro de acesso é
+-- reavaliado a cada tentativa; uma assinatura expirada não recebe retry.
+-- Reserva atomica antes de chamar o Telegram. Assim dois crons concorrentes
+-- nao enviam o mesmo lote. Reserva apos aceite do Telegram fica para
+-- reconciliação manual, pois Telegram não oferece chave de idempotência.
+CREATE OR REPLACE FUNCTION public.claim_futebol_publication_alert_deliveries()
+RETURNS TABLE(batch_id uuid, user_id uuid, chat_id text, attempt_id uuid, opportunities jsonb)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+BEGIN
+  -- Sem item pre-live restante, a entrega deixa de ser pendencia operacional.
+  UPDATE public.futebol_publication_alert_deliveries d
+  SET status = 'expired', attempt_id = NULL, claimed_at = NULL
+  WHERE d.status IN ('pending', 'failed', 'processing')
+    AND NOT EXISTS (
+      SELECT 1 FROM public.futebol_publication_alerts a
+      WHERE a.batch_id = d.batch_id AND a.kickoff_utc > now()
+    );
+
+  RETURN QUERY
+  WITH claimed AS (
+    UPDATE public.futebol_publication_alert_deliveries d
+    SET status = 'processing',
+        attempts = d.attempts + 1,
+        attempt_id = gen_random_uuid(),
+        claimed_at = now(),
+        last_attempt_at = now()
+    FROM public.users u
+    WHERE d.user_id = u.id
+      AND d.status IN ('pending', 'failed')
+      AND u.telegram_chat_id IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM public.futebol_publication_alerts a
+        WHERE a.batch_id = d.batch_id AND a.kickoff_utc > now()
+      )
+      AND (
+        coalesce(u.futebol_subscription_status, 'free') = 'premium'
+        OR (
+          u.futebol_trial_started_at IS NOT NULL
+          AND u.futebol_trial_started_at + interval '7 days' > now()
+        )
+      )
+    RETURNING d.batch_id, d.user_id, u.telegram_chat_id::text, d.attempt_id
+  )
+  SELECT c.batch_id,
+         c.user_id,
+         c.telegram_chat_id,
+         c.attempt_id,
+         jsonb_agg(
+           jsonb_build_object(
+             'alert_id', a.id,
+             'fixture_id', a.fixture_id,
+             'home_team_name', a.home_team_name,
+             'away_team_name', a.away_team_name,
+             'competition', a.competition,
+             'kickoff_utc', a.kickoff_utc,
+             'market', a.market,
+             'outcome', a.outcome,
+             'line_value', a.line_value,
+             'best_odd', a.best_odd,
+             'score', a.score,
+             'faixa', a.faixa,
+             'evidencias', a.evidencias
+           ) ORDER BY a.score DESC
+         )
+  FROM claimed c
+  JOIN public.futebol_publication_alerts a ON a.batch_id = c.batch_id
+  WHERE a.kickoff_utc > now()
+  GROUP BY c.batch_id, c.user_id, c.telegram_chat_id, c.attempt_id;
+END;
+$function$;
+REVOKE ALL ON FUNCTION public.claim_futebol_publication_alert_deliveries() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_futebol_publication_alert_deliveries() TO service_role;
+
+-- Polling curto: o detector só envia quando encontra uma publicação ainda não
+-- registrada; entre syncs ele apenas pode retentar uma entrega que falhou.
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'notify-published-opportunities') THEN
+    PERFORM cron.unschedule('notify-published-opportunities');
+  END IF;
+END $$;
+
+SELECT cron.schedule('notify-published-opportunities', '*/10 * * * *', $job$
+  SELECT net.http_post(
+    url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_published_opportunities_url'),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'notify_opportunities_cron_secret')
+    ),
+    body := '{}'::jsonb,
+    timeout_milliseconds := 60000
+  );
+$job$);


### PR DESCRIPTION
Closes #292\n\nImplementa alertas de Telegram para novas oportunidades de futebol: ledger idempotente, lote por execução, recorte pre-live, destinatários elegíveis, persistência de snapshot, rastreamento separado, registro no Betinho e deploy da Edge Function.\n\nValidação: 105 testes Deno passaram.\n\nPasso operacional após o merge: cadastrar no Vault a URL da nova Edge Function e configurar o serviço externo de refresh para chamá-la ao concluir cada atualização. Enquanto isso, o cron de 10 minutos mantém a detecção como contingência.