### PR TITLE
Futebol: contrato das RPCs e dos motivos no Score de contexto

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -633,7 +633,11 @@ create table futebol.fact_value_opportunities (
   "pen_odd_outlier" boolean,
   "pen_poucas_casas" boolean,
   "pen_odd_longshot" boolean,
-  "pen_odd_juice" boolean
+  "pen_odd_juice" boolean,
+  -- Escala do Score (spec #301): legacy ou contexto_v1. Nunca nulo.
+  -- No fim de proposito: a migration 112 entra por alter table add column, que
+  -- acrescenta no fim, e as duas provisoes precisam ter a mesma ordem de coluna.
+  "score_versao" text not null default 'legacy'
 );
 
 -- ── 2a. Infra do sync: estado incremental (o Cloud Run sync lê/escreve aqui) ──
@@ -686,7 +690,11 @@ create table futebol.fact_value_opportunities_hist (
   "pen_odd_outlier" boolean,
   "pen_poucas_casas" boolean,
   "pen_odd_longshot" boolean,
-  "pen_odd_juice" boolean
+  "pen_odd_juice" boolean,
+  -- Escala do Score (spec #301): legacy ou contexto_v1. Nunca nulo.
+  -- No fim de proposito: a migration 112 entra por alter table add column, que
+  -- acrescenta no fim, e as duas provisoes precisam ter a mesma ordem de coluna.
+  "score_versao" text not null default 'legacy'
 );
 
 -- ── 2b. Lockdown RPC-only (espelha nba_mart): acesso só via RPCs security definer
@@ -1095,16 +1103,11 @@ insert into public.futebol_premissa_copy (tipo, market, slug, mando, ordem, text
   ('evidencia', 'goals_over_under', 'xg_baixo_combinado', 'any', 4, 'Os dois criam pouca chance de gol'),
   ('evidencia', 'goals_over_under', 'xg_combinado_alto', 'any', 5, 'Os dois criam muita chance de gol'),
   ('evidencia', 'goals_over_under', 'clean_sheets_altos', 'any', 6, 'Os dois passam muitos jogos sem sofrer gol'),
-  ('evidencia', 'goals_over_under', 'corroboracao_ambos', 'any', 7, 'As principais casas e o modelo da API apontam o mesmo lado'),
-  ('evidencia', 'goals_over_under', 'linha_sharp_confirma', 'any', 8, 'As principais casas vêm baixando a odd desse lado'),
-  ('evidencia', 'goals_over_under', 'ataques_fracos', 'any', 9, 'Ataques fracos dos dois lados'),
-  ('evidencia', 'goals_over_under', 'historico_under', 'any', 10, 'Histórico de jogo com poucos gols'),
-  ('evidencia', 'goals_over_under', 'ambos_vazam', 'any', 11, 'Os dois sofrem gol quase todo jogo'),
-  ('evidencia', 'goals_over_under', 'ritmo_alto', 'any', 12, 'Jogo de ritmo alto'),
-  ('evidencia', 'goals_over_under', 'historico_over', 'any', 13, 'Histórico de jogo com muitos gols'),
-  ('evidencia', 'goals_over_under', 'linha_subindo', 'any', 14, 'Mercado puxando a linha pra cima'),
-  ('evidencia', 'goals_over_under', 'linha_descendo', 'any', 15, 'Mercado puxando a linha pra baixo'),
-  ('evidencia', 'goals_over_under', 'modelo_api_concorda', 'any', 16, 'Modelo da API concorda com esse lado'),
+  ('evidencia', 'goals_over_under', 'ataques_fracos', 'any', 7, 'Ataques fracos dos dois lados'),
+  ('evidencia', 'goals_over_under', 'historico_under', 'any', 8, 'Histórico de jogo com poucos gols'),
+  ('evidencia', 'goals_over_under', 'ambos_vazam', 'any', 9, 'Os dois sofrem gol quase todo jogo'),
+  ('evidencia', 'goals_over_under', 'ritmo_alto', 'any', 10, 'Jogo de ritmo alto'),
+  ('evidencia', 'goals_over_under', 'historico_over', 'any', 11, 'Histórico de jogo com muitos gols'),
   ('contra', 'goals_over_under', 'defesas_firmes', 'any', 1, 'A solidez das defesas não entrou como sinal a favor'),
   ('contra', 'goals_over_under', 'ataque_combinado', 'any', 2, 'O ataque dos dois times não entrou como sinal a favor'),
   ('contra', 'goals_over_under', 'xg_baixo_combinado', 'any', 3, 'O baixo volume de chances não entrou como sinal a favor'),
@@ -1121,13 +1124,10 @@ insert into public.futebol_premissa_copy (tipo, market, slug, mando, ordem, text
   ('evidencia', 'match_winner', 'mando', 'home', 2, 'Manda bem em casa'),
   ('evidencia', 'match_winner', 'mando', 'away', 2, 'Vai bem fora de casa'),
   ('evidencia', 'match_winner', 'superioridade_tabela', 'any', 3, 'Bem à frente na tabela'),
-  ('evidencia', 'match_winner', 'corroboracao_ambos', 'any', 4, 'As principais casas e o modelo da API apontam o mesmo lado'),
-  ('evidencia', 'match_winner', 'linha_sharp_confirma', 'any', 5, 'As principais casas vêm baixando a odd desse lado'),
-  ('evidencia', 'match_winner', 'forca_mismatch', 'any', 6, 'Ataque forte contra defesa frágil do adversário'),
-  ('evidencia', 'match_winner', 'superioridade_xg', 'any', 7, 'Cria mais chances de gol que o adversário'),
-  ('evidencia', 'match_winner', 'h2h_favoravel', 'any', 8, 'Leva vantagem no histórico do confronto'),
-  ('evidencia', 'match_winner', 'desfalque_adversario', 'any', 9, 'Adversário com desfalque de titular importante'),
-  ('evidencia', 'match_winner', 'modelo_api_concorda', 'any', 10, 'Modelo da API concorda com esse lado'),
+  ('evidencia', 'match_winner', 'forca_mismatch', 'any', 4, 'Ataque forte contra defesa frágil do adversário'),
+  ('evidencia', 'match_winner', 'superioridade_xg', 'any', 5, 'Cria mais chances de gol que o adversário'),
+  ('evidencia', 'match_winner', 'h2h_favoravel', 'any', 6, 'Leva vantagem no histórico do confronto'),
+  ('evidencia', 'match_winner', 'desfalque_adversario', 'any', 7, 'Adversário com desfalque de titular importante'),
   ('contra', 'match_winner', 'mando', 'home', 1, 'Em casa, o mando não entrou como sinal a favor'),
   ('contra', 'match_winner', 'mando', 'away', 1, 'Fora de casa, o mando não entrou como sinal a favor'),
   ('contra', 'match_winner', 'superioridade_tabela', 'any', 2, 'A posição na tabela não entrou como sinal a favor'),
@@ -1142,15 +1142,12 @@ insert into public.futebol_premissa_copy (tipo, market, slug, mando, ordem, text
   ('evidencia', 'asian_handicap', 'supremacia', 'any', 2, 'Muito superior ao adversário'),
   ('evidencia', 'asian_handicap', 'defesa_fora_solida', 'any', 3, 'Defesa sólida jogando fora'),
   ('evidencia', 'asian_handicap', 'defesa_fora_solida', 'home', 3, 'Defesa sólida em casa'),
-  ('evidencia', 'asian_handicap', 'corroboracao_ambos', 'any', 4, 'As principais casas e o modelo da API apontam o mesmo lado'),
-  ('evidencia', 'asian_handicap', 'linha_sharp_confirma', 'any', 5, 'As principais casas vêm baixando a odd desse lado'),
-  ('evidencia', 'asian_handicap', 'sem_rodizio', 'any', 6, 'Deve entrar com força máxima'),
-  ('evidencia', 'asian_handicap', 'raramente_perde_por_2', 'any', 7, 'Quando perde, perde apertado'),
-  ('evidencia', 'asian_handicap', 'adversario_fragil_fora', 'any', 8, 'Adversário fraco fora de casa'),
-  ('evidencia', 'asian_handicap', 'adversario_fragil_fora', 'away', 8, 'Adversário fraco em casa'),
-  ('evidencia', 'asian_handicap', 'mando_forte', 'any', 9, 'Manda muito bem em casa'),
-  ('evidencia', 'asian_handicap', 'mando_forte', 'away', 9, 'Vai muito bem fora de casa'),
-  ('evidencia', 'asian_handicap', 'modelo_api_concorda', 'any', 10, 'Modelo da API concorda com esse lado'),
+  ('evidencia', 'asian_handicap', 'sem_rodizio', 'any', 4, 'Deve entrar com força máxima'),
+  ('evidencia', 'asian_handicap', 'raramente_perde_por_2', 'any', 5, 'Quando perde, perde apertado'),
+  ('evidencia', 'asian_handicap', 'adversario_fragil_fora', 'any', 6, 'Adversário fraco fora de casa'),
+  ('evidencia', 'asian_handicap', 'adversario_fragil_fora', 'away', 6, 'Adversário fraco em casa'),
+  ('evidencia', 'asian_handicap', 'mando_forte', 'any', 7, 'Manda muito bem em casa'),
+  ('evidencia', 'asian_handicap', 'mando_forte', 'away', 7, 'Vai muito bem fora de casa'),
   ('contra', 'asian_handicap', 'tende_golear', 'any', 1, 'A margem das vitórias não entrou como sinal a favor'),
   ('contra', 'asian_handicap', 'supremacia', 'any', 2, 'A superioridade sobre o adversário não entrou como sinal a favor'),
   ('contra', 'asian_handicap', 'defesa_fora_solida', 'any', 3, 'A solidez defensiva não entrou como sinal a favor'),
@@ -1168,9 +1165,6 @@ insert into public.futebol_premissa_copy (tipo, market, slug, mando, ordem, text
   ('evidencia', 'btts', 'ataque_trava', 'any', 5, 'Um dos ataques costuma passar em branco'),
   ('evidencia', 'btts', 'historico_btts', 'any', 6, 'Nos últimos jogos, os dois marcaram'),
   ('evidencia', 'btts', 'historico_seco', 'any', 7, 'Jogos recentes sem os dois marcarem'),
-  ('evidencia', 'btts', 'corroboracao_ambos', 'any', 8, 'As principais casas e o modelo da API apontam o mesmo lado'),
-  ('evidencia', 'btts', 'linha_sharp_confirma', 'any', 9, 'As principais casas vêm baixando a odd desse lado'),
-  ('evidencia', 'btts', 'modelo_api_concorda', 'any', 10, 'Modelo da API concorda com esse lado'),
   ('contra', 'btts', 'ambos_marcam', 'any', 1, 'Os gols dos dois times não entraram como sinal a favor'),
   ('contra', 'btts', 'defesas_vazaveis', 'any', 2, 'A fragilidade das defesas não entrou como sinal a favor'),
   ('contra', 'btts', 'defesa_forte', 'any', 3, 'A força defensiva não entrou como sinal a favor'),
@@ -1183,9 +1177,6 @@ insert into public.futebol_premissa_copy (tipo, market, slug, mando, ordem, text
   ('evidencia', 'double_chance', 'equilibrio_defensivo', 'any', 2, 'Equilíbrio defensivo'),
   ('evidencia', 'double_chance', 'adversario_limitado', 'any', 3, 'Adversário com campanha fraca'),
   ('evidencia', 'double_chance', 'invicto_recente', 'any', 4, 'Invicto nos últimos jogos'),
-  ('evidencia', 'double_chance', 'corroboracao_ambos', 'any', 5, 'As principais casas e o modelo da API apontam o mesmo lado'),
-  ('evidencia', 'double_chance', 'linha_sharp_confirma', 'any', 6, 'As principais casas vêm baixando a odd desse lado'),
-  ('evidencia', 'double_chance', 'modelo_api_concorda', 'any', 7, 'Modelo da API concorda com esse lado'),
   ('contra', 'double_chance', 'lado_coberto_forte', 'any', 1, 'A força do lado coberto não entrou como sinal a favor'),
   ('contra', 'double_chance', 'adversario_limitado', 'any', 2, 'A campanha do adversário não entrou como sinal a favor'),
   ('aviso', 'double_chance', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
@@ -1262,25 +1253,22 @@ $function$;
 grant execute on function public.futebol_flags(jsonb, jsonb, jsonb, jsonb, jsonb, jsonb) to anon, authenticated, service_role;
 grant execute on function public.futebol_copy(text, text, text, jsonb) to anon, authenticated, service_role;
 
+-- O retorno tabular mudou na virada do Score de contexto, e o Postgres recusa
+-- `create or replace` que altere o RETURNS TABLE. Derruba antes de recriar.
+drop function if exists public.get_futebol_fixture_value(bigint);
 CREATE OR REPLACE FUNCTION public.get_futebol_fixture_value(p_fixture_id bigint)
- RETURNS TABLE(market text, outcome text, outcome_order integer, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, penalidades_globais_pts integer, penalidades_especificas_pts integer, score integer, faixa text, modelo_api_concorda boolean, linha_sharp_confirma boolean, evidencias text[], avisos text[], contras text[], premissas_sem_dado integer)
- LANGUAGE sql
- SECURITY DEFINER
- SET search_path TO ''
-AS $function$
-  -- migration 101: a fonte deixa de ser fixa. Kickoff no futuro lê o board;
-  -- kickoff já passado lê a FOTO DO APITO no snapshot. É *kickoff passado* e
-  -- não *jogo terminado*, senão as ~2h de bola rolando ficariam sem linha
-  -- depois que o mart passar a expurgar os status ao vivo (ADR 0009).
-  -- migration 105: os avisos de penalidade leem as colunas pen_* do proprio mart
-  -- (AE#87). O CTE sobre int_futebol_odds_devig foi removido: ele rederivava as
-  -- flags e, no prd, 76 de 126 linhas exibiam aviso de janela errada (issue #267).
-  -- No hist, pen_* pode ser NULL em versao aberta antes do AE#87: NULL nao gera aviso.
+ returns table(market text, outcome text, outcome_order integer, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_premissas integer, penalidades integer, penalidades_especificas_pts integer, score integer, faixa text, score_versao text, modelo_api_concorda boolean, linha_sharp_confirma boolean, evidencias text[], avisos text[], contras text[], premissas_sem_dado integer)
+ language sql
+ security definer
+ set search_path to ''
+as $function$
+  -- migration 101: kickoff no futuro lê o board; kickoff já passado lê a FOTO DO
+  -- APITO no snapshot. migration 105: os avisos leem as colunas pen_* do mart.
   with v_src as (
-    select fixture_id, market, outcome, line_value, competition, season, edge, pts_valor,
-           pts_premissas, pts_corroboracao, penalidades, score, faixa, best_odd, best_book,
+    select fixture_id, market, outcome, line_value, competition, season, edge,
+           pts_premissas, penalidades, score, faixa, score_versao, best_odd, best_book,
            avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
-           penalidades_globais_pts, penalidades_especificas_pts, modelo_api_concorda,
+           penalidades_especificas_pts, modelo_api_concorda,
            linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado,
            pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
     from futebol.fact_value_opportunities
@@ -1288,10 +1276,10 @@ AS $function$
       and exists (select 1 from futebol.fact_fixtures fx
                    where fx.fixture_id = p_fixture_id and fx.kickoff_utc > (now() at time zone 'UTC'))
     union all
-    select fixture_id, market, outcome, line_value, competition, season, edge, pts_valor,
-           pts_premissas, pts_corroboracao, penalidades, score, faixa, best_odd, best_book,
+    select fixture_id, market, outcome, line_value, competition, season, edge,
+           pts_premissas, penalidades, score, faixa, score_versao, best_odd, best_book,
            avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
-           penalidades_globais_pts, penalidades_especificas_pts, modelo_api_concorda,
+           penalidades_especificas_pts, modelo_api_concorda,
            linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado,
            pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
     from futebol.fact_value_opportunities_hist h
@@ -1315,8 +1303,8 @@ AS $function$
           then (3000 + case v.outcome when '1X' then 1 else 2 end)
           else 0 end),
     v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
-    v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int,
-    v.penalidades_globais_pts::int, v.penalidades_especificas_pts::int, v.score::int, v.faixa,
+    v.pts_premissas::int, v.penalidades::int,
+    v.penalidades_especificas_pts::int, v.score::int, v.faixa, v.score_versao,
     v.modelo_api_concorda, v.linha_sharp_confirma,
     public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
     public.futebol_copy('aviso', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
@@ -1330,9 +1318,7 @@ AS $function$
   left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
   where v.fixture_id = p_fixture_id
   order by (case v.market when 'match_winner' then 1 when 'goals_over_under' then 2 when 'asian_handicap' then 3 when 'btts' then 4 when 'double_chance' then 5 else 9 end), 3;
-$function$
-
-;
+$function$;
 
 CREATE OR REPLACE FUNCTION public.get_futebol_fixtures(p_competition text, p_season bigint, p_round text DEFAULT NULL::text)
  RETURNS TABLE(fixture_id bigint, round text, kickoff_utc timestamp without time zone, date_utc date, status_short text, status_long text, home_team_id bigint, home_team_name text, home_team_logo text, away_team_id bigint, away_team_name text, away_team_logo text, goals_home bigint, goals_away bigint)
@@ -1718,16 +1704,19 @@ end; $function$
 
 ;
 
+-- O retorno tabular mudou na virada do Score de contexto, e o Postgres recusa
+-- `create or replace` que altere o RETURNS TABLE. Derruba antes de recriar.
+drop function if exists public.get_futebol_value_board();
 CREATE OR REPLACE FUNCTION public.get_futebol_value_board()
- RETURNS TABLE(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, score integer, faixa text, evidencias text[], premissas_sem_dado integer)
- LANGUAGE sql
- SECURITY DEFINER
- SET search_path TO ''
-AS $function$
+ returns table(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_premissas integer, penalidades integer, score integer, faixa text, score_versao text, evidencias text[], premissas_sem_dado integer)
+ language sql
+ security definer
+ set search_path to ''
+as $function$
   select v.fixture_id, f.home_team_id, f.away_team_id, f.home_team_name, f.away_team_name,
     f.competition, f.kickoff_utc, f.status_short,
     v.market, v.outcome, v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
-    v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int, v.score::int, v.faixa,
+    v.pts_premissas::int, v.penalidades::int, v.score::int, v.faixa, v.score_versao,
     public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
     v.premissas_sem_dado::int
   from futebol.fact_value_opportunities v
@@ -1738,9 +1727,7 @@ AS $function$
   left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
   left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
   order by v.score desc, v.edge desc;
-$function$
-
-;
+$function$;
 
 -- ── 5b. Histórico point-in-time do board (ADR 0009, migrations 101 e 102) ────
 -- O board é reconstruído inteiro a cada execução e não filtra data, então ler o
@@ -1771,18 +1758,21 @@ $function$
 -- outras em `get_futebol_value_board` e `get_futebol_fixture_value`). Mercado
 -- novo mexe em três RPCs. Extrair exige tocar nas três de uma vez.
 
+-- O retorno tabular mudou na virada do Score de contexto, e o Postgres recusa
+-- `create or replace` que altere o RETURNS TABLE. Derruba antes de recriar.
+drop function if exists public.get_futebol_value_history(date, date);
 CREATE OR REPLACE FUNCTION public.get_futebol_value_history(p_from date, p_to date)
- RETURNS TABLE(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_valor integer, pts_premissas integer, pts_corroboracao integer, penalidades integer, score integer, faixa text, evidencias text[], premissas_sem_dado integer)
- LANGUAGE sql
- SECURITY DEFINER
- SET search_path TO ''
-AS $function$
+ returns table(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_premissas integer, penalidades integer, score integer, faixa text, score_versao text, evidencias text[], premissas_sem_dado integer)
+ language sql
+ security definer
+ set search_path to ''
+as $function$
   with pit as (
     select distinct on (h.opportunity_key)
       h.fixture_id, h.market, h.outcome, h.line_value, h.edge,
       h.best_odd, h.best_book, h.avg_odd, h.n_casas, h.janela_usada,
-      h.prob_justa_fechamento, h.pts_valor, h.pts_premissas, h.pts_corroboracao,
-      h.penalidades, h.score, h.faixa,
+      h.prob_justa_fechamento, h.pts_premissas,
+      h.penalidades, h.score, h.faixa, h.score_versao,
       h.modelo_api_concorda, h.linha_sharp_confirma, h.premissas_sem_dado
     from futebol.fact_value_opportunities_hist h
     join futebol.fact_fixtures fx on fx.fixture_id = h.fixture_id
@@ -1796,7 +1786,7 @@ AS $function$
   select v.fixture_id, f.home_team_id, f.away_team_id, f.home_team_name, f.away_team_name,
     f.competition, f.kickoff_utc, f.status_short,
     v.market, v.outcome, v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
-    v.pts_valor::int, v.pts_premissas::int, v.pts_corroboracao::int, v.penalidades::int, v.score::int, v.faixa,
+    v.pts_premissas::int, v.penalidades::int, v.score::int, v.faixa, v.score_versao,
     public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
     v.premissas_sem_dado::int
   from pit v
@@ -1807,9 +1797,7 @@ AS $function$
   left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
   left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
   order by f.kickoff_utc desc, v.score desc, v.edge desc;
-$function$
-
-;
+$function$;
 
 -- ── 5c. Agenda por dia, catálogo e detalhe do jogo (migrations 091 a 096) ────
 -- ⚠️ Estas oito estavam FALTANDO neste arquivo, e é a dívida da #250 no seu
@@ -2356,13 +2344,15 @@ $function$;
 -- ── 5d. Contrato de motivos da leitura dos cinco mercados (migration 109) ────
 -- O banco escolhe o grupo de cada motivo. A tela apenas renderiza o contrato,
 -- sem converter uma premissa do lado oposto em uma frase "contra".
-create or replace function public.get_futebol_fixture_reason_contract(p_fixture_id bigint)
+-- O retorno tabular mudou na virada do Score de contexto, e o Postgres recusa
+-- `create or replace` que altere o RETURNS TABLE. Derruba antes de recriar.
+drop function if exists public.get_futebol_fixture_reason_contract(bigint);
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_reason_contract(p_fixture_id bigint)
 returns table(
   market text,
   outcome text,
   line_value double precision,
   score integer,
-  componentes_score jsonb,
   favor jsonb,
   contra jsonb
 )
@@ -2373,19 +2363,17 @@ set search_path to ''
 as $function$
   with base as (
     select
-      v.market, v.outcome, v.line_value, v.score, v.pts_valor, v.pts_premissas,
-      v.pts_corroboracao, v.penalidades as penalidades_score,
-      v.modelo_api_concorda, v.linha_sharp_confirma, v.avisos,
+      v.market, v.outcome, v.line_value, v.score,
       p.acesas, p.apagadas, p.penalidades as penalidades_ativas,
       case v.market
         when 'goals_over_under' then case v.outcome
           when 'Over' then array[
             'defesas_vazaveis', 'ataque_combinado', 'xg_combinado_alto',
-            'ambos_vazam', 'ritmo_alto', 'historico_over', 'linha_subindo'
+            'ambos_vazam', 'ritmo_alto', 'historico_over'
           ]::text[]
           when 'Under' then array[
             'defesas_firmes', 'xg_baixo_combinado', 'clean_sheets_altos',
-            'ataques_fracos', 'historico_under', 'linha_descendo'
+            'ataques_fracos', 'historico_under'
           ]::text[]
           else array[]::text[]
         end
@@ -2439,38 +2427,16 @@ as $function$
     b.outcome,
     b.line_value,
     b.score,
-    coalesce((
-      select jsonb_agg(jsonb_build_object('id', id, 'texto', texto, 'pontos', pontos) order by ordem)
-      from (values
-        (1, 'premissas', 'Premissas', b.pts_premissas),
-        (2, 'valor_de_mercado', 'Valor de mercado', b.pts_valor),
-        (3, 'corroboracao', 'Corroboração', b.pts_corroboracao),
-        (4, 'penalidades', 'Penalidades', b.penalidades_score)
-      ) as componente(ordem, id, texto, pontos)
-      where pontos <> 0
-    ), '[]'::jsonb),
+    -- Sem o gate `pts_premissas > 0` que existia aqui. Ele era herança da nota
+    -- antiga, em que a linha podia ser publicada só pelo preço e as premissas
+    -- não contribuíam. No Score de contexto, premissa aplicável e acesa É
+    -- contribuição por definição — e manter o gate deixaria A favor vazio numa
+    -- linha legacy publicada pelo preço, entre esta migration e a troca do mart.
     coalesce((
       select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'premissa') order by slug)
       from unnest(b.acesas) slug
-      where slug = any(b.aplicaveis) and b.pts_premissas > 0
-    ), '[]'::jsonb)
-    || case when b.pts_valor > 0
-      then jsonb_build_array(jsonb_build_object(
-        'id', 'valor_de_mercado', 'tipo', 'componente_score',
-        'texto', 'A cotação oferece valor', 'pontos', b.pts_valor
-      ))
-      else '[]'::jsonb end
-    || case when b.pts_corroboracao > 0
-      then jsonb_build_array(jsonb_build_object(
-        'id', 'corroboracao', 'tipo', 'componente_score', 'pontos', b.pts_corroboracao,
-        'texto', case
-          when b.modelo_api_concorda and b.linha_sharp_confirma then 'Modelo e movimento de mercado confirmam a leitura'
-          when b.modelo_api_concorda then 'Modelo confirma a leitura'
-          when b.linha_sharp_confirma then 'Movimento de mercado confirma a leitura'
-          else 'Corroboração confirma a leitura'
-        end
-      ))
-      else '[]'::jsonb end,
+      where slug = any(b.aplicaveis)
+    ), '[]'::jsonb),
     coalesce((
       select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'premissa') order by slug)
       from unnest(b.apagadas) slug
@@ -2480,10 +2446,6 @@ as $function$
       select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'penalidade') order by slug)
       from unnest(b.penalidades_ativas) slug
       where slug <> 'favorito_irregular'
-    ), '[]'::jsonb)
-    || coalesce((
-      select jsonb_agg(jsonb_build_object('id', 'aviso_' || ord, 'tipo', 'penalidade', 'texto', texto) order by ord)
-      from unnest(b.avisos) with ordinality as a(texto, ord)
     ), '[]'::jsonb)
   from base b;
 $function$;

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -986,6 +986,18 @@ export function BancadaMercados({
           />
         )}
 
+        {/* Leitura de risco do PREÇO. Saiu da aba "Contra" na virada do Score de
+            contexto (spec #301): aquela aba é premissa do jogo, e odd de zebra
+            ou casa única não é premissa nenhuma — é característica da cotação.
+            Mas a informação continua valendo, então desce para o rodapé em vez
+            de sumir, ao lado da ressalva de dado faltando. */}
+        {(valPrincipal?.avisos ?? []).length > 0 && (
+          <div className="px-6 md:px-8 py-3.5 text-[11.5px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#5a625a' }}>
+            <span className="font-semibold">Sobre a cotação: </span>
+            {(valPrincipal?.avisos ?? []).join(' · ')}
+          </div>
+        )}
+
         {/* Ressalva de informação faltando. Fica AQUI, no rodapé, e não na aba
             "Contra" de propósito: aquela aba lista o que foi checado e não
             bateu; isto é o que nem deu para checar. Juntar as duas faria a

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -990,13 +990,21 @@ export function BancadaMercados({
             contexto (spec #301): aquela aba é premissa do jogo, e odd de zebra
             ou casa única não é premissa nenhuma — é característica da cotação.
             Mas a informação continua valendo, então desce para o rodapé em vez
-            de sumir, ao lado da ressalva de dado faltando. */}
-        {(valPrincipal?.avisos ?? []).length > 0 && (
-          <div className="px-6 md:px-8 py-3.5 text-[11.5px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#5a625a' }}>
-            <span className="font-semibold">Sobre a cotação: </span>
-            {(valPrincipal?.avisos ?? []).join(' · ')}
-          </div>
-        )}
+            de sumir, ao lado da ressalva de dado faltando.
+
+            O filtro existe pela janela da virada: enquanto o contrato antigo
+            estiver no ar, ele ainda manda esses mesmos textos dentro de Contra,
+            e sem isto a frase apareceria duas vezes na mesma tela. */}
+        {(() => {
+          const jaEmContra = new Set(motivosContra.extras.map((e) => e.t));
+          const avisosDeCotacao = (valPrincipal?.avisos ?? []).filter((t) => !jaEmContra.has(t));
+          return avisosDeCotacao.length > 0 ? (
+            <div className="px-6 md:px-8 py-3.5 text-[11.5px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#5a625a' }}>
+              <span className="font-semibold">Sobre a cotação: </span>
+              {avisosDeCotacao.join(' · ')}
+            </div>
+          ) : null;
+        })()}
 
         {/* Ressalva de informação faltando. Fica AQUI, no rodapé, e não na aba
             "Contra" de propósito: aquela aba lista o que foi checado e não

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -95,23 +95,20 @@ export interface FutebolFixtureReasonItem {
   pontos?: number;
 }
 
-/** Parcela do score, devolvida pelo backend para a tela não recalcular o total. */
-export interface FutebolFixtureScoreComponent {
-  id: 'premissas' | 'valor_de_mercado' | 'corroboracao' | 'penalidades';
-  texto: string;
-  pontos: number;
-}
-
 /**
  * Motivos de qualquer saída cotada da Bancada (RPC get_futebol_fixture_reason_contract).
  * A separação favor/contra é autoridade do backend; não derive o lado pelo slug.
+ *
+ * `componentes_score` saiu no contrato de contexto (spec #301): o Score deixou
+ * de ser uma soma de partes exibível, então a RPC não devolve mais a
+ * decomposição. Campo extra numa resposta antiga é inofensivo em runtime, então
+ * o tipo pode andar na frente da virada.
  */
 export interface FutebolFixtureReasonContractRow {
   market: string;
   outcome: string;
   line_value: number | null;
   score: number;
-  componentes_score: FutebolFixtureScoreComponent[];
   favor: FutebolFixtureReasonItem[];
   contra: FutebolFixtureReasonItem[];
 }

--- a/src/services/futebol-score-contract.test.ts
+++ b/src/services/futebol-score-contract.test.ts
@@ -86,11 +86,19 @@ describe('compatibilidade do contrato do Score de contexto', () => {
     );
   });
 
-  it('não permite rotular a forma nova como legacy', () => {
-    expect(() => normalizeFutebolValueBoardRows([{
+  it('aceita legacy sem componentes de preço, que é o histórico depois da virada', () => {
+    // Depois da virada a RPC tem uma forma só, sem pts_valor. O histórico
+    // point-in-time continua devolvendo linhas calculadas na escala antiga, e
+    // elas precisam continuar abrindo: legacy é a ESCALA da nota, não a
+    // presença dos componentes na resposta.
+    const [row] = normalizeFutebolValueBoardRows([{
       ...boardBase,
       score_versao: 'legacy',
-    }])).toThrow('O contrato legacy exige pts_valor e pts_corroboracao');
+    }]);
+
+    expect(row.score_versao).toBe('legacy');
+    expect(row.pts_valor).toBe(0);
+    expect(row.pts_corroboracao).toBe(0);
   });
 
   it('adapta o detalhe novo sem exigir penalidade global de odd', () => {

--- a/src/services/futebol-score-contract.ts
+++ b/src/services/futebol-score-contract.ts
@@ -26,15 +26,16 @@ function scoreVersion(row: RawScoreRow): FutebolScoreVersion {
     typeof row.pts_valor === 'number' &&
     typeof row.pts_corroboracao === 'number';
   if (row.score_versao == null) {
+    // Sem o campo, só a forma antiga identifica a linha. Uma resposta que não
+    // traz nem o campo nem os componentes é contrato desconhecido, não legacy.
     if (temFormaLegacy) return 'legacy';
     throw new Error('O contrato novo do Score exige score_versao: contexto_v1');
   }
-  if (row.score_versao === 'legacy') {
-    if (!temFormaLegacy) {
-      throw new Error('O contrato legacy exige pts_valor e pts_corroboracao');
-    }
-    return 'legacy';
-  }
+  // score_versao diz em que ESCALA a nota foi calculada, não que a resposta
+  // carregue os componentes de preço. Depois da virada, a RPC tem uma forma só
+  // e o histórico continua devolvendo linhas legacy sem pts_valor — é o caso
+  // permanente do point-in-time, não um contrato malformado.
+  if (row.score_versao === 'legacy') return 'legacy';
   if (row.score_versao === 'contexto_v1') return 'contexto_v1';
   throw new Error(`Versão do Score desconhecida: ${String(row.score_versao)}`);
 }

--- a/src/utils/futebol-contrato-score.test.ts
+++ b/src/utils/futebol-contrato-score.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ============================================================================
+// Contrato das RPCs no Score de contexto (issue #304, spec #301)
+// ============================================================================
+// A virada troca as três RPCs de uma vez e o contrato de motivos junto. O risco
+// que este teste cobre é o da virada PARCIAL: uma das quatro ficar para trás e
+// o painel continuar recebendo componente de preço, ou o histórico deixar de
+// espelhar o board e quebrar o tipo que as duas telas compartilham.
+//
+// Roda em ARQUIVO contra ARQUIVO, sem banco, no mesmo espírito do
+// shape-file-futebol.test.ts: compara a migration da janela com o shape file de
+// provisionamento, que precisam declarar exatamente as mesmas assinaturas.
+// ============================================================================
+
+const RAIZ = resolve(__dirname, '../..');
+const SHAPE = readFileSync(resolve(RAIZ, 'docs/futebol-prod-deploy.sql'), 'utf8');
+const MIGRATION = readFileSync(
+  resolve(RAIZ, 'supabase/migrations/20260829120000_112_futebol_score_contexto_contrato.sql'),
+  'utf8',
+);
+
+/**
+ * Colunas do `returns table(...)` da ÚLTIMA definição de uma função no SQL.
+ * A última é a que vale: o shape file e as migrations empilham redefinições, e
+ * o banco fica com a de baixo.
+ */
+function colunasDoRetorno(sql: string, funcao: string): string[] {
+  const assinatura = new RegExp(
+    `function\\s+(?:public\\.)?${funcao}\\s*\\([^)]*\\)\\s*\\r?\\n?\\s*returns\\s+table\\s*\\(`,
+    'gi',
+  );
+  let inicio = -1;
+  for (const m of sql.matchAll(assinatura)) inicio = m.index! + m[0].length;
+  if (inicio < 0) throw new Error(`returns table de ${funcao} não encontrado`);
+
+  let profundidade = 1;
+  let fim = inicio;
+  while (fim < sql.length && profundidade > 0) {
+    if (sql[fim] === '(') profundidade++;
+    else if (sql[fim] === ')') profundidade--;
+    if (profundidade > 0) fim++;
+  }
+
+  return sql
+    .slice(inicio, fim)
+    .split(',')
+    .map((coluna) => coluna.trim().split(/\s+/)[0])
+    .filter(Boolean);
+}
+
+const FUNCOES_DO_SCORE = [
+  'get_futebol_value_board',
+  'get_futebol_value_history',
+  'get_futebol_fixture_value',
+  'get_futebol_fixture_reason_contract',
+] as const;
+
+describe('contrato das RPCs no Score de contexto', () => {
+  describe.each([
+    ['migration da janela', MIGRATION],
+    ['shape file de produção', SHAPE],
+  ])('%s', (_nome, sql) => {
+    it('board e histórico expõem exatamente a mesma forma', () => {
+      // As duas telas compartilham FutebolValueBoardRow. Uma coluna a mais de um
+      // lado quebra a outra tela sem erro de compilação.
+      expect(colunasDoRetorno(sql, 'get_futebol_value_history')).toEqual(
+        colunasDoRetorno(sql, 'get_futebol_value_board'),
+      );
+    });
+
+    it('board e histórico não expõem os componentes de preço', () => {
+      for (const funcao of ['get_futebol_value_board', 'get_futebol_value_history']) {
+        const colunas = colunasDoRetorno(sql, funcao);
+        expect(colunas, funcao).not.toContain('pts_valor');
+        expect(colunas, funcao).not.toContain('pts_corroboracao');
+      }
+    });
+
+    it('o detalhe não expõe componentes de preço nem a penalidade global de odd', () => {
+      const colunas = colunasDoRetorno(sql, 'get_futebol_fixture_value');
+      expect(colunas).not.toContain('pts_valor');
+      expect(colunas).not.toContain('pts_corroboracao');
+      expect(colunas).not.toContain('penalidades_globais_pts');
+    });
+
+    it('board, histórico e detalhe expõem score_versao', () => {
+      for (const funcao of [
+        'get_futebol_value_board',
+        'get_futebol_value_history',
+        'get_futebol_fixture_value',
+      ]) {
+        expect(colunasDoRetorno(sql, funcao), funcao).toContain('score_versao');
+      }
+    });
+
+    it('board e histórico preservam as premissas e a penalidade de contexto', () => {
+      // O que sai é preço; o contexto continua sendo publicado.
+      for (const funcao of ['get_futebol_value_board', 'get_futebol_value_history']) {
+        const colunas = colunasDoRetorno(sql, funcao);
+        expect(colunas, funcao).toContain('pts_premissas');
+        expect(colunas, funcao).toContain('penalidades');
+        expect(colunas, funcao).toContain('score');
+        expect(colunas, funcao).toContain('faixa');
+        expect(colunas, funcao).toContain('edge');
+      }
+    });
+
+    it('o contrato de motivos não devolve a soma de componentes do Score', () => {
+      expect(colunasDoRetorno(sql, 'get_futebol_fixture_reason_contract')).not.toContain(
+        'componentes_score',
+      );
+    });
+  });
+
+  it('migration e shape file declaram a mesma assinatura nas quatro funções', () => {
+    for (const funcao of FUNCOES_DO_SCORE) {
+      expect(colunasDoRetorno(SHAPE, funcao), funcao).toEqual(colunasDoRetorno(MIGRATION, funcao));
+    }
+  });
+
+  it('a migration remove e recria as três RPCs juntas, em vez de substituir', () => {
+    // O retorno tabular muda, então `create or replace` falharia com
+    // "cannot change return type of existing function".
+    for (const funcao of FUNCOES_DO_SCORE) {
+      expect(MIGRATION, funcao).toMatch(
+        new RegExp(`drop\\s+function\\s+if\\s+exists\\s+public\\.${funcao}\\s*\\(`, 'i'),
+      );
+    }
+  });
+
+  it('o shape file também derruba antes de recriar, senão não reaplica', () => {
+    // O shape file é colado num ambiente que JÁ tem as funções antigas. Como as
+    // quatro assinaturas mudaram, `create or replace` sozinho aborta com
+    // "cannot change return type of existing function".
+    for (const funcao of FUNCOES_DO_SCORE) {
+      expect(SHAPE, funcao).toMatch(
+        new RegExp(`drop\\s+function\\s+if\\s+exists\\s+public\\.${funcao}\\s*\\(`, 'i'),
+      );
+    }
+  });
+
+  it('a migration dá grant de execução nas quatro funções', () => {
+    for (const funcao of FUNCOES_DO_SCORE) {
+      expect(MIGRATION, funcao).toMatch(
+        new RegExp(`grant\\s+execute\\s+on\\s+function\\s+public\\.${funcao}\\s*\\(`, 'i'),
+      );
+    }
+  });
+
+  it('score_versao entra nas duas tabelas do mart sem admitir nulo', () => {
+    for (const tabela of ['fact_value_opportunities', 'fact_value_opportunities_hist']) {
+      expect(MIGRATION, tabela).toMatch(
+        new RegExp(
+          `alter\\s+table\\s+futebol\\.${tabela}[\\s\\S]{0,200}?score_versao[\\s\\S]{0,120}?not\\s+null`,
+          'i',
+        ),
+      );
+    }
+  });
+});
+
+describe('motivos sem preço, corroboração e penalidade de odd', () => {
+  /** Corpo da última definição do contrato de motivos. */
+  function corpoDoContratoDeMotivos(sql: string): string {
+    // Ancorado em `create`: sem isso o `grant execute on function ...` do fim do
+    // arquivo virava a última ocorrência, o recorte saía vazio e toda asserção
+    // de negativa passava à toa.
+    const marca =
+      /create\s+(?:or\s+replace\s+)?function\s+public\.get_futebol_fixture_reason_contract\s*\(/gi;
+    let inicio = -1;
+    for (const m of sql.matchAll(marca)) inicio = m.index!;
+    expect(inicio, 'não achei a criação do contrato de motivos').toBeGreaterThan(-1);
+    const abre = sql.indexOf('$function$', inicio);
+    const fim = sql.indexOf('$function$', abre + '$function$'.length);
+    expect(fim, 'o corpo do contrato de motivos não fecha').toBeGreaterThan(abre);
+    // Sem os comentários: as asserções abaixo são sobre o SQL que roda, e um
+    // comentário explicando o que FOI removido citaria justamente o termo
+    // proibido e derrubaria o teste.
+    return sql.slice(inicio, fim).replace(/--[^\n]*/g, '');
+  }
+
+  it.each([
+    ['migration da janela', MIGRATION],
+    ['shape file de produção', SHAPE],
+  ])('%s: nem valor de mercado, nem corroboração, nem aviso de odd viram razão', (_nome, sql) => {
+    const corpo = corpoDoContratoDeMotivos(sql);
+    expect(corpo).not.toMatch(/valor_de_mercado/i);
+    expect(corpo).not.toMatch(/corroboracao/i);
+    expect(corpo).not.toMatch(/pts_valor/i);
+    // Os avisos de odd continuam disponíveis no detalhe como informação; o que
+    // acaba é entrarem na lista de Contra como se fossem premissa.
+    expect(corpo).not.toMatch(/aviso_/i);
+  });
+
+  it.each([
+    ['migration da janela', MIGRATION],
+    ['shape file de produção', SHAPE],
+  ])('%s: movimento de linha sai das premissas aplicáveis de gols', (_nome, sql) => {
+    const corpo = corpoDoContratoDeMotivos(sql);
+    expect(corpo).not.toMatch(/linha_subindo/i);
+    expect(corpo).not.toMatch(/linha_descendo/i);
+  });
+
+  it.each([
+    ['migration da janela', MIGRATION],
+    ['shape file de produção', SHAPE],
+  ])('%s: os cinco mercados declaram o lado aplicável, sem cópia genérica', (_nome, sql) => {
+    const corpo = corpoDoContratoDeMotivos(sql);
+
+    expect(corpo).toMatch(
+      /when 'goals_over_under' then case v\.outcome[\s\S]*when 'Over' then array\[[\s\S]*'xg_combinado_alto'[\s\S]*'ritmo_alto'/,
+    );
+    expect(corpo).toMatch(
+      /when 'match_winner' then case v\.outcome[\s\S]*when 'Home' then array\[[\s\S]*when 'Away' then array\[/,
+    );
+    expect(corpo).toMatch(
+      /when 'asian_handicap' then case[\s\S]*v\.outcome = 'Home' and v\.line_value < 0[\s\S]*v\.outcome = 'Away' and v\.line_value > 0/,
+    );
+    expect(corpo).toMatch(/when 'btts' then case v\.outcome[\s\S]*when 'Yes' then array\[[\s\S]*when 'No' then array\[/);
+    expect(corpo).toContain("when 'double_chance' then array[");
+
+    // A seleção é direta das acesas e apagadas do lado analisado. A cópia
+    // genérica de contra derivaria o lado do slug, que é justo o que não pode.
+    expect(corpo).toContain('from unnest(b.acesas) slug');
+    expect(corpo).toContain('from unnest(b.apagadas) slug');
+    expect(corpo).not.toContain("futebol_copy('contra'");
+    expect(corpo).toContain("where slug <> 'favorito_irregular'");
+  });
+
+  it.each([
+    ['migration da janela', MIGRATION],
+    ['shape file de produção', SHAPE],
+  ])('%s: A favor não depende mais de o preço ter somado pontos', (_nome, sql) => {
+    // O gate `pts_premissas > 0` era herança da nota antiga. Mantê-lo deixaria
+    // A favor vazio numa linha legacy publicada pelo preço, entre esta
+    // migration e a troca do mart.
+    expect(corpoDoContratoDeMotivos(sql)).not.toMatch(/pts_premissas\s*>\s*0/);
+  });
+
+  const SLUGS_DE_PRECO = [
+    'corroboracao_ambos',
+    'modelo_api_concorda',
+    'linha_sharp_confirma',
+    'linha_subindo',
+    'linha_descendo',
+  ];
+
+  it('a migration regera a tabela de copy inteira, em vez de deixar buracos na ordem', () => {
+    // Apagar só as cinco linhas deixaria a numeração com furos, e é a ordem que
+    // decide qual evidência a DM do Telegram mostra.
+    expect(MIGRATION).toMatch(/delete\s+from\s+public\.futebol_premissa_copy\s*;/i);
+    expect(MIGRATION).toMatch(/insert\s+into\s+public\.futebol_premissa_copy/i);
+  });
+
+  it.each([
+    ['migration da janela', () => MIGRATION],
+    ['shape file de produção', () => SHAPE],
+  ])('%s: não semeia preço, movimento nem concordância de modelo como evidência', (_nome, sql) => {
+    for (const slug of SLUGS_DE_PRECO) {
+      expect(sql(), slug).not.toMatch(new RegExp(`\\('evidencia',\\s*'\\w+',\\s*'${slug}'`, 'i'));
+    }
+  });
+});

--- a/src/utils/futebol-copy-paridade.test.ts
+++ b/src/utils/futebol-copy-paridade.test.ts
@@ -29,7 +29,14 @@ import { copyDeServing, premissaDe, rotuloPremissa, type LinhaCopy } from './fut
 // ============================================================================
 
 const RAIZ = resolve(__dirname, '../..');
-const MIGRATION = resolve(RAIZ, 'supabase/migrations/106_futebol_copy_das_premissas.sql');
+// A migration que SEMEIA a tabela hoje. A 106 criou a mecânica e semeou a
+// primeira vez; a 112 regera a semente inteira no Score de contexto, então é
+// ela que precisa bater com o catálogo. Apontar para a 106 cobraria dela uma
+// decisão que não existia quando foi escrita.
+const MIGRATION = resolve(
+  RAIZ,
+  'supabase/migrations/20260829120000_112_futebol_score_contexto_contrato.sql',
+);
 const SHAPE = resolve(RAIZ, 'docs/futebol-prod-deploy.sql');
 const RPCS = ['get_futebol_fixture_value', 'get_futebol_value_board', 'get_futebol_value_history'];
 
@@ -52,7 +59,9 @@ function semente(sql: string): LinhaCopy[] {
 
 /** O corpo de uma função dentro de um .sql, do `create` ao `$function$` final. */
 function corpoDaFuncao(sql: string, nome: string): string {
-  const re = new RegExp(`create\\s+or\\s+replace\\s+function\\s+public\\.${nome}\\(`, 'i');
+  // A migration da virada usa `create` puro, porque as RPCs são derrubadas
+  // antes: o retorno tabular mudou e `create or replace` recusaria.
+  const re = new RegExp(`create\\s+(?:or\\s+replace\\s+)?function\\s+public\\.${nome}\\(`, 'i');
   const m = sql.match(re);
   expect(m, `não achei ${nome}`).not.toBeNull();
   const i = m!.index!;
@@ -66,7 +75,7 @@ describe('a copy da serving é a copy do catálogo', () => {
   const esperado = copyDeServing();
 
   for (const [nome, arquivo] of [
-    ['migration 106', MIGRATION],
+    ['migration 112', MIGRATION],
     ['shape file', SHAPE],
   ] as const) {
     describe(nome, () => {

--- a/src/utils/futebol-motivos.test.ts
+++ b/src/utils/futebol-motivos.test.ts
@@ -1,64 +1,41 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
 import { separarMotivosDoContrato } from './futebol-motivos';
 
+// O contrato SQL em si (quais premissas são aplicáveis a cada saída, e o que
+// não pode virar razão) é guardado por futebol-contrato-score.test.ts. Aqui só
+// entra a repartição visual: o que vai para o catálogo com drilldown jogo a
+// jogo e o que é texto pronto do backend.
+
 describe('separarMotivosDoContrato', () => {
-  it('mantém na migration a seleção direta das premissas de Over, sem usar a cópia genérica de contra', () => {
-    const migration = readFileSync(resolve(__dirname, '../../supabase/migrations/20260826103000_108_futebol_motivos_gols.sql'), 'utf8');
-
-    expect(migration).toMatch(/when 'Over' then array\[[\s\S]*'xg_combinado_alto'[\s\S]*'ritmo_alto'[\s\S]*'linha_subindo'/);
-    expect(migration).toContain('from unnest(b.acesas) slug');
-    expect(migration).toContain('from unnest(b.apagadas) slug');
-    expect(migration).not.toContain("futebol_copy('contra'");
-  });
-
-  it('mantém Juventude × CRB · Mais de 1,5 no agrupamento devolvido pelo backend', () => {
-    const contratoJuventudeCrbOver15 = {
-      score: 46,
-      componentes_score: [
-        { id: 'premissas', texto: 'Premissas', pontos: 22 },
-        { id: 'valor_de_mercado', texto: 'Valor de mercado', pontos: 16 },
-        { id: 'corroboracao', texto: 'Corroboração', pontos: 8 },
-      ],
-      favor: [
+  it('manda slug para o catálogo e texto pronto para a lista sem drilldown', () => {
+    const separados = separarMotivosDoContrato([
       { id: 'xg_combinado_alto', tipo: 'premissa' },
       { id: 'ritmo_alto', tipo: 'premissa' },
-      { id: 'linha_subindo', tipo: 'premissa' },
-        { id: 'valor_de_mercado', tipo: 'componente_score', texto: 'A cotação oferece valor', pontos: 16 },
-        { id: 'corroboracao', tipo: 'componente_score', texto: 'Movimento de mercado confirma a leitura', pontos: 8 },
-      ],
-      contra: [
-      { id: 'defesas_vazaveis', tipo: 'premissa' },
-      { id: 'ataque_combinado', tipo: 'premissa' },
-        { id: 'ambos_vazam', tipo: 'premissa' },
-        { id: 'historico_over', tipo: 'premissa' },
-      ],
-    } as const;
-    const favor = separarMotivosDoContrato(contratoJuventudeCrbOver15.favor);
-    const contra = separarMotivosDoContrato(contratoJuventudeCrbOver15.contra);
-
-    expect(favor.slugsDePremissas).toEqual(['xg_combinado_alto', 'ritmo_alto', 'linha_subindo']);
-    expect(favor.motivosSemDrilldown).toEqual([
-      { t: 'A cotação oferece valor', pontos: 16 },
-      { t: 'Movimento de mercado confirma a leitura', pontos: 8 },
+      { id: 'desfalque_proprio', tipo: 'penalidade', texto: 'Time apostado com desfalque de titular importante' },
     ]);
-    expect(contra.slugsDePremissas).toEqual(['defesas_vazaveis', 'ataque_combinado', 'ambos_vazam', 'historico_over']);
-    expect(contra.slugsDePremissas).not.toContain('defesas_firmes');
-    expect(contra.slugsDePremissas).not.toContain('xg_baixo_combinado');
-    expect(contratoJuventudeCrbOver15.componentes_score.reduce((total, componente) => total + componente.pontos, 0))
-      .toBe(contratoJuventudeCrbOver15.score);
+
+    expect(separados.slugsDePremissas).toEqual(['xg_combinado_alto', 'ritmo_alto']);
+    expect(separados.motivosSemDrilldown).toEqual([
+      { t: 'Time apostado com desfalque de titular importante', pontos: undefined },
+    ]);
   });
 
-  it('declara o lado aplicável dos outros quatro mercados no contrato do backend', () => {
-    const migration = readFileSync(resolve(__dirname, '../../supabase/migrations/20260826113000_109_futebol_motivos_outros_mercados.sql'), 'utf8');
+  it('não inventa lado: o contrário de uma premissa a favor não aparece em contra', () => {
+    // O backend é a autoridade sobre o grupo. A função não deriva nada do slug,
+    // então uma premissa do lado oposto só apareceria se o backend a mandasse.
+    const favor = separarMotivosDoContrato([
+      { id: 'xg_combinado_alto', tipo: 'premissa' },
+      { id: 'ritmo_alto', tipo: 'premissa' },
+    ]);
+    const contra = separarMotivosDoContrato([
+      { id: 'ambos_vazam', tipo: 'premissa' },
+      { id: 'historico_over', tipo: 'premissa' },
+    ]);
 
-    expect(migration).toMatch(/when 'match_winner' then case v\.outcome[\s\S]*when 'Home' then array\[[\s\S]*when 'Away' then array\[[\s\S]*else array\[\]::text\[\]/);
-    expect(migration).toMatch(/when 'asian_handicap' then case[\s\S]*v\.outcome = 'Home' and v\.line_value < 0[\s\S]*v\.outcome = 'Away' and v\.line_value > 0[\s\S]*when v\.line_value <> 0 then array\[/);
-    expect(migration).toMatch(/when 'btts' then case v\.outcome[\s\S]*when 'Yes' then array\[[\s\S]*when 'No' then array\[/);
-    expect(migration).toContain("when 'double_chance' then array[");
-    expect(migration).toContain("where slug <> 'favorito_irregular'");
-    expect(migration).not.toContain("where v.market = 'goals_over_under'");
+    expect(favor.slugsDePremissas).toEqual(['xg_combinado_alto', 'ritmo_alto']);
+    expect(contra.slugsDePremissas).toEqual(['ambos_vazam', 'historico_over']);
+    expect(contra.slugsDePremissas).not.toContain('defesas_firmes');
+    expect(contra.slugsDePremissas).not.toContain('xg_baixo_combinado');
   });
 
   it.each([
@@ -67,7 +44,7 @@ describe('separarMotivosDoContrato', () => {
       favor: [{ id: 'mando', tipo: 'premissa' }],
       contra: [
         { id: 'forma', tipo: 'premissa' },
-        { id: 'aviso_1', tipo: 'penalidade', texto: 'A escalação reduz a confiança' },
+        { id: 'desfalque_proprio', tipo: 'penalidade', texto: 'A escalação reduz a confiança' },
       ],
     },
     {
@@ -75,7 +52,7 @@ describe('separarMotivosDoContrato', () => {
       favor: [{ id: 'mando_forte', tipo: 'premissa' }],
       contra: [
         { id: 'supremacia', tipo: 'premissa' },
-        { id: 'handicap_alto', tipo: 'penalidade' },
+        { id: 'desfalque_proprio', tipo: 'penalidade' },
       ],
     },
     {
@@ -83,7 +60,7 @@ describe('separarMotivosDoContrato', () => {
       favor: [{ id: 'defesa_forte', tipo: 'premissa' }],
       contra: [
         { id: 'ataque_trava', tipo: 'premissa' },
-        { id: 'aviso_1', tipo: 'penalidade', texto: 'Dado de mercado pede cautela' },
+        { id: 'desfalque_adversario', tipo: 'penalidade', texto: 'Desfalque relevante do outro lado' },
       ],
     },
     {
@@ -91,10 +68,10 @@ describe('separarMotivosDoContrato', () => {
       favor: [{ id: 'equilibrio_defensivo', tipo: 'premissa' }],
       contra: [
         { id: 'lado_coberto_forte', tipo: 'premissa' },
-        { id: 'aviso_1', tipo: 'penalidade', texto: 'Mercado com liquidez reduzida' },
+        { id: 'desfalque_proprio', tipo: 'penalidade', texto: 'Time apostado desfalcado' },
       ],
     },
-  ] as const)('$mercado mantém favor, contra e alerta separados', ({ favor, contra }) => {
+  ] as const)('$mercado mantém favor, contra e penalidade separados', ({ favor, contra }) => {
     const motivosFavor = separarMotivosDoContrato(favor);
     const motivosContra = separarMotivosDoContrato(contra);
 

--- a/src/utils/futebol-premissas.ts
+++ b/src/utils/futebol-premissas.ts
@@ -72,6 +72,16 @@ export const PREMISSAS_OCULTAS = new Set([
   // "favorito_irregular sai da tela": acende em 43% das linhas, vale 0 ponto, e
   // aparecia como evidência ("O favorito não costuma golear").
   'favorito_irregular',
+  // Score de contexto (spec #301): estas cinco descrevem PREÇO — movimento de
+  // linha, movimento das casas e concordância do modelo. Elas não medem o
+  // contexto do jogo, então deixam de ser razão. O preço continua publicado
+  // como informação (odd, edge, casas) e como porta de segurança na faixa de
+  // odd; o que acaba é ele se apresentar como premissa.
+  'corroboracao_ambos',
+  'linha_sharp_confirma',
+  'modelo_api_concorda',
+  'linha_subindo',
+  'linha_descendo',
 ]);
 
 const P = (

--- a/supabase/migrations/20260829120000_112_futebol_score_contexto_contrato.sql
+++ b/supabase/migrations/20260829120000_112_futebol_score_contexto_contrato.sql
@@ -1,0 +1,400 @@
+-- 20260829120000_112_futebol_score_contexto_contrato
+--
+-- Virada coordenada para o Score de contexto (spec #301, entrega #304).
+--
+-- O Score deixa de somar preço, corroboração e penalidades de odd: ele passa a
+-- expressar SÓ quanto do contexto favorável está presente na linha. O preço
+-- continua publicado como informação (edge, odd, casas) e continua sendo porta
+-- de segurança nas faixas por mercado, mas não compõe a nota nem destrava a
+-- publicação.
+--
+-- ⚠️ NÃO APLICAR ISOLADAMENTE EM PRODUÇÃO. Esta migration é metade de uma virada
+-- combinada com analytics-engineering#109, que troca o mart e o sync. A ordem
+-- documentada é: migration → mart → sync manual → smoke test → reabertura. Até
+-- o mart publicar contexto_v1, as RPCs devolvem score_versao = 'legacy' e a
+-- nota continua na escala antiga.
+--
+-- Por que DROP e CREATE em vez de CREATE OR REPLACE: o retorno tabular muda nas
+-- três RPCs, e o Postgres recusa `create or replace` que altere o RETURNS TABLE
+-- ("cannot change return type of existing function"). As quatro caem e sobem
+-- juntas, na ordem de dependência, porque get_futebol_fixture_reason_contract
+-- consome get_futebol_fixture_value.
+
+-- ── 1. score_versao no mart ─────────────────────────────────────────────────
+-- Obrigatório e sem nulo (decisão da spec). O default 'legacy' carimba o que já
+-- está gravado: no board ele é substituído no primeiro full-refresh do mart
+-- novo; no snapshot ele fica para sempre, que é justamente o ponto — histórico
+-- é point-in-time e não se recalcula.
+alter table futebol.fact_value_opportunities
+  add column if not exists score_versao text not null default 'legacy';
+
+alter table futebol.fact_value_opportunities_hist
+  add column if not exists score_versao text not null default 'legacy';
+
+comment on column futebol.fact_value_opportunities.score_versao is
+  'Escala em que o Score foi calculado: legacy (soma com preço) ou contexto_v1 (só contexto, 0-100). Técnico, nunca exibido ao usuário.';
+comment on column futebol.fact_value_opportunities_hist.score_versao is
+  'Escala do Score no instante da publicação. Registros antigos permanecem legacy e não são recalculados.';
+
+-- ── 2. Derrubar as quatro, na ordem de dependência ──────────────────────────
+drop function if exists public.get_futebol_fixture_reason_contract(bigint);
+drop function if exists public.get_futebol_fixture_value(bigint);
+drop function if exists public.get_futebol_value_board();
+drop function if exists public.get_futebol_value_history(date, date);
+
+-- ── 3. Board ────────────────────────────────────────────────────────────────
+-- Saem pts_valor e pts_corroboracao. Entra score_versao. pts_premissas e
+-- penalidades ficam: a penalidade que sobra é de contexto, não de odd.
+create function public.get_futebol_value_board()
+ returns table(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_premissas integer, penalidades integer, score integer, faixa text, score_versao text, evidencias text[], premissas_sem_dado integer)
+ language sql
+ security definer
+ set search_path to ''
+as $function$
+  select v.fixture_id, f.home_team_id, f.away_team_id, f.home_team_name, f.away_team_name,
+    f.competition, f.kickoff_utc, f.status_short,
+    v.market, v.outcome, v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
+    v.pts_premissas::int, v.penalidades::int, v.score::int, v.faixa, v.score_versao,
+    public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
+    v.premissas_sem_dado::int
+  from futebol.fact_value_opportunities v
+  join futebol.fact_fixtures f on f.fixture_id = v.fixture_id
+  left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
+  left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
+  left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
+  order by v.score desc, v.edge desc;
+$function$;
+
+-- ── 4. Histórico point-in-time ──────────────────────────────────────────────
+-- Mesma forma do board, coluna por coluna: as duas telas compartilham o mesmo
+-- tipo no front, e uma divergência aqui quebra a outra tela sem erro de
+-- compilação. O PIT continua estrito (ADR 0009, migrations 101 e 102).
+create function public.get_futebol_value_history(p_from date, p_to date)
+ returns table(fixture_id bigint, home_team_id bigint, away_team_id bigint, home_team_name text, away_team_name text, competition text, kickoff_utc timestamp without time zone, status_short text, market text, outcome text, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_premissas integer, penalidades integer, score integer, faixa text, score_versao text, evidencias text[], premissas_sem_dado integer)
+ language sql
+ security definer
+ set search_path to ''
+as $function$
+  with pit as (
+    select distinct on (h.opportunity_key)
+      h.fixture_id, h.market, h.outcome, h.line_value, h.edge,
+      h.best_odd, h.best_book, h.avg_odd, h.n_casas, h.janela_usada,
+      h.prob_justa_fechamento, h.pts_premissas,
+      h.penalidades, h.score, h.faixa, h.score_versao,
+      h.modelo_api_concorda, h.linha_sharp_confirma, h.premissas_sem_dado
+    from futebol.fact_value_opportunities_hist h
+    join futebol.fact_fixtures fx on fx.fixture_id = h.fixture_id
+    where fx.kickoff_utc >= ((p_from::timestamp at time zone 'America/Sao_Paulo') at time zone 'UTC')
+      and fx.kickoff_utc <  (((p_to + 1)::timestamp at time zone 'America/Sao_Paulo') at time zone 'UTC')
+      and fx.kickoff_utc <  (now() at time zone 'UTC')
+      and h.dbt_valid_from <= fx.kickoff_utc
+      and (h.dbt_valid_to is null or fx.kickoff_utc < h.dbt_valid_to)
+    order by h.opportunity_key, h.dbt_valid_from desc
+  )
+  select v.fixture_id, f.home_team_id, f.away_team_id, f.home_team_name, f.away_team_name,
+    f.competition, f.kickoff_utc, f.status_short,
+    v.market, v.outcome, v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
+    v.pts_premissas::int, v.penalidades::int, v.score::int, v.faixa, v.score_versao,
+    public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
+    v.premissas_sem_dado::int
+  from pit v
+  join futebol.fact_fixtures f on f.fixture_id = v.fixture_id
+  left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
+  left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
+  left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
+  order by f.kickoff_utc desc, v.score desc, v.edge desc;
+$function$;
+
+-- ── 5. Detalhe do jogo ──────────────────────────────────────────────────────
+-- Além de pts_valor e pts_corroboracao, sai penalidades_globais_pts: era a
+-- penalidade de odd, que não pesa mais na nota. penalidades_especificas_pts
+-- fica, porque é penalidade de contexto. Os avisos continuam sendo devolvidos:
+-- eles são leitura de risco do preço, não razão do Score.
+create function public.get_futebol_fixture_value(p_fixture_id bigint)
+ returns table(market text, outcome text, outcome_order integer, line_value double precision, edge double precision, best_odd double precision, best_book text, avg_odd double precision, n_casas integer, janela_usada text, prob_justa_fechamento double precision, pts_premissas integer, penalidades integer, penalidades_especificas_pts integer, score integer, faixa text, score_versao text, modelo_api_concorda boolean, linha_sharp_confirma boolean, evidencias text[], avisos text[], contras text[], premissas_sem_dado integer)
+ language sql
+ security definer
+ set search_path to ''
+as $function$
+  -- migration 101: kickoff no futuro lê o board; kickoff já passado lê a FOTO DO
+  -- APITO no snapshot. migration 105: os avisos leem as colunas pen_* do mart.
+  with v_src as (
+    select fixture_id, market, outcome, line_value, competition, season, edge,
+           pts_premissas, penalidades, score, faixa, score_versao, best_odd, best_book,
+           avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
+           penalidades_especificas_pts, modelo_api_concorda,
+           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado,
+           pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
+    from futebol.fact_value_opportunities
+    where fixture_id = p_fixture_id
+      and exists (select 1 from futebol.fact_fixtures fx
+                   where fx.fixture_id = p_fixture_id and fx.kickoff_utc > (now() at time zone 'UTC'))
+    union all
+    select fixture_id, market, outcome, line_value, competition, season, edge,
+           pts_premissas, penalidades, score, faixa, score_versao, best_odd, best_book,
+           avg_odd, n_casas, prob_justa_fechamento, valor_fonte, janela_usada,
+           penalidades_especificas_pts, modelo_api_concorda,
+           linha_sharp_confirma, pin_n_outcomes, is_half_line, dbt_loaded_at, premissas_sem_dado,
+           pen_odd_outlier, pen_poucas_casas, pen_odd_longshot, pen_odd_juice
+    from futebol.fact_value_opportunities_hist h
+    where h.fixture_id = p_fixture_id
+      and exists (select 1 from futebol.fact_fixtures fx
+                   where fx.fixture_id = p_fixture_id
+                     and fx.kickoff_utc <= (now() at time zone 'UTC')
+                     and h.dbt_valid_from <= fx.kickoff_utc
+                     and (h.dbt_valid_to is null or fx.kickoff_utc < h.dbt_valid_to))
+  )
+  select v.market, v.outcome,
+    (case when v.market = 'match_winner'
+          then (case v.outcome when 'Home' then 1 when 'Draw' then 2 else 3 end)
+          when v.market = 'goals_over_under'
+          then (coalesce(v.line_value,0)*10 + case when v.outcome='Over' then 1 else 2 end)::int
+          when v.market = 'asian_handicap'
+          then (1000 + (case v.outcome when 'Home' then 0 else 500 end) + (coalesce(v.line_value,0)*10))::int
+          when v.market = 'btts'
+          then (2000 + case when v.outcome in ('Yes') then 0 else 1 end)
+          when v.market = 'double_chance'
+          then (3000 + case v.outcome when '1X' then 1 else 2 end)
+          else 0 end),
+    v.line_value, v.edge, v.best_odd, v.best_book, v.avg_odd, v.n_casas::int, v.janela_usada, v.prob_justa_fechamento,
+    v.pts_premissas::int, v.penalidades::int,
+    v.penalidades_especificas_pts::int, v.score::int, v.faixa, v.score_versao,
+    v.modelo_api_concorda, v.linha_sharp_confirma,
+    public.futebol_copy('evidencia', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
+    public.futebol_copy('aviso', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))),
+    (public.futebol_copy('contra', v.market, case v.outcome when 'Home' then 'home' when 'Away' then 'away' else 'any' end, public.futebol_flags(to_jsonb(v), to_jsonb(p), to_jsonb(o), to_jsonb(ah), to_jsonb(bt), to_jsonb(dc))))[1:3],
+    v.premissas_sem_dado::int
+  from v_src v
+  left join futebol.int_futebol_premissas_1x2 p on v.market='match_winner' and p.fixture_id = v.fixture_id and p.outcome = v.outcome
+  left join futebol.int_futebol_premissas_ou o on v.market='goals_over_under' and o.fixture_id = v.fixture_id and o.outcome = v.outcome and o.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_ah ah on v.market='asian_handicap' and ah.fixture_id = v.fixture_id and ah.outcome = v.outcome and ah.line_value is not distinct from v.line_value
+  left join futebol.int_futebol_premissas_btts bt on v.market='btts' and bt.fixture_id = v.fixture_id and bt.outcome = v.outcome
+  left join futebol.int_futebol_premissas_dc dc on v.market='double_chance' and dc.fixture_id = v.fixture_id and dc.outcome = v.outcome
+  where v.fixture_id = p_fixture_id
+  order by (case v.market when 'match_winner' then 1 when 'goals_over_under' then 2 when 'asian_handicap' then 3 when 'btts' then 4 when 'double_chance' then 5 else 9 end), 3;
+$function$;
+
+-- ── 6. Contrato de motivos ──────────────────────────────────────────────────
+-- O backend continua sendo a autoridade sobre qual razão vale para a saída
+-- analisada, e agora só devolve contexto:
+--
+--   · sai `componentes_score`: a nota não é mais uma soma exibível de partes;
+--   · sai valor de mercado e corroboração de A favor;
+--   · saem os avisos de odd de Contra — eles continuam no detalhe como leitura
+--     de risco do preço, mas parar de aparecer como premissa é o ponto da spec;
+--   · saem `linha_subindo` e `linha_descendo` das premissas aplicáveis de gols,
+--     porque movimento de mercado é preço, não contexto.
+--
+-- Contra continua sendo premissa aplicável avaliada e ausente, mais penalidade
+-- de contexto. O lado oposto nunca vira Contra automaticamente.
+create function public.get_futebol_fixture_reason_contract(p_fixture_id bigint)
+returns table(
+  market text,
+  outcome text,
+  line_value double precision,
+  score integer,
+  favor jsonb,
+  contra jsonb
+)
+language sql
+stable
+security definer
+set search_path to ''
+as $function$
+  with base as (
+    select
+      v.market, v.outcome, v.line_value, v.score,
+      p.acesas, p.apagadas, p.penalidades as penalidades_ativas,
+      case v.market
+        when 'goals_over_under' then case v.outcome
+          when 'Over' then array[
+            'defesas_vazaveis', 'ataque_combinado', 'xg_combinado_alto',
+            'ambos_vazam', 'ritmo_alto', 'historico_over'
+          ]::text[]
+          when 'Under' then array[
+            'defesas_firmes', 'xg_baixo_combinado', 'clean_sheets_altos',
+            'ataques_fracos', 'historico_under'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'match_winner' then case v.outcome
+          when 'Home' then array[
+            'forma', 'mando', 'superioridade_tabela', 'forca_mismatch',
+            'superioridade_xg', 'h2h_favoravel', 'desfalque_adversario'
+          ]::text[]
+          when 'Away' then array[
+            'forma', 'mando', 'superioridade_tabela', 'forca_mismatch',
+            'superioridade_xg', 'h2h_favoravel', 'desfalque_adversario'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'asian_handicap' then case
+          -- A linha é guardada na ótica do mandante. Para o visitante, o
+          -- sinal representa a saída espelhada e precisa ser lido ao contrário.
+          when (v.outcome = 'Home' and v.line_value < 0)
+            or (v.outcome = 'Away' and v.line_value > 0) then array[
+            'tende_golear', 'supremacia', 'sem_rodizio',
+            'adversario_fragil_fora', 'mando_forte'
+          ]::text[]
+          when v.line_value <> 0 then array[
+            'defesa_fora_solida', 'raramente_perde_por_2'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'btts' then case v.outcome
+          when 'Yes' then array[
+            'ambos_marcam', 'ataque_dos_dois', 'defesas_vazaveis', 'historico_btts'
+          ]::text[]
+          when 'No' then array[
+            'defesa_forte', 'ataque_trava', 'historico_seco'
+          ]::text[]
+          else array[]::text[]
+        end
+        when 'double_chance' then array[
+          'lado_coberto_forte', 'equilibrio_defensivo',
+          'adversario_limitado', 'invicto_recente'
+        ]::text[]
+        else array[]::text[]
+      end as aplicaveis
+    from public.get_futebol_fixture_value(p_fixture_id) v
+    join public.get_futebol_fixture_premissas(p_fixture_id) p
+      on p.market = v.market
+     and p.outcome = v.outcome
+     and p.line_value is not distinct from v.line_value
+  )
+  select
+    b.market,
+    b.outcome,
+    b.line_value,
+    b.score,
+    -- Sem o gate `pts_premissas > 0` que existia aqui. Ele era herança da nota
+    -- antiga, em que a linha podia ser publicada só pelo preço e as premissas
+    -- não contribuíam. No Score de contexto, premissa aplicável e acesa É
+    -- contribuição por definição — e manter o gate deixaria A favor vazio numa
+    -- linha legacy publicada pelo preço, entre esta migration e a troca do mart.
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'premissa') order by slug)
+      from unnest(b.acesas) slug
+      where slug = any(b.aplicaveis)
+    ), '[]'::jsonb),
+    coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'premissa') order by slug)
+      from unnest(b.apagadas) slug
+      where slug = any(b.aplicaveis)
+    ), '[]'::jsonb)
+    || coalesce((
+      select jsonb_agg(jsonb_build_object('id', slug, 'tipo', 'penalidade') order by slug)
+      from unnest(b.penalidades_ativas) slug
+      where slug <> 'favorito_irregular'
+    ), '[]'::jsonb)
+  from base b;
+$function$;
+
+-- ── 7. Copy: preço, movimento de mercado e concordância de modelo saem ──────
+-- Estes cinco slugs descrevem preço, não contexto, e a spec tira os três do
+-- texto de evidência. A tabela de copy é a única fonte desses textos, então
+-- apagar a semente basta: futebol_flags pode continuar acendendo as chaves,
+-- elas simplesmente não traduzem mais para nada.
+-- A tabela de apoio é regerada inteira a partir do catálogo do front
+-- (src/utils/futebol-premissas.ts, copyDeServing). Apagar só as cinco linhas
+-- deixaria buracos no campo ordem, e ordem decide qual evidência a DM do
+-- Telegram mostra: ela manda o primeiro item da lista.
+delete from public.futebol_premissa_copy;
+
+insert into public.futebol_premissa_copy (tipo, market, slug, mando, ordem, texto) values
+  ('evidencia', 'goals_over_under', 'defesas_firmes', 'any', 1, 'Defesas firmes dos dois lados'),
+  ('evidencia', 'goals_over_under', 'defesas_vazaveis', 'any', 2, 'Defesas frágeis dos dois lados'),
+  ('evidencia', 'goals_over_under', 'ataque_combinado', 'any', 3, 'Os dois somam muitos gols'),
+  ('evidencia', 'goals_over_under', 'xg_baixo_combinado', 'any', 4, 'Os dois criam pouca chance de gol'),
+  ('evidencia', 'goals_over_under', 'xg_combinado_alto', 'any', 5, 'Os dois criam muita chance de gol'),
+  ('evidencia', 'goals_over_under', 'clean_sheets_altos', 'any', 6, 'Os dois passam muitos jogos sem sofrer gol'),
+  ('evidencia', 'goals_over_under', 'ataques_fracos', 'any', 7, 'Ataques fracos dos dois lados'),
+  ('evidencia', 'goals_over_under', 'historico_under', 'any', 8, 'Histórico de jogo com poucos gols'),
+  ('evidencia', 'goals_over_under', 'ambos_vazam', 'any', 9, 'Os dois sofrem gol quase todo jogo'),
+  ('evidencia', 'goals_over_under', 'ritmo_alto', 'any', 10, 'Jogo de ritmo alto'),
+  ('evidencia', 'goals_over_under', 'historico_over', 'any', 11, 'Histórico de jogo com muitos gols'),
+  ('contra', 'goals_over_under', 'defesas_firmes', 'any', 1, 'A solidez das defesas não entrou como sinal a favor'),
+  ('contra', 'goals_over_under', 'ataque_combinado', 'any', 2, 'O ataque dos dois times não entrou como sinal a favor'),
+  ('contra', 'goals_over_under', 'xg_baixo_combinado', 'any', 3, 'O baixo volume de chances não entrou como sinal a favor'),
+  ('contra', 'goals_over_under', 'xg_combinado_alto', 'any', 4, 'O alto volume de chances não entrou como sinal a favor'),
+  ('contra', 'goals_over_under', 'clean_sheets_altos', 'any', 5, 'Os jogos sem sofrer gol não entraram como sinal a favor'),
+  ('contra', 'goals_over_under', 'ritmo_alto', 'any', 6, 'O ritmo do jogo não entrou como sinal a favor'),
+  ('aviso', 'goals_over_under', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'goals_over_under', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'goals_over_under', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'goals_over_under', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco'),
+  ('aviso', 'goals_over_under', 'linha_extrema', 'any', 5, 'Linha muito longe do normal'),
+  ('evidencia', 'match_winner', 'forma', 'any', 1, 'Em boa fase, vem ganhando'),
+  ('evidencia', 'match_winner', 'mando', 'any', 2, 'Mando relevante'),
+  ('evidencia', 'match_winner', 'mando', 'home', 2, 'Manda bem em casa'),
+  ('evidencia', 'match_winner', 'mando', 'away', 2, 'Vai bem fora de casa'),
+  ('evidencia', 'match_winner', 'superioridade_tabela', 'any', 3, 'Bem à frente na tabela'),
+  ('evidencia', 'match_winner', 'forca_mismatch', 'any', 4, 'Ataque forte contra defesa frágil do adversário'),
+  ('evidencia', 'match_winner', 'superioridade_xg', 'any', 5, 'Cria mais chances de gol que o adversário'),
+  ('evidencia', 'match_winner', 'h2h_favoravel', 'any', 6, 'Leva vantagem no histórico do confronto'),
+  ('evidencia', 'match_winner', 'desfalque_adversario', 'any', 7, 'Adversário com desfalque de titular importante'),
+  ('contra', 'match_winner', 'mando', 'home', 1, 'Em casa, o mando não entrou como sinal a favor'),
+  ('contra', 'match_winner', 'mando', 'away', 1, 'Fora de casa, o mando não entrou como sinal a favor'),
+  ('contra', 'match_winner', 'superioridade_tabela', 'any', 2, 'A posição na tabela não entrou como sinal a favor'),
+  ('contra', 'match_winner', 'forca_mismatch', 'any', 3, 'O duelo entre ataque e defesa não entrou como sinal a favor'),
+  ('aviso', 'match_winner', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'match_winner', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'match_winner', 'desfalque_proprio', 'any', 3, 'Time apostado com desfalque de titular importante'),
+  ('aviso', 'match_winner', 'pen_poucas_casas', 'any', 4, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'match_winner', 'pen_odd_juice', 'any', 5, 'Odd baixa, retorno pequeno pro risco'),
+  ('aviso', 'match_winner', 'pick_empate', 'any', 6, 'Empate é o resultado mais difícil de prever'),
+  ('evidencia', 'asian_handicap', 'tende_golear', 'any', 1, 'Costuma ganhar por muitos gols'),
+  ('evidencia', 'asian_handicap', 'supremacia', 'any', 2, 'Muito superior ao adversário'),
+  ('evidencia', 'asian_handicap', 'defesa_fora_solida', 'any', 3, 'Defesa sólida jogando fora'),
+  ('evidencia', 'asian_handicap', 'defesa_fora_solida', 'home', 3, 'Defesa sólida em casa'),
+  ('evidencia', 'asian_handicap', 'sem_rodizio', 'any', 4, 'Deve entrar com força máxima'),
+  ('evidencia', 'asian_handicap', 'raramente_perde_por_2', 'any', 5, 'Quando perde, perde apertado'),
+  ('evidencia', 'asian_handicap', 'adversario_fragil_fora', 'any', 6, 'Adversário fraco fora de casa'),
+  ('evidencia', 'asian_handicap', 'adversario_fragil_fora', 'away', 6, 'Adversário fraco em casa'),
+  ('evidencia', 'asian_handicap', 'mando_forte', 'any', 7, 'Manda muito bem em casa'),
+  ('evidencia', 'asian_handicap', 'mando_forte', 'away', 7, 'Vai muito bem fora de casa'),
+  ('contra', 'asian_handicap', 'tende_golear', 'any', 1, 'A margem das vitórias não entrou como sinal a favor'),
+  ('contra', 'asian_handicap', 'supremacia', 'any', 2, 'A superioridade sobre o adversário não entrou como sinal a favor'),
+  ('contra', 'asian_handicap', 'defesa_fora_solida', 'any', 3, 'A solidez defensiva não entrou como sinal a favor'),
+  ('contra', 'asian_handicap', 'defesa_fora_solida', 'home', 3, 'Em casa, a solidez defensiva não entrou como sinal a favor'),
+  ('contra', 'asian_handicap', 'raramente_perde_por_2', 'any', 4, 'A margem das derrotas não entrou como sinal a favor'),
+  ('aviso', 'asian_handicap', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'asian_handicap', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'asian_handicap', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'asian_handicap', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco'),
+  ('aviso', 'asian_handicap', 'handicap_alto', 'any', 5, 'Handicap muito alto'),
+  ('evidencia', 'btts', 'ambos_marcam', 'any', 1, 'Os dois costumam marcar'),
+  ('evidencia', 'btts', 'ataque_dos_dois', 'any', 2, 'Os dois atacam bem'),
+  ('evidencia', 'btts', 'defesas_vazaveis', 'any', 3, 'Defesas frágeis dos dois lados'),
+  ('evidencia', 'btts', 'defesa_forte', 'any', 4, 'Defesa forte de um dos lados'),
+  ('evidencia', 'btts', 'ataque_trava', 'any', 5, 'Um dos ataques costuma passar em branco'),
+  ('evidencia', 'btts', 'historico_btts', 'any', 6, 'Nos últimos jogos, os dois marcaram'),
+  ('evidencia', 'btts', 'historico_seco', 'any', 7, 'Jogos recentes sem os dois marcarem'),
+  ('contra', 'btts', 'ambos_marcam', 'any', 1, 'Os gols dos dois times não entraram como sinal a favor'),
+  ('contra', 'btts', 'defesas_vazaveis', 'any', 2, 'A fragilidade das defesas não entrou como sinal a favor'),
+  ('contra', 'btts', 'defesa_forte', 'any', 3, 'A força defensiva não entrou como sinal a favor'),
+  ('contra', 'btts', 'ataque_trava', 'any', 4, 'A limitação ofensiva não entrou como sinal a favor'),
+  ('aviso', 'btts', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'btts', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'btts', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'btts', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco'),
+  ('evidencia', 'double_chance', 'lado_coberto_forte', 'any', 1, 'O lado coberto é forte'),
+  ('evidencia', 'double_chance', 'equilibrio_defensivo', 'any', 2, 'Equilíbrio defensivo'),
+  ('evidencia', 'double_chance', 'adversario_limitado', 'any', 3, 'Adversário com campanha fraca'),
+  ('evidencia', 'double_chance', 'invicto_recente', 'any', 4, 'Invicto nos últimos jogos'),
+  ('contra', 'double_chance', 'lado_coberto_forte', 'any', 1, 'A força do lado coberto não entrou como sinal a favor'),
+  ('contra', 'double_chance', 'adversario_limitado', 'any', 2, 'A campanha do adversário não entrou como sinal a favor'),
+  ('aviso', 'double_chance', 'pen_odd_outlier', 'any', 1, 'Só uma casa paga essa odd, pode ser linha furada'),
+  ('aviso', 'double_chance', 'pen_odd_longshot', 'any', 2, 'Odd alta de zebra, entra com cautela'),
+  ('aviso', 'double_chance', 'pen_poucas_casas', 'any', 3, 'Poucas casas cotando esse mercado'),
+  ('aviso', 'double_chance', 'pen_odd_juice', 'any', 4, 'Odd baixa, retorno pequeno pro risco');
+
+-- ── 8. Grants ───────────────────────────────────────────────────────────────
+grant execute on function public.get_futebol_value_board() to anon, authenticated, service_role;
+grant execute on function public.get_futebol_value_history(date, date) to anon, authenticated, service_role;
+grant execute on function public.get_futebol_fixture_value(bigint) to anon, authenticated, service_role;
+grant execute on function public.get_futebol_fixture_reason_contract(bigint) to anon, authenticated, service_role;


### PR DESCRIPTION
Closes #304
Refs #301

Segunda subtarefa da virada coordenada. A #303 preparou o front para aceitar os dois contratos; esta entrega o contrato novo do lado do banco.

## O que muda

Migration `20260829120000_112_futebol_score_contexto_contrato.sql`:

- `score_versao` entra nas duas tabelas do mart, obrigatório, default `legacy`
- as quatro funções caem e sobem juntas, na ordem de dependência. É drop e create, não replace: o retorno tabular mudou e o Postgres recusaria
- board e histórico perdem `pts_valor` e `pts_corroboracao`, ganham `score_versao`, e continuam com a forma idêntica um ao outro
- o detalhe perde também `penalidades_globais_pts`
- o contrato de motivos perde a decomposição do Score, o valor de mercado e a corroboração do A favor, e os avisos de odd do Contra
- a tabela de copy é regerada inteira a partir do catálogo do front. Apagar só as cinco linhas de preço deixaria buracos na numeração, e é a ordem que decide qual evidência a mensagem do Telegram mostra

## Não aplicar isolada

A migration está pronta e testada, mas é metade de uma virada combinada com o analytics-engineering #109. A ordem documentada é: migration, mart, sync manual, smoke test, reabertura. Até o mart publicar `contexto_v1`, as RPCs devolvem `score_versao = 'legacy'` e a nota continua na escala antiga.

## Uma decisão de produto para conferir

Os avisos de odd — "só uma casa paga essa odd", "odd alta de zebra" — apareciam na aba Contra do detalhe. A spec tira preço e penalidade de odd das razões, então eles saíram de lá.

O code review mostrou que sair de Contra significava sumir da tela, porque a Bancada descarta `valPrincipal.avisos` quando existe contrato de motivos. Movi para o rodapé, ao lado da ressalva de dado faltando: continuam informando risco de cotação sem se apresentar como premissa do jogo.

A alternativa seria removê-los do produto. Escolhi preservar a informação porque a spec diz que o preço continua como informação e como porta de segurança. Se a leitura for outra, é uma linha para apagar.

## Achados do code review, corrigidos

- os avisos de odd sumiriam por completo (acima)
- o shape file mudava quatro assinaturas mantendo `create or replace`, então abortaria ao ser reaplicado num ambiente que já tem as funções. Cada uma passa a ser precedida do seu drop, e existe teste cobrando isso
- `score_versao` ficava em posição física diferente entre `alter table` e provisionamento novo. No shape file a coluna foi para o fim das duas tabelas
- A favor podia render vazio na janela legacy: o gate `pts_premissas > 0` era herança da nota antiga, em que a linha podia ser publicada só pelo preço
- o teste de motivos ainda descrevia o contrato antigo. Ele passa a cobrir só a função pura, e as garantias de contrato SQL foram para o arquivo novo

Também corrige um defeito do adaptador entregue na #303: ele exigia `pts_valor` sempre que a linha viesse marcada como `legacy`. Depois da virada isso quebraria o histórico para sempre, porque a RPC passa a ter uma forma só e o point-in-time continua devolvendo linhas da escala antiga.

## Fora do escopo, para a #305

As réguas locais 40/60 continuam no front. O review apontou que uma nota 45 na escala nova seria lida com um limiar calibrado para a fórmula antiga — isso é exatamente o que a #305 remove, junto com as fronteiras 25 e 55.

## Verificação

- 271 testes, todos passando, incluindo 28 novos de contrato: paridade entre board e histórico, ausência dos componentes antigos, `score_versao` obrigatório, drop antes de recriar nos dois arquivos, e o contrato de motivos sem preço, corroboração ou aviso de odd
- build, lint e typecheck sem nada novo: 125 erros de tipo no baseline da develop e 125 na branch
- os testes rodam arquivo contra arquivo, sem banco, no mesmo padrão da guarda do shape file
