### PR TITLE
Futebol: histórico convive com as duas escalas sem compará-las

### DIFF
--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -16,7 +16,7 @@ import { competitionLabel, sortCompetitions, ALL_COMPETITIONS } from '@/utils/fu
 import {
   pickLabel, marketLabel, fmtEdgeScore,
   faixaBadgeCls, faixaWord, faixaTone, chancePct, edgeToneCls,
-  opcoesDeFaixa, passaNoFiltroDeFaixa, versaoPredominante, ehDestaque,
+  opcoesDeFaixa, passaNoFiltroDeFaixa, versaoDaJanela, ehDestaque, compararOportunidades,
   FAIXA_FILTRO_PADRAO, type FaixaFilter,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
@@ -41,11 +41,16 @@ const FINISHED_STATUS = new Set(['FT', 'AET', 'PEN']);
  * foram guardados. Ela continua sendo oportunidade do dia; só esses campos ficam
  * vazios. FutebolValueBoardRow é atribuível a isto (number → number | null).
  */
-type OppLike = Omit<FutebolValueBoardRow, 'score' | 'faixa' | 'edge' | 'prob_justa_fechamento'> & {
+type OppLike = Omit<FutebolValueBoardRow, 'score' | 'faixa' | 'edge' | 'prob_justa_fechamento' | 'score_versao'> & {
   score: number | null;
   faixa: string | null;
   edge: number | null;
   prob_justa_fechamento: number | null;
+  /**
+   * Ausente na oportunidade registrada: a tabela de picks nunca guardou versão,
+   * e carimbá-la de legacy faria a legenda achar que toda janela é mista.
+   */
+  score_versao?: FutebolValueBoardRow['score_versao'];
 };
 
 /**
@@ -82,7 +87,6 @@ function oppFromAlerted(a: FutebolAlertedPick, fx?: FutebolFixture): OppLike {
     avg_odd: Number(a.odds),
     n_casas: 0,
     janela_usada: a.janela_usada ?? '',
-    score_versao: 'legacy',
     pts_valor: 0,
     pts_premissas: 0,
     pts_corroboracao: 0,
@@ -500,12 +504,7 @@ export default function FutebolOportunidades() {
   // topo do ranking, então na hora do envio ela era das melhores do dia — o
   // número exato daquele instante é que não foi guardado.
   const realBestRows = useMemo(
-    () => [...filtered].sort((a, b) => {
-      if (a.score == null && b.score == null) return 0;
-      if (a.score == null) return -1;
-      if (b.score == null) return 1;
-      return b.score - a.score;
-    }),
+    () => [...filtered].sort(compararOportunidades),
     [filtered]
   );
   const bestRows: OppLike[] = isDemo ? demoFutebolBoard : realBestRows;
@@ -747,9 +746,11 @@ export default function FutebolOportunidades() {
             <ul className="mt-2 space-y-2 text-[12px] text-ink-2">
               {/* Os números saem de FAIXA_ALTA_MIN e FAIXA_MEDIA_MIN, em um
                   lugar só, para a legenda não voltar a divergir do backend. */}
-              {opcoesDeFaixa(versaoPredominante(dayRows)).map(({ tone, rotulo, selo }) => (
+              {opcoesDeFaixa(versaoDaJanela(dayRows)).map(({ tone, rotulo, selo }) => (
                 <li key={tone} className="flex items-center gap-2">
-                  <span className={`w-9 text-center text-[11px] font-bold rounded px-1 py-0.5 ${faixaBadgeCls(rotulo)}`}>{selo}</span>
+                  {/* Sem selo na janela mista: as duas escalas têm cortes
+                      diferentes, e um número descreveria errado metade da lista. */}
+                  {selo && <span className={`w-9 text-center text-[11px] font-bold rounded px-1 py-0.5 ${faixaBadgeCls(rotulo)}`}>{selo}</span>}
                   {tone === 'alta' ? 'Alta, cenário bem presente' : tone === 'media' ? 'Média, cenário parcial' : 'Baixa, pouco cenário a favor'}
                 </li>
               ))}

--- a/src/pages/Onboarding.test.tsx
+++ b/src/pages/Onboarding.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { configure, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Onboarding from './Onboarding';
@@ -36,7 +36,14 @@ function renderOnboarding(search = '') {
   );
 }
 
-describe('Onboarding', () => {
+// Folga nos DOIS limites, que são independentes: o do vitest cobre importar,
+// montar e esperar; o da testing-library governa cada findBy/waitFor e vem com
+// 1s. A tela espera duas idas ao Supabase antes de pintar, e com a suíte
+// inteira em paralelo qualquer um dos dois estoura por saturação da máquina,
+// não por regressão. Rodando sozinho, o arquivo leva meio segundo.
+configure({ asyncUtilTimeout: 10_000 });
+
+describe('Onboarding', { timeout: 20_000 }, () => {
   beforeEach(() => {
     mocks.navigate.mockReset();
     mocks.single.mockResolvedValue({ data: { telegram_chat_id: null } });

--- a/src/utils/futebol-faixas.test.ts
+++ b/src/utils/futebol-faixas.test.ts
@@ -11,7 +11,6 @@ import {
   fronteirasDoScore,
   opcoesDeFaixa,
   passaNoFiltroDeFaixa,
-  versaoPredominante,
 } from './futebol-score';
 
 // ============================================================================
@@ -42,15 +41,6 @@ describe('fronteiras da faixa', () => {
     expect(fronteirasDoScore('legacy')).toEqual({ media: 40, alta: 60 });
     expect(fronteirasDoScore('contexto_v1')).toEqual({ media: 25, alta: 55 });
     expect(opcoesDeFaixa('legacy').map((o) => o.selo)).toEqual(['60+', '40+', '<40']);
-  });
-
-  it('basta uma linha no contrato novo para a leitura ser a nova', () => {
-    // O histórico traz linhas legacy para sempre; elas não podem prender a
-    // legenda na escala antiga depois da virada.
-    expect(versaoPredominante([])).toBe('legacy');
-    expect(versaoPredominante([{ score_versao: 'legacy' }])).toBe('legacy');
-    expect(versaoPredominante([{ score_versao: 'legacy' }, { score_versao: 'contexto_v1' }]))
-      .toBe('contexto_v1');
   });
 });
 

--- a/src/utils/futebol-historico-escalas.test.ts
+++ b/src/utils/futebol-historico-escalas.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compararOportunidades,
+  opcoesDeFaixa,
+  ordemDaFaixa,
+  versaoDaJanela,
+} from './futebol-score';
+
+// ============================================================================
+// Histórico point-in-time convivendo com o Score de contexto (issue #307)
+// ============================================================================
+// O histórico guarda a nota como ela foi publicada, e continua devolvendo
+// linhas da escala antiga para sempre. A tela precisa conviver com isso sem
+// recalcular nada e sem colocar as duas escalas lado a lado como se fossem a
+// mesma régua.
+// ============================================================================
+
+const linha = (faixa: string | null, score: number | null, score_versao?: 'legacy' | 'contexto_v1') => ({
+  faixa,
+  score,
+  score_versao,
+});
+
+describe('a escala da janela', () => {
+  it('é a antiga enquanto só houver registro antigo', () => {
+    expect(versaoDaJanela([linha('Alta', 62, 'legacy')])).toBe('legacy');
+  });
+
+  it('é a nova quando a janela inteira já virou', () => {
+    expect(versaoDaJanela([linha('Alta', 62, 'contexto_v1')])).toBe('contexto_v1');
+  });
+
+  it('é indefinida no dia da virada, quando as duas convivem', () => {
+    // A lista do dia corrente une a foto do apito com o board.
+    expect(
+      versaoDaJanela([linha('Alta', 62, 'legacy'), linha('Alta', 58, 'contexto_v1')]),
+    ).toBe('indefinida');
+  });
+
+  it('é indefinida sem nenhuma linha que declare escala', () => {
+    // Dia futuro que ainda não tem board, e a oportunidade registrada, que vem
+    // de uma tabela sem coluna de versão. Nos dois casos o número seria chute.
+    expect(versaoDaJanela([])).toBe('indefinida');
+    expect(versaoDaJanela([linha(null, null)])).toBe('indefinida');
+  });
+
+  it('a registrada não arrasta a janela para indefinida sozinha', () => {
+    // Era o defeito: carimbada de legacy, ela aparecia em quase todo dia e a
+    // legenda ficava sem números para sempre, não só na virada.
+    expect(
+      versaoDaJanela([linha('Alta', 58, 'contexto_v1'), linha(null, null)]),
+    ).toBe('contexto_v1');
+  });
+});
+
+describe('a legenda não afirma número quando as escalas convivem', () => {
+  it('some com os cortes na janela indefinida, e mantém as três faixas', () => {
+    const opcoes = opcoesDeFaixa('indefinida');
+
+    expect(opcoes.map((o) => o.tone)).toEqual(['alta', 'media', 'baixa']);
+    expect(opcoes.map((o) => o.selo)).toEqual([null, null, null]);
+  });
+
+  it('nas janelas de uma escala só, o número aparece', () => {
+    expect(opcoesDeFaixa('contexto_v1').map((o) => o.selo)).toEqual(['55+', '25+', '<25']);
+    expect(opcoesDeFaixa('legacy').map((o) => o.selo)).toEqual(['60+', '40+', '<40']);
+  });
+});
+
+describe('a lista ranqueia por faixa antes do Score', () => {
+  it('não põe um Score de uma escala à frente da faixa da outra', () => {
+    // 46 na escala antiga é Média; 46 na escala nova é Alta. Ordenar só pelo
+    // número colocaria as duas empatadas, afirmando uma comparação que não
+    // existe. A faixa é o que as duas escalas têm em comum.
+    const legacyMedia = linha('Média', 46, 'legacy');
+    const contextoAlta = linha('Alta', 46, 'contexto_v1');
+
+    expect([legacyMedia, contextoAlta].sort(compararOportunidades)).toEqual([
+      contextoAlta,
+      legacyMedia,
+    ]);
+  });
+
+  it('dentro da mesma faixa, o Score continua desempatando', () => {
+    const maior = linha('Alta', 71, 'contexto_v1');
+    const menor = linha('Alta', 58, 'contexto_v1');
+
+    expect([menor, maior].sort(compararOportunidades)).toEqual([maior, menor]);
+  });
+
+  it('registrada sem Score continua vindo primeiro', () => {
+    // Ela foi enviada no daily, ou seja, estava entre as melhores do dia. O que
+    // falta é o número, não a qualidade da leitura.
+    const registrada = linha(null, null);
+    const alta = linha('Alta', 71, 'contexto_v1');
+
+    expect([alta, registrada].sort(compararOportunidades)).toEqual([registrada, alta]);
+  });
+
+  it('mas linha COM nota e sem banda não é promovida ao topo', () => {
+    // A promoção olha o Score, não a faixa. Chaveando pela faixa, uma linha com
+    // nota e sem banda declarada passava na frente de toda oportunidade Alta.
+    const semBanda = linha(null, 44, 'contexto_v1');
+    const alta = linha('Alta', 71, 'contexto_v1');
+
+    expect([semBanda, alta].sort(compararOportunidades)).toEqual([alta, semBanda]);
+    expect(ordemDaFaixa(null)).toBeGreaterThan(ordemDaFaixa('Baixa'));
+  });
+
+  it('a ordem das faixas é alta, média, baixa', () => {
+    expect(ordemDaFaixa('Alta')).toBeLessThan(ordemDaFaixa('Média'));
+    expect(ordemDaFaixa('Média')).toBeLessThan(ordemDaFaixa('Baixa'));
+  });
+});

--- a/src/utils/futebol-score.ts
+++ b/src/utils/futebol-score.ts
@@ -162,20 +162,53 @@ export function fronteirasDoScore(versao: FutebolScoreVersion): { media: number;
 }
 
 /**
- * A versão que a tela deve assumir para um conjunto de linhas. Basta uma linha
- * no contrato novo para a leitura já ser a nova: o histórico continua trazendo
- * linhas legacy para sempre, e elas não podem prender a legenda no passado.
+ * A escala de uma janela da tela.
+ *
+ * `indefinida` cobre os dois casos em que não dá para afirmar um corte: a janela
+ * mistura as duas escalas (acontece no dia da virada, quando a foto do apito
+ * ainda é legacy e o board já é contexto_v1), ou não há linha nenhuma que
+ * declare a sua escala.
  */
-export function versaoPredominante(
+export type VersaoDaJanela = FutebolScoreVersion | 'indefinida';
+
+/**
+ * Só vota quem declara a escala. Linha sem o campo — a oportunidade registrada,
+ * que vem de uma tabela que nunca guardou versão — se abstém, em vez de contar
+ * como legacy: contando, quase todo dia teria uma e a legenda ficaria sem
+ * números para sempre, não só na virada.
+ */
+export function versaoDaJanela(
   linhas: readonly { score_versao?: FutebolScoreVersion }[],
-): FutebolScoreVersion {
-  return linhas.some((l) => l.score_versao === 'contexto_v1') ? 'contexto_v1' : 'legacy';
+): VersaoDaJanela {
+  let temLegacy = false;
+  let temContexto = false;
+  for (const l of linhas) {
+    if (l.score_versao === 'contexto_v1') temContexto = true;
+    else if (l.score_versao === 'legacy') temLegacy = true;
+  }
+  if (temContexto && !temLegacy) return 'contexto_v1';
+  if (temLegacy && !temContexto) return 'legacy';
+  return 'indefinida';
 }
 
-/** As três faixas, na ordem em que a legenda as apresenta. */
+/**
+ * As três faixas, na ordem em que a legenda as apresenta.
+ *
+ * Numa janela indefinida o selo sai: ou as duas escalas convivem e um número
+ * descreveria errado metade da lista, ou não há linha nenhuma declarando escala
+ * e o número seria chute. As três faixas seguem explicadas em palavras, que
+ * valem nos dois casos.
+ */
 export function opcoesDeFaixa(
-  versao: FutebolScoreVersion,
-): { tone: Faixa; rotulo: string; selo: string }[] {
+  versao: VersaoDaJanela,
+): { tone: Faixa; rotulo: string; selo: string | null }[] {
+  if (versao === 'indefinida') {
+    return [
+      { tone: 'alta', rotulo: 'Alta', selo: null },
+      { tone: 'media', rotulo: 'Média', selo: null },
+      { tone: 'baixa', rotulo: 'Baixa', selo: null },
+    ];
+  }
   const { media, alta } = fronteirasDoScore(versao);
   return [
     { tone: 'alta', rotulo: 'Alta', selo: `${alta}+` },
@@ -257,4 +290,45 @@ export function groupBoardByFixture(rows: FutebolValueBoardRow[]): BoardFixture[
     out.push({ fixtureId, best, all });
   }
   return out.sort((a, b) => b.best.score - a.best.score);
+}
+
+
+/**
+ * Ordem da faixa para ranquear a lista. Sem faixa vai para o fim: não dá para
+ * colocar numa banda a linha que não declara nenhuma.
+ */
+export function ordemDaFaixa(faixa: string | null | undefined): number {
+  if (faixa == null) return 3;
+  switch (faixaTone(faixa)) {
+    case 'alta': return 0;
+    case 'media': return 1;
+    default: return 2;
+  }
+}
+
+/**
+ * Ranqueia por FAIXA e só depois por Score.
+ *
+ * A ordenação era só pelo Score, e isso vira comparação entre escalas no dia da
+ * virada: um 46 legacy ao lado de um 46 de contexto não medem a mesma coisa. A
+ * faixa é comparável, porque cada escala tem a sua fronteira e as duas produzem
+ * as mesmas três palavras. Dentro da faixa o Score continua desempatando.
+ */
+export function compararOportunidades(
+  a: { faixa: string | null; score: number | null },
+  b: { faixa: string | null; score: number | null },
+): number {
+  // Sem Score vem primeiro: é a oportunidade registrada de antes da migration
+  // 091, que foi enviada no daily e portanto estava entre as melhores do dia —
+  // o número daquele instante é que não foi guardado. A promoção olha o Score, e
+  // não a faixa, para não empurrar ao topo uma linha que tem nota mas não tem
+  // banda declarada.
+  const aSemNota = a.score == null;
+  const bSemNota = b.score == null;
+  if (aSemNota !== bSemNota) return aSemNota ? -1 : 1;
+  if (aSemNota && bSemNota) return 0;
+
+  const porFaixa = ordemDaFaixa(a.faixa) - ordemDaFaixa(b.faixa);
+  if (porFaixa !== 0) return porFaixa;
+  return (b.score as number) - (a.score as number);
 }


### PR DESCRIPTION
Closes #307
Refs #301

O histórico guarda a nota como foi publicada e continua devolvendo linhas da escala antiga para sempre. A tela precisa conviver com isso sem recalcular nada e sem colocar as duas réguas lado a lado como se fossem a mesma.

## A comparação existia e era silenciosa

No dia da virada, a lista do dia corrente une a foto do apito, que ainda é da escala antiga, com o board, que já é da nova. Ordenada só pelo Score, um 46 antigo e um 46 novo apareciam empatados — e 46 é Média numa escala e Alta na outra.

- A ordenação passa a ser **por faixa**, com o Score desempatando dentro dela. A faixa é o que as duas escalas têm em comum: cada uma tem a sua fronteira e as duas produzem as mesmas três palavras
- A legenda omite os cortes quando a janela não tem uma escala só
- A versão técnica continua sem aparecer em lugar nenhum da interface

## Achados do code review, corrigidos

O mais importante invalidaria a entrega inteira:

**A legenda ficaria sem números para sempre.** A oportunidade registrada vinha carimbada como escala antiga, porque a tabela de picks nunca guardou versão. Como quase todo dia tem uma dessas, toda janela seria mista e os cortes nunca mais apareceriam — não só na virada. Agora ela não declara escala e se abstém da conta.

Os outros quatro:

- janela vazia caía na escala antiga e anunciava os cortes aposentados. Um dia futuro sem board mostraria 60+ e 40+. Vazia e mista passam a ser o mesmo caso, indefinida, sem número
- versão desconhecida contava como antiga. Só vota quem declara
- a promoção da registrada ao topo era chaveada pela faixa, então uma linha com nota e sem banda declarada passava na frente de toda oportunidade Alta. A promoção agora olha o Score, que é exatamente o que falta nessas linhas
- o limite de tempo que eu tinha ampliado no teste do onboarding não é o que a testing-library usa nas esperas. Os dois estão cobertos

## Verificação

- 312 testes, 12 novos: as três janelas (só antiga, só nova e indefinida), a registrada não arrastando a janela sozinha, e a ordenação por faixa
- build, lint e typecheck sem nada novo em relação à develop
