### PR TITLE
Futebol: onboarding contextual dos alertas de oportunidade

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -2551,6 +2551,7 @@ $function$;
 alter table public.users add column if not exists futebol_trial_started_at timestamptz;
 alter table public.users add column if not exists futebol_subscription_status text not null default 'free';
 alter table public.users add column if not exists futebol_publication_alerts_enabled boolean not null default true;
+alter table public.users add column if not exists futebol_publication_alerts_ack_at timestamptz;
 
 CREATE OR REPLACE FUNCTION public.get_futebol_publication_alert_recipients()
 RETURNS TABLE(user_id uuid, chat_id text, user_name text)

--- a/scripts/apply-sql-dev.mjs
+++ b/scripts/apply-sql-dev.mjs
@@ -1,0 +1,59 @@
+// Aplica um arquivo .sql no Supabase de DEV.
+//
+// Existe porque o banco de dev não aplica as migrations do repositório sozinho:
+// toda migration nova precisa ser rodada na mão, e esquecer disso deixa o dev
+// fora de sincronia sem erro visível na tela.
+//
+// Uso:  node scripts/apply-sql-dev.mjs supabase/migrations/<arquivo>.sql
+//
+// Credencial: SUPABASE_ACCESS_TOKEN no .env.local (token pessoal sbp_ da API de
+// gerenciamento). A service role key não serve aqui — PostgREST não roda DDL, e
+// este projeto não tem a função execute_sql.
+//
+// Trava de segurança: só roda contra o projeto de dev. Para qualquer outro,
+// aborta — produção continua sendo deploy manual e consciente.
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const DEV_PROJECT_REF = 'kpbjuplcwiyrymafhehz';
+
+function readEnvLocal(key) {
+  const env = readFileSync(resolve('.env.local'), 'utf8');
+  const match = env.match(new RegExp(`^${key}=(.*)$`, 'm'));
+  return match ? match[1].trim().replace(/^"|"$/g, '') : null;
+}
+
+const sqlPath = process.argv[2];
+if (!sqlPath) {
+  console.error('Informe o arquivo .sql. Ex.: node scripts/apply-sql-dev.mjs supabase/migrations/x.sql');
+  process.exit(1);
+}
+
+const url = (readEnvLocal('SUPABASE_URL') || '').replace(/\/$/, '');
+if (!url.includes(DEV_PROJECT_REF)) {
+  console.error(`Este script só roda contra o projeto de dev (${DEV_PROJECT_REF}). Alvo encontrado: ${url}`);
+  process.exit(1);
+}
+
+const token = readEnvLocal('SUPABASE_ACCESS_TOKEN');
+if (!token) {
+  console.error('Falta SUPABASE_ACCESS_TOKEN no .env.local (token pessoal sbp_ do Supabase).');
+  process.exit(1);
+}
+
+const sql = readFileSync(resolve(sqlPath), 'utf8');
+console.log(`Aplicando ${sqlPath} em ${DEV_PROJECT_REF}...`);
+
+const response = await fetch(`https://api.supabase.com/v1/projects/${DEV_PROJECT_REF}/database/query`, {
+  method: 'POST',
+  headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+  body: JSON.stringify({ query: sql }),
+});
+
+const body = await response.text();
+if (!response.ok) {
+  console.error(`Falhou (HTTP ${response.status}): ${body.slice(0, 400)}`);
+  process.exit(1);
+}
+console.log(`OK (HTTP ${response.status}). ${body.slice(0, 200)}`);

