### PR TITLE
fix(ops): repetir leitura transitória do settlement e calibrar o vigia

### DIFF
--- a/supabase/functions/notify-settlement/index.ts
+++ b/supabase/functions/notify-settlement/index.ts
@@ -41,6 +41,7 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 import { generateTraceId, trackEvent } from "../shared/posthog.ts";
 import { esc } from "../shared/format.ts";
 import { logMessageRun } from "../shared/runs.ts";
+import { readWithRetry } from "../shared/retry.ts";
 import {
   type Candidate,
   type FinishedMatch,
@@ -283,7 +284,10 @@ serve(async (req) => {
 
   try {
     // 1) Apostas candidatas (pendentes, usuário linkado, cadência ok)
-    const { data: candData, error: candErr } = await supabase.rpc("get_settlement_reminder_candidates");
+    const { data: candData, error: candErr } = await readWithRetry(
+      "get_settlement_reminder_candidates",
+      () => supabase.rpc("get_settlement_reminder_candidates"),
+    );
     if (candErr) throw candErr;
     const candidates: Candidate[] = candData ?? [];
     if (candidates.length === 0) return json({ ok: true, candidates: 0, sent: 0 });
@@ -304,13 +308,15 @@ serve(async (req) => {
     }
 
     // 2a) wc_matches (Copa)
-    const { data: wcData, error: wcErr } = await supabase
-      .from("wc_matches")
-      .select(
-        "id, stage, home_team, away_team, home_team_code, away_team_code, match_date, match_time_brasilia, home_score, away_score, fulltime_home, fulltime_away, is_finished"
-      )
-      .eq("is_finished", true)
-      .gte("match_date", new Date(since).toISOString().slice(0, 10));
+    const { data: wcData, error: wcErr } = await readWithRetry("wc_matches", () =>
+      supabase
+        .from("wc_matches")
+        .select(
+          "id, stage, home_team, away_team, home_team_code, away_team_code, match_date, match_time_brasilia, home_score, away_score, fulltime_home, fulltime_away, is_finished"
+        )
+        .eq("is_finished", true)
+        .gte("match_date", new Date(since).toISOString().slice(0, 10))
+    );
     if (wcErr) throw wcErr;
 
     const wcFinished: FinishedMatch[] = (wcData ?? [])
@@ -333,11 +339,13 @@ serve(async (req) => {
     //     placar de 90'; nunca CANC/ABD/WO/PST (sem placar válido). Ligas ligadas.
     const { data: enData } = await supabase.from("leagues_config").select("league_id").eq("enabled", true);
     const enabledLeagues = new Set<number>((enData ?? []).map((l: any) => l.league_id));
-    const { data: fxData, error: fxErr } = await supabase
-      .from("fixtures")
-      .select("fixture_id, league_id, home_team_id, home_team, away_team_id, away_team, kickoff_utc, status_short, goals_home, goals_away, fulltime_home, fulltime_away")
-      .in("status_short", ["FT", "AET", "PEN"])
-      .gte("kickoff_utc", new Date(since).toISOString());
+    const { data: fxData, error: fxErr } = await readWithRetry("fixtures", () =>
+      supabase
+        .from("fixtures")
+        .select("fixture_id, league_id, home_team_id, home_team, away_team_id, away_team, kickoff_utc, status_short, goals_home, goals_away, fulltime_home, fulltime_away")
+        .in("status_short", ["FT", "AET", "PEN"])
+        .gte("kickoff_utc", new Date(since).toISOString())
+    );
     if (fxErr) throw fxErr;
 
     const fxFinished: FinishedMatch[] = (fxData ?? [])

--- a/supabase/functions/ops-healthcheck/health.ts
+++ b/supabase/functions/ops-healthcheck/health.ts
@@ -1,22 +1,103 @@
 // health.ts — lógica pura do healthcheck (testada no CI).
+//
+// Duas leituras diferentes das mesmas linhas de message_runs, porque "falhou"
+// não quer dizer sempre a mesma coisa:
+//
+//   • STREAK  — os últimos runs falharam TODOS e num intervalo CURTO. É a
+//     função quebrada de verdade: um cron de 15 min quebrado acumula 3 falhas
+//     em 45 min. Alerta vermelho.
+//   • FLAKY   — falhas espalhadas dentro da janela. A função funciona, mas
+//     goteja (ex.: 26–27/08, ~7% dos runs do notify-settlement morreram com
+//     "JWT issued at future" vindo da plataforma). Alerta amarelo.
+//
+// O span existe porque as funções não gravam TODO run: o notify-settlement só
+// registra run com candidato ou com erro (regra anti-ruído da migration 089).
+// Numa madrugada sem aposta pendente, as três últimas linhas da tabela podem
+// ser três falhas separadas por dois dias — sem o span, isso vira alarme de
+// "função quebrada" para algo que está a 93% de saúde.
 export interface RunRow {
   fn: string;
   ok: boolean;
+  ran_at: string; // ISO
+}
+
+const HOUR_MS = 3_600_000;
+
+// ran_at é timestamptz NOT NULL no banco, mas o parse é a fronteira do módulo:
+// linha com carimbo ilegível é descartada aqui, e não vira nem alarme nem
+// silêncio acidental mais adiante.
+interface Run {
+  fn: string;
+  ok: boolean;
+  t: number;
+}
+
+function parseRows(rows: RunRow[]): Run[] {
+  const out: Run[] = [];
+  for (const r of rows) {
+    const t = Date.parse(r.ran_at);
+    if (!Number.isNaN(t)) out.push({ fn: r.fn, ok: r.ok, t });
+  }
+  return out;
 }
 
 // rows ordenados do MAIS RECENTE pro mais antigo. Devolve as funções cujos
-// últimos `threshold` runs falharam TODOS (streak de falha = alerta).
+// últimos `threshold` runs falharam TODOS **e** cabem em `maxSpanMs`.
 // Menos runs que o threshold = sem veredito (função nova não alarma).
-export function failingStreaks(rows: RunRow[], threshold = 3): string[] {
-  const byFn = new Map<string, boolean[]>();
-  for (const r of rows) {
+export function failingStreaks(
+  rows: RunRow[],
+  threshold = 3,
+  opts: { now?: number; maxSpanMs?: number } = {},
+): string[] {
+  const now = opts.now ?? Date.now();
+  const maxSpanMs = opts.maxSpanMs ?? 6 * HOUR_MS;
+
+  const byFn = new Map<string, Run[]>();
+  for (const r of parseRows(rows)) {
     const list = byFn.get(r.fn) ?? [];
-    if (list.length < threshold) list.push(r.ok);
+    if (list.length < threshold) list.push(r);
     byFn.set(r.fn, list);
   }
+
   const out: string[] = [];
-  for (const [fn, oks] of byFn) {
-    if (oks.length >= threshold && oks.every((ok) => !ok)) out.push(fn);
+  for (const [fn, runs] of byFn) {
+    if (runs.length < threshold) continue;
+    if (!runs.every((r) => !r.ok)) continue;
+    // runs[último] é o mais antigo do streak: se ele já é velho, as falhas
+    // estão espalhadas no tempo — isso é flaky, não quebra.
+    if (now - runs[runs.length - 1].t > maxSpanMs) continue;
+    out.push(fn);
   }
   return out.sort();
+}
+
+export interface FlakyFn {
+  fn: string;
+  failures: number;
+  total: number;
+}
+
+// Falhas espalhadas na janela. Sinal mais fraco que o streak, mas real — é
+// exatamente o que passava batido antes. `minFailures` evita alarmar com um
+// 429 isolado do Telegram numa terça-feira.
+export function flakyFns(
+  rows: RunRow[],
+  opts: { now?: number; windowMs?: number; minFailures?: number } = {},
+): FlakyFn[] {
+  const now = opts.now ?? Date.now();
+  const windowMs = opts.windowMs ?? 24 * HOUR_MS;
+  const minFailures = opts.minFailures ?? 3;
+
+  const agg = new Map<string, FlakyFn>();
+  for (const r of parseRows(rows)) {
+    if (now - r.t > windowMs) continue;
+    const cur = agg.get(r.fn) ?? { fn: r.fn, failures: 0, total: 0 };
+    cur.total++;
+    if (!r.ok) cur.failures++;
+    agg.set(r.fn, cur);
+  }
+
+  return [...agg.values()]
+    .filter((f) => f.failures >= minFailures)
+    .sort((a, b) => a.fn.localeCompare(b.fn));
 }

--- a/supabase/functions/ops-healthcheck/index.ts
+++ b/supabase/functions/ops-healthcheck/index.ts
@@ -19,11 +19,12 @@
 // ============================================================
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
-import { failingStreaks, type RunRow } from "./health.ts";
+import { failingStreaks, flakyFns, type RunRow } from "./health.ts";
 
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
 const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
 const FAIL_THRESHOLD = 3; // de 5 execuções recentes
+const RUNS_WINDOW_H = 48;  // janela de message_runs lida a cada check
 
 interface JobHealth {
   jobname: string;
@@ -77,14 +78,20 @@ serve(async (req) => {
     // Onda 4: carteiros com streak de falha (message_runs, migration 089).
     // O cron pode dizer "succeeded" (o http_post saiu) e a FUNÇÃO ter falhado —
     // esta é a visão de dentro.
+    // Janela por TEMPO, não por contagem: com "limit(60)" fixo, uma função
+    // tagarela (o notify-published-opportunities grava todo run, de 10 em 10
+    // min) empurrava as demais para fora da amostra e escondia falha alheia.
     const { data: runData } = await supabase
       .from("message_runs")
-      .select("fn, ok")
+      .select("fn, ok, ran_at")
+      .gte("ran_at", new Date(Date.now() - RUNS_WINDOW_H * 3_600_000).toISOString())
       .order("ran_at", { ascending: false })
-      .limit(60);
-    const failingFns = failingStreaks((runData ?? []) as RunRow[], FAIL_THRESHOLD);
+      .limit(1000);
+    const runs = (runData ?? []) as RunRow[];
+    const failingFns = failingStreaks(runs, FAIL_THRESHOLD);
+    const flaky = flakyFns(runs).filter((f) => !failingFns.includes(f.fn));
 
-    if (mode !== "report" && (problems.length > 0 || failingFns.length > 0)) {
+    if (mode !== "report" && (problems.length > 0 || failingFns.length > 0 || flaky.length > 0)) {
       const lines = ["🚨 ops-healthcheck — problemas encontrados:", ""];
       for (const p of problems) {
         if (p.missing_secrets.length > 0) {
@@ -95,9 +102,18 @@ serve(async (req) => {
         }
       }
       for (const fn of failingFns) {
-        lines.push(`• ${fn}: últimos ${FAIL_THRESHOLD} runs da FUNÇÃO falharam (message_runs)`);
+        lines.push(`• ${fn}: últimos ${FAIL_THRESHOLD} runs da FUNÇÃO falharam EM SEQUÊNCIA (message_runs) — quebrada`);
       }
-      lines.push("", "Runbook: criar os secrets (vault.create_secret), investigar cron.job_run_details ou message_runs.errors.");
+      for (const f of flaky) {
+        lines.push(`• ${f.fn}: ${f.failures} de ${f.total} runs falharam nas últimas 24h (message_runs) — intermitente, não quebrada`);
+      }
+      // Runbook sob medida: a linha fixa de antes mandava caçar secret em
+      // incidente que não tinha secret nenhum envolvido.
+      const dicas: string[] = [];
+      if (problems.some((p) => p.missing_secrets.length > 0)) dicas.push("secret faltando → vault.create_secret");
+      if (problems.some((p) => p.failed_recent >= FAIL_THRESHOLD)) dicas.push("falha de cron → cron.job_run_details");
+      if (failingFns.length > 0 || flaky.length > 0) dicas.push("falha de função → message_runs.errors");
+      if (dicas.length > 0) lines.push("", `Runbook: ${dicas.join(" · ")}.`);
       if (adminChat) {
         await sendAdminDm(adminChat, lines.join("\n"));
       } else {
@@ -116,6 +132,7 @@ serve(async (req) => {
         total_recent: p.total_recent,
       })),
       failing_message_fns: failingFns,
+      flaky_message_fns: flaky,
       admin_configured: adminChat != null,
     });
   } catch (e) {

--- a/supabase/functions/shared/retry.ts
+++ b/supabase/functions/shared/retry.ts
@@ -1,0 +1,36 @@
+// shared/retry.ts — repetição curta para LEITURAS idempotentes no PostgREST.
+//
+// Motivo concreto (26–27/08): ~7% das execuções do notify-settlement morreram
+// com "JWT issued at future" na primeira consulta. É erro TRANSITÓRIO da
+// plataforma — a chamada seguinte passa, e o projeto ainda usa a service_role
+// legada (o painel já marca a chave como deprecated em favor das JWT Signing
+// Keys). Sem repetição, um soluço de um segundo derruba o run inteiro e o
+// healthcheck acusa a função de quebrada.
+//
+// Só para LEITURA: repetir um SELECT/RPC STABLE é seguro. Escrita não passa
+// por aqui — quem grava tem guarda otimista própria (ver settleBet).
+//
+// Repete em QUALQUER erro de propósito: casar mensagem ("JWT issued at
+// future", "timeout", …) é frágil e a plataforma inventa texto novo. Erro
+// permanente (coluna que não existe) só custa as tentativas extras e chega
+// igual ao chamador.
+// run() devolve PromiseLike, não Promise: o builder do supabase-js é thenable
+// (só ganha .catch/.finally depois do await), e exigir Promise aqui quebra a
+// inferência de tipo de quem chama.
+export async function readWithRetry<T extends { error: unknown }>(
+  label: string,
+  run: () => PromiseLike<T>,
+  opts: { attempts?: number; delayMs?: number } = {},
+): Promise<T> {
+  const attempts = opts.attempts ?? 3;
+  const delayMs = opts.delayMs ?? 400;
+
+  let last = await run();
+  for (let i = 1; i < attempts && last.error; i++) {
+    const msg = (last.error as { message?: string })?.message ?? String(last.error);
+    console.warn(`readWithRetry(${label}): tentativa ${i}/${attempts} falhou (${msg}); repetindo`);
+    await new Promise((r) => setTimeout(r, delayMs * i)); // 400ms, 800ms
+    last = await run();
+  }
+  return last;
+}

--- a/supabase/functions/tests/health.test.ts
+++ b/supabase/functions/tests/health.test.ts
@@ -1,31 +1,102 @@
-// Testes da lógica de streak do ops-healthcheck (health.ts).
+// Testes da lógica do ops-healthcheck (health.ts).
 import { assertEquals } from "./_assert.ts";
-import { failingStreaks, type RunRow } from "../ops-healthcheck/health.ts";
+import { failingStreaks, flakyFns, type RunRow } from "../ops-healthcheck/health.ts";
 
-const r = (fn: string, ok: boolean): RunRow => ({ fn, ok });
+const T0 = Date.parse("2026-08-27T12:00:00Z"); // "agora" fixo dos testes
+const MIN = 60_000;
+const HOUR = 3_600_000;
 
-Deno.test("3 falhas seguidas → alerta", () => {
-  assertEquals(failingStreaks([r("a", false), r("a", false), r("a", false)]), ["a"]);
+// r("a", false, 15) = run da função "a", falhou, 15 min atrás
+const r = (fn: string, ok: boolean, minsAgo: number): RunRow => ({
+  fn,
+  ok,
+  ran_at: new Date(T0 - minsAgo * MIN).toISOString(),
+});
+const streaks = (rows: RunRow[]) => failingStreaks(rows, 3, { now: T0 });
+const flaky = (rows: RunRow[]) => flakyFns(rows, { now: T0 });
+
+// ── streak: quebrada de verdade ──────────────────────────────
+Deno.test("3 falhas seguidas e recentes → alerta", () => {
+  assertEquals(streaks([r("a", false, 0), r("a", false, 15), r("a", false, 30)]), ["a"]);
 });
 Deno.test("2 falhas → sem alerta (abaixo do threshold)", () => {
-  assertEquals(failingStreaks([r("a", false), r("a", false)]), []);
+  assertEquals(streaks([r("a", false, 0), r("a", false, 15)]), []);
 });
 Deno.test("falha-ok-falha → sem alerta (não é streak)", () => {
-  assertEquals(failingStreaks([r("a", false), r("a", true), r("a", false)]), []);
+  assertEquals(streaks([r("a", false, 0), r("a", true, 15), r("a", false, 30)]), []);
 });
 Deno.test("recuperou (ok mais recente) → sem alerta mesmo com falhas antigas", () => {
-  assertEquals(failingStreaks([r("a", true), r("a", false), r("a", false), r("a", false)]), []);
+  assertEquals(
+    streaks([r("a", true, 0), r("a", false, 15), r("a", false, 30), r("a", false, 45)]),
+    [],
+  );
 });
 Deno.test("só os 3 mais recentes contam (4ª falha antiga irrelevante)", () => {
-  // mais recente primeiro: fail, fail, fail, ok → streak de 3 → alerta
-  assertEquals(failingStreaks([r("a", false), r("a", false), r("a", false), r("a", true)]), ["a"]);
+  assertEquals(
+    streaks([r("a", false, 0), r("a", false, 15), r("a", false, 30), r("a", true, 45)]),
+    ["a"],
+  );
 });
 Deno.test("funções independentes: uma falhando, outra saudável", () => {
   const rows = [
-    r("b", true), r("a", false), r("b", true), r("a", false), r("b", true), r("a", false),
+    r("b", true, 0), r("a", false, 1), r("b", true, 15), r("a", false, 16),
+    r("b", true, 30), r("a", false, 31),
   ];
-  assertEquals(failingStreaks(rows), ["a"]);
+  assertEquals(streaks(rows), ["a"]);
 });
 Deno.test("função nova (1 run) nunca alarma", () => {
-  assertEquals(failingStreaks([r("nova", false)]), []);
+  assertEquals(streaks([r("nova", false, 0)]), []);
+});
+
+// ── o span: o incidente de 26/08 ─────────────────────────────
+// 3 falhas espalhadas por 2 dias eram as 3 últimas linhas da tabela (a função
+// só grava run com candidato ou erro) e viravam alarme de "quebrada".
+Deno.test("3 falhas espalhadas por 2 dias NÃO são streak", () => {
+  assertEquals(
+    streaks([r("a", false, 30), r("a", false, 14 * 60), r("a", false, 40 * 60)]),
+    [],
+  );
+});
+Deno.test("streak antigo (nada rodou desde) não alarma", () => {
+  assertEquals(
+    streaks([r("a", false, 20 * 60), r("a", false, 20 * 60 + 15), r("a", false, 20 * 60 + 30)]),
+    [],
+  );
+});
+Deno.test("ran_at inválido não derruba nem alarma", () => {
+  const rows: RunRow[] = [
+    { fn: "a", ok: false, ran_at: "sei lá" },
+    r("a", false, 15),
+    r("a", false, 30),
+  ];
+  assertEquals(streaks(rows), []);
+});
+
+// ── flaky: goteja, mas está de pé ────────────────────────────
+Deno.test("falhas espalhadas na janela viram flaky", () => {
+  const rows = [
+    r("a", false, 30), r("a", true, 60), r("a", false, 5 * 60),
+    r("a", true, 8 * 60), r("a", false, 20 * 60),
+  ];
+  assertEquals(flaky(rows), [{ fn: "a", failures: 3, total: 5 }]);
+});
+Deno.test("2 falhas na janela → abaixo do mínimo, sem ruído", () => {
+  assertEquals(flaky([r("a", false, 30), r("a", true, 60), r("a", false, 5 * 60)]), []);
+});
+Deno.test("falhas fora da janela de 24h não contam", () => {
+  const rows = [r("a", false, 30), r("a", false, 30 * 60), r("a", false, 40 * 60)];
+  assertEquals(flaky(rows), []);
+});
+Deno.test("função saudável não vira flaky", () => {
+  assertEquals(flaky([r("a", true, 30), r("a", true, 60), r("a", true, 90)]), []);
+});
+Deno.test("flaky ordena por nome e separa funções", () => {
+  const rows = [
+    r("z", false, 10), r("z", false, 20), r("z", false, 30),
+    r("a", false, 10), r("a", false, 20), r("a", false, 30),
+  ];
+  assertEquals(flaky(rows), [
+    { fn: "a", failures: 3, total: 3 },
+    { fn: "z", failures: 3, total: 3 },
+  ]);
 });

--- a/supabase/functions/tests/retry.test.ts
+++ b/supabase/functions/tests/retry.test.ts
@@ -1,0 +1,43 @@
+// Testes do readWithRetry (shared/retry.ts) — delay 0 pra não arrastar o CI.
+import { assertEquals } from "./_assert.ts";
+import { readWithRetry } from "../shared/retry.ts";
+
+const fast = { delayMs: 0 };
+
+Deno.test("sucesso de primeira → uma chamada só", async () => {
+  let n = 0;
+  const res = await readWithRetry("x", () => {
+    n++;
+    return Promise.resolve({ data: "ok", error: null });
+  }, fast);
+  assertEquals([n, res.data], [1, "ok"]);
+});
+
+Deno.test("falha transitória → repete e entrega o sucesso", async () => {
+  let n = 0;
+  const res = await readWithRetry("x", () => {
+    n++;
+    return Promise.resolve(
+      n < 3 ? { data: null, error: { message: "JWT issued at future" } } : { data: "ok", error: null },
+    );
+  }, fast);
+  assertEquals([n, res.data, res.error], [3, "ok", null]);
+});
+
+Deno.test("erro permanente → desiste no teto e devolve o erro", async () => {
+  let n = 0;
+  const res = await readWithRetry("x", () => {
+    n++;
+    return Promise.resolve({ data: null, error: { message: "column does not exist" } });
+  }, fast);
+  assertEquals([n, (res.error as { message: string }).message], [3, "column does not exist"]);
+});
+
+Deno.test("attempts=1 não repete", async () => {
+  let n = 0;
+  await readWithRetry("x", () => {
+    n++;
+    return Promise.resolve({ data: null, error: { message: "erro" } });
+  }, { attempts: 1, delayMs: 0 });
+  assertEquals(n, 1);
+});


### PR DESCRIPTION
## O incidente

DM do vigia às 8h de 27/08: `notify-settlement: últimos 3 runs da FUNÇÃO falharam`.

A causa está gravada em `message_runs.errors`: **`JWT issued at future`** — o PostgREST recusando a `service_role` de forma intermitente. **14 falhas desde 26/08 10:15 UTC, ~7% dos runs.**

Não é regressão de código: o `notify-settlement` não é tocado há semanas e o último deploy de produção foi 19/08, uma semana antes do erro começar. O projeto usa a chave legada (o painel já a marca como *deprecated* em favor das JWT Signing Keys) e a causa raiz é da plataforma — vale um ticket no Supabase. Este PR trata do que é nosso: **não morrer por causa disso, e não gritar errado quando acontecer.**

## O que muda

**1. Repetição nas leituras** (`shared/retry.ts`)

As três leituras iniciais do settlement (RPC de candidatas, `wc_matches`, `fixtures`) ganham até 3 tentativas com espera crescente. A chamada seguinte sempre passava — uma tentativa extra transforma o run perdido em run normal.

Só leitura entra no esquema; escrita não passa por aqui (quem grava mantém a guarda otimista do `settleBet`). Repete em qualquer erro de propósito: casar mensagem de erro é frágil, e erro permanente só custa as tentativas extras.

**2. O vigia separa "quebrada" de "intermitente"** (`ops-healthcheck/health.ts`)

Era a raiz do alarme desproporcional. O settlement só registra run com candidato ou com erro (regra anti-ruído da 089), então numa madrugada sem aposta pendente **três falhas espalhadas por dois dias eram as três últimas linhas da tabela** — e viravam "últimos 3 runs falharam", leitura de função quebrada para algo a 93% de saúde.

- `failingStreaks` passa a exigir que o streak caiba em **6h** — um cron de 15 min quebrado acumula 3 falhas em 45 minutos, cabe folgado;
- `flakyFns` (novo) reporta **falhas espalhadas nas últimas 24h** como sinal separado. Mais fraco, mas é exatamente o que passava batido antes.

Neste incidente a DM teria sido `8 de 34 runs falharam nas últimas 24h — intermitente, não quebrada`.

**3. Janela de `message_runs` por tempo, não por contagem**

Era `limit(60)` sobre a tabela inteira. Com o `notify-published-opportunities` gravando todo run de 10 em 10 min, essas 60 linhas encolheriam para poucas horas e começariam a **esconder falha das outras funções**. Passa a ler as últimas 48h.

**4. Runbook condicional**

A linha `Runbook: criar os secrets (vault.create_secret)…` era fixa em toda DM. Neste incidente mandou caçar secret num problema que não tinha secret nenhum envolvido. Agora só aparece a dica que corresponde ao tipo de problema detectado.

## Verificação

- `deno test supabase/functions/tests/` — **118 passando** (12 novos: span do streak, janela do flaky, carimbo ilegível, e os 4 do retry)
- `deno check` nas duas edge functions — limpo

Dois defeitos foram pegos por essas verificações, não por revisão: o teste do carimbo ilegível mostrou que eu validava só uma das linhas do streak, e o `deno check` mostrou que o builder do supabase-js é *thenable*, não `Promise` (a assinatura do retry pedia `Promise` e quebrava a inferência de quem chama). O `deno check` não roda no CI — pode valer adicionar.

## Fora de escopo

A causa raiz no Supabase. Sugestão de acompanhamento: ticket com projeto `kpbjuplcwiyrymafhehz`, chave `service_role` com `iat` de 04/03, início em 26/08 10:15 UTC. A correção definitiva é migrar para `SUPABASE_SECRET_KEYS` (JWT Signing Keys), mas com a repetição no ar isso deixa de ser urgente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
