### PR TITLE
Futebol: Telegram e demonstrações no Score de contexto

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -2462,48 +2462,85 @@ AS $function$
 DECLARE
   v_batch_id uuid;
 BEGIN
+  -- O advisory lock torna o polling idempotente mesmo se dois crons
+  -- coincidirem: sem ele, duas execuções sobrepostas não enxergam as linhas
+  -- ainda não commitadas uma da outra, criam dois lotes e mandam duas mensagens
+  -- para o mesmo destinatário no mesmo minuto.
   PERFORM pg_advisory_xact_lock(hashtext('futebol-publication-alerts'));
 
   WITH incoming AS (
-    SELECT * FROM jsonb_to_recordset(p_opportunities) AS x(
-      opportunity_key text, fixture_id bigint, home_team_name text,
-      away_team_name text, competition text, kickoff_utc timestamptz,
-      market text, outcome text, line_value double precision, best_odd numeric,
-      score integer, faixa text, janela_usada text, edge double precision,
-      prob_justa_fechamento double precision, evidencias text[]
+    SELECT *
+    FROM jsonb_to_recordset(p_opportunities) AS x(
+      opportunity_key text,
+      fixture_id bigint,
+      home_team_name text,
+      away_team_name text,
+      competition text,
+      kickoff_utc timestamptz,
+      market text,
+      outcome text,
+      line_value double precision,
+      best_odd numeric,
+      score integer,
+      faixa text,
+      score_versao text,
+      janela_usada text,
+      edge double precision,
+      prob_justa_fechamento double precision,
+      evidencias text[]
     )
   )
   INSERT INTO public.futebol_publication_alert_batches (sync_at)
-  SELECT p_sync_at WHERE EXISTS (
-    SELECT 1 FROM incoming i WHERE NOT EXISTS (
+  SELECT p_sync_at
+  WHERE EXISTS (
+    SELECT 1 FROM incoming i
+    WHERE NOT EXISTS (
       SELECT 1 FROM public.futebol_publication_alerts a
       WHERE a.opportunity_key = i.opportunity_key
     )
   )
   RETURNING id INTO v_batch_id;
 
-  IF v_batch_id IS NULL THEN RETURN; END IF;
+  IF v_batch_id IS NULL THEN
+    RETURN;
+  END IF;
 
   RETURN QUERY
   WITH incoming AS (
-    SELECT * FROM jsonb_to_recordset(p_opportunities) AS x(
-      opportunity_key text, fixture_id bigint, home_team_name text,
-      away_team_name text, competition text, kickoff_utc timestamptz,
-      market text, outcome text, line_value double precision, best_odd numeric,
-      score integer, faixa text, janela_usada text, edge double precision,
-      prob_justa_fechamento double precision, evidencias text[]
+    SELECT *
+    FROM jsonb_to_recordset(p_opportunities) AS x(
+      opportunity_key text,
+      fixture_id bigint,
+      home_team_name text,
+      away_team_name text,
+      competition text,
+      kickoff_utc timestamptz,
+      market text,
+      outcome text,
+      line_value double precision,
+      best_odd numeric,
+      score integer,
+      faixa text,
+      score_versao text,
+      janela_usada text,
+      edge double precision,
+      prob_justa_fechamento double precision,
+      evidencias text[]
     )
   ), inserted AS (
     INSERT INTO public.futebol_publication_alerts (
       batch_id, opportunity_key, fixture_id, home_team_name, away_team_name,
       competition, kickoff_utc, market, outcome, line_value, best_odd, score,
-      faixa, janela_usada, edge, prob_justa_fechamento, evidencias
+      faixa, score_versao, janela_usada, edge, prob_justa_fechamento, evidencias
     )
     SELECT v_batch_id, i.opportunity_key, i.fixture_id, i.home_team_name,
-      i.away_team_name, i.competition, i.kickoff_utc, i.market, i.outcome,
-      i.line_value, i.best_odd, i.score, i.faixa, i.janela_usada, i.edge,
-      i.prob_justa_fechamento, i.evidencias
-    FROM incoming i ON CONFLICT (opportunity_key) DO NOTHING
+           i.away_team_name, i.competition, i.kickoff_utc, i.market,
+           i.outcome, i.line_value, i.best_odd, i.score, i.faixa,
+           -- Alerta antigo permanece legacy; o detector novo manda a escala.
+           coalesce(i.score_versao, 'legacy'),
+           i.janela_usada, i.edge, i.prob_justa_fechamento, i.evidencias
+    FROM incoming i
+    ON CONFLICT (opportunity_key) DO NOTHING
     RETURNING id, opportunity_key
   )
   SELECT v_batch_id, i.id, i.opportunity_key FROM inserted i;
@@ -2512,6 +2549,13 @@ $function$;
 
 alter table public.users add column if not exists futebol_trial_started_at timestamptz;
 alter table public.users add column if not exists futebol_subscription_status text not null default 'free';
+-- ⚠️ DÍVIDA: as tabelas da migration 111 (futebol_publication_alerts,
+-- _batches, _deliveries e _pick_refs) nunca entraram neste arquivo, embora as
+-- funções que as usam tenham entrado. Um ALTER TABLE aqui abortaria a provisão
+-- inteira, porque check_function_bodies=off cobre corpo de função e não DDL de
+-- tabela. A coluna score_versao é da migration 113; trazer as tabelas para cá é
+-- a correção de verdade, e é o mesmo modo de falha da issue #250.
+
 alter table public.users add column if not exists futebol_publication_alerts_enabled boolean not null default true;
 alter table public.users add column if not exists futebol_publication_alerts_ack_at timestamptz;
 

--- a/src/components/onboarding/demo/futebol.test.ts
+++ b/src/components/onboarding/demo/futebol.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  demoFutebolBoard,
+  demoFixtureValueRows,
+} from './futebol';
+import { FAIXA_ALTA_MIN, FAIXA_MEDIA_MIN, faixaTone } from '@/utils/futebol-score';
+
+// ============================================================================
+// A demonstração ensina a metodologia vigente (issue #308, spec #301)
+// ============================================================================
+// O tour e a landing são a primeira leitura que alguém faz do produto. Se os
+// números ali seguem a régua aposentada, a pessoa aprende a régua errada — e
+// ninguém percebe, porque dado de demonstração não quebra teste de tela.
+// ============================================================================
+
+const faixaEsperada = (score: number) =>
+  score >= FAIXA_ALTA_MIN ? 'alta' : score >= FAIXA_MEDIA_MIN ? 'media' : 'baixa';
+
+describe('dados de demonstração do futebol', () => {
+  it.each([
+    ['board do painel', demoFutebolBoard],
+    ['saídas do jogo', demoFixtureValueRows],
+  ])('%s: toda linha declara a escala nova', (_nome, linhas) => {
+    for (const linha of linhas) {
+      expect(linha.score_versao, `${linha.market} ${linha.outcome}`).toBe('contexto_v1');
+    }
+  });
+
+  it.each([
+    ['board do painel', demoFutebolBoard],
+    ['saídas do jogo', demoFixtureValueRows],
+  ])('%s: a faixa bate com as fronteiras 25 e 55', (_nome, linhas) => {
+    for (const linha of linhas) {
+      expect(faixaTone(linha.faixa), `${linha.market} ${linha.outcome} · Score ${linha.score}`)
+        .toBe(faixaEsperada(linha.score));
+    }
+  });
+
+  it('o board de exemplo continua mostrando as três faixas', () => {
+    // A mistura é o ponto da demonstração: sem ela, o filtro de faixa e a
+    // legenda não têm o que ensinar.
+    const faixas = new Set(demoFutebolBoard.map((l) => faixaTone(l.faixa)));
+    expect([...faixas].sort()).toEqual(['alta', 'baixa', 'media']);
+  });
+
+  it('nenhuma linha de exemplo carrega componente de preço no Score', () => {
+    // Os campos continuam no tipo durante a janela de compatibilidade, mas a
+    // demonstração não pode sugerir que preço soma na nota.
+    for (const linha of demoFutebolBoard) {
+      expect(linha.pts_valor, `${linha.market} ${linha.outcome}`).toBe(0);
+      expect(linha.pts_corroboracao, `${linha.market} ${linha.outcome}`).toBe(0);
+    }
+  });
+});

--- a/src/components/onboarding/demo/futebol.ts
+++ b/src/components/onboarding/demo/futebol.ts
@@ -23,20 +23,25 @@ const base = (over: Partial<FutebolValueBoardRow>): FutebolValueBoardRow => ({
   n_casas: 6,
   janela_usada: 't1h',
   prob_justa_fechamento: 0.5,
-  pts_valor: 20,
+  // Preço não soma na nota desde o Score de contexto (spec #301). Os campos
+  // seguem no tipo durante a janela de compatibilidade e a demonstração os
+  // mantém zerados, para não ensinar a fórmula aposentada.
+  pts_valor: 0,
   pts_premissas: 20,
-  pts_corroboracao: 15,
+  pts_corroboracao: 0,
   penalidades: 0,
   score: 50,
   faixa: 'Média',
   evidencias: [],
   ...over,
-  score_versao: over.score_versao ?? 'legacy',
+  score_versao: over.score_versao ?? 'contexto_v1',
   premissas_sem_dado: over.premissas_sem_dado ?? 0,
 });
 
 // "Melhor por jogo" (é o que a tela de Oportunidades exibe). Mistura de faixas
-// pra mostrar a régua (com valor × sem valor).
+// pra mostrar a classificação do backend. As notas seguem as fronteiras do
+// Score de contexto — 55 para Alta, 25 para Média (spec #301) —, senão a
+// demonstração ensinaria a régua aposentada.
 export const demoFutebolBoard: FutebolValueBoardRow[] = [
   base({
     fixture_id: 9001, home_team_id: 121, away_team_id: 127,
@@ -74,7 +79,7 @@ export const demoFutebolBoard: FutebolValueBoardRow[] = [
     fixture_id: 9005, home_team_id: 135, away_team_id: 118,
     home_team_name: 'Cruzeiro', away_team_name: 'Bahia',
     market: 'match_winner', outcome: 'Home', best_odd: 1.72, avg_odd: 1.7,
-    edge: -0.008, prob_justa_fechamento: 0.6, score: 34, faixa: 'Baixa',
+    edge: -0.008, prob_justa_fechamento: 0.6, score: 18, faixa: 'Baixa',
     kickoff_utc: '2025-08-10T19:00:00Z',
     evidencias: [],
   }),
@@ -220,11 +225,11 @@ export const demoFixtureDetail: FutebolFixtureDetail = {
 const vr = (over: Partial<FutebolFixtureValueRow>): FutebolFixtureValueRow => ({
   market: 'match_winner', outcome: 'Home', outcome_order: 1, line_value: null,
   edge: 0.05, best_odd: 2, best_book: 'Bet365', avg_odd: 1.95, n_casas: 6, janela_usada: 't1h',
-  prob_justa_fechamento: 0.5, pts_valor: 20, pts_premissas: 20, pts_corroboracao: 15,
+  prob_justa_fechamento: 0.5, pts_valor: 0, pts_premissas: 20, pts_corroboracao: 0,
   penalidades: 0, penalidades_globais_pts: 0, penalidades_especificas_pts: 0,
   score: 50, faixa: 'Média', modelo_api_concorda: true, linha_sharp_confirma: true,
   evidencias: [], avisos: [], contras: [], ...over,
-  score_versao: over.score_versao ?? 'legacy',
+  score_versao: over.score_versao ?? 'contexto_v1',
   premissas_sem_dado: over.premissas_sem_dado ?? 0,
 });
 
@@ -241,9 +246,9 @@ export const demoFixtureValueRows: FutebolFixtureValueRow[] = [
     avisos: [],
   }),
   vr({ market: 'match_winner', outcome: 'Draw', outcome_order: 2, best_odd: 3.30, avg_odd: 3.2, edge: 0.02, prob_justa_fechamento: 0.28, score: 46, faixa: 'Média' }),
-  vr({ market: 'match_winner', outcome: 'Away', outcome_order: 3, best_odd: 3.60, avg_odd: 3.5, edge: -0.03, prob_justa_fechamento: 0.24, score: 33, faixa: 'Baixa' }),
-  vr({ market: 'goals_over_under', outcome: 'Over', outcome_order: 1, line_value: 2.5, best_odd: 1.95, avg_odd: 1.9, edge: 0.06, prob_justa_fechamento: 0.55, score: 58, faixa: 'Média' }),
-  vr({ market: 'goals_over_under', outcome: 'Under', outcome_order: 2, line_value: 2.5, best_odd: 1.90, avg_odd: 1.85, edge: -0.01, prob_justa_fechamento: 0.45, score: 39, faixa: 'Baixa' }),
+  vr({ market: 'match_winner', outcome: 'Away', outcome_order: 3, best_odd: 3.60, avg_odd: 3.5, edge: -0.03, prob_justa_fechamento: 0.24, score: 19, faixa: 'Baixa' }),
+  vr({ market: 'goals_over_under', outcome: 'Over', outcome_order: 1, line_value: 2.5, best_odd: 1.95, avg_odd: 1.9, edge: 0.06, prob_justa_fechamento: 0.55, score: 48, faixa: 'Média' }),
+  vr({ market: 'goals_over_under', outcome: 'Under', outcome_order: 2, line_value: 2.5, best_odd: 1.90, avg_odd: 1.85, edge: -0.01, prob_justa_fechamento: 0.45, score: 21, faixa: 'Baixa' }),
 ];
 
 // Artilheiros de exemplo.

--- a/src/pages/FutebolLP.tsx
+++ b/src/pages/FutebolLP.tsx
@@ -60,7 +60,7 @@ const OPPS: MockOpp[] = [
   },
   {
     id: "bah-flu", home: "Bahia", away: "Fluminense", homeId: 118, awayId: 124, comp: "Brasileirão", hora: "19:00",
-    market: "Resultado (1X2)", pick: "Bahia", faixa: "Baixa", score: 34,
+    market: "Resultado (1X2)", pick: "Bahia", faixa: "Baixa", score: 19,
     chance: 44, odd: 2.30, edge: 0.011,
     porque: ["Leve vantagem do mando"],
     atencao: ["A odd está perto do justo — valor magro", "Fluminense reage bem fora de casa"],
@@ -116,8 +116,11 @@ const FutebolLP = () => {
   const selected = useMemo(() => OPPS.find((o) => o.id === selectedId) ?? OPPS[0], [selectedId]);
   const v = verdict(selected.edge);
 
-  const comValor = OPPS.filter((o) => o.score >= 40);
-  const semValor = OPPS.filter((o) => o.score < 40);
+  // Separado pela FAIXA, como o produto faz. O corte por número que existia
+  // aqui era da fórmula antiga e, na escala do Score de contexto, classificaria
+  // errado a própria demonstração (spec #301).
+  const comValor = OPPS.filter((o) => o.faixa !== "Baixa");
+  const semValor = OPPS.filter((o) => o.faixa === "Baixa");
 
   const goAuth = () => navigate("/auth");
   const goProduct = () => navigate("/futebol");

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -7,7 +7,7 @@
 //
 //   1. Lê o board (mesma fonte do site — zero lógica duplicada)
 //   2. Jogos de HOJE ainda não iniciados → melhor pick por jogo → top 3
-//      por Score, com corte mínimo (>= 40 / faixa Média)
+//      por Score, restrito à faixa Média para cima
 //   3. SEM oportunidade boa → NÃO manda nada (o silêncio no dia fraco é o
 //      que torna a mensagem crível no dia forte)
 //   4. Envia pros dois segmentos (RPC get_opportunity_recipients):
@@ -29,6 +29,7 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 import { generateTraceId, trackEvent } from "../shared/posthog.ts";
 import { esc } from "../shared/format.ts";
 import { trackedUrl } from "../shared/links.ts";
+import { ehFaixaPublicavel } from "../shared/faixa.ts";
 import { logMessageRun } from "../shared/runs.ts";
 
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
@@ -36,7 +37,9 @@ const CRON_SECRET = Deno.env.get("CRON_SECRET") || "";
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL") || "";
 const SITE = "https://www.smartbetting.app";
 
-const MIN_SCORE = 40;   // corte: faixa Média pra cima
+// O corte por número saiu na virada do Score de contexto (spec #301): 40 era
+// da fórmula antiga e, na escala nova, selecionaria outro conjunto. Quem decide
+// é a faixa publicada pelo backend, lida por ehFaixaPublicavel.
 const MAX_PICKS = 3;    // top N do dia
 const CAMPAIGN = "daily_opportunities";
 
@@ -208,7 +211,7 @@ serve(async (req) => {
     const today = brtDay(now);
     const todayRows = ((board ?? []) as BoardRow[]).filter((r) => {
       const k = kickoffDate(r.kickoff_utc);
-      return k.getTime() > now.getTime() && brtDay(k) === today && r.score >= MIN_SCORE;
+      return k.getTime() > now.getTime() && brtDay(k) === today && ehFaixaPublicavel(r.faixa);
     });
 
     // principais oportunidades do dia por Score — pode ter mais de uma do mesmo jogo

--- a/supabase/functions/notify-published-opportunities/index.ts
+++ b/supabase/functions/notify-published-opportunities/index.ts
@@ -32,7 +32,8 @@ interface BoardRow extends PublicationBoardRow {
   competition: string;
   status_short: string;
   best_odd: number;
-  faixa: string;
+  /** Técnica: viaja para o instantâneo e nunca para a mensagem. */
+  score_versao: string | null;
   janela_usada: string | null;
   edge: number | null;
   prob_justa_fechamento: number | null;
@@ -168,6 +169,7 @@ function payload(row: BoardRow & { key: string }) {
     best_odd: row.best_odd,
     score: row.score,
     faixa: row.faixa,
+    score_versao: row.score_versao ?? "legacy",
     janela_usada: row.janela_usada,
     edge: row.edge,
     prob_justa_fechamento: row.prob_justa_fechamento,

--- a/supabase/functions/notify-published-opportunities/planner.ts
+++ b/supabase/functions/notify-published-opportunities/planner.ts
@@ -1,3 +1,5 @@
+import { ehFaixaPublicavel } from "../shared/faixa.ts";
+
 export interface PublicationBoardRow {
   fixture_id: number;
   market: string;
@@ -5,11 +7,13 @@ export interface PublicationBoardRow {
   line_value: number | null;
   kickoff_utc: string;
   score: number;
+  /** A classificação do backend. É ela que decide, não o número. */
+  faixa: string;
 }
 
-// O painel só publica oportunidades a partir da faixa Média. O detector deve
-// receber exatamente o mesmo conjunto, nunca candidatas de score inferior.
-export const MIN_PUBLICATION_SCORE = 40;
+// O painel mostra da faixa Média para cima, e o detector precisa receber
+// exatamente o mesmo conjunto. O corte por número que existia aqui era da
+// fórmula antiga: na escala nova ele selecionaria outra coisa (spec #301).
 
 function kickoffDate(kickoffUtc: string): Date {
   return new Date(
@@ -46,7 +50,7 @@ export function planPublicationBatch<T extends PublicationBoardRow>({
 } {
   const newOpportunities = board
     .filter((row) =>
-      row.score >= MIN_PUBLICATION_SCORE &&
+      ehFaixaPublicavel(row.faixa) &&
       kickoffDate(row.kickoff_utc).getTime() > now.getTime()
     )
     .map((row) => ({ ...row, key: opportunityKey(row) }))

--- a/supabase/functions/shared/faixa.ts
+++ b/supabase/functions/shared/faixa.ts
@@ -1,0 +1,29 @@
+/**
+ * A faixa publicada pelo backend, lida do jeito que o painel lê.
+ *
+ * ⚠️ É uma cópia deliberada de `faixaTone` em `src/utils/futebol-score.ts`. As
+ * edge functions rodam em Deno e não alcançam o `src/`, então não há como
+ * importar. O que dá para garantir é que exista UMA cópia deste lado da
+ * fronteira, e não uma por função de notificação.
+ *
+ * O corte por NÚMERO que morava nas duas — `score >= 40` — saiu na virada do
+ * Score de contexto (spec #301). Ele foi calibrado para a fórmula antiga e, na
+ * escala nova, mandaria para o Telegram um conjunto diferente do que o painel
+ * publica: 40 é Média na escala antiga e Alta na nova.
+ */
+export type FaixaTone = "alta" | "media" | "baixa";
+
+export function faixaTone(faixa: string | null | undefined): FaixaTone {
+  const f = (faixa ?? "").toLowerCase();
+  if (f.startsWith("alta")) return "alta";
+  if (f.startsWith("m")) return "media";
+  return "baixa";
+}
+
+/**
+ * O painel mostra Alta e Média por padrão, e é esse o conjunto que o Telegram
+ * deve alcançar. A decisão é do backend: aqui só se lê a palavra que ele mandou.
+ */
+export function ehFaixaPublicavel(faixa: string | null | undefined): boolean {
+  return faixaTone(faixa) !== "baixa";
+}

--- a/supabase/functions/tests/published-opportunities.test.ts
+++ b/supabase/functions/tests/published-opportunities.test.ts
@@ -14,6 +14,7 @@ Deno.test("publicação: uma oportunidade pré-live nova entra no lote uma únic
       line_value: 1.5,
       kickoff_utc: "2026-08-27 19:30:00",
       score: 46,
+      faixa: "Média",
     }],
   });
 
@@ -34,6 +35,7 @@ Deno.test("publicação: a mesma oportunidade não volta ao lote quando já foi 
       line_value: 1.5,
       kickoff_utc: "2026-08-27 19:30:00",
       score: 62,
+      faixa: "Alta",
     }],
   });
 
@@ -51,13 +53,14 @@ Deno.test("publicação: não inclui oportunidade depois do kickoff", () => {
       line_value: 1.5,
       kickoff_utc: "2026-08-27 11:59:59",
       score: 62,
+      faixa: "Alta",
     }],
   });
 
   assertEquals(batch.newOpportunities.length, 0);
 });
 
-Deno.test("publicação: candidata abaixo da régua do painel não entra no lote", () => {
+Deno.test("publicação: candidata em faixa Baixa não entra no lote", () => {
   const batch = planPublicationBatch({
     now,
     alreadyAlerted: new Set<string>(),
@@ -68,10 +71,43 @@ Deno.test("publicação: candidata abaixo da régua do painel não entra no lote
       line_value: 1.5,
       kickoff_utc: "2026-08-27T19:30:00Z",
       score: 39,
+      faixa: "Baixa",
     }],
   });
 
   assertEquals(batch.newOpportunities.length, 0);
+});
+
+Deno.test("publicação: quem decide é a faixa do backend, não o número do Score", () => {
+  // O corte por número era 40, calibrado para a fórmula antiga. Na escala nova
+  // um 39 pode ser Média e um 44 pode ser Baixa: aplicar o número mandaria para
+  // o Telegram um conjunto diferente do que o painel publica.
+  const batch = planPublicationBatch({
+    now,
+    alreadyAlerted: new Set<string>(),
+    board: [
+      {
+        fixture_id: 1,
+        market: "goals_over_under",
+        outcome: "Over",
+        line_value: 1.5,
+        kickoff_utc: "2026-08-27T19:30:00Z",
+        score: 39,
+        faixa: "Média",
+      },
+      {
+        fixture_id: 2,
+        market: "match_winner",
+        outcome: "Home",
+        line_value: null,
+        kickoff_utc: "2026-08-27T19:30:00Z",
+        score: 44,
+        faixa: "Baixa",
+      },
+    ],
+  });
+
+  assertEquals(batch.newOpportunities.map((o) => o.fixture_id), [1]);
 });
 
 Deno.test("publicação: lote mantém todas as novas e detalha as três de maior Score", () => {
@@ -86,6 +122,7 @@ Deno.test("publicação: lote mantém todas as novas e detalha as três de maior
         line_value: 1.5,
         kickoff_utc: "2026-08-27 19:30:00",
         score: 43,
+        faixa: "Média",
       },
       {
         fixture_id: 2,
@@ -94,6 +131,7 @@ Deno.test("publicação: lote mantém todas as novas e detalha as três de maior
         line_value: 1.5,
         kickoff_utc: "2026-08-27 19:30:00",
         score: 58,
+        faixa: "Alta",
       },
       {
         fixture_id: 3,
@@ -102,6 +140,7 @@ Deno.test("publicação: lote mantém todas as novas e detalha as três de maior
         line_value: 1.5,
         kickoff_utc: "2026-08-27 19:30:00",
         score: 70,
+        faixa: "Alta",
       },
       {
         fixture_id: 4,
@@ -110,6 +149,7 @@ Deno.test("publicação: lote mantém todas as novas e detalha as três de maior
         line_value: 1.5,
         kickoff_utc: "2026-08-27 19:30:00",
         score: 51,
+        faixa: "Média",
       },
     ],
   });

--- a/supabase/migrations/20260829180000_113_futebol_alerta_score_versao.sql
+++ b/supabase/migrations/20260829180000_113_futebol_alerta_score_versao.sql
@@ -1,0 +1,117 @@
+-- 20260829180000_113_futebol_alerta_score_versao
+--
+-- O instantâneo do alerta guarda a escala em que a nota foi calculada
+-- (spec #301, entrega #308).
+--
+-- A tabela já preserva Score e faixa do momento do envio, que é o que faz o
+-- alerta continuar verdadeiro depois de o board ser reescrito. Sem a escala,
+-- porém, um alerta de agosto e um de setembro trazem "Score 46" significando
+-- coisas diferentes, e nada na base permite distinguir — que é o mesmo motivo
+-- pelo qual o histórico do painel ganhou a coluna na migration 112.
+--
+-- Técnico: acompanha auditoria e diagnóstico, nunca aparece na mensagem.
+
+ALTER TABLE public.futebol_publication_alerts
+  ADD COLUMN IF NOT EXISTS score_versao text NOT NULL DEFAULT 'legacy';
+
+COMMENT ON COLUMN public.futebol_publication_alerts.score_versao IS
+  'Escala do Score no instante do alerta: legacy ou contexto_v1. Técnico, nunca exibido ao assinante.';
+
+-- O detector passa a mandar a escala junto do resto do instantâneo. O retorno
+-- tabular não muda, então basta recriar o corpo.
+CREATE OR REPLACE FUNCTION public.claim_futebol_publication_alert_batch(
+  p_sync_at timestamptz,
+  p_opportunities jsonb
+)
+RETURNS TABLE(batch_id uuid, alert_id uuid, opportunity_key text)
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_batch_id uuid;
+BEGIN
+  -- O advisory lock torna o polling idempotente mesmo se dois crons
+  -- coincidirem: sem ele, duas execuções sobrepostas não enxergam as linhas
+  -- ainda não commitadas uma da outra, criam dois lotes e mandam duas mensagens
+  -- para o mesmo destinatário no mesmo minuto.
+  PERFORM pg_advisory_xact_lock(hashtext('futebol-publication-alerts'));
+
+  WITH incoming AS (
+    SELECT *
+    FROM jsonb_to_recordset(p_opportunities) AS x(
+      opportunity_key text,
+      fixture_id bigint,
+      home_team_name text,
+      away_team_name text,
+      competition text,
+      kickoff_utc timestamptz,
+      market text,
+      outcome text,
+      line_value double precision,
+      best_odd numeric,
+      score integer,
+      faixa text,
+      score_versao text,
+      janela_usada text,
+      edge double precision,
+      prob_justa_fechamento double precision,
+      evidencias text[]
+    )
+  )
+  INSERT INTO public.futebol_publication_alert_batches (sync_at)
+  SELECT p_sync_at
+  WHERE EXISTS (
+    SELECT 1 FROM incoming i
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.futebol_publication_alerts a
+      WHERE a.opportunity_key = i.opportunity_key
+    )
+  )
+  RETURNING id INTO v_batch_id;
+
+  IF v_batch_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH incoming AS (
+    SELECT *
+    FROM jsonb_to_recordset(p_opportunities) AS x(
+      opportunity_key text,
+      fixture_id bigint,
+      home_team_name text,
+      away_team_name text,
+      competition text,
+      kickoff_utc timestamptz,
+      market text,
+      outcome text,
+      line_value double precision,
+      best_odd numeric,
+      score integer,
+      faixa text,
+      score_versao text,
+      janela_usada text,
+      edge double precision,
+      prob_justa_fechamento double precision,
+      evidencias text[]
+    )
+  ), inserted AS (
+    INSERT INTO public.futebol_publication_alerts (
+      batch_id, opportunity_key, fixture_id, home_team_name, away_team_name,
+      competition, kickoff_utc, market, outcome, line_value, best_odd, score,
+      faixa, score_versao, janela_usada, edge, prob_justa_fechamento, evidencias
+    )
+    SELECT v_batch_id, i.opportunity_key, i.fixture_id, i.home_team_name,
+           i.away_team_name, i.competition, i.kickoff_utc, i.market,
+           i.outcome, i.line_value, i.best_odd, i.score, i.faixa,
+           -- Alerta antigo permanece legacy; o detector novo manda a escala.
+           coalesce(i.score_versao, 'legacy'),
+           i.janela_usada, i.edge, i.prob_justa_fechamento, i.evidencias
+    FROM incoming i
+    ON CONFLICT (opportunity_key) DO NOTHING
+    RETURNING id, opportunity_key
+  )
+  SELECT v_batch_id, i.id, i.opportunity_key FROM inserted i;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.claim_futebol_publication_alert_batch(timestamptz, jsonb) TO service_role;


### PR DESCRIPTION
Closes #308
Refs #301

As superfícies auxiliares passam a apresentar a mesma oportunidade, faixa e explicação do painel.

## Dois cortes por número no Telegram

O resumo diário filtrava `score >= 40` e o detector de publicação também. Os dois foram calibrados para a fórmula antiga, então na escala nova mandariam um conjunto diferente do que o painel publica: 40 é Média numa escala e Alta na outra.

Agora os dois leem a faixa que o backend mandou. Como as edge functions rodam em Deno e não alcançam o `src/`, a leitura da faixa virou um arquivo compartilhado entre elas — a cópia é inevitável, mas passa a existir uma só deste lado da fronteira, com o motivo escrito no topo.

## A escala no instantâneo do alerta

Migration 113. A tabela já preservava Score e faixa do instante do envio, que é o que faz o alerta continuar verdadeiro depois de o board ser reescrito. Sem a escala, um alerta de agosto e um de setembro trazem "Score 46" significando coisas diferentes, e nada na base distingue. Técnica: acompanha auditoria, nunca aparece na mensagem.

## Demonstrações

- O tour tinha um 34 marcado como Baixa, que na escala nova é Média, e componentes de preço somando na nota
- A landing ainda filtrava por 40 sobre os seus dados estáticos
- Teste novo confere cada linha de exemplo contra as fronteiras 25 e 55. Dado de demonstração não quebra teste de tela, então precisava de guarda própria

## Achados do code review, corrigidos

**Perdi um lock ao recriar a função.** A `claim_futebol_publication_alert_batch` da migration 111 abre com `pg_advisory_xact_lock`, e ao reescrever o corpo eu omiti a primeira linha. Sem ele, duas execuções sobrepostas do detector não enxergam as linhas ainda não commitadas uma da outra: criam dois lotes e mandam duas mensagens para o mesmo destinatário no mesmo minuto. Restaurado na migration e no shape file, agora com o motivo escrito por extenso.

**O ALTER TABLE que pus no shape file abortaria a provisão.** Aquele arquivo nunca criou as tabelas do alerta, e o `check_function_bodies = off` do topo cobre corpo de função, não DDL de tabela — então o comando falharia e tudo depois dele deixaria de rodar. A coluna é da migration 113.

## Dívida registrada, não corrigida

As tabelas da migration 111 nunca entraram no shape file de provisionamento, embora as funções que as usam tenham entrado. Deixei o registro no lugar onde tropecei. É o mesmo modo de falha que a issue #250 já caçou uma vez: a função responde em produção, e só quebra quando alguém provisiona ambiente novo.

## Verificação

- 318 testes no front, 6 novos, e mais 1 no Deno cobrindo que quem decide é a faixa e não o número
- build, lint e typecheck sem nada novo em relação à develop
