### PR TITLE
Futebol · compatibilidade do Score legacy e contexto_v1

### DIFF
--- a/src/components/onboarding/demo/futebol.ts
+++ b/src/components/onboarding/demo/futebol.ts
@@ -31,6 +31,8 @@ const base = (over: Partial<FutebolValueBoardRow>): FutebolValueBoardRow => ({
   faixa: 'Média',
   evidencias: [],
   ...over,
+  score_versao: over.score_versao ?? 'legacy',
+  premissas_sem_dado: over.premissas_sem_dado ?? 0,
 });
 
 // "Melhor por jogo" (é o que a tela de Oportunidades exibe). Mistura de faixas
@@ -222,6 +224,8 @@ const vr = (over: Partial<FutebolFixtureValueRow>): FutebolFixtureValueRow => ({
   penalidades: 0, penalidades_globais_pts: 0, penalidades_especificas_pts: 0,
   score: 50, faixa: 'Média', modelo_api_concorda: true, linha_sharp_confirma: true,
   evidencias: [], avisos: [], contras: [], ...over,
+  score_versao: over.score_versao ?? 'legacy',
+  premissas_sem_dado: over.premissas_sem_dado ?? 0,
 });
 
 export const demoFixtureValueRows: FutebolFixtureValueRow[] = [

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -80,11 +80,13 @@ function oppFromAlerted(a: FutebolAlertedPick, fx?: FutebolFixture): OppLike {
     avg_odd: Number(a.odds),
     n_casas: 0,
     janela_usada: a.janela_usada ?? '',
+    score_versao: 'legacy',
     pts_valor: 0,
     pts_premissas: 0,
     pts_corroboracao: 0,
     penalidades: 0,
     evidencias: [],
+    premissas_sem_dado: 0,
     // Números do instante em que era oportunidade. Null nas enviadas antes da
     // migration 091 (o pipeline sobrescreve a janela e destrói chance/valor/Score
     // da manhã); daí em diante vêm preenchidos e a linha fica igual à do board.

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -1,4 +1,9 @@
 import { supabase } from '@/integrations/supabase/client';
+import {
+  normalizeFutebolFixtureValueRows,
+  normalizeFutebolValueBoardRows,
+  type FutebolScoreVersion,
+} from './futebol-score-contract';
 
 // As RPCs de futebol ainda não estão nos tipos gerados do Supabase (existem
 // só no dev, lendo BigQuery via FDW no schema bq_futebol). Cast pra any, mesmo
@@ -512,6 +517,7 @@ export interface FutebolValueBoardRow {
   n_casas: number;
   janela_usada: string;    // t15m | t1h | t24h
   prob_justa_fechamento: number; // "Chance" (prob justa devigada) 0..1
+  score_versao: FutebolScoreVersion;
   pts_valor: number;
   pts_premissas: number;
   pts_corroboracao: number;
@@ -565,6 +571,7 @@ export interface FutebolFixtureValueRow {
   n_casas: number;
   janela_usada: string;
   prob_justa_fechamento: number;
+  score_versao: FutebolScoreVersion;
   pts_valor: number;
   pts_premissas: number;
   pts_corroboracao: number;
@@ -867,7 +874,7 @@ export const futebolDataService = {
     return withRetry(async () => {
       const { data, error } = await supabaseClient.rpc('get_futebol_value_board');
       if (error) throw error;
-      return (data || []) as FutebolValueBoardRow[];
+      return normalizeFutebolValueBoardRows(data || []);
     });
   },
 
@@ -896,7 +903,7 @@ export const futebolDataService = {
         p_to: to,
       });
       if (error) throw error;
-      return (data || []) as FutebolValueBoardRow[];
+      return normalizeFutebolValueBoardRows(data || []);
     });
   },
 
@@ -922,7 +929,7 @@ export const futebolDataService = {
         p_fixture_id: fixtureId,
       });
       if (error) throw error;
-      return (data || []) as FutebolFixtureValueRow[];
+      return normalizeFutebolFixtureValueRows(data || []);
     });
   },
 

