### PR TITLE
Futebol: alinhar o shape file com as premissas que o mart removeu

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -524,13 +524,11 @@ create table futebol.int_futebol_premissas_ou (
   "ritmo_alto" boolean,
   "ambos_vazam" boolean,
   "historico_over" boolean,
-  "linha_subindo" boolean,
   "defesas_firmes" boolean,
   "clean_sheets_altos" boolean,
   "xg_baixo_combinado" boolean,
   "ataques_fracos" boolean,
   "historico_under" boolean,
-  "linha_descendo" boolean,
   "linha_extrema" boolean,
   "pts_premissas" bigint,
   "penalidades_ou_pts" bigint,
@@ -1956,9 +1954,7 @@ AS $function$
            case when p.historico_under     then 'historico_under' end,
            case when p.historico_over      then 'historico_over' end,
            case when p.ambos_vazam         then 'ambos_vazam' end,
-           case when p.ritmo_alto          then 'ritmo_alto' end,
-           case when p.linha_subindo       then 'linha_subindo' end,
-           case when p.linha_descendo      then 'linha_descendo' end
+           case when p.ritmo_alto          then 'ritmo_alto' end
          ], null),
          array_remove(array[
            case when not p.defesas_firmes     then 'defesas_firmes' end,
@@ -1971,9 +1967,7 @@ AS $function$
            case when not p.historico_under    then 'historico_under' end,
            case when not p.historico_over     then 'historico_over' end,
            case when not p.ambos_vazam        then 'ambos_vazam' end,
-           case when not p.ritmo_alto         then 'ritmo_alto' end,
-           case when not p.linha_subindo      then 'linha_subindo' end,
-           case when not p.linha_descendo     then 'linha_descendo' end
+           case when not p.ritmo_alto         then 'ritmo_alto' end
          ], null),
          array_remove(array[
            case when p.linha_extrema then 'linha_extrema' end

--- a/src/utils/futebol-contrato-score.test.ts
+++ b/src/utils/futebol-contrato-score.test.ts
@@ -263,4 +263,15 @@ describe('motivos sem preço, corroboração e penalidade de odd', () => {
       expect(sql(), slug).not.toMatch(new RegExp(`\\('evidencia',\\s*'\\w+',\\s*'${slug}'`, 'i'));
     }
   });
+
+  it('o shape file não descreve as premissas de movimento de linha, que o mart não publica mais', () => {
+    // O AE #103 removeu linha_subindo e linha_descendo do modelo de gols, e as
+    // colunas caíram no Postgres. O shape file continuou declarando as duas, e
+    // esse tipo de divergência não aparece sozinha: o parity check do sync
+    // aborta quando existe coluna no Postgres que não existe no BigQuery, e foi
+    // o que derrubou o sync por três dias, cerca de 72 execuções (issue #302).
+    for (const slug of ['linha_subindo', 'linha_descendo']) {
+      expect(SHAPE, slug).not.toContain(slug);
+    }
+  });
 });

--- a/supabase/migrations/20260829120000_112_futebol_score_contexto_contrato.sql
+++ b/supabase/migrations/20260829120000_112_futebol_score_contexto_contrato.sql
@@ -8,11 +8,22 @@
 -- de segurança nas faixas por mercado, mas não compõe a nota nem destrava a
 -- publicação.
 --
--- ⚠️ NÃO APLICAR ISOLADAMENTE EM PRODUÇÃO. Esta migration é metade de uma virada
--- combinada com analytics-engineering#109, que troca o mart e o sync. A ordem
--- documentada é: migration → mart → sync manual → smoke test → reabertura. Até
--- o mart publicar contexto_v1, as RPCs devolvem score_versao = 'legacy' e a
--- nota continua na escala antiga.
+-- ⚠️ NÃO APLICAR ISOLADAMENTE. Esta migration é metade de uma virada combinada
+-- com analytics-engineering#109, que troca o mart e o sync.
+--
+-- ⚠️ E NÃO APLICAR ANTES DO MART. A seção 1 acrescenta score_versao nas tabelas
+-- do mart no Postgres. O pre-flight de paridade do sync aborta quando encontra
+-- coluna que existe no Postgres e NÃO existe no BigQuery — e aborta antes de
+-- qualquer carga, então o board simplesmente congela. Não é hipótese: foi o que
+-- aconteceu de 26 a 29/08/2026, quando o AE #103 removeu duas colunas do
+-- BigQuery e o Postgres ficou com elas. O sync abortou de hora em hora, em
+-- produção e em dev, por cerca de 72 execuções (issue #302).
+--
+-- Ordem correta: o BigQuery publica score_versao PRIMEIRO (ou as duas pontas
+-- sobem na mesma janela com o sync pausado); depois esta migration; depois o
+-- sync manual; depois o smoke test; e só então a reabertura. Enquanto o mart
+-- não publicar contexto_v1, as RPCs devolvem score_versao = 'legacy' e a nota
+-- continua na escala antiga.
 --
 -- Por que DROP e CREATE em vez de CREATE OR REPLACE: o retorno tabular muda nas
 -- três RPCs, e o Postgres recusa `create or replace` que altere o RETURNS TABLE


### PR DESCRIPTION
Closes #302

O AE #103 tirou `linha_subindo` e `linha_descendo` do modelo de gols, e as colunas caíram no Postgres de produção e de dev. O shape file de provisionamento continuou declarando as duas e ainda as montava em `acesas`/`apagadas` — então uma provisão nova recriaria exatamente a divergência que derrubou o sync por três dias.

## O que muda

- as duas colunas saem do DDL de `int_futebol_premissas_ou`
- `get_futebol_fixture_premissas` para de listá-las
- teste novo cobra que o shape file não volte a citá-las, com o incidente escrito no comentário

As outras três RPCs de valor e o contrato de motivos já tinham parado de lê-las nas entregas #304 e #306. Sobre o outro ponto levantado na issue: conferi e `get_futebol_value_history` e `get_futebol_fixture_premissas` estão as duas no arquivo.

## E uma correção de ordem na virada do Score

A #302 documenta uma coisa que muda o plano da janela da spec #301: o pre-flight de paridade do sync **aborta quando encontra coluna que existe no Postgres e não existe no BigQuery**, e aborta antes de qualquer carga.

A migration 112 acrescenta `score_versao` nas tabelas do mart no Postgres. O cabeçalho dela dizia que a ordem era "migration, depois mart" — e é o contrário. Aplicada antes, ela congelaria o board exatamente como aconteceu de 26 a 29/08, por cerca de 72 execuções sem sincronizar nada.

O cabeçalho foi corrigido: o BigQuery publica `score_versao` primeiro, ou as duas pontas sobem na mesma janela com o sync pausado.

## Verificação

- 319 testes, 1 novo
- build, lint e typecheck sem nada novo
