### PR TITLE
Futebol: detalhe do jogo explica só o cenário

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -491,6 +491,10 @@ export function BancadaMercados({
       ? { premissas: [], extras: [] }
       : { premissas: naoAconteceu, extras: contras };
 
+  // Zero motivo listado a favor. Alimenta o veredito, para ele não afirmar um
+  // cenário que a aba ao lado não consegue mostrar.
+  const semMotivosAFavor = motivosFavor.premissas.length + motivosFavor.extras.length === 0;
+
   // O veredito em uma frase, sem inventar número.
   const veredito = useMemo(() => {
     const lbl = labelDe(principal);
@@ -499,6 +503,12 @@ export function BancadaMercados({
       return r ? `O mapa apontava ${lbl}: ${resultBadge(r).label.toLowerCase()}.` : `Jogo encerrado.`;
     }
     if (valPrincipal) {
+      // Sem nenhum motivo listado, o veredito não afirma cenário. Acontece na
+      // janela da virada: a nota legacy podia vir do preço, e o contrato antigo
+      // devolvia só os componentes de preço em A favor — que a tela não mostra
+      // mais. Prometer "o cenário está bem a favor" acima de uma aba vazia é a
+      // tela se contradizendo.
+      if (semMotivosAFavor) return `${lbl} está publicada, mas o cenário do jogo não foi detalhado aqui.`;
       if (ehFaixaAlta(valPrincipal.faixa)) return `O cenário do jogo está bem a favor de ${lbl}.`;
       if (ehDestaque(valPrincipal.faixa)) return `${lbl} tem parte do cenário a favor: leitura parcial.`;
       return `Pouco do cenário sustenta ${lbl}: entra como consulta, não como aposta.`;
@@ -510,7 +520,7 @@ export function BancadaMercados({
     if (n >= PORTA_PREMISSAS) return `O jogo aponta para ${lbl}, mas falta o preço: as odds entram perto do jogo.`;
     return `O jogo não sustenta esta saída.`;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [principal, valPrincipal, cotacaoPrincipal.estado, fim, mercado.slug, placar]);
+  }, [principal, valPrincipal, cotacaoPrincipal.estado, fim, mercado.slug, placar, semMotivosAFavor]);
 
   // Distribuição de gols: só no mercado de gols, cortada pela linha selecionada.
   const dist = useMemo(() => {

--- a/src/components/futebol/MotivosJogoPorJogo.test.tsx
+++ b/src/components/futebol/MotivosJogoPorJogo.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MotivosJogoPorJogo } from './MotivosJogoPorJogo';
+import { premissaDe } from '@/utils/futebol-premissas';
+import { separarMotivosDoContrato } from '@/utils/futebol-motivos';
+
+// ============================================================================
+// O que as abas A favor e Contra mostram (issue #306, spec #301)
+// ============================================================================
+// A decisão de qual motivo entra em qual grupo é do backend. O que se testa
+// aqui é o observável: a aba exibe as premissas que recebeu, não anuncia preço
+// como cenário do jogo, e não afirma o contrário de uma premissa a favor.
+// ============================================================================
+
+const premissas = (market: string, slugs: string[]) =>
+  slugs.map((s) => premissaDe(market, s)!).filter(Boolean);
+
+function renderAba(
+  modo: 'favor' | 'contra',
+  slugs: string[],
+  extras: { t: string; sub?: string }[] = [],
+) {
+  return render(
+    <MotivosJogoPorJogo
+      premissas={premissas('goals_over_under', slugs)}
+      modo={modo}
+      extras={extras}
+      historico={[]}
+      numeros={[]}
+      lado={null}
+      linha={1.5}
+      saidaLabel="Mais de 1,5 gols"
+    />,
+  );
+}
+
+describe('aba A favor', () => {
+  it('lista as premissas que o backend mandou, com a saída no fechamento', () => {
+    renderAba('favor', ['xg_combinado_alto', 'ritmo_alto']);
+
+    expect(screen.getByText(/2 motivos sustentam mais de 1,5 gols/i)).toBeInTheDocument();
+  });
+
+  it('diz que não há motivo quando o backend não mandou nenhum', () => {
+    renderAba('favor', []);
+
+    expect(screen.getByText('Nenhum motivo a favor desta saída.')).toBeInTheDocument();
+  });
+});
+
+describe('aba Contra', () => {
+  it('descreve o que o jogo não sustenta, sem citar preço', () => {
+    renderAba('contra', ['defesas_vazaveis']);
+
+    const cabecalho = screen.getByText(/colocam contra|deixa de sustentar/i);
+    expect(cabecalho).toHaveTextContent('O que o jogo deixa de sustentar nesta saída.');
+    expect(cabecalho).not.toHaveTextContent(/preço/i);
+  });
+
+  it('sem nada contra, afirma que as premissas que valem aconteceram', () => {
+    renderAba('contra', []);
+
+    expect(
+      screen.getByText('Nada pesando contra esta saída: todas as premissas que valem aconteceram.'),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('preço não chega à aba como premissa do jogo', () => {
+  it('o contrato antigo ainda manda movimento de linha, e ele é barrado antes', () => {
+    // Durante a janela da virada, a RPC antiga lista linha_subindo entre as
+    // premissas aplicáveis de Over. É premissasVisiveisDoContrato que a
+    // descarta, antes de virar catálogo visual.
+    const visiveis = separarMotivosDoContrato([
+      { id: 'xg_combinado_alto', tipo: 'premissa' },
+      { id: 'linha_subindo', tipo: 'premissa' },
+      { id: 'ritmo_alto', tipo: 'premissa' },
+    ]);
+
+    expect(visiveis.slugsDePremissas).toEqual(['xg_combinado_alto', 'ritmo_alto']);
+  });
+
+  it('e o que sobra é o que a aba renderiza', () => {
+    renderAba('favor', separarMotivosDoContrato([
+      { id: 'linha_subindo', tipo: 'premissa' },
+      { id: 'linha_descendo', tipo: 'premissa' },
+    ]).slugsDePremissas);
+
+    expect(screen.getByText('Nenhum motivo a favor desta saída.')).toBeInTheDocument();
+  });
+});

--- a/src/components/futebol/MotivosJogoPorJogo.tsx
+++ b/src/components/futebol/MotivosJogoPorJogo.tsx
@@ -490,7 +490,7 @@ export function MotivosJogoPorJogo({
               ? `${total} ${total === 1 ? 'motivo sustenta' : 'motivos sustentam'} ${saidaLabel.toLowerCase()}. Clique numa premissa para ver os jogos que produziram o número.`
               : 'Nenhum motivo a favor desta saída.'
             : total > 0
-              ? 'O que o jogo e o preço colocam contra esta saída.'
+              ? 'O que o jogo deixa de sustentar nesta saída.'
               : 'Nada pesando contra esta saída: todas as premissas que valem aconteceram.'}
         </div>
         {itens.some((x) => x.story != null) && (

--- a/src/utils/futebol-motivos.test.ts
+++ b/src/utils/futebol-motivos.test.ts
@@ -20,6 +20,48 @@ describe('separarMotivosDoContrato', () => {
     ]);
   });
 
+  it('descarta a decomposição da nota antiga, que o contrato antigo ainda manda', () => {
+    // Durante a janela da virada, a RPC antiga continua devolvendo os
+    // componentes de preço. Eles não são premissa nem penalidade de contexto, e
+    // exibi-los seria mostrar a fórmula antiga que a spec #301 tirou da tela.
+    const separados = separarMotivosDoContrato([
+      { id: 'xg_combinado_alto', tipo: 'premissa' },
+      { id: 'valor_de_mercado', tipo: 'componente_score', texto: 'A cotação oferece valor', pontos: 16 },
+      { id: 'corroboracao', tipo: 'componente_score', texto: 'Movimento de mercado confirma a leitura', pontos: 8 },
+    ]);
+
+    expect(separados.slugsDePremissas).toEqual(['xg_combinado_alto']);
+    expect(separados.motivosSemDrilldown).toEqual([]);
+  });
+
+  it('descarta os avisos de odd que o contrato antigo despeja em Contra', () => {
+    // Eles chegam como penalidade, não como componente do Score, então o
+    // primeiro filtro não os pegava: a aba Contra continuaria mostrando "odd
+    // alta de zebra" logo abaixo de um título que promete só cenário de jogo.
+    // Eles seguem visíveis no rodapé do painel, como leitura da cotação.
+    const separados = separarMotivosDoContrato([
+      { id: 'defesas_vazaveis', tipo: 'premissa' },
+      { id: 'desfalque_proprio', tipo: 'penalidade', texto: 'Time apostado desfalcado' },
+      { id: 'aviso_1', tipo: 'penalidade', texto: 'Odd alta de zebra, entra com cautela' },
+      { id: 'aviso_2', tipo: 'penalidade', texto: 'Poucas casas cotando esse mercado' },
+    ]);
+
+    expect(separados.slugsDePremissas).toEqual(['defesas_vazaveis']);
+    expect(separados.motivosSemDrilldown).toEqual([
+      { t: 'Time apostado desfalcado', pontos: undefined },
+    ]);
+  });
+
+  it('descarta as premissas de preço que o contrato antigo lista como aplicáveis', () => {
+    const separados = separarMotivosDoContrato([
+      { id: 'xg_combinado_alto', tipo: 'premissa' },
+      { id: 'linha_subindo', tipo: 'premissa' },
+      { id: 'modelo_api_concorda', tipo: 'premissa' },
+    ]);
+
+    expect(separados.slugsDePremissas).toEqual(['xg_combinado_alto']);
+  });
+
   it('não inventa lado: o contrário de uma premissa a favor não aparece em contra', () => {
     // O backend é a autoridade sobre o grupo. A função não deriva nada do slug,
     // então uma premissa do lado oposto só apareceria se o backend a mandasse.

--- a/src/utils/futebol-motivos.ts
+++ b/src/utils/futebol-motivos.ts
@@ -1,14 +1,40 @@
 import type { FutebolFixtureReasonItem } from '@/services/futebol-data.service';
+import { PREMISSAS_OCULTAS } from '@/utils/futebol-premissas';
 
 /**
- * Separa apenas a forma de apresentar o contrato já decidido pelo backend.
- * Slugs seguem para o catálogo visual; itens com texto são componentes explícitos
- * do score e não têm drilldown jogo a jogo.
+ * Um item do contrato que não é razão de contexto e por isso não vai para a
+ * tela. Existem por causa da janela da virada: o contrato antigo continua no ar
+ * até a migration 112 ser aplicada, e ele ainda manda preço junto do cenário.
+ *
+ *   · `componente_score` era a decomposição da nota antiga ("A cotação oferece
+ *     valor", "Corroboração confirma a leitura"). O Score de contexto não é
+ *     soma de partes exibível.
+ *   · `aviso_N` são os avisos de odd, que o contrato antigo despeja dentro de
+ *     Contra. Eles continuam visíveis no rodapé do painel, como leitura de
+ *     risco da cotação — o que acaba é entrarem como premissa do jogo.
+ *   · os slugs de preço do catálogo (movimento de linha, movimento das casas,
+ *     concordância do modelo) chegam como premissa aplicável no contrato antigo.
+ */
+function ehDePreco(item: FutebolFixtureReasonItem): boolean {
+  return (
+    item.tipo === 'componente_score' ||
+    (item.tipo === 'penalidade' && item.id.startsWith('aviso_')) ||
+    PREMISSAS_OCULTAS.has(item.id)
+  );
+}
+
+/**
+ * Separa apenas a forma de apresentar o contrato já decidido pelo backend, e
+ * descarta o que é preço.
+ *
+ * Slugs seguem para o catálogo visual, com drilldown jogo a jogo; itens com
+ * texto são frases prontas do backend e não têm de onde tirar drilldown.
  */
 export function separarMotivosDoContrato(itens: readonly FutebolFixtureReasonItem[]) {
+  const doContexto = itens.filter((item) => !ehDePreco(item));
   return {
-    slugsDePremissas: itens.filter((item) => !item.texto).map((item) => item.id),
-    motivosSemDrilldown: itens
+    slugsDePremissas: doContexto.filter((item) => !item.texto).map((item) => item.id),
+    motivosSemDrilldown: doContexto
       .filter((item) => item.texto)
       .map((item) => ({ t: item.texto as string, pontos: item.pontos })),
   };


### PR DESCRIPTION
Closes #306
Refs #301

O detalhe passa a explicar exatamente a saída publicada, com preço fora das razões. A separação favor/contra continua sendo autoridade do backend, entregue na #304. O que muda aqui é a tela parar de deixar preço entrar pela porta dos fundos.

## Por que ainda havia furo depois da #304

A migration 112 não é aplicada até a janela, então o contrato antigo continua no ar. E ele manda preço junto do cenário por três caminhos diferentes:

1. **Premissas de preço listadas como aplicáveis.** O contrato antigo tem `linha_subindo` entre as premissas de Over. A tela encontraria o slug no catálogo e renderizaria "Mercado puxando a linha pra cima" em A favor, como se fosse cenário de jogo
2. **A decomposição da nota antiga.** "A cotação oferece valor" e "Corroboração confirma a leitura" chegam como componentes do Score
3. **Os avisos de odd.** O contrato antigo os despeja dentro de Contra como penalidade — e esse foi o achado do review, porque eu tinha filtrado só o lado de A favor

Os três passam a ser barrados na apresentação, num ponto só. A tela fica correta antes e depois da virada.

Os avisos de odd seguem visíveis no rodapé do painel, como leitura de risco da cotação, que é onde a #304 os colocou.

## Também

- A aba Contra dizia "o que o jogo **e o preço** colocam contra esta saída". Agora descreve só o que o jogo deixa de sustentar
- O veredito afirmava "o cenário do jogo está bem a favor de X" mesmo com a aba ao lado vazia. Isso é alcançável na janela: a nota legacy podia vir do preço, e aí não sobra motivo de contexto para listar. Sem motivos, ele para de afirmar cenário

## Achados do code review, corrigidos

- **o filtro de preço existia só de um lado.** Os avisos de odd chegam como `penalidade`, não como componente do Score, então escapavam para Contra — logo abaixo do título que acabou de prometer só cenário de jogo
- **o veredito contradizia a aba vazia**
- **duas listas de slugs em escopo**, uma filtrada e outra não, com a não filtrada a um descuido de voltar à tela. Virou uma só

## Verificação

- 301 testes, 10 novos: os três caminhos de preço, as duas abas renderizadas, e o contrário de uma premissa a favor não virando Contra
- build, lint e typecheck sem nada novo em relação à develop

## Registrado para a #310

`src/utils/futebol-value.ts` tem a implementação client-side da fórmula antiga inteira, com corroboração e Kelly. Já está marcado como aposentado e nenhuma tela importa. E o catálogo ainda guarda as cinco premissas de preço como dado — elas não chegam à tela porque estão na lista de ocultas, que é justamente a guarda descrita acima.