--- a/src/services/futebol-score-contract.test.ts
+++ b/src/services/futebol-score-contract.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  normalizeFutebolFixtureValueRows,
+  normalizeFutebolValueBoardRows,
+} from './futebol-score-contract';
+
+const boardBase = {
+  fixture_id: 101,
+  home_team_id: 1,
+  away_team_id: 2,
+  home_team_name: 'Casa',
+  away_team_name: 'Fora',
+  competition: 'brasileirao',
+  kickoff_utc: '2026-08-30T20:00:00',
+  status_short: 'NS',
+  market: 'goals_over_under',
+  outcome: 'Over',
+  line_value: 1.5,
+  edge: 0.04,
+  best_odd: 1.8,
+  best_book: 'Casa A',
+  avg_odd: 1.75,
+  n_casas: 6,
+  janela_usada: 't1h',
+  prob_justa_fechamento: 0.58,
+  pts_premissas: 42,
+  penalidades: 0,
+  score: 62,
+  faixa: 'Alta',
+  evidencias: ['Contexto favorável'],
+  premissas_sem_dado: 0,
+};
+
+const fixtureBase = {
+  market: 'goals_over_under',
+  outcome: 'Over',
+  outcome_order: 1,
+  line_value: 1.5,
+  edge: 0.04,
+  best_odd: 1.8,
+  best_book: 'Casa A',
+  avg_odd: 1.75,
+  n_casas: 6,
+  janela_usada: 't1h',
+  prob_justa_fechamento: 0.58,
+  pts_premissas: 42,
+  penalidades: 0,
+  penalidades_especificas_pts: 0,
+  score: 62,
+  faixa: 'Alta',
+  modelo_api_concorda: false,
+  linha_sharp_confirma: false,
+  evidencias: ['Contexto favorável'],
+  avisos: [],
+  contras: [],
+  premissas_sem_dado: 0,
+};
+
+describe('compatibilidade do contrato do Score de contexto', () => {
+  it('identifica como legacy uma linha antiga e preserva seus componentes', () => {
+    const [row] = normalizeFutebolValueBoardRows([{
+      ...boardBase,
+      pts_valor: 20,
+      pts_corroboracao: 8,
+    }]);
+
+    expect(row.score_versao).toBe('legacy');
+    expect(row.pts_valor).toBe(20);
+    expect(row.pts_corroboracao).toBe(8);
+  });
+
+  it('aceita contexto_v1 sem exigir os componentes removidos', () => {
+    const [row] = normalizeFutebolValueBoardRows([{
+      ...boardBase,
+      score_versao: 'contexto_v1',
+    }]);
+
+    expect(row.score_versao).toBe('contexto_v1');
+    expect(row.pts_valor).toBe(0);
+    expect(row.pts_corroboracao).toBe(0);
+  });
+
+  it('rejeita a forma nova quando contexto_v1 não foi declarado', () => {
+    expect(() => normalizeFutebolValueBoardRows([boardBase])).toThrow(
+      'O contrato novo do Score exige score_versao: contexto_v1',
+    );
+  });
+
+  it('não permite rotular a forma nova como legacy', () => {
+    expect(() => normalizeFutebolValueBoardRows([{
+      ...boardBase,
+      score_versao: 'legacy',
+    }])).toThrow('O contrato legacy exige pts_valor e pts_corroboracao');
+  });
+
+  it('adapta o detalhe novo sem exigir penalidade global de odd', () => {
+    const [row] = normalizeFutebolFixtureValueRows([{
+      ...fixtureBase,
+      score_versao: 'contexto_v1',
+    }]);
+
+    expect(row.score_versao).toBe('contexto_v1');
+    expect(row.pts_valor).toBe(0);
+    expect(row.pts_corroboracao).toBe(0);
+    expect(row.penalidades_globais_pts).toBe(0);
+  });
+
+  it('preserva o contrato legacy do detalhe usado em produção', () => {
+    const [row] = normalizeFutebolFixtureValueRows([{
+      ...fixtureBase,
+      pts_valor: 20,
+      pts_corroboracao: 8,
+      penalidades_globais_pts: 5,
+    }]);
+
+    expect(row.score_versao).toBe('legacy');
+    expect(row.pts_valor).toBe(20);
+    expect(row.pts_corroboracao).toBe(8);
+    expect(row.penalidades_globais_pts).toBe(5);
+  });
+
+  it('rejeita uma versão desconhecida em vez de mascarar contrato inválido', () => {
+    expect(() => normalizeFutebolValueBoardRows([{
+      ...boardBase,
+      score_versao: 'contexto_v2',
+    }])).toThrow('Versão do Score desconhecida: contexto_v2');
+  });
+});