--- a/src/components/futebol/AlertasPublicacao.test.tsx
+++ b/src/components/futebol/AlertasPublicacao.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AlertasPublicacaoAtalho, AlertasPublicacaoCartao } from './AlertasPublicacao';
+
+describe('AlertasPublicacaoCartao', () => {
+  it('explica que os alertas já estão ligados e podem ser pausados', () => {
+    render(<AlertasPublicacaoCartao onDismiss={vi.fn()} />);
+    expect(screen.getByText(/Agora avisamos no Telegram/i)).toBeInTheDocument();
+    expect(screen.getByText(/pode pausar quando quiser/i)).toBeInTheDocument();
+  });
+
+  it('"Entendi" apenas dispensa a explicação', async () => {
+    const onDismiss = vi.fn();
+    render(<AlertasPublicacaoCartao onDismiss={onDismiss} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Entendi' }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('o X também dispensa', async () => {
+    const onDismiss = vi.fn();
+    render(<AlertasPublicacaoCartao onDismiss={onDismiss} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Dispensar explicação' }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('AlertasPublicacaoAtalho', () => {
+  const ligado = { telegramLinked: true, accessActive: true, enabled: true };
+
+  it('mostra alertas ligados e leva ao controle em Configurações', async () => {
+    const onOpenSettings = vi.fn();
+    const onConnect = vi.fn();
+    render(<AlertasPublicacaoAtalho estado={ligado} onConnect={onConnect} onOpenSettings={onOpenSettings} />);
+
+    expect(screen.getByText('Alertas do Telegram ativos')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button'));
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+    expect(onConnect).not.toHaveBeenCalled();
+  });
+
+  it('mostra alertas pausados quando a preferência está desligada', () => {
+    render(
+      <AlertasPublicacaoAtalho
+        estado={{ ...ligado, enabled: false }}
+        onConnect={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Alertas do Telegram pausados')).toBeInTheDocument();
+  });
+
+  it('separa acesso inativo de pausa escolhida pelo usuário', () => {
+    render(
+      <AlertasPublicacaoAtalho
+        estado={{ ...ligado, accessActive: false }}
+        onConnect={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Alertas indisponíveis com o acesso atual')).toBeInTheDocument();
+    expect(screen.getByText(/preferência está salva/i)).toBeInTheDocument();
+  });
+
+  it('sem Telegram conectado, chama a conexão em vez das configurações', async () => {
+    const onOpenSettings = vi.fn();
+    const onConnect = vi.fn();
+    render(
+      <AlertasPublicacaoAtalho
+        estado={{ ...ligado, telegramLinked: false }}
+        onConnect={onConnect}
+        onOpenSettings={onOpenSettings}
+      />,
+    );
+
+    expect(screen.getByText('Conecte o Telegram para receber alertas')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button'));
+    expect(onConnect).toHaveBeenCalledTimes(1);
+    expect(onOpenSettings).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/futebol/AlertasPublicacao.test.tsx
+++ b/src/components/futebol/AlertasPublicacao.test.tsx
@@ -62,6 +62,24 @@ describe('AlertasPublicacaoAtalho', () => {
     expect(screen.getByText(/preferência está salva/i)).toBeInTheDocument();
   });
 
+  it('acesso inativo vence o convite de conectar, para não prometer entrega', async () => {
+    const onConnect = vi.fn();
+    const onOpenSettings = vi.fn();
+    render(
+      <AlertasPublicacaoAtalho
+        estado={{ ...ligado, telegramLinked: false, accessActive: false }}
+        onConnect={onConnect}
+        onOpenSettings={onOpenSettings}
+      />,
+    );
+
+    expect(screen.getByText('Alertas indisponíveis com o acesso atual')).toBeInTheDocument();
+    expect(screen.queryByText('Conectar')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button'));
+    expect(onConnect).not.toHaveBeenCalled();
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
   it('sem Telegram conectado, chama a conexão em vez das configurações', async () => {
     const onOpenSettings = vi.fn();
     const onConnect = vi.fn();

--- a/src/components/futebol/AlertasPublicacao.tsx
+++ b/src/components/futebol/AlertasPublicacao.tsx
@@ -1,0 +1,111 @@
+import { Bell, ChevronRight, Send, X } from 'lucide-react';
+
+// Superfícies do controle de alertas dentro de Oportunidades. Ficam aqui, sem
+// hook nem navegação própria, para que a página continue sendo a única dona do
+// estado e para que cada estado seja testável isoladamente.
+
+export interface AlertasPublicacaoEstado {
+  telegramLinked: boolean;
+  accessActive: boolean;
+  enabled: boolean;
+}
+
+/**
+ * Cartão explicativo mostrado uma única vez a quem já tem Telegram conectado e
+ * acesso ativo. "Entendi" dispensa só a explicação: não pausa nada.
+ */
+export function AlertasPublicacaoCartao({
+  onDismiss,
+  isDismissing = false,
+}: {
+  onDismiss: () => void;
+  isDismissing?: boolean;
+}) {
+  return (
+    <div
+      role="region"
+      aria-label="Novidade: alertas de oportunidades no Telegram"
+      className="w-full rounded-rebrand-md bg-forest-tint border border-forest/20 px-4 py-3 flex items-start gap-3"
+    >
+      <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-forest/10">
+        <Bell className="w-4 h-4 text-forest" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-[13px] font-bold text-ink">Agora avisamos no Telegram</p>
+        <p className="text-[12px] text-ink-2 mt-0.5">
+          Quando uma oportunidade nova for publicada aqui antes do jogo, o Betinho te manda no chat.
+          Já está ligado — você pode pausar quando quiser.
+        </p>
+        <button
+          type="button"
+          onClick={onDismiss}
+          disabled={isDismissing}
+          className="mt-2.5 inline-flex items-center rounded-lg bg-forest px-3 py-1.5 text-[12px] font-bold text-white transition-colors hover:bg-forest-soft disabled:opacity-60"
+        >
+          {isDismissing ? 'Salvando...' : 'Entendi'}
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        disabled={isDismissing}
+        aria-label="Dispensar explicação"
+        className="shrink-0 text-ink-3 hover:text-ink transition-colors disabled:opacity-60"
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Atalho compacto e permanente. Quem ainda não conectou o Telegram vai para o
+ * onboarding existente; os demais vão para o mesmo controle em Configurações.
+ */
+export function AlertasPublicacaoAtalho({
+  estado,
+  onConnect,
+  onOpenSettings,
+}: {
+  estado: AlertasPublicacaoEstado;
+  onConnect: () => void;
+  onOpenSettings: () => void;
+}) {
+  const { telegramLinked, accessActive, enabled } = estado;
+  const ativo = telegramLinked && accessActive && enabled;
+
+  const titulo = !telegramLinked
+    ? 'Conecte o Telegram para receber alertas'
+    : !accessActive
+      ? 'Alertas indisponíveis com o acesso atual'
+      : enabled
+        ? 'Alertas do Telegram ativos'
+        : 'Alertas do Telegram pausados';
+
+  const descricao = !telegramLinked
+    ? 'Conecte em um toque e receba as novas oportunidades antes do jogo.'
+    : !accessActive
+      ? 'Sua preferência está salva e volta a valer quando o acesso retornar.'
+      : enabled
+        ? 'Vamos avisar quando uma oportunidade for publicada antes do jogo.'
+        : 'Retome nas configurações quando quiser voltar a receber.';
+
+  return (
+    <button
+      type="button"
+      onClick={telegramLinked ? onOpenSettings : onConnect}
+      className="w-full rounded-rebrand-md bg-white border border-line px-4 py-3 text-left flex items-center gap-3 hover:bg-canvas-2 transition-colors"
+    >
+      {telegramLinked ? (
+        <span className={`w-2 h-2 rounded-full shrink-0 ${ativo ? 'bg-forest' : 'bg-ink-3'}`} />
+      ) : (
+        <Send className="w-4 h-4 text-forest shrink-0" />
+      )}
+      <span className="min-w-0 flex-1">
+        <span className="block text-[13px] font-bold text-ink">{titulo}</span>
+        <span className="block text-[12px] text-ink-2 mt-0.5">{descricao}</span>
+      </span>
+      <ChevronRight className="w-4 h-4 text-ink-3 shrink-0" />
+    </button>
+  );
+}

--- a/src/components/futebol/AlertasPublicacao.tsx
+++ b/src/components/futebol/AlertasPublicacao.tsx
@@ -1,4 +1,4 @@
-import { Bell, ChevronRight, Send, X } from 'lucide-react';
+import { ArrowRight, Bell, ChevronRight, Send, X } from 'lucide-react';
 
 // Superfícies do controle de alertas dentro de Oportunidades. Ficam aqui, sem
 // hook nem navegação própria, para que a página continue sendo a única dona do
@@ -74,33 +74,56 @@ export function AlertasPublicacaoAtalho({
   const { telegramLinked, accessActive, enabled } = estado;
   const ativo = telegramLinked && accessActive && enabled;
 
-  const titulo = !telegramLinked
-    ? 'Conecte o Telegram para receber alertas'
-    : !accessActive
-      ? 'Alertas indisponíveis com o acesso atual'
+  // O acesso vem antes do vínculo: sem assinatura nem teste ativo, nenhum
+  // alerta é entregue, então convidar para conectar levaria a pessoa a um
+  // fluxo que termina numa promessa que o backend não cumpre.
+  const titulo = !accessActive
+    ? 'Alertas indisponíveis com o acesso atual'
+    : !telegramLinked
+      ? 'Conecte o Telegram para receber alertas'
       : enabled
         ? 'Alertas do Telegram ativos'
         : 'Alertas do Telegram pausados';
 
-  const descricao = !telegramLinked
-    ? 'Conecte em um toque e receba as novas oportunidades antes do jogo.'
-    : !accessActive
-      ? 'Sua preferência está salva e volta a valer quando o acesso retornar.'
+  const descricao = !accessActive
+    ? 'Sua preferência está salva e volta a valer quando o acesso retornar.'
+    : !telegramLinked
+      ? 'Conecte em um toque e receba as novas oportunidades antes do jogo.'
       : enabled
         ? 'Vamos avisar quando uma oportunidade for publicada antes do jogo.'
         : 'Retome nas configurações quando quiser voltar a receber.';
 
+  // Quem já conectou vê só status, então a linha fica discreta. Quem não
+  // conectou está diante de um convite, e convite tem que parecer botão.
+  if (accessActive && !telegramLinked) {
+    return (
+      <button
+        type="button"
+        onClick={onConnect}
+        className="w-full rounded-rebrand-md bg-forest-tint border border-forest/25 px-4 py-3.5 text-left flex items-center gap-3.5 hover:bg-forest/10 transition-colors"
+      >
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-forest">
+          <Send className="w-[18px] h-[18px] text-white" />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block text-[14px] font-bold text-ink">{titulo}</span>
+          <span className="block text-[12px] text-ink-2 mt-0.5">{descricao}</span>
+        </span>
+        <span className="shrink-0 inline-flex items-center gap-1.5 rounded-lg bg-forest px-3.5 py-2 text-[13px] font-bold text-white">
+          Conectar
+          <ArrowRight className="w-3.5 h-3.5" />
+        </span>
+      </button>
+    );
+  }
+
   return (
     <button
       type="button"
-      onClick={telegramLinked ? onOpenSettings : onConnect}
+      onClick={onOpenSettings}
       className="w-full rounded-rebrand-md bg-white border border-line px-4 py-3 text-left flex items-center gap-3 hover:bg-canvas-2 transition-colors"
     >
-      {telegramLinked ? (
-        <span className={`w-2 h-2 rounded-full shrink-0 ${ativo ? 'bg-forest' : 'bg-ink-3'}`} />
-      ) : (
-        <Send className="w-4 h-4 text-forest shrink-0" />
-      )}
+      <span className={`w-2 h-2 rounded-full shrink-0 ${ativo ? 'bg-forest' : 'bg-ink-3'}`} />
       <span className="min-w-0 flex-1">
         <span className="block text-[13px] font-bold text-ink">{titulo}</span>
         <span className="block text-[12px] text-ink-2 mt-0.5">{descricao}</span>

--- a/src/hooks/use-futebol-publication-alerts.ts
+++ b/src/hooks/use-futebol-publication-alerts.ts
@@ -6,6 +6,8 @@ export interface FutebolPublicationAlerts {
   enabled: boolean;
   telegramLinked: boolean;
   accessActive: boolean;
+  /** O cartão explicativo já foi dispensado alguma vez, em qualquer dispositivo. */
+  onboardingAcknowledged: boolean;
 }
 
 function hasActiveFutebolAccess(status: string | null, trialStartedAt: string | null): boolean {
@@ -31,7 +33,7 @@ export function useFutebolPublicationAlerts() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('users')
-        .select('telegram_chat_id, futebol_publication_alerts_enabled, futebol_subscription_status, futebol_trial_started_at')
+        .select('telegram_chat_id, futebol_publication_alerts_enabled, futebol_publication_alerts_ack_at, futebol_subscription_status, futebol_trial_started_at')
         .eq('id', user!.id)
         .maybeSingle();
       if (error) throw error;
@@ -40,6 +42,7 @@ export function useFutebolPublicationAlerts() {
         enabled: data.futebol_publication_alerts_enabled ?? true,
         telegramLinked: !!data.telegram_chat_id,
         accessActive: hasActiveFutebolAccess(data.futebol_subscription_status, data.futebol_trial_started_at),
+        onboardingAcknowledged: !!data.futebol_publication_alerts_ack_at,
       };
     },
     staleTime: 30 * 1000,
@@ -62,9 +65,29 @@ export function useFutebolPublicationAlerts() {
     },
   });
 
+  // Dispensar a explicação é independente de pausar: grava só o reconhecimento
+  // e nunca toca em futebol_publication_alerts_enabled.
+  const acknowledgeMutation = useMutation({
+    mutationFn: async () => {
+      if (!user?.id) throw new Error('Usuário não autenticado');
+      const { error } = await supabase
+        .from('users')
+        .update({ futebol_publication_alerts_ack_at: new Date().toISOString() })
+        .eq('id', user.id);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.setQueryData<FutebolPublicationAlerts | null>(queryKey, (current) =>
+        current ? { ...current, onboardingAcknowledged: true } : current,
+      );
+    },
+  });
+
   return {
     ...query,
     setEnabled: mutation.mutateAsync,
     isSaving: mutation.isPending,
+    acknowledgeOnboarding: acknowledgeMutation.mutateAsync,
+    isAcknowledging: acknowledgeMutation.isPending,
   };
 }

--- a/src/hooks/use-futebol-publication-alerts.ts
+++ b/src/hooks/use-futebol-publication-alerts.ts
@@ -70,11 +70,16 @@ export function useFutebolPublicationAlerts() {
   const acknowledgeMutation = useMutation({
     mutationFn: async () => {
       if (!user?.id) throw new Error('Usuário não autenticado');
-      const { error } = await supabase
+      // O select devolve as linhas afetadas. Sem ele, um update que não achou
+      // linha nenhuma volta sem erro, o cartão sumiria da sessão e voltaria em
+      // toda recarga, para sempre, sem nada indicar o motivo.
+      const { data, error } = await supabase
         .from('users')
         .update({ futebol_publication_alerts_ack_at: new Date().toISOString() })
-        .eq('id', user.id);
+        .eq('id', user.id)
+        .select('id');
       if (error) throw error;
+      if (!data?.length) throw new Error('Não foi possível salvar: nenhum registro atualizado');
     },
     onSuccess: () => {
       queryClient.setQueryData<FutebolPublicationAlerts | null>(queryKey, (current) =>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -505,6 +505,7 @@ export type Database = {
           conversation_id: string | null
           created_at: string | null
           email: string
+          futebol_publication_alerts_ack_at: string | null
           futebol_publication_alerts_enabled: boolean
           futebol_subscription_status: string
           futebol_trial_started_at: string | null
@@ -547,6 +548,7 @@ export type Database = {
           conversation_id?: string | null
           created_at?: string | null
           email: string
+          futebol_publication_alerts_ack_at?: string | null
           futebol_publication_alerts_enabled?: boolean
           futebol_subscription_status?: string
           futebol_trial_started_at?: string | null
@@ -589,6 +591,7 @@ export type Database = {
           conversation_id?: string | null
           created_at?: string | null
           email?: string
+          futebol_publication_alerts_ack_at?: string | null
           futebol_publication_alerts_enabled?: boolean
           futebol_subscription_status?: string
           futebol_trial_started_at?: string | null

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -611,8 +611,12 @@ export default function FutebolOportunidades() {
         <FutebolAccessBanner access={access} />
         {publicationAlerts && (
           <>
+            {/* Também exige enabled: o cartão afirma que os alertas estão
+                ligados, e quem já pausou veria essa frase logo acima do atalho
+                dizendo o contrário. */}
             {publicationAlerts.telegramLinked
               && publicationAlerts.accessActive
+              && publicationAlerts.enabled
               && !publicationAlerts.onboardingAcknowledged && (
               <AlertasPublicacaoCartao
                 onDismiss={handleAcknowledgeAlerts}

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -9,6 +9,7 @@ import { useFutebolPublicationAlerts } from '@/hooks/use-futebol-publication-ale
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
+import { AlertasPublicacaoAtalho, AlertasPublicacaoCartao } from '@/components/futebol/AlertasPublicacao';
 import { draftFromBoardRow } from '@/components/futebol/registrar-aposta-utils';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
 import { competitionLabel, sortCompetitions, ALL_COMPETITIONS } from '@/utils/futebol-competitions';
@@ -19,6 +20,7 @@ import {
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { mergeBoardAndHistory, opportunityKey } from '@/utils/futebol-history';
 import { parseUtc, brtDayOf, brtDateStr, fmtTime } from '@/utils/futebol-datas';
+import { onboardingHref, ONBOARDING_SRC_ALERTAS_FUTEBOL } from '@/utils/onboarding-return';
 import { useNow } from '@/hooks/use-now';
 import type { FutebolValueBoardRow, FutebolAlertedPick, FutebolFixture } from '@/services/futebol-data.service';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
@@ -331,7 +333,7 @@ export default function FutebolOportunidades() {
   const { data: rows, isLoading } = useFutebolValueBoard();
   const { data: fixtures } = useFutebolFixturesMulti(ALL_COMPETITIONS, 2026);
   const { data: access } = useFutebolAccess();
-  const { data: publicationAlerts } = useFutebolPublicationAlerts();
+  const { data: publicationAlerts, acknowledgeOnboarding, isAcknowledging } = useFutebolPublicationAlerts();
   const oppTour = useOnboardingTour(FUT_OPP_TOUR_ID, { enabled: !isLoading });
   const isDemo = oppTour.run; // durante o tour, preenche a tela com exemplo
   const locked = isDemo ? false : !access?.unlocked;
@@ -339,6 +341,13 @@ export default function FutebolOportunidades() {
   const [faixa, setFaixa] = useState<FaixaFilter>('all');
   const [comp, setComp] = useState<CompFilter>('all');
   const [day, setDay] = useState<string | null>(null);
+
+  // Dispensar o cartão é só marcar que a explicação foi lida; a preferência de
+  // alerta continua onde estava. Um erro aqui não pode quebrar o painel: o
+  // cartão simplesmente reaparece na próxima visita.
+  const handleAcknowledgeAlerts = () => {
+    acknowledgeOnboarding().catch(() => {});
+  };
 
   // ── Board (presente e futuro) + histórico (passado, na foto do apito) ─────
   // As duas fontes viram UMA lista aqui, de uma vez, em vez de cada consumidor
@@ -601,34 +610,21 @@ export default function FutebolOportunidades() {
         <DemoRibbon show={isDemo} />
         <FutebolAccessBanner access={access} />
         {publicationAlerts && (
-          <button
-            type="button"
-            onClick={() => navigate('/settings')}
-            className="w-full rounded-rebrand-md bg-white border border-line px-4 py-3 text-left flex items-center gap-3 hover:bg-canvas-2 transition-colors"
-          >
-            <span className={`w-2 h-2 rounded-full shrink-0 ${publicationAlerts.telegramLinked && publicationAlerts.accessActive && publicationAlerts.enabled ? 'bg-forest' : 'bg-ink-3'}`} />
-            <span className="min-w-0 flex-1">
-              <span className="block text-[13px] font-bold text-ink">
-                {!publicationAlerts.telegramLinked
-                  ? 'Conecte o Telegram para receber alertas'
-                  : !publicationAlerts.accessActive
-                    ? 'Alertas indisponíveis com o acesso atual'
-                    : publicationAlerts.enabled
-                      ? 'Alertas do Telegram ativos'
-                      : 'Alertas do Telegram pausados'}
-              </span>
-              <span className="block text-[12px] text-ink-2 mt-0.5">
-                {!publicationAlerts.telegramLinked
-                  ? 'Escolha nas configurações como quer receber novas oportunidades.'
-                  : !publicationAlerts.accessActive
-                    ? 'Sua preferência está salva e volta a valer quando o acesso retornar.'
-                    : publicationAlerts.enabled
-                      ? 'Vamos avisar quando uma oportunidade for publicada antes do jogo.'
-                      : 'Retome nas configurações quando quiser voltar a receber.'}
-              </span>
-            </span>
-            <ChevronRight className="w-4 h-4 text-ink-3 shrink-0" />
-          </button>
+          <>
+            {publicationAlerts.telegramLinked
+              && publicationAlerts.accessActive
+              && !publicationAlerts.onboardingAcknowledged && (
+              <AlertasPublicacaoCartao
+                onDismiss={handleAcknowledgeAlerts}
+                isDismissing={isAcknowledging}
+              />
+            )}
+            <AlertasPublicacaoAtalho
+              estado={publicationAlerts}
+              onConnect={() => navigate(onboardingHref(ONBOARDING_SRC_ALERTAS_FUTEBOL, '/futebol/oportunidades'))}
+              onOpenSettings={() => navigate('/settings')}
+            />
+          </>
         )}
 
         {/* Filtros — desktop: 1 linha (Mercado à esq · dropdowns à dir); mobile: 2 linhas */}

--- a/src/pages/Onboarding.test.tsx
+++ b/src/pages/Onboarding.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Onboarding from './Onboarding';
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  single: vi.fn(async () => ({ data: { telegram_chat_id: null } })),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mocks.navigate };
+});
+
+vi.mock('../integrations/supabase/client', () => ({
+  createClient: () => ({
+    auth: { getUser: async () => ({ data: { user: { id: 'user-1' } } }) },
+    from: () => ({ select: () => ({ eq: () => ({ single: mocks.single }) }) }),
+    rpc: vi.fn(),
+  }),
+}));
+
+vi.mock('@posthog/react', () => ({ usePostHog: () => null }));
+
+vi.mock('embla-carousel-react', () => ({ default: () => [vi.fn(), undefined] }));
+
+vi.mock('../components/AnalyticsNav', () => ({ default: () => null }));
+
+function renderOnboarding(search = '') {
+  return render(
+    <MemoryRouter initialEntries={[`/onboarding${search}`]}>
+      <Onboarding />
+    </MemoryRouter>,
+  );
+}
+
+describe('Onboarding', () => {
+  beforeEach(() => {
+    mocks.navigate.mockReset();
+    mocks.single.mockResolvedValue({ data: { telegram_chat_id: null } });
+  });
+
+  it('vindo dos alertas, a introdução fala das novas oportunidades', async () => {
+    renderOnboarding('?src=alertas-futebol&return=%2Ffutebol%2Foportunidades');
+
+    expect(await screen.findByText('Alertas de oportunidades')).toBeInTheDocument();
+    expect(screen.getByText(/Receba as novas oportunidades no/i)).toBeInTheDocument();
+    // Os demais benefícios e a mecânica de conexão continuam iguais.
+    expect(screen.getByText('Registra pelo print')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Conectar meu Telegram/i })).toBeInTheDocument();
+  });
+
+  it('sem origem, mantém o onboarding genérico', async () => {
+    renderOnboarding();
+
+    expect(await screen.findByText('Conheça o Betinho')).toBeInTheDocument();
+    expect(screen.getByText(/Seu assistente de apostas/i)).toBeInTheDocument();
+  });
+
+  it('pular volta para a tela de origem permitida', async () => {
+    renderOnboarding('?src=alertas-futebol&return=%2Ffutebol%2Foportunidades');
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Pular por agora' }));
+    expect(mocks.navigate).toHaveBeenCalledWith('/futebol/oportunidades');
+  });
+
+  it('destino de retorno inválido cai na rota segura', async () => {
+    renderOnboarding('?src=alertas-futebol&return=https%3A%2F%2Fevil.com');
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Pular por agora' }));
+    expect(mocks.navigate).toHaveBeenCalledWith('/inicio');
+  });
+
+  it('quem já tem Telegram conectado é levado direto ao destino', async () => {
+    mocks.single.mockResolvedValue({ data: { telegram_chat_id: '123' } });
+    renderOnboarding('?src=alertas-futebol&return=%2Ffutebol%2Foportunidades');
+
+    await waitFor(() =>
+      expect(mocks.navigate).toHaveBeenCalledWith('/futebol/oportunidades', { replace: true }),
+    );
+  });
+
+  it('regressão: já conectado sem origem continua indo para o hub', async () => {
+    mocks.single.mockResolvedValue({ data: { telegram_chat_id: '123' } });
+    renderOnboarding();
+
+    await waitFor(() => expect(mocks.navigate).toHaveBeenCalledWith('/inicio', { replace: true }));
+  });
+});

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -18,6 +18,10 @@ import {
 import AnalyticsNav from '../components/AnalyticsNav';
 import { telegramBotUsername } from '../config/environment';
 import { createClient } from '../integrations/supabase/client';
+import {
+  ONBOARDING_SRC_ALERTAS_FUTEBOL,
+  resolveOnboardingReturn,
+} from '../utils/onboarding-return';
 
 // Onboarding do Betinho — redesign benefit-led (docs/onboarding-betinho-redesign.md).
 // Momento 1: valor (gancho + carrossel do que a conexão entrega). Momento 2: conexão por
@@ -222,6 +226,11 @@ export default function Onboarding() {
   const navigate = useNavigate();
   const posthog = usePostHog();
   const [searchParams] = useSearchParams();
+
+  // Origem e destino chegam pela URL. O destino passa pela lista de rotas
+  // permitidas: um valor inválido vira a rota segura, nunca um redirect aberto.
+  const returnTo = resolveOnboardingReturn(searchParams.get('return'));
+  const fromOportunidades = searchParams.get('src') === ONBOARDING_SRC_ALERTAS_FUTEBOL;
   const supabase = createClient();
 
   const [userId, setUserId] = useState<string | null>(null);
@@ -258,7 +267,7 @@ export default function Onboarding() {
       const alreadySynced = !!row?.telegram_chat_id;
       if (alreadySynced) {
         // Já conectou antes de chegar aqui → não mostra o onboarding, manda pro hub.
-        navigate('/inicio', { replace: true });
+        navigate(returnTo, { replace: true });
         return;
       }
 
@@ -332,7 +341,7 @@ export default function Onboarding() {
 
   const handleSkip = () => {
     posthog?.capture('betinho_onboarding_skipped', { product: 'betinho' });
-    navigate('/inicio');
+    navigate(returnTo);
   };
 
   if (!userId) {
@@ -354,15 +363,23 @@ export default function Onboarding() {
           {/* Gancho */}
           <div className="order-1 px-6 pt-10 sm:px-10 lg:col-start-1 lg:row-start-1 lg:self-end lg:px-16 lg:pt-0">
             <div className="mx-auto max-w-md lg:mx-0">
+              {/* Quem chega de Oportunidades já sabe o que quer: a introdução
+                  fala do alerta que o trouxe. Os benefícios abaixo e a mecânica
+                  de conexão continuam iguais para todo mundo. */}
               <div className="mb-3 text-[12px] font-semibold uppercase tracking-[0.18em] text-forest">
-                Conheça o Betinho
+                {fromOportunidades ? 'Alertas de oportunidades' : 'Conheça o Betinho'}
               </div>
               <h1 className="mb-4 font-display text-[32px] font-extrabold leading-[1.08] tracking-tight text-ink lg:text-[42px]">
-                Seu assistente de apostas, direto no <span className="text-amber">Telegram.</span>
+                {fromOportunidades ? (
+                  <>Receba as novas oportunidades no <span className="text-amber">Telegram.</span></>
+                ) : (
+                  <>Seu assistente de apostas, direto no <span className="text-amber">Telegram.</span></>
+                )}
               </h1>
               <p className="text-[15px] leading-relaxed text-ink-2">
-                Você manda a aposta por print ou texto e o Betinho registra sozinho. Ele calcula
-                seu ROI de verdade e ainda te avisa das oportunidades do dia, no chat onde você já conversa.
+                {fromOportunidades
+                  ? 'Conecte o Telegram e o Betinho te avisa quando uma oportunidade nova entrar no painel, antes do jogo começar. Você pode pausar os alertas quando quiser.'
+                  : 'Você manda a aposta por print ou texto e o Betinho registra sozinho. Ele calcula seu ROI de verdade e ainda te avisa das oportunidades do dia, no chat onde você já conversa.'}
               </p>
             </div>
           </div>
@@ -453,12 +470,13 @@ export default function Onboarding() {
             </div>
             <h1 className="text-xl font-bold text-ink mb-2">Conectado!</h1>
             <p className="text-[14px] text-ink-2 mb-8 max-w-sm mx-auto">
-              O Betinho já te mandou uma mensagem no Telegram. Manda sua primeira aposta pra ele
-              por lá (print ou texto) quando quiser.
+              {fromOportunidades
+                ? 'Os alertas de novas oportunidades já estão ligados. Você pode pausá-los quando quiser, no site ou pelo Telegram.'
+                : 'O Betinho já te mandou uma mensagem no Telegram. Manda sua primeira aposta pra ele por lá (print ou texto) quando quiser.'}
             </p>
             <button
               type="button"
-              onClick={() => navigate('/inicio')}
+              onClick={() => navigate(returnTo)}
               className="w-full h-12 rounded-lg bg-forest hover:bg-forest-soft text-white text-[15px] font-semibold flex items-center justify-center gap-2 transition-colors"
             >
               Continuar

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -361,7 +361,9 @@ export default function Onboarding() {
         <AnalyticsNav variant="rebrand" />
         <div className="flex-1 grid grid-cols-1 lg:grid-cols-2 max-w-screen-2xl mx-auto w-full">
           {/* Gancho */}
-          <div className="order-1 px-6 pt-10 sm:px-10 lg:col-start-1 lg:row-start-1 lg:self-end lg:px-16 lg:pt-0">
+          {/* pt no desktop também: sem ele, quando o conteúdo da coluna
+              esquerda passa da altura da tela, o gancho encosta no cabeçalho. */}
+          <div className="order-1 px-6 pt-10 sm:px-10 lg:col-start-1 lg:row-start-1 lg:self-end lg:px-16 lg:pt-12">
             <div className="mx-auto max-w-md lg:mx-0">
               {/* Quem chega de Oportunidades já sabe o que quer: a introdução
                   fala do alerta que o trouxe. Os benefícios abaixo e a mecânica

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import UserNav from '../components/UserNav';
 import { useSettingsData } from '../hooks/use-settings-data';
 import { useFutebolPublicationAlerts } from '../hooks/use-futebol-publication-alerts';
+import { onboardingHref, ONBOARDING_SRC_ALERTAS_FUTEBOL } from '../utils/onboarding-return';
 import { useToast } from '../hooks/use-toast';
 import { stripeService } from '../services/stripe.service';
 import { User, CreditCard, ArrowLeft, Send, ExternalLink, Compass, Bell } from 'lucide-react';
@@ -282,10 +283,12 @@ export default function Settings() {
                 <p className="text-sm text-ink-2">
                   Conecte seu Telegram para escolher se quer receber esses alertas.
                 </p>
+                {/* Vai para o onboarding já existente, e não direto ao bot: é lá
+                    que a conexão é explicada e confirmada. */}
                 <Button
                   type="button"
                   variant="outline"
-                  onClick={() => window.open(`${telegramBotUrl}?start=force_contact`, '_blank')}
+                  onClick={() => navigate(onboardingHref(ONBOARDING_SRC_ALERTAS_FUTEBOL, '/settings'))}
                   className="bg-white border-line text-ink hover:bg-canvas-2"
                 >
                   <Send className="w-4 h-4 mr-2" />

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -276,9 +276,27 @@ export default function Settings() {
             <CardDescription>Receba no Telegram quando uma nova oportunidade entrar no painel.</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            {isLoadingPublicationAlerts ? (
+            {isLoadingPublicationAlerts || !publicationAlerts ? (
               <p className="text-sm text-ink-2">Carregando...</p>
-            ) : !publicationAlerts?.telegramLinked ? (
+            ) : !publicationAlerts.accessActive ? (
+              // Acesso inativo vem antes do vínculo: nada é entregue nesse
+              // estado, então chamar para conectar prometeria algo que o
+              // backend não cumpre.
+              <>
+                <p className="text-sm text-ink-2">
+                  Indisponíveis enquanto seu acesso ao Futebol estiver inativo. Sua preferência está {publicationAlerts.enabled ? 'ativada' : 'pausada'} e será mantida quando voltar.
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handlePublicationAlerts}
+                  disabled={isSavingPublicationAlerts}
+                  className="bg-white border-line text-ink hover:bg-canvas-2"
+                >
+                  {publicationAlerts.enabled ? 'Pausar para quando voltar' : 'Retomar para quando voltar'}
+                </Button>
+              </>
+            ) : !publicationAlerts.telegramLinked ? (
               <>
                 <p className="text-sm text-ink-2">
                   Conecte seu Telegram para escolher se quer receber esses alertas.
@@ -293,21 +311,6 @@ export default function Settings() {
                 >
                   <Send className="w-4 h-4 mr-2" />
                   Conectar Telegram
-                </Button>
-              </>
-            ) : !publicationAlerts.accessActive ? (
-              <>
-                <p className="text-sm text-ink-2">
-                  Indisponíveis enquanto seu acesso ao Futebol estiver inativo. Sua preferência está {publicationAlerts.enabled ? 'ativada' : 'pausada'} e será mantida quando voltar.
-                </p>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={handlePublicationAlerts}
-                  disabled={isSavingPublicationAlerts}
-                  className="bg-white border-line text-ink hover:bg-canvas-2"
-                >
-                  {publicationAlerts.enabled ? 'Pausar para quando voltar' : 'Retomar para quando voltar'}
                 </Button>
               </>
             ) : (

--- a/src/utils/onboarding-return.test.ts
+++ b/src/utils/onboarding-return.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ONBOARDING_RETURN_FALLBACK,
+  onboardingHref,
+  resolveOnboardingReturn,
+} from './onboarding-return';
+
+describe('resolveOnboardingReturn', () => {
+  it('aceita as rotas internas da lista', () => {
+    expect(resolveOnboardingReturn('/futebol/oportunidades')).toBe('/futebol/oportunidades');
+    expect(resolveOnboardingReturn('/settings')).toBe('/settings');
+    expect(resolveOnboardingReturn('/inicio')).toBe('/inicio');
+  });
+
+  it('ignora barra final e espaços em volta', () => {
+    expect(resolveOnboardingReturn('  /futebol/oportunidades/  ')).toBe('/futebol/oportunidades');
+  });
+
+  it('descarta query e hash antes de comparar', () => {
+    expect(resolveOnboardingReturn('/futebol/oportunidades?dia=hoje#topo')).toBe('/futebol/oportunidades');
+  });
+
+  it('cai na rota segura quando não há destino', () => {
+    expect(resolveOnboardingReturn(null)).toBe(ONBOARDING_RETURN_FALLBACK);
+    expect(resolveOnboardingReturn(undefined)).toBe(ONBOARDING_RETURN_FALLBACK);
+    expect(resolveOnboardingReturn('')).toBe(ONBOARDING_RETURN_FALLBACK);
+  });
+
+  it('recusa rota interna que não está na lista', () => {
+    expect(resolveOnboardingReturn('/admin')).toBe(ONBOARDING_RETURN_FALLBACK);
+    expect(resolveOnboardingReturn('/futebol/oportunidades/extra')).toBe(ONBOARDING_RETURN_FALLBACK);
+  });
+
+  it('recusa destino externo', () => {
+    expect(resolveOnboardingReturn('https://evil.com')).toBe(ONBOARDING_RETURN_FALLBACK);
+    expect(resolveOnboardingReturn('//evil.com')).toBe(ONBOARDING_RETURN_FALLBACK);
+    expect(resolveOnboardingReturn('/\\evil.com')).toBe(ONBOARDING_RETURN_FALLBACK);
+    expect(resolveOnboardingReturn('javascript:alert(1)')).toBe(ONBOARDING_RETURN_FALLBACK);
+    expect(resolveOnboardingReturn('futebol/oportunidades')).toBe(ONBOARDING_RETURN_FALLBACK);
+  });
+});
+
+describe('onboardingHref', () => {
+  it('monta a rota existente com origem e retorno codificados', () => {
+    expect(onboardingHref('alertas-futebol', '/futebol/oportunidades')).toBe(
+      '/onboarding?src=alertas-futebol&return=%2Ffutebol%2Foportunidades',
+    );
+  });
+
+  it('mantém o onboarding genérico quando não há retorno', () => {
+    expect(onboardingHref('configuracoes')).toBe('/onboarding?src=configuracoes');
+  });
+});

--- a/src/utils/onboarding-return.ts
+++ b/src/utils/onboarding-return.ts
@@ -1,0 +1,37 @@
+// Destino de retorno do onboarding do Betinho.
+//
+// O valor chega pela URL (`/onboarding?return=...`), então a lista é fechada de
+// propósito: qualquer coisa fora dela vira a rota segura, e nunca um
+// redirecionamento aberto para fora do produto.
+
+export const ONBOARDING_RETURN_FALLBACK = '/inicio';
+
+const ALLOWED_RETURNS: readonly string[] = [
+  '/inicio',
+  '/futebol',
+  '/futebol/oportunidades',
+  '/futebol/jogos',
+  '/settings',
+];
+
+/** Origem que troca a introdução do onboarding para o contexto de alertas. */
+export const ONBOARDING_SRC_ALERTAS_FUTEBOL = 'alertas-futebol';
+
+export function resolveOnboardingReturn(raw: string | null | undefined): string {
+  if (typeof raw !== 'string') return ONBOARDING_RETURN_FALLBACK;
+
+  const value = raw.trim();
+  // Só caminho interno absoluto. "//host" e "/\host" são protocol-relative e
+  // levariam para fora do domínio.
+  if (!value.startsWith('/')) return ONBOARDING_RETURN_FALLBACK;
+  if (value.startsWith('//') || value.startsWith('/\\')) return ONBOARDING_RETURN_FALLBACK;
+
+  const path = value.split(/[?#]/)[0].replace(/\/+$/, '') || '/';
+  return ALLOWED_RETURNS.includes(path) ? path : ONBOARDING_RETURN_FALLBACK;
+}
+
+export function onboardingHref(src: string, returnTo?: string): string {
+  const params = new URLSearchParams({ src });
+  if (returnTo) params.set('return', returnTo);
+  return `/onboarding?${params.toString()}`;
+}

--- a/supabase/migrations/20260828113000_futebol_ack_alertas_publicacao.sql
+++ b/supabase/migrations/20260828113000_futebol_ack_alertas_publicacao.sql
@@ -1,0 +1,11 @@
+-- O cartão explicativo dos alertas de publicação aparece uma única vez. O
+-- reconhecimento fica no banco (e não no navegador) para não voltar quando o
+-- usuário troca de dispositivo.
+--
+-- Dispensar o cartão é uma ação de leitura: não altera
+-- futebol_publication_alerts_enabled nem interrompe qualquer entrega.
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS futebol_publication_alerts_ack_at timestamptz;
+
+COMMENT ON COLUMN public.users.futebol_publication_alerts_ack_at IS
+  'Momento em que o usuário dispensou o cartão explicativo dos alertas de oportunidades publicadas. Nulo significa que o cartão ainda não foi visto.';


### PR DESCRIPTION
Closes #294

Apresenta os alertas de oportunidades publicadas sem criar um segundo onboarding.

## O que muda

- Cartão explicativo em Oportunidades, mostrado uma única vez a quem tem Telegram conectado, acesso ativo e a preferência ligada. O "Entendi" grava o reconhecimento no banco, então não volta em outro navegador ou dispositivo, e nunca altera a preferência de alerta.
- O atalho de estado continua na página depois do cartão. Sem Telegram conectado ele vira um convite visual e leva ao onboarding existente.
- Configurações passa a chamar a mesma rota de onboarding, em vez de abrir o bot direto.
- O onboarding ganha introdução contextual e destino de retorno. Carrossel, benefícios e mecânica de conexão seguem iguais. Sem os parâmetros de origem e retorno, o fluxo genérico não muda.
- O destino de retorno passa por uma lista fechada de rotas internas: valor externo, protocol-relative ou fora da lista cai em /inicio.

## Precedência de estados

Acesso inativo vem antes do vínculo com o Telegram, tanto no atalho quanto em Configurações. Sem assinatura ou teste ativo nenhuma entrega acontece, então convidar para conectar levaria a pessoa a um fluxo que termina numa promessa que o backend não cumpre.

## Migration

Uma coluna nova em users, futebol_publication_alerts_ack_at, que guarda o reconhecimento do cartão. Já aplicada no projeto de dev.

Vai junto o script scripts/apply-sql-dev.mjs. Ele existe porque o banco de dev não aplica as migrations do repositório sozinho: a coluna nova não estava lá, a consulta do painel falhava inteira e nem o cartão nem o atalho apareciam na tela, sem erro visível. O script tem trava para só rodar contra o projeto de dev.

## Verificação

- 22 testes novos passando: lista de rotas permitidas, cartão único, os quatro estados do atalho, precedência do acesso inativo, copy contextual, retorno válido e inválido, e regressão do onboarding genérico.
- Suíte completa: 227 passam. A única falha é gen-route-heads, que exige dist/index.html e falha igual na develop sem build.
- Lint limpo nos arquivos tocados. Nenhum erro de tipo novo.
- Code review aplicado nesta branch, com três achados corrigidos: o cartão contradizendo o atalho para quem já tinha pausado, o convite de conexão levando a um beco sem saída para quem está sem acesso, e o "Entendi" tratando zero linhas afetadas como sucesso.

## Não validado manualmente

O vínculo real com o Telegram e a tela de "Conectado". A mecânica de conexão não foi alterada, só o destino da volta, mas essa parte não passou por teste manual porque a conta de teste já tinha outro vínculo ativo.
