### PR TITLE
Futebol: painel nas faixas do Score de contexto

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -29,7 +29,8 @@ import { evidenciaDe, ladoDaSaida } from '@/utils/futebol-evidencias';
 import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 import { MotivosJogoPorJogo } from './MotivosJogoPorJogo';
 import { avisoSemDado } from '@/utils/futebol-sem-dado';
-import { valueDoCandidato, resumoDosMercados, mesmaLinha, REGUA_SCORE, type SaidaPreferida } from '@/utils/futebol-leitura';
+import { valueDoCandidato, resumoDosMercados, mesmaLinha, type SaidaPreferida } from '@/utils/futebol-leitura';
+import { ehDestaque, ehFaixaAlta, rotuloDaFaixa, fronteirasDoScore } from '@/utils/futebol-score';
 import { leituraDaCotacao } from '@/utils/futebol-cotacao';
 import { separarMotivosDoContrato } from '@/utils/futebol-motivos';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
@@ -498,9 +499,9 @@ export function BancadaMercados({
       return r ? `O mapa apontava ${lbl}: ${resultBadge(r).label.toLowerCase()}.` : `Jogo encerrado.`;
     }
     if (valPrincipal) {
-      if (valPrincipal.score >= 60) return `O jogo e o preço concordam: ${lbl} é onde este jogo paga.`;
-      if (valPrincipal.score >= REGUA_SCORE) return `${lbl} passa a régua, em faixa média: leitura razoável e algum valor.`;
-      return `Abaixo da régua de ${REGUA_SCORE}: ${lbl} entra como consulta, não como aposta.`;
+      if (ehFaixaAlta(valPrincipal.faixa)) return `O cenário do jogo está bem a favor de ${lbl}.`;
+      if (ehDestaque(valPrincipal.faixa)) return `${lbl} tem parte do cenário a favor: leitura parcial.`;
+      return `Pouco do cenário sustenta ${lbl}: entra como consulta, não como aposta.`;
     }
     if (cotacaoPrincipal.estado === 'cotada') {
       return `${lbl} tem cotação, mas ficou fora dos filtros de oportunidade.`;
@@ -590,7 +591,7 @@ export function BancadaMercados({
           chave: o.outcome,
           rotulo: outcomeLabel(o, jogo.home, jogo.away),
           ativa: o.outcome === (saida ?? candidatoInicialDoMercado?.outcome),
-          passa: val ? val.score >= REGUA_SCORE : n >= PORTA_PREMISSAS,
+          passa: val ? ehDestaque(val.faixa) : n >= PORTA_PREMISSAS,
           res: placar ? settleFutebol(o, placar.home, placar.away) : null,
           escolher: () => setSaida(o.outcome),
         };
@@ -620,8 +621,11 @@ export function BancadaMercados({
             Os 5 mercados
           </div>
           <div className="mt-1 text-[11.5px] leading-relaxed" style={{ color: '#6b6350' }}>
+            {/* A frase conta só os mercados COTADOS. `passa` também é verdadeiro
+                para mercado sem odds, pela porta de premissas, e contar os dois
+                juntos afirmaria uma faixa para quem não tem faixa nenhuma. */}
             {resumos.some((r) => r.value)
-              ? `${resumos.filter((r) => r.passa).length} de ${resumos.length} passam a régua de ${REGUA_SCORE}. A barra é o Score; o tracinho é a régua.`
+              ? `${resumos.filter((r) => r.value && r.passa).length} de ${resumos.filter((r) => r.value).length} mercados cotados em faixa Alta ou Média. A barra é o Score; o tracinho marca onde começa a faixa Alta.`
               : mercadosCotados > 0
                 ? `${mercadosCotados} de ${resumos.length} mercados têm cotação. Os demais continuam analisados pelas premissas.`
               : `Sem preço ainda: a barra conta as premissas e o tracinho é a porta de ${PORTA_PREMISSAS}.`}
@@ -644,8 +648,11 @@ export function BancadaMercados({
             const candidataCotada = leituraCotacao.estado === 'cotada';
             const s = temScore ? r.value!.score : r.nValem;
             const larg = temScore ? `${s}%` : `${Math.min(100, (r.nValem / Math.max(r.totalQueValem, 1)) * 100)}%`;
-            const regua = temScore ? `${REGUA_SCORE}%` : `${(PORTA_PREMISSAS / Math.max(r.totalQueValem, 1)) * 100}%`;
-            const cor = on ? '#fbbf24' : r.passa ? (temScore && s >= 60 ? '#0a3d2e' : '#d4a017') : '#c4bda8';
+            // O tracinho marca onde começa a faixa Alta NA ESCALA daquela linha.
+            const regua = temScore
+              ? `${fronteirasDoScore(r.value!.score_versao).alta}%`
+              : `${(PORTA_PREMISSAS / Math.max(r.totalQueValem, 1)) * 100}%`;
+            const cor = on ? '#fbbf24' : r.passa ? (temScore && ehFaixaAlta(r.value!.faixa) ? '#0a3d2e' : '#d4a017') : '#c4bda8';
             const pick = outcomeLabel(r.candidato, jogo.home, jogo.away);
             return (
               <button
@@ -798,7 +805,7 @@ export function BancadaMercados({
                 </div>
                 <div className="mt-1.5 text-[9.5px] uppercase tracking-[0.12em]" style={{ color: 'rgba(255,255,255,.5)' }}>
                   {valPrincipal
-                    ? `Score · ${valPrincipal.score >= 60 ? 'faixa alta' : valPrincipal.score >= REGUA_SCORE ? 'faixa média' : 'abaixo da régua'}`
+                    ? `Score · ${rotuloDaFaixa(valPrincipal.faixa)}`
                     : 'premissas a favor'}
                 </div>
               </div>

--- a/src/components/futebol/FaixaPartida.tsx
+++ b/src/components/futebol/FaixaPartida.tsx
@@ -5,7 +5,8 @@ import { Crest } from '@/components/futebol/Crest';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
 import { useFutebolFixturePremissas } from '@/hooks/use-futebol-data';
 import type { FutebolFixtureValueRow, FutebolFormResult } from '@/services/futebol-data.service';
-import { melhorLeitura, resumoDosMercados, REGUA_SCORE, type SaidaPreferida } from '@/utils/futebol-leitura';
+import { melhorLeitura, resumoDosMercados, type SaidaPreferida } from '@/utils/futebol-leitura';
+import { rotuloDaFaixa } from '@/utils/futebol-score';
 import { outcomeLabel, contaQueValem, PORTA_PREMISSAS } from '@/utils/futebol-premissas';
 import { isFinished, isLive } from '@/utils/futebol-datas';
 import type { JogoInfo } from './JogoResumo';
@@ -223,7 +224,7 @@ export function FaixaPartida({
               {v ? <Blur active={locked}>{String(v.score)}</Blur> : nValem}
             </div>
             <div className="mt-1.5 text-[9.5px] uppercase tracking-[0.12em] text-white/50">
-              {v ? `Score · ${v.score >= 60 ? 'faixa alta' : v.score >= REGUA_SCORE ? 'faixa média' : 'abaixo da régua'}` : 'premissas a favor'}
+              {v ? `Score · ${rotuloDaFaixa(v.faixa)}` : 'premissas a favor'}
             </div>
             {v && !fim && !locked && top && (
               <div className="mt-2.5 flex justify-center">

--- a/src/components/futebol/FixtureRow.tsx
+++ b/src/components/futebol/FixtureRow.tsx
@@ -1,7 +1,6 @@
 import { Crest } from './Crest';
 import { fmtTime, isFinished, isLive } from '@/utils/futebol-datas';
-import { chancePct, marketShort, pickLabel } from '@/utils/futebol-score';
-import { REGUA_SCORE } from '@/utils/futebol-leitura';
+import { chancePct, ehDestaque, ehFaixaAlta, marketShort, pickLabel } from '@/utils/futebol-score';
 import { settleFutebol, isHit } from '@/utils/futebol-settlement';
 import type { FutebolFixture, FutebolValueBoardRow } from '@/services/futebol-data.service';
 
@@ -48,7 +47,7 @@ export function FixtureRow({
       venceu ? 'font-bold text-ink' : perdeu ? 'font-medium text-ink-3' : 'font-semibold text-ink'
     }`;
 
-  const alto = !!best && best.score >= 60;
+  const alto = ehFaixaAlta(best?.faixa);
   const chance = best ? chancePct(best.prob_justa_fechamento) : null;
 
   // Jogo encerrado não precisa mais do Score, que é uma previsão: o que importa
@@ -128,7 +127,7 @@ export function FixtureRow({
                 : { borderRadius: 11, background: '#fbe3e8', border: '1px solid #f0c2cc', color: '#be123c' }
               : alto
                 ? { borderRadius: 11, background: '#0a3d2e', color: '#fff' }
-                : best.score >= REGUA_SCORE
+                : ehDestaque(best.faixa)
                   ? { borderRadius: 11, background: '#fdf3d9', border: '1px solid #eccf85', color: '#b8870f' }
                   : { borderRadius: 11, background: '#f4eddc', color: '#8d8672' }
         }

--- a/src/components/futebol/JogoResumo.tsx
+++ b/src/components/futebol/JogoResumo.tsx
@@ -14,10 +14,10 @@ import {
   premissaDe,
 } from '@/utils/futebol-premissas';
 import { evidenciaDe, ladoDaSaida, manchete } from '@/utils/futebol-evidencias';
-import { melhorLeitura, resumoDosMercados, REGUA_SCORE, type MercadoResumo } from '@/utils/futebol-leitura';
+import { melhorLeitura, resumoDosMercados, type MercadoResumo } from '@/utils/futebol-leitura';
 import { fmtDayShort, isFinished } from '@/utils/futebol-datas';
 import { settleFutebol, resultBadge, isHit } from '@/utils/futebol-settlement';
-import { faixaWord } from '@/utils/futebol-score';
+import { ehDestaque, ehFaixaAlta, faixaWord } from '@/utils/futebol-score';
 
 /**
  * Aba RESUMO da tela de jogo (Protótipo 1b do Claude Design):
@@ -47,8 +47,9 @@ export interface JogoInfo {
 function scoreBadge(r: MercadoResumo): { texto: string; cls: string; style?: React.CSSProperties } {
   if (r.value) {
     const s = r.value.score;
-    if (s >= 60) return { texto: String(s), cls: 'bg-forest text-canvas border-forest' };
-    if (s >= REGUA_SCORE)
+    // Cor pela FAIXA que o backend publicou, não por número comparado aqui.
+    if (ehFaixaAlta(r.value.faixa)) return { texto: String(s), cls: 'bg-forest text-canvas border-forest' };
+    if (ehDestaque(r.value.faixa))
       return { texto: String(s), cls: '', style: { background: 'rgba(212,160,23,.15)', color: '#b8870f', border: '1px solid rgba(212,160,23,.4)' } };
     return { texto: String(s), cls: 'bg-canvas-2 text-ink-3 border-line' };
   }
@@ -261,15 +262,19 @@ export function JogoResumo({
   const ate = numeros?.[0]?.ate ?? null;
   const temValor = (valueRows?.length ?? 0) > 0;
 
-  const foraDaRegua = resumos.filter((r) => !r.passa).map((r) => r.mercado.label.toLowerCase());
+  // Só os mercados COTADOS têm faixa. `passa` também é verdadeiro por premissas
+  // num mercado sem odds, e juntar os dois faria a frase atribuir faixa a quem
+  // não tem preço coletado.
+  const cotados = resumos.filter((r) => r.value);
+  const emFaixaBaixa = cotados.filter((r) => !r.passa).map((r) => r.mercado.label.toLowerCase());
   const juntar = (arr: string[]) => (arr.length <= 1 ? arr[0] ?? '' : `${arr.slice(0, -1).join(', ')} e ${arr[arr.length - 1]}`);
   const nota = fim && retro
     ? retro
     : !temValor
       ? 'Sem preço coletado ainda: as odds entram perto do jogo, e com elas o Score fecha.'
-      : foraDaRegua.length
-        ? `${juntar(foraDaRegua)} ${foraDaRegua.length === 1 ? 'fica' : 'ficam'} abaixo da régua de ${REGUA_SCORE}, ${foraDaRegua.length === 1 ? 'entra' : 'entram'} como consulta.`
-        : `Os cinco mercados passam a régua de ${REGUA_SCORE} neste jogo.`;
+      : emFaixaBaixa.length
+        ? `${juntar(emFaixaBaixa)} ${emFaixaBaixa.length === 1 ? 'fica' : 'ficam'} em faixa baixa, ${emFaixaBaixa.length === 1 ? 'entra' : 'entram'} como consulta.`
+        : `${cotados.length === 1 ? 'O mercado cotado aparece' : `Os ${cotados.length} mercados cotados aparecem`} em faixa Alta ou Média neste jogo.`;
 
   if (isLoading) {
     return (

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -11,9 +11,9 @@ import {
 } from '@/hooks/use-futebol-data';
 import { fmtDayChip, fmtTime, isFinished, isLive } from '@/utils/futebol-datas';
 import { chancePct, pickLabel } from '@/utils/futebol-score';
-import { marketShort } from '@/utils/futebol-score';
+import { marketShort, rotuloDaFaixa } from '@/utils/futebol-score';
 import { contaQueValem, premissaDe, rotuloPremissa, pesoForte } from '@/utils/futebol-premissas';
-import { melhorLeitura, resumoDosMercados, REGUA_SCORE } from '@/utils/futebol-leitura';
+import { melhorLeitura, resumoDosMercados } from '@/utils/futebol-leitura';
 import { evidenciaDe, ladoDaSaida } from '@/utils/futebol-evidencias';
 import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 import { settleFutebol, isHit } from '@/utils/futebol-settlement';
@@ -251,7 +251,7 @@ export function JogoResumoPanel({
                 {best ? best.score : nValem}
               </div>
               <div className="mt-1 text-[9px] uppercase tracking-[0.12em]" style={{ color: 'rgba(255,255,255,.5)' }}>
-                {best ? `Score · ${best.score >= 60 ? 'faixa alta' : best.score >= REGUA_SCORE ? 'faixa média' : 'abaixo da régua'}` : 'premissas a favor'}
+                {best ? `Score · ${rotuloDaFaixa(best.faixa)}` : 'premissas a favor'}
               </div>
             </div>
           </div>

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -11,7 +11,7 @@ import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
 import { competitionLabel, ALL_COMPETITIONS } from '@/utils/futebol-competitions';
 import {
   pickLabel, marketLabel, fmtEdgeScore, freqEmDez, groupBoardByFixture,
-  faixaBadgeCls, faixaWord, faixaTone, topEvidencia, chancePct, SCORE_MEDIA,
+  faixaBadgeCls, faixaWord, faixaTone, topEvidencia, chancePct, ehDestaque,
 } from '@/utils/futebol-score';
 import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
@@ -301,7 +301,11 @@ export default function FutebolHoje() {
 
   const realOppsByFixture = useMemo(() => board.map((bf) => bf.best), [board]);
   const oppsByFixture = isDemo ? demoFutebolBoard : realOppsByFixture;
-  const heroOpp = oppsByFixture[0] && oppsByFixture[0].score >= SCORE_MEDIA ? oppsByFixture[0] : null;
+  // O destaque é a primeira em faixa Alta ou Média, e não necessariamente a de
+  // maior Score: faixa não é função pura do Score, porque as portas de odd por
+  // mercado podem deixar a linha mais bem pontuada fora do destaque. Testar só a
+  // posição zero fazia o bloco sumir num dia que tinha destaque.
+  const heroOpp = oppsByFixture.find((o) => ehDestaque(o.faixa)) ?? null;
   // "Ponto de atenção" do hero: vem do detalhe (contras/avisos) do jogo em destaque
   const { data: heroRows } = useFutebolFixtureValue(heroOpp?.fixture_id);
   const heroAtencao = useMemo(() => {
@@ -310,12 +314,12 @@ export default function FutebolHoje() {
     const list = row ? [...(row.contras ?? []), ...(row.avisos ?? [])] : [];
     return list[0] ?? null;
   }, [heroOpp, heroRows]);
-  const moreOpps = (heroOpp ? oppsByFixture.slice(1) : oppsByFixture).filter((o) => o.score >= SCORE_MEDIA).slice(0, 4);
+  const moreOpps = oppsByFixture.filter((o) => o !== heroOpp && ehDestaque(o.faixa)).slice(0, 4);
   const nOpps = isDemo ? demoFutebolBoard.length : dayRows.length;
   const gameList = isDemo ? demoFutebolFixtures : dayGames;
   const alta = oppsByFixture.filter((o) => faixaTone(o.faixa) === 'alta').length;
-  // melhor valor entre as oportunidades realmente exibidas (score ≥ Média), não o edge bruto de longshots
-  const surfaced = oppsByFixture.filter((o) => o.score >= SCORE_MEDIA);
+  // melhor valor entre as oportunidades realmente exibidas, não o edge bruto de longshots
+  const surfaced = oppsByFixture.filter((o) => ehDestaque(o.faixa));
   const melhorValor = surfaced.length ? Math.round(Math.max(...surfaced.map((o) => o.edge)) * 100) : null;
 
   // contagem de jogos por dia (BRT) — pros chips do stepper

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -16,7 +16,7 @@ import {
 import { type SaidaPreferida } from '@/utils/futebol-leitura';
 import {
   pickLabel, marketLabel, valorVerdict, fmtEdgeScore,
-  faixaWord, faixaBadgeCls, chancePct, SCORE_MEDIA,
+  faixaWord, faixaBadgeCls, chancePct,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { escalacaoExibida, rotuloEscalacao } from '@/utils/futebol-escalacao';

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -15,7 +15,9 @@ import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
 import { competitionLabel, sortCompetitions, ALL_COMPETITIONS } from '@/utils/futebol-competitions';
 import {
   pickLabel, marketLabel, fmtEdgeScore,
-  faixaBadgeCls, faixaWord, faixaTone, chancePct, SCORE_MEDIA,
+  faixaBadgeCls, faixaWord, faixaTone, chancePct, edgeToneCls,
+  opcoesDeFaixa, passaNoFiltroDeFaixa, versaoPredominante, ehDestaque,
+  FAIXA_FILTRO_PADRAO, type FaixaFilter,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { mergeBoardAndHistory, opportunityKey } from '@/utils/futebol-history';
@@ -125,7 +127,6 @@ const LABEL = 'text-[10px] uppercase tracking-[0.14em] font-bold text-ink-3';
 const GRID = 'grid grid-cols-[56px_64px_1fr_140px_64px_80px_72px_28px] gap-3 items-center';
 
 type MarketFilter = 'all' | 'match_winner' | 'goals_over_under' | 'asian_handicap' | 'btts' | 'double_chance';
-type FaixaFilter = 'all' | 'alta' | 'media';
 type CompFilter = string; // 'all' | slug da competição (data-driven)
 
 function Chip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
@@ -251,7 +252,7 @@ function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
       </div>
       <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={showLock}>{chance != null ? `${chance}%` : '—'}</Blur></div>
       <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={showLock}>{o.best_odd.toFixed(2)}</Blur></div>
-      <div className="text-right tabular-nums text-[14px] font-bold text-forest"><Blur active={showLock}>{o.edge != null ? fmtEdgeScore(o.edge) : '—'}</Blur></div>
+      <div className={`text-right tabular-nums text-[14px] font-bold ${edgeToneCls(o.edge)}`}><Blur active={showLock}>{o.edge != null ? fmtEdgeScore(o.edge) : '—'}</Blur></div>
       <ChevronRight className="w-4 h-4 text-ink-3 justify-self-end" />
     </button>
   );
@@ -340,7 +341,7 @@ export default function FutebolOportunidades() {
   const isDemo = oppTour.run; // durante o tour, preenche a tela com exemplo
   const locked = isDemo ? false : !access?.unlocked;
   const [mercado, setMercado] = useState<MarketFilter>('all');
-  const [faixa, setFaixa] = useState<FaixaFilter>('all');
+  const [faixa, setFaixa] = useState<FaixaFilter>(FAIXA_FILTRO_PADRAO);
   const [comp, setComp] = useState<CompFilter>('all');
   const [day, setDay] = useState<string | null>(null);
 
@@ -458,7 +459,13 @@ export default function FutebolOportunidades() {
     return s;
   }, [allRows, selectedDay, registradasAll]);
 
-  const faixaOptions = [{ value: 'all', label: 'Todas' }, { value: 'alta', label: 'Alta' }, { value: 'media', label: 'Média' }];
+  const faixaOptions = [
+    { value: 'destaque', label: 'Alta e Média' },
+    { value: 'alta', label: 'Alta' },
+    { value: 'media', label: 'Média' },
+    { value: 'baixa', label: 'Baixa' },
+    { value: 'all', label: 'Todas' },
+  ];
   const compOptions = [
     { value: 'all', label: 'Todas' },
     ...sortCompetitions([...compsOnDay]).map((c) => ({ value: c, label: competitionLabel(c) })),
@@ -481,7 +488,7 @@ export default function FutebolOportunidades() {
     () => dayRows.filter((r) => {
       if (mercado !== 'all' && r.market !== mercado) return false;
       // Sem faixa não dá pra classificar, então o filtro de faixa a esconde.
-      if (faixa !== 'all' && (r.faixa == null || faixaTone(r.faixa) !== faixa)) return false;
+      if (!passaNoFiltroDeFaixa(faixa, r.faixa)) return false;
       if (comp !== 'all' && r.competition !== comp) return false;
       return true;
     }),
@@ -502,16 +509,20 @@ export default function FutebolOportunidades() {
     [filtered]
   );
   const bestRows: OppLike[] = isDemo ? demoFutebolBoard : realBestRows;
-  // Registro sem Score conta como com valor: foi enviado acima do corte.
-  //
-  // Não existe o "sem valor claro" como contraparte, e não é esquecimento: o
-  // gate do mart é score >= 40 e o SCORE_MEDIA também é 40, então a lista de
-  // score < 40 era sempre vazia. A seção inteira era código morto e saiu junto
-  // com este PR (achado do Matheus, 17/08, encaminhado para a [E]).
-  const comValor = bestRows.filter((o) => o.score == null || o.score >= SCORE_MEDIA);
-  const nAlta = bestRows.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'alta').length;
-  const nMedia = bestRows.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'media').length;
-  const nBaixa = bestRows.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'baixa').length;
+  // A lista mostra o que o backend publicou. O corte local por número de Score
+  // saiu na virada do Score de contexto (spec #301): a régua era calibrada para
+  // a fórmula antiga e aplicá-la à escala nova classificaria errado.
+  const comValor = bestRows;
+  // A distribuição descreve o DIA, e por isso sai de dayRows e não de bestRows:
+  // contar sobre a lista já filtrada faria o resumo dizer "Baixa 0" sempre que o
+  // filtro escondesse a faixa Baixa, que é justamente o padrão.
+  // Quantas o dia tem e o filtro escondeu. Serve ao estado vazio: sem isto ele
+  // diz "não há oportunidade nesse dia" quando o que houve foi um filtro.
+  const escondidasPeloFiltro = (isDemo ? demoFutebolBoard.length : dayRows.length) - bestRows.length;
+  const distribuicao = isDemo ? demoFutebolBoard : dayRows;
+  const nAlta = distribuicao.filter((o) => faixaTone(o.faixa ?? '') === 'alta' && o.faixa != null).length;
+  const nMedia = distribuicao.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'media').length;
+  const nBaixa = distribuicao.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'baixa').length;
 
   // Contagem de oportunidades COM VALOR por dia (badge do stepper).
   const countByDay = useMemo(() => {
@@ -523,7 +534,9 @@ export default function FutebolOportunidades() {
       byDay.get(d)!.push(r);
     });
     const out: Record<string, number> = {};
-    byDay.forEach((rs, d) => { out[d] = rs.filter((o) => o.score >= SCORE_MEDIA).length; });
+    // Conta o mesmo recorte que a lista abre por padrão (Alta e Média), senão o
+    // selo promete um número que a tela não mostra ao ser aberta.
+    byDay.forEach((rs, d) => { out[d] = rs.filter((o) => ehDestaque(o.faixa)).length; });
     // Registrada que o board não tem entra na conta, senão dia que só tem
     // registro apareceria zerado no seletor.
     registradasAll.forEach((a) => {
@@ -593,7 +606,14 @@ export default function FutebolOportunidades() {
               </>
             ) : (
               <>
-                <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{comValor.length} aposta{comValor.length === 1 ? '' : 's'} com valor</h1>
+                {/* O título não afirma "com valor" quando a pessoa pediu para
+                    ver a faixa Baixa: ali ela está olhando o que o cenário NÃO
+                    sustenta, e chamar aquilo de aposta com valor contradiz a
+                    própria legenda. */}
+                <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">
+                  {comValor.length} {comValor.length === 1 ? 'oportunidade' : 'oportunidades'}
+                  {faixa === 'baixa' ? ' em faixa baixa' : faixa === 'all' ? '' : ' com valor'}
+                </h1>
                 <p className="text-[13px] mt-1 text-ink-2">{isPastDay ? 'Resultado das oportunidades com valor deste dia' : 'Onde a odd paga acima da chance estimada · em ordem de confiança'}</p>
               </>
             )}
@@ -649,13 +669,19 @@ export default function FutebolOportunidades() {
           <div className="space-y-2">{Array.from({ length: 6 }).map((_, i) => <Skeleton key={i} className="h-16 w-full bg-canvas-2 rounded-rebrand-md" />)}</div>
         ) : (isPastDay ? comValor.length === 0 : bestRows.length === 0) ? (
           <div className="rounded-rebrand-md bg-white border border-line p-6 text-center">
+            {/* Quando o dia TEM oportunidade e a lista está vazia, quem esvaziou
+                foi o filtro. Culpar o dado nesse caso manda a pessoa embora de
+                uma tela que só precisava de um clique em Todas. */}
             <p className="text-sm text-ink-2">
-              {isPastDay ? 'Nenhuma oportunidade com valor nesse dia.'
+              {escondidasPeloFiltro > 0 ? 'Nenhuma oportunidade nesse filtro.'
+                : isPastDay ? 'Nenhuma oportunidade com valor nesse dia.'
                 : isFutureDay ? 'Ainda sem oportunidades para este dia.'
                 : 'Nenhum jogo com odds nesse filtro.'}
             </p>
             <p className="text-xs text-ink-3 mt-1">
-              {isPastDay ? 'Só listamos aqui as apostas que sinalizamos com valor.'
+              {escondidasPeloFiltro > 0
+                ? `Este dia tem ${escondidasPeloFiltro} ${escondidasPeloFiltro === 1 ? 'oportunidade' : 'oportunidades'} em outra faixa ou mercado. Troque o filtro para ver.`
+                : isPastDay ? 'Só listamos aqui as apostas que sinalizamos com valor.'
                 : isFutureDay ? 'As odds costumam ser coletadas a partir de ~24h antes do jogo — as oportunidades aparecem aqui quando chegarem.'
                 : 'As oportunidades aparecem quando há odds coletadas antes do jogo.'}
             </p>
@@ -713,15 +739,20 @@ export default function FutebolOportunidades() {
           <div className="rounded-rebrand-md bg-white border border-line p-4">
             <div className={LABEL}>Como ler o Score</div>
             <p className="text-[12px] text-ink-2 mt-2 leading-relaxed">
-              O <b className="text-ink">Score (0–100)</b> mostra o quanto a oportunidade é <b className="text-ink">confiável</b>, não a chance de acerto. Ele junta quatro coisas: o tamanho do valor (o quanto a odd paga acima do risco real), o cenário do jogo (ataque, defesa, mando, forma…), se a odd não é exagerada (nem zebra, nem mixaria) e se as principais casas vêm concordando com esse lado. Por isso uma "zebra" com valor alto bancada por uma casa só fica com score baixo.
+              O <b className="text-ink">Score (0–100)</b> mede <b className="text-ink">quanto do cenário favorável está presente</b> nessa linha: ataque, defesa, mando, forma, histórico do confronto. Ele não mede chance de acerto e não olha o preço. A odd e a diferença para o preço justo aparecem ao lado, separadas, porque preço e cenário são duas leituras diferentes e misturá-las esconde as duas.
             </p>
           </div>
           <div className="rounded-rebrand-md bg-white border border-line p-4">
             <div className={LABEL}>Faixas</div>
             <ul className="mt-2 space-y-2 text-[12px] text-ink-2">
-              <li className="flex items-center gap-2"><span className={`w-9 text-center text-[11px] font-bold rounded px-1 py-0.5 ${faixaBadgeCls('Alta')}`}>60+</span> Alta, oportunidade de destaque</li>
-              <li className="flex items-center gap-2"><span className={`w-9 text-center text-[11px] font-bold rounded px-1 py-0.5 ${faixaBadgeCls('Média')}`}>40+</span> Média, vale acompanhar</li>
-              <li className="flex items-center gap-2"><span className={`w-9 text-center text-[11px] font-bold rounded px-1 py-0.5 ${faixaBadgeCls('Baixa')}`}>&lt;40</span> Baixa, não sinaliza</li>
+              {/* Os números saem de FAIXA_ALTA_MIN e FAIXA_MEDIA_MIN, em um
+                  lugar só, para a legenda não voltar a divergir do backend. */}
+              {opcoesDeFaixa(versaoPredominante(dayRows)).map(({ tone, rotulo, selo }) => (
+                <li key={tone} className="flex items-center gap-2">
+                  <span className={`w-9 text-center text-[11px] font-bold rounded px-1 py-0.5 ${faixaBadgeCls(rotulo)}`}>{selo}</span>
+                  {tone === 'alta' ? 'Alta, cenário bem presente' : tone === 'media' ? 'Média, cenário parcial' : 'Baixa, pouco cenário a favor'}
+                </li>
+              ))}
             </ul>
             <p className="text-[10px] text-ink-3 mt-3 leading-snug">
               Odds pré-jogo (não ao vivo). Mercados: Resultado (1X2), Gols (Over/Under), Handicap asiático, Ambos marcam e Dupla chance; outros entram conforme liberados.

--- a/src/utils/futebol-faixas.test.ts
+++ b/src/utils/futebol-faixas.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FAIXA_ALTA_MIN,
+  FAIXA_MEDIA_MIN,
+  FAIXA_FILTRO_PADRAO,
+  edgeToneCls,
+  ehDestaque,
+  ehFaixaAlta,
+  faixaTone,
+  rotuloDaFaixa,
+  fronteirasDoScore,
+  opcoesDeFaixa,
+  passaNoFiltroDeFaixa,
+  versaoPredominante,
+} from './futebol-score';
+
+// ============================================================================
+// Faixas do Score de contexto (issue #305, spec #301)
+// ============================================================================
+// Quem classifica é o backend: a faixa chega pronta na resposta e o front só
+// lê. O que mora aqui é o filtro da tela e a legenda — e as fronteiras, que
+// existem em UM lugar só para a legenda não voltar a mentir o número.
+// ============================================================================
+
+describe('fronteiras da faixa', () => {
+  it('pertencem à faixa de cima', () => {
+    // Uma nota exatamente 25 é Média; exatamente 55 é Alta.
+    expect(FAIXA_MEDIA_MIN).toBe(25);
+    expect(FAIXA_ALTA_MIN).toBe(55);
+  });
+
+  it('a legenda descreve as três faixas sem furo nem sobreposição', () => {
+    const [alta, media, baixa] = opcoesDeFaixa('contexto_v1');
+    expect(alta).toEqual({ tone: 'alta', rotulo: 'Alta', selo: '55+' });
+    expect(media).toEqual({ tone: 'media', rotulo: 'Média', selo: '25+' });
+    expect(baixa).toEqual({ tone: 'baixa', rotulo: 'Baixa', selo: '<25' });
+  });
+
+  it('na escala antiga a legenda mostra os números antigos', () => {
+    // Entre esta entrega e a troca do mart o board ainda vem em legacy. Anunciar
+    // 55+ ali classificaria errado: uma nota legacy de 57 é Média.
+    expect(fronteirasDoScore('legacy')).toEqual({ media: 40, alta: 60 });
+    expect(fronteirasDoScore('contexto_v1')).toEqual({ media: 25, alta: 55 });
+    expect(opcoesDeFaixa('legacy').map((o) => o.selo)).toEqual(['60+', '40+', '<40']);
+  });
+
+  it('basta uma linha no contrato novo para a leitura ser a nova', () => {
+    // O histórico traz linhas legacy para sempre; elas não podem prender a
+    // legenda na escala antiga depois da virada.
+    expect(versaoPredominante([])).toBe('legacy');
+    expect(versaoPredominante([{ score_versao: 'legacy' }])).toBe('legacy');
+    expect(versaoPredominante([{ score_versao: 'legacy' }, { score_versao: 'contexto_v1' }]))
+      .toBe('contexto_v1');
+  });
+});
+
+describe('faixaTone lê a classificação do backend', () => {
+  it.each([
+    ['Alta', 'alta'],
+    ['alta', 'alta'],
+    ['Média', 'media'],
+    ['Media', 'media'],
+    ['Baixa', 'baixa'],
+  ])('%s vira %s', (recebido, esperado) => {
+    expect(faixaTone(recebido)).toBe(esperado);
+  });
+});
+
+describe('filtro de faixa do painel', () => {
+  it('abre em Alta e Média', () => {
+    expect(FAIXA_FILTRO_PADRAO).toBe('destaque');
+  });
+
+  it('o padrão mostra Alta e Média e esconde Baixa', () => {
+    expect(passaNoFiltroDeFaixa('destaque', 'Alta')).toBe(true);
+    expect(passaNoFiltroDeFaixa('destaque', 'Média')).toBe(true);
+    expect(passaNoFiltroDeFaixa('destaque', 'Baixa')).toBe(false);
+  });
+
+  it('Baixa continua acessível por escolha explícita', () => {
+    expect(passaNoFiltroDeFaixa('baixa', 'Baixa')).toBe(true);
+    expect(passaNoFiltroDeFaixa('baixa', 'Alta')).toBe(false);
+    expect(passaNoFiltroDeFaixa('baixa', 'Média')).toBe(false);
+  });
+
+  it('Todas não esconde nenhuma faixa', () => {
+    for (const faixa of ['Alta', 'Média', 'Baixa']) {
+      expect(passaNoFiltroDeFaixa('all', faixa), faixa).toBe(true);
+    }
+  });
+
+  it('Alta e Média isoladas mostram só a sua', () => {
+    expect(passaNoFiltroDeFaixa('alta', 'Alta')).toBe(true);
+    expect(passaNoFiltroDeFaixa('alta', 'Média')).toBe(false);
+    expect(passaNoFiltroDeFaixa('media', 'Média')).toBe(true);
+    expect(passaNoFiltroDeFaixa('media', 'Alta')).toBe(false);
+  });
+
+  it('oportunidade registrada sem faixa continua no padrão', () => {
+    // Enviada no daily antes da migration 091: estava acima do corte naquele
+    // dia, mas o número não foi guardado. Some do padrão e a lista apaga uma
+    // oportunidade que existiu — inclusive em dia cujo seletor a contou.
+    expect(passaNoFiltroDeFaixa('destaque', null)).toBe(true);
+    expect(passaNoFiltroDeFaixa('all', null)).toBe(true);
+  });
+
+  it('mas ela não entra nos filtros específicos, que afirmariam uma faixa', () => {
+    expect(passaNoFiltroDeFaixa('alta', null)).toBe(false);
+    expect(passaNoFiltroDeFaixa('media', null)).toBe(false);
+    expect(passaNoFiltroDeFaixa('baixa', null)).toBe(false);
+  });
+});
+
+describe('rótulo e testes de faixa saem da classificação do backend', () => {
+  it('traduz a faixa em palavras sem olhar o número do Score', () => {
+    expect(rotuloDaFaixa('Alta')).toBe('faixa alta');
+    expect(rotuloDaFaixa('Média')).toBe('faixa média');
+    expect(rotuloDaFaixa('Baixa')).toBe('faixa baixa');
+    expect(rotuloDaFaixa(null)).toBe('sem faixa');
+  });
+
+  it('destaque é Alta ou Média; faixa alta é só Alta', () => {
+    expect(ehDestaque('Alta')).toBe(true);
+    expect(ehDestaque('Média')).toBe(true);
+    expect(ehDestaque('Baixa')).toBe(false);
+    expect(ehDestaque(null)).toBe(false);
+
+    expect(ehFaixaAlta('Alta')).toBe(true);
+    expect(ehFaixaAlta('Média')).toBe(false);
+    expect(ehFaixaAlta(null)).toBe(false);
+  });
+});
+
+describe('cor da diferença para o preço justo', () => {
+  it('positivo usa verde da marca', () => {
+    expect(edgeToneCls(0.12)).toBe('text-forest');
+  });
+
+  it('zero e negativo usam cor neutra, nunca vermelho de erro', () => {
+    // A diferença é informativa. Pintar de vermelho leria como defeito da
+    // leitura, e um preço abaixo do justo não invalida o contexto.
+    expect(edgeToneCls(0)).toBe('text-ink-2');
+    expect(edgeToneCls(-0.03)).toBe('text-ink-2');
+  });
+
+  it('ausência de preço cai no neutro em vez de inventar sinal', () => {
+    expect(edgeToneCls(null)).toBe('text-ink-2');
+    expect(edgeToneCls(undefined)).toBe('text-ink-2');
+  });
+});

--- a/src/utils/futebol-leitura.test.ts
+++ b/src/utils/futebol-leitura.test.ts
@@ -52,11 +52,17 @@ const VALUE_BASE: FutebolFixtureValueRow = {
   premissas_sem_dado: 0,
 };
 
-const value = (outcome: string, line: number | null, score: number): FutebolFixtureValueRow => ({
+const value = (
+  outcome: string,
+  line: number | null,
+  score: number,
+  faixa = 'Média',
+): FutebolFixtureValueRow => ({
   ...VALUE_BASE,
   outcome,
   line_value: line,
   score,
+  faixa,
 });
 
 const OVER_15 = ['defesas_vazaveis', 'ataque_combinado', 'xg_combinado_alto'];
@@ -121,9 +127,13 @@ describe('resumoDosMercados', () => {
     expect(r.value?.score).toBe(58);
   });
 
-  it('passa a régua pelo Score da própria saída', () => {
-    expect(gols(resumoDosMercados(rows, [value('Over', 1.5, 54)])).passa).toBe(true);
-    expect(gols(resumoDosMercados(rows, [value('Over', 1.5, 31)])).passa).toBe(false);
+  it('destaca pela faixa que o backend publicou, não por régua local', () => {
+    // A régua de 40 saiu na virada do Score de contexto (spec #301). Um Score
+    // baixo em faixa Média continua sendo destaque, e um Score alto em faixa
+    // Baixa não é: quem classifica é o backend.
+    expect(gols(resumoDosMercados(rows, [value('Over', 1.5, 54, 'Alta')])).passa).toBe(true);
+    expect(gols(resumoDosMercados(rows, [value('Over', 1.5, 31, 'Média')])).passa).toBe(true);
+    expect(gols(resumoDosMercados(rows, [value('Over', 1.5, 54, 'Baixa')])).passa).toBe(false);
   });
 });
 

--- a/src/utils/futebol-leitura.ts
+++ b/src/utils/futebol-leitura.ts
@@ -1,4 +1,5 @@
 import type { FutebolFixturePremissas, FutebolFixtureValueRow } from '@/services/futebol-data.service';
+import { ehDestaque } from '@/utils/futebol-score';
 import type { Saida } from '@/utils/futebol-saida';
 import {
   MERCADOS,
@@ -113,13 +114,13 @@ export interface MercadoResumo {
   /** Linha de valor real (odds), quando coletada. */
   value: FutebolFixtureValueRow | null;
   /**
-   * Passa a régua? Com odds, régua de Score (40). Sem odds, a porta de contexto
-   * (2+ premissas) — que é o que existe para afirmar.
+   * Destaque na leitura. Com odds, quem decide é a FAIXA publicada pelo
+   * backend: a régua local de 40 saiu na virada do Score de contexto (spec
+   * #301), porque era calibrada para a fórmula antiga e classificaria errado a
+   * escala nova. Sem odds, continua a porta de contexto (2+ premissas).
    */
   passa: boolean;
 }
-
-export const REGUA_SCORE = 40;
 
 export function resumoDosMercados(
   rows: FutebolFixturePremissas[] | null | undefined,
@@ -147,7 +148,7 @@ export function resumoDosMercados(
       (p) => p.peso == null || p.peso > 0,
     ).length;
     const value = comPreco?.value ?? null;
-    const passa = value ? value.score >= REGUA_SCORE : nValem >= PORTA_PREMISSAS;
+    const passa = value ? ehDestaque(value.faixa) : nValem >= PORTA_PREMISSAS;
     return [{ mercado: m, candidato: c, nValem, totalQueValem, value, passa }];
   });
 }

--- a/src/utils/futebol-score.ts
+++ b/src/utils/futebol-score.ts
@@ -8,6 +8,7 @@ import { linhaDaSaida, type Saida } from '@/utils/futebol-saida';
 // Mercados: Resultado (1X2), Gols (Over/Under), Handicap asiático, Ambos marcam e Dupla chance.
 // ============================================================
 import type { FutebolFixtureValueRow, FutebolValueBoardRow } from '@/services/futebol-data.service';
+import type { FutebolScoreVersion } from '@/services/futebol-score-contract';
 
 export type Faixa = 'alta' | 'media' | 'baixa';
 
@@ -135,9 +136,107 @@ export function bestOf(rows: FutebolFixtureValueRow[]): FutebolFixtureValueRow |
   return rows.reduce<FutebolFixtureValueRow | null>((b, r) => (b == null || r.score > b.score ? r : b), null);
 }
 
-/** Limiares de faixa (espelham o backend). */
-export const SCORE_ALTA = 60;
-export const SCORE_MEDIA = 40;
+/**
+ * Fronteiras do Score de contexto (spec #301). As duas pertencem à faixa de
+ * cima: 25 é Média, 55 é Alta.
+ *
+ * Elas existem aqui para a LEGENDA declarar o número certo, e para mais nada.
+ * Quem classifica é o backend: a faixa chega pronta na resposta, e o front que
+ * recalcula é o front que discorda da metodologia sem saber.
+ */
+export const FAIXA_MEDIA_MIN = 25;
+export const FAIXA_ALTA_MIN = 55;
+
+/**
+ * As fronteiras da escala em que a nota foi calculada.
+ *
+ * Durante a janela da virada o board ainda chega em `legacy`, e anunciar 55+ ao
+ * lado de uma nota legacy de 57 classificaria errado na cara do usuário: ela é
+ * Média naquela escala. A versão não aparece na tela, mas decide o número que
+ * a legenda mostra.
+ */
+export function fronteirasDoScore(versao: FutebolScoreVersion): { media: number; alta: number } {
+  return versao === 'contexto_v1'
+    ? { media: FAIXA_MEDIA_MIN, alta: FAIXA_ALTA_MIN }
+    : { media: 40, alta: 60 };
+}
+
+/**
+ * A versão que a tela deve assumir para um conjunto de linhas. Basta uma linha
+ * no contrato novo para a leitura já ser a nova: o histórico continua trazendo
+ * linhas legacy para sempre, e elas não podem prender a legenda no passado.
+ */
+export function versaoPredominante(
+  linhas: readonly { score_versao?: FutebolScoreVersion }[],
+): FutebolScoreVersion {
+  return linhas.some((l) => l.score_versao === 'contexto_v1') ? 'contexto_v1' : 'legacy';
+}
+
+/** As três faixas, na ordem em que a legenda as apresenta. */
+export function opcoesDeFaixa(
+  versao: FutebolScoreVersion,
+): { tone: Faixa; rotulo: string; selo: string }[] {
+  const { media, alta } = fronteirasDoScore(versao);
+  return [
+    { tone: 'alta', rotulo: 'Alta', selo: `${alta}+` },
+    { tone: 'media', rotulo: 'Média', selo: `${media}+` },
+    { tone: 'baixa', rotulo: 'Baixa', selo: `<${media}` },
+  ];
+}
+
+/**
+ * O filtro de faixa do painel. `destaque` é o padrão e mostra Alta e Média;
+ * Baixa e Todas continuam a um toque de distância.
+ */
+export type FaixaFilter = 'destaque' | 'alta' | 'media' | 'baixa' | 'all';
+
+export const FAIXA_FILTRO_PADRAO: FaixaFilter = 'destaque';
+
+export function passaNoFiltroDeFaixa(filtro: FaixaFilter, faixa: string | null | undefined): boolean {
+  if (filtro === 'all') return true;
+  // Sem faixa guardada é a oportunidade REGISTRADA de antes da migration 091:
+  // ela foi enviada no daily, ou seja, estava acima do corte no dia. Esconder do
+  // padrão apagaria da lista uma oportunidade que existiu de verdade, então ela
+  // conta como destaque. O que não dá é afirmar QUAL faixa era, e por isso ela
+  // fica fora dos filtros específicos.
+  if (faixa == null) return filtro === 'destaque';
+  const tone = faixaTone(faixa);
+  if (filtro === 'destaque') return tone !== 'baixa';
+  return tone === filtro;
+}
+
+/**
+ * Cor da diferença para o preço justo. Positivo em verde; zero ou negativo em
+ * cor neutra, nunca em vermelho: a diferença é informação, e um preço abaixo do
+ * justo não é erro da leitura nem desvantagem a ser anunciada.
+ */
+export function edgeToneCls(edge: number | null | undefined): string {
+  return typeof edge === 'number' && edge > 0 ? 'text-forest' : 'text-ink-2';
+}
+
+/**
+ * A faixa em palavras, para o selo do Score. Existia em três cópias, cada uma
+ * comparando o número contra 60 e 40 por conta própria — e era esse trio que
+ * classificaria errado assim que a escala mudasse.
+ */
+export function rotuloDaFaixa(faixa: string | null | undefined): string {
+  if (faixa == null) return 'sem faixa';
+  switch (faixaTone(faixa)) {
+    case 'alta': return 'faixa alta';
+    case 'media': return 'faixa média';
+    default: return 'faixa baixa';
+  }
+}
+
+/** A linha está na faixa de destaque do painel (Alta ou Média). */
+export function ehDestaque(faixa: string | null | undefined): boolean {
+  return faixa != null && faixaTone(faixa) !== 'baixa';
+}
+
+/** A linha está na faixa Alta. */
+export function ehFaixaAlta(faixa: string | null | undefined): boolean {
+  return faixa != null && faixaTone(faixa) === 'alta';
+}
 
 // Board: melhor oportunidade por fixture.
 export interface BoardFixture {


### PR DESCRIPTION
Closes #305
Refs #301

O front passa a confiar na classificação do backend. Toda régua local por número saiu: elas foram calibradas para a fórmula antiga e, na escala nova, classificariam errado sem ninguém perceber.

## O que muda

- O filtro de faixa abre em **Alta e Média**, e ganha **Baixa** e **Todas**, que não existiam: só dava para escolher Alta, Média ou Todas
- As fronteiras 25 e 55 passam a viver em um lugar só. A legenda dizia 60+, 40+ e menos de 40
- Saem a régua de 40 de cinco componentes, o `score >= 60` de quatro, e os dois filtros de visibilidade que escondiam oportunidade abaixo de 40
- Três cópias do mesmo trecho comparando o número contra 60 e 40 viraram uma função só
- A diferença para o preço justo era sempre verde na lista. Agora é verde só quando positiva; zero ou negativa fica neutra, nunca vermelha
- A barra dos cinco mercados deixa de marcar régua de aprovação e passa a marcar onde começa a faixa Alta
- Os textos que descreviam a fórmula antiga foram reescritos. A explicação do Score dizia que ele junta quatro coisas, incluindo o tamanho do valor e a concordância das casas

## As fronteiras seguem a escala da própria linha

Entre esta entrega e a troca do mart, o board ainda chega em `legacy`. Anunciar 55+ ali classificaria errado na cara do usuário: uma nota legacy de 57 é Média.

Por isso a legenda e o tracinho da barra saem de `score_versao`, que já viaja em cada linha e não aparece na tela. Depois da virada eles passam a 25 e 55 sozinhos, sem precisar de deploy.

## Achados do code review, corrigidos

- **oportunidade registrada some do padrão.** As enviadas antes da migration 091 não têm faixa guardada. Elas foram enviadas no daily, ou seja, estavam acima do corte naquele dia. Continuam no padrão, e ficam fora só dos filtros específicos, que afirmariam uma faixa que ninguém sabe. Sem isso, um dia que existe no seletor só por causa de uma registrada abria vazio, com o selo prometendo 1
- **a distribuição Alta/Média/Baixa** saía da lista já filtrada, então dizia "Baixa 0" em toda primeira carga. Agora descreve o dia
- **o selo do dia** contava tudo enquanto a lista abria só com destaque
- **o destaque da home** testava só a primeira posição. Faixa não é função pura do Score, porque as portas de odd por mercado podem deixar a linha mais bem pontuada em Baixa: o bloco sumia num dia que tinha destaque
- **duas frases afirmavam faixa para mercado sem cotação**, porque `passa` também é verdadeiro pela porta de premissas. Agora contam só os mercados cotados
- **o estado vazio culpava o dado** quando quem esvaziou foi o filtro
- **o título dizia "apostas com valor"** mesmo com o filtro em Baixa
- **a home reescrevia o `ehDestaque`** que este PR acabou de exportar, que é exatamente a duplicação que ele veio remover

## Verificação

- 292 testes, 23 deles novos: fronteiras nas duas escalas, os cinco estados do filtro, registrada sem faixa, cor do valor e leitura da versão
- build, lint e typecheck sem nada novo em relação à develop
- o teste de leitura que afirmava "passa a régua pelo Score" foi reescrito para a regra nova: Score baixo em faixa Média é destaque, Score alto em faixa Baixa não é

## Fora do escopo

A landing do futebol ainda tem um corte local de 40 sobre dados estáticos de demonstração. É da #308, que trata justamente de demonstrações.