--- a/src/services/futebol-score-contract.ts
+++ b/src/services/futebol-score-contract.ts
@@ -1,0 +1,79 @@
+import type {
+  FutebolFixtureValueRow,
+  FutebolValueBoardRow,
+} from './futebol-data.service';
+
+export type FutebolScoreVersion = 'legacy' | 'contexto_v1';
+
+type RawBoardRow = Omit<Partial<FutebolValueBoardRow>, 'score_versao'> & {
+  score_versao?: unknown;
+  [key: string]: unknown;
+};
+
+type RawFixtureRow = Omit<Partial<FutebolFixtureValueRow>, 'score_versao'> & {
+  score_versao?: unknown;
+  [key: string]: unknown;
+};
+
+type RawScoreRow = {
+  score_versao?: unknown;
+  pts_valor?: unknown;
+  pts_corroboracao?: unknown;
+};
+
+function scoreVersion(row: RawScoreRow): FutebolScoreVersion {
+  const temFormaLegacy =
+    typeof row.pts_valor === 'number' &&
+    typeof row.pts_corroboracao === 'number';
+  if (row.score_versao == null) {
+    if (temFormaLegacy) return 'legacy';
+    throw new Error('O contrato novo do Score exige score_versao: contexto_v1');
+  }
+  if (row.score_versao === 'legacy') {
+    if (!temFormaLegacy) {
+      throw new Error('O contrato legacy exige pts_valor e pts_corroboracao');
+    }
+    return 'legacy';
+  }
+  if (row.score_versao === 'contexto_v1') return 'contexto_v1';
+  throw new Error(`Versão do Score desconhecida: ${String(row.score_versao)}`);
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' ? value : 0;
+}
+
+function normalizeCommonScoreFields(row: RawScoreRow) {
+  return {
+    score_versao: scoreVersion(row),
+    pts_valor: numberOrZero(row.pts_valor),
+    pts_corroboracao: numberOrZero(row.pts_corroboracao),
+  };
+}
+
+/**
+ * Costura temporária de expansão do contrato.
+ *
+ * A interface pública continua completa para os consumidores legacy enquanto
+ * as RPCs passam a omitir os componentes de preço no contexto_v1. A contração
+ * remove estes defaults depois da virada coordenada.
+ */
+export function normalizeFutebolValueBoardRows(
+  rows: readonly RawBoardRow[],
+): FutebolValueBoardRow[] {
+  return rows.map((row) => ({
+    ...row,
+    ...normalizeCommonScoreFields(row),
+  })) as FutebolValueBoardRow[];
+}
+
+/** Mesma expansão para a RPC de detalhe, que também perde a penalidade global. */
+export function normalizeFutebolFixtureValueRows(
+  rows: readonly RawFixtureRow[],
+): FutebolFixtureValueRow[] {
+  return rows.map((row) => ({
+    ...row,
+    ...normalizeCommonScoreFields(row),
+    penalidades_globais_pts: numberOrZero(row.penalidades_globais_pts),
+  })) as FutebolFixtureValueRow[];
+}

--- a/src/utils/futebol-leitura.test.ts
+++ b/src/utils/futebol-leitura.test.ts
@@ -35,6 +35,7 @@ const VALUE_BASE: FutebolFixtureValueRow = {
   n_casas: 5,
   janela_usada: 'fechamento',
   prob_justa_fechamento: 0.6114,
+  score_versao: 'legacy',
   pts_valor: 20,
   pts_premissas: 34,
   pts_corroboracao: 0,


### PR DESCRIPTION
## Resumo

- aceita respostas legacy e contexto_v1 em um adaptador compartilhado
- mantém os componentes antigos somente como compatibilidade temporária
- rejeita payload novo sem versão e payload rotulado incorretamente como legacy
- normaliza board, histórico e detalhe antes de chegarem às telas

## Validação

- 42 testes relacionados passaram
- build de produção passou
- revisão em dois eixos: Standards 0 achados; Spec 0 achados
- a checagem TypeScript do app mantém erros preexistentes, sem erros nos arquivos deste PR

Parent: #301
Closes #303