### PR TITLE
Futebol: Disponível desde no detalhe do jogo

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -2652,6 +2652,96 @@ grant execute on function public.get_futebol_fixture_premissas(p_fixture_id bigi
 grant execute on function public.get_futebol_fixture_numeros(p_fixture_id bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_historico(p_fixture_id bigint, p_max integer) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_reason_contract(p_fixture_id bigint) to anon, authenticated, service_role;
+
+-- ── "Disponível desde" no detalhe do jogo (migration 114, issue #300) ──────
+-- ⚠️ A função devolve a corrida da ÚLTIMA versão que o snapshot tem, inclusive
+-- de chave que já saiu do board. É de propósito: é o que faz o campo continuar
+-- respondendo no jogo encerrado, cujo detalhe lê a foto do apito (migration
+-- 101) — e o caso de aceite da issue é justamente um jogo de 25/08. Quem decide
+-- se aquilo está publicado AGORA é get_futebol_fixture_value, e a tela só
+-- escreve a frase quando as duas concordam.
+--
+-- Medido no dev em 29/08/2026: das 284 chaves do snapshot, 276 têm a última
+-- versão fechada e 8 têm versão aberta; nenhuma das 8 está fora do board. Ou
+-- seja, o snapshot fecha a linha quando a oportunidade sai, e por isso os
+-- buracos existem — são 74 chaves com reativação. Sem esse fechamento não
+-- haveria ilha nenhuma e o campo viraria o MIN da chave, que é a forma 1 de
+-- mentir.
+
+DROP FUNCTION IF EXISTS public.get_futebol_fixture_disponivel_desde(bigint);
+
+CREATE FUNCTION public.get_futebol_fixture_disponivel_desde(p_fixture_id bigint)
+RETURNS TABLE(
+  market text,
+  outcome text,
+  line_value double precision,
+  disponivel_desde timestamp without time zone
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+  -- Ilhas e buracos sobre as versões do snapshot. Versões contíguas
+  -- (dbt_valid_to de uma = dbt_valid_from da seguinte) são ATUALIZAÇÃO da mesma
+  -- disponibilidade; um buraco entre elas é REATIVAÇÃO, e reinicia o relógio.
+  with versoes as (
+    select
+      h.opportunity_key,
+      h.market,
+      h.outcome,
+      h.line_value,
+      h.dbt_valid_from,
+      lag(h.dbt_valid_to) over (
+        partition by h.opportunity_key order by h.dbt_valid_from
+      ) as fim_da_anterior
+    from futebol.fact_value_opportunities_hist h
+    where h.fixture_id = p_fixture_id
+  ), ilhas as (
+    select
+      v.*,
+      -- Cada vez que o fim da versão anterior não encosta no início desta,
+      -- começa uma ilha nova. A primeira versão sempre abre uma.
+      count(*) filter (where v.fim_da_anterior is distinct from v.dbt_valid_from) over (
+        partition by v.opportunity_key
+        order by v.dbt_valid_from
+        rows between unbounded preceding and current row
+      ) as ilha
+    from versoes v
+  ), por_chave as (
+    select distinct on (i.opportunity_key)
+      i.opportunity_key,
+      i.market,
+      i.outcome,
+      i.line_value,
+      -- Início da ilha da versão MAIS RECENTE: a disponibilidade atual.
+      min(i.dbt_valid_from) over (partition by i.opportunity_key, i.ilha) as inicio_da_ilha,
+      -- Primeira versão que o snapshot tem desta chave, para detectar o caso 3.
+      min(i.dbt_valid_from) over (partition by i.opportunity_key) as primeira_versao
+    from ilhas i
+    order by i.opportunity_key, i.dbt_valid_from desc
+  )
+  select
+    c.market,
+    c.outcome,
+    c.line_value,
+    -- Vazio quando a corrida atual começa na primeira versão que o snapshot tem
+    -- E essa versão está na estreia dele: aí o horário é a data em que o
+    -- snapshot passou a existir, não a hora em que a oportunidade foi publicada.
+    -- Uma reativação POSTERIOR à estreia continua confiável, e por isso a
+    -- comparação é com o início da ilha, não com a chave inteira.
+    case
+      when c.inicio_da_ilha = c.primeira_versao
+       and c.primeira_versao < timestamp '2026-07-28 00:00:00'
+      then null
+      else c.inicio_da_ilha
+    end
+  from por_chave c
+  order by c.market, c.outcome, c.line_value;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_fixture_disponivel_desde(bigint) TO anon, authenticated, service_role;
+
 revoke all on function public.claim_futebol_publication_alert_batch(timestamptz, jsonb) from public, anon, authenticated;
 grant execute on function public.claim_futebol_publication_alert_batch(timestamptz, jsonb) to service_role;
 revoke all on function public.get_futebol_publication_alert_recipients() from public, anon, authenticated;

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -9,6 +9,7 @@ import {
   useFutebolFixtureInjuries,
   useFutebolFixtureOdds,
   useFutebolFixtureReasonContract,
+  useFutebolFixtureDisponibilidade,
 } from '@/hooks/use-futebol-data';
 import type { FutebolFixturePremissas, FutebolFixtureReasonContractRow, FutebolFixtureValueRow } from '@/services/futebol-data.service';
 import {
@@ -32,6 +33,7 @@ import { avisoSemDado } from '@/utils/futebol-sem-dado';
 import { valueDoCandidato, resumoDosMercados, mesmaLinha, type SaidaPreferida } from '@/utils/futebol-leitura';
 import { ehDestaque, ehFaixaAlta, rotuloDaFaixa, fronteirasDoScore } from '@/utils/futebol-score';
 import { leituraDaCotacao } from '@/utils/futebol-cotacao';
+import { disponivelDesdeDaSaida, rotuloDisponivelDesde } from '@/utils/futebol-disponibilidade';
 import { separarMotivosDoContrato } from '@/utils/futebol-motivos';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { hasKickoffPassed, isFinished, parseUtc } from '@/utils/futebol-datas';
@@ -253,6 +255,7 @@ export function BancadaMercados({
     isLoading: carregandoContratoMotivos,
     isError: falhaContratoMotivos,
   } = useFutebolFixtureReasonContract(jogo.fixtureId);
+  const { data: disponibilidade } = useFutebolFixtureDisponibilidade(jogo.fixtureId);
 
   const fim = isFinished(jogo.statusShort);
   const jogoJaComecou = useJogoJaComecou(jogo.kickoffUtc);
@@ -1022,6 +1025,22 @@ export function BancadaMercados({
             </div>
           ) : null;
         })()}
+
+        {/* Desde quando esta saída está publicada. Responde a pergunta que o
+            usuário faz de verdade — "desde quando isso está aqui?" — e que a
+            tela respondia com a janela de odds, que é outra coisa (issue #300).
+
+            Preso a valPrincipal de propósito. A RPC devolve a corrida da última
+            versão que o snapshot tem, inclusive de chave já retirada do board;
+            é o que faz o campo continuar respondendo em jogo encerrado, que lê
+            a foto do apito. Sem esta trava, arrastar a régua até uma parada sem
+            cotação mostraria "disponível desde" de algo que não está publicado. */}
+        {valPrincipal && rotuloDisponivelDesde(disponivelDesdeDaSaida(disponibilidade, principal)) && (
+          <div className="px-6 md:px-8 py-3.5 text-[11.5px] leading-relaxed" style={{ borderTop: '1px solid #f1e9d6', background: '#fdfbf6', color: '#5a625a' }}>
+            <span className="font-semibold">Disponível desde: </span>
+            {rotuloDisponivelDesde(disponivelDesdeDaSaida(disponibilidade, principal))}
+          </div>
+        )}
 
         {/* Ressalva de informação faltando. Fica AQUI, no rodapé, e não na aba
             "Contra" de propósito: aquela aba lista o que foi checado e não

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -12,6 +12,7 @@ import {
   type FutebolFixtureDay,
   type FutebolFixturePremissas,
   type FutebolFixtureReasonContractRow,
+  type FutebolFixtureDisponibilidade,
   type FutebolFixtureNumeros,
   type FutebolFixtureHistorico,
   type FutebolCompetitionInfo,
@@ -99,6 +100,18 @@ export function useFutebolFixturePremissas(fixtureId: number | undefined) {
     enabled: !!fixtureId,
     staleTime: 10 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+/** Desde quando cada saída está publicada, por oportunidade (issue #300). */
+export function useFutebolFixtureDisponibilidade(fixtureId: number | undefined) {
+  return useQuery<FutebolFixtureDisponibilidade[]>({
+    queryKey: ['futebol', 'fixture-disponivel-desde', fixtureId],
+    queryFn: () => futebolDataService.getFixtureDisponibilidade(fixtureId as number),
+    enabled: !!fixtureId,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 }

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -96,6 +96,22 @@ export interface FutebolFixtureReasonItem {
 }
 
 /**
+ * Desde quando cada saída está publicada, por oportunidade
+ * (RPC get_futebol_fixture_disponivel_desde, issue #300).
+ *
+ * É o início da disponibilidade CONTÍNUA ATUAL: uma rejeição seguida de
+ * reativação reinicia o relógio. Vem `null` quando a chave já existia antes de
+ * o snapshot estrear, porque ali o horário dataria a estreia e não a
+ * publicação — melhor vazio que inventado.
+ */
+export interface FutebolFixtureDisponibilidade {
+  market: string;
+  outcome: string;
+  line_value: number | null;
+  disponivel_desde: string | null;
+}
+
+/**
  * Motivos de qualquer saída cotada da Bancada (RPC get_futebol_fixture_reason_contract).
  * A separação favor/contra é autoridade do backend; não derive o lado pelo slug.
  *
@@ -695,6 +711,17 @@ export const futebolDataService = {
       });
       if (error) throw error;
       return (data || []) as FutebolFixtureReasonContractRow[];
+    });
+  },
+
+  /** Desde quando cada saída está publicada (issue #300). */
+  async getFixtureDisponibilidade(fixtureId: number): Promise<FutebolFixtureDisponibilidade[]> {
+    return withRetry(async () => {
+      const { data, error } = await supabaseClient.rpc('get_futebol_fixture_disponivel_desde', {
+        p_fixture_id: fixtureId,
+      });
+      if (error) throw error;
+      return (data || []) as FutebolFixtureDisponibilidade[];
     });
   },
 

--- a/src/utils/futebol-disponibilidade.test.ts
+++ b/src/utils/futebol-disponibilidade.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { disponivelDesdeDaSaida, rotuloDisponivelDesde } from './futebol-disponibilidade';
+
+// ============================================================================
+// "Disponível desde" (issue #300, investigação AE #120/#121)
+// ============================================================================
+// A regra de contiguidade — o que é atualização e o que é reativação — mora no
+// backend, e é lá que ela está testada contra o snapshot. O que se testa aqui é
+// a escolha da linha e a frase: pegar a saída certa e não escrever horário
+// quando o backend não tem um para dar.
+// ============================================================================
+
+const linhas = [
+  { market: 'goals_over_under', outcome: 'Over', line_value: 3.5, disponivel_desde: '2026-08-25T18:03:09.498041' },
+  { market: 'goals_over_under', outcome: 'Under', line_value: 3.5, disponivel_desde: '2026-08-25T19:00:00' },
+  { market: 'match_winner', outcome: 'Home', line_value: null, disponivel_desde: null },
+];
+
+describe('escolher a linha da saída analisada', () => {
+  it('casa mercado, saída e linha', () => {
+    expect(
+      disponivelDesdeDaSaida(linhas, { market: 'goals_over_under', outcome: 'Over', line_value: 3.5 }),
+    ).toBe('2026-08-25T18:03:09.498041');
+  });
+
+  it('não confunde os dois lados da mesma linha', () => {
+    expect(
+      disponivelDesdeDaSaida(linhas, { market: 'goals_over_under', outcome: 'Under', line_value: 3.5 }),
+    ).toBe('2026-08-25T19:00:00');
+  });
+
+  it('casa mercado sem linha, como o 1X2', () => {
+    expect(
+      disponivelDesdeDaSaida(linhas, { market: 'match_winner', outcome: 'Home', line_value: null }),
+    ).toBeNull();
+  });
+
+  it('saída que o backend não devolveu não inventa horário', () => {
+    expect(
+      disponivelDesdeDaSaida(linhas, { market: 'btts', outcome: 'Yes', line_value: null }),
+    ).toBeNull();
+    expect(
+      disponivelDesdeDaSaida(linhas, { market: 'goals_over_under', outcome: 'Over', line_value: 2.5 }),
+    ).toBeNull();
+  });
+
+  it('sem dados ou sem saída, devolve nulo em vez de estourar', () => {
+    expect(disponivelDesdeDaSaida(undefined, { market: 'btts', outcome: 'Yes', line_value: null })).toBeNull();
+    expect(disponivelDesdeDaSaida(linhas, null)).toBeNull();
+  });
+});
+
+describe('a frase', () => {
+  it('sai em horário de Brasília, e não no UTC que vem do banco', () => {
+    // O caso medido da issue: publicado às 15:03 BRT, que são 18:03 UTC.
+    expect(rotuloDisponivelDesde('2026-08-25T18:03:09.498041')).toBe('25/08 às 15:03');
+  });
+
+  it('não escreve nada quando o backend não tem horário para dar', () => {
+    // Chave anterior à estreia do snapshot: o horário dataria a estreia, não a
+    // publicação. Melhor vazio que inventado.
+    expect(rotuloDisponivelDesde(null)).toBeNull();
+    expect(rotuloDisponivelDesde(undefined)).toBeNull();
+    expect(rotuloDisponivelDesde('')).toBeNull();
+  });
+});

--- a/src/utils/futebol-disponibilidade.ts
+++ b/src/utils/futebol-disponibilidade.ts
@@ -1,0 +1,49 @@
+import type { FutebolFixtureDisponibilidade } from '@/services/futebol-data.service';
+import { mesmaLinha } from '@/utils/futebol-leitura';
+import { parseUtc } from '@/utils/futebol-datas';
+
+/**
+ * "Disponível desde" da saída analisada (issue #300).
+ *
+ * O backend entrega o início da disponibilidade CONTÍNUA ATUAL por oportunidade;
+ * aqui só se escolhe a linha certa e se escreve a frase. A tela não calcula
+ * nada: uma segunda implementação da regra de contiguidade seria uma segunda
+ * chance de errá-la.
+ */
+
+/** A disponibilidade da saída que a tela está mostrando, ou null. */
+export function disponivelDesdeDaSaida(
+  linhas: readonly FutebolFixtureDisponibilidade[] | undefined,
+  saida: { market: string; outcome: string; line_value: number | null } | null | undefined,
+): string | null {
+  if (!linhas?.length || !saida) return null;
+  const achada = linhas.find(
+    (l) =>
+      l.market === saida.market &&
+      l.outcome === saida.outcome &&
+      mesmaLinha(l.line_value, saida.line_value),
+  );
+  return achada?.disponivel_desde ?? null;
+}
+
+/**
+ * A frase, em horário de Brasília.
+ *
+ * Devolve null quando não há valor — o que acontece de propósito nas chaves
+ * anteriores à estreia do snapshot, em que o horário dataria a estreia e não a
+ * publicação. Nesse caso a tela não escreve nada, em vez de escrever um horário
+ * que não é verdade.
+ */
+export function rotuloDisponivelDesde(disponivelDesde: string | null | undefined): string | null {
+  const quando = parseUtc(disponivelDesde ?? null);
+  if (!quando) return null;
+  return new Intl.DateTimeFormat('pt-BR', {
+    timeZone: 'America/Sao_Paulo',
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+    .format(quando)
+    .replace(', ', ' às ');
+}

--- a/supabase/migrations/20260829200000_114_futebol_disponivel_desde.sql
+++ b/supabase/migrations/20260829200000_114_futebol_disponivel_desde.sql
@@ -1,0 +1,113 @@
+-- 20260829200000_114_futebol_disponivel_desde
+--
+-- "Disponível desde": o início do período de disponibilidade CONTÍNUA ATUAL de
+-- cada oportunidade do jogo (issue #300, investigação AE #120/#121).
+--
+-- A pergunta que o usuário faz é "desde quando isso está aqui?", e a tela
+-- respondia com `janela_usada`, que é a janela de odds da versão viva — outra
+-- coisa. O caso que abriu a investigação: um assinante achou que o Valencia ×
+-- Betis Mais de 3,5 "não estava lá de tarde". Estava: foi publicado às 15:03:09
+-- BRT, 56 minutos antes do apito, e ficou disponível sem interrupção.
+--
+-- RPC PRÓPRIA, e não uma coluna a mais em get_futebol_fixture_value, por duas
+-- razões. A issue pede para não empilhar duas mudanças de contrato na mesma
+-- janela — e a migration 112 já troca a assinatura daquela RPC na virada do
+-- Score de contexto. E como função nova não altera contrato de ninguém, esta
+-- entrega pode subir sozinha, sem esperar a janela.
+--
+-- ⚠️ Três formas de o campo mentir, todas endereçadas abaixo:
+--   1. MIN(dbt_valid_from) da chave data o PRIMEIRO nascimento de sempre e
+--      ignora reativação, que é justamente a distinção pedida.
+--   2. janela_usada não é isto.
+--   3. O snapshot estreou em 27/07/2026. Para uma chave que já existia antes,
+--      o primeiro dbt_valid_from data a estreia do snapshot, não a publicação
+--      da oportunidade. Nesse caso o campo vem VAZIO: melhor vazio que um
+--      horário inventado.
+
+-- ⚠️ A função devolve a corrida da ÚLTIMA versão que o snapshot tem, inclusive
+-- de chave que já saiu do board. É de propósito: é o que faz o campo continuar
+-- respondendo no jogo encerrado, cujo detalhe lê a foto do apito (migration
+-- 101) — e o caso de aceite da issue é justamente um jogo de 25/08. Quem decide
+-- se aquilo está publicado AGORA é get_futebol_fixture_value, e a tela só
+-- escreve a frase quando as duas concordam.
+--
+-- Medido no dev em 29/08/2026: das 284 chaves do snapshot, 276 têm a última
+-- versão fechada e 8 têm versão aberta; nenhuma das 8 está fora do board. Ou
+-- seja, o snapshot fecha a linha quando a oportunidade sai, e por isso os
+-- buracos existem — são 74 chaves com reativação. Sem esse fechamento não
+-- haveria ilha nenhuma e o campo viraria o MIN da chave, que é a forma 1 de
+-- mentir.
+
+DROP FUNCTION IF EXISTS public.get_futebol_fixture_disponivel_desde(bigint);
+
+CREATE FUNCTION public.get_futebol_fixture_disponivel_desde(p_fixture_id bigint)
+RETURNS TABLE(
+  market text,
+  outcome text,
+  line_value double precision,
+  disponivel_desde timestamp without time zone
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+  -- Ilhas e buracos sobre as versões do snapshot. Versões contíguas
+  -- (dbt_valid_to de uma = dbt_valid_from da seguinte) são ATUALIZAÇÃO da mesma
+  -- disponibilidade; um buraco entre elas é REATIVAÇÃO, e reinicia o relógio.
+  with versoes as (
+    select
+      h.opportunity_key,
+      h.market,
+      h.outcome,
+      h.line_value,
+      h.dbt_valid_from,
+      lag(h.dbt_valid_to) over (
+        partition by h.opportunity_key order by h.dbt_valid_from
+      ) as fim_da_anterior
+    from futebol.fact_value_opportunities_hist h
+    where h.fixture_id = p_fixture_id
+  ), ilhas as (
+    select
+      v.*,
+      -- Cada vez que o fim da versão anterior não encosta no início desta,
+      -- começa uma ilha nova. A primeira versão sempre abre uma.
+      count(*) filter (where v.fim_da_anterior is distinct from v.dbt_valid_from) over (
+        partition by v.opportunity_key
+        order by v.dbt_valid_from
+        rows between unbounded preceding and current row
+      ) as ilha
+    from versoes v
+  ), por_chave as (
+    select distinct on (i.opportunity_key)
+      i.opportunity_key,
+      i.market,
+      i.outcome,
+      i.line_value,
+      -- Início da ilha da versão MAIS RECENTE: a disponibilidade atual.
+      min(i.dbt_valid_from) over (partition by i.opportunity_key, i.ilha) as inicio_da_ilha,
+      -- Primeira versão que o snapshot tem desta chave, para detectar o caso 3.
+      min(i.dbt_valid_from) over (partition by i.opportunity_key) as primeira_versao
+    from ilhas i
+    order by i.opportunity_key, i.dbt_valid_from desc
+  )
+  select
+    c.market,
+    c.outcome,
+    c.line_value,
+    -- Vazio quando a corrida atual começa na primeira versão que o snapshot tem
+    -- E essa versão está na estreia dele: aí o horário é a data em que o
+    -- snapshot passou a existir, não a hora em que a oportunidade foi publicada.
+    -- Uma reativação POSTERIOR à estreia continua confiável, e por isso a
+    -- comparação é com o início da ilha, não com a chave inteira.
+    case
+      when c.inicio_da_ilha = c.primeira_versao
+       and c.primeira_versao < timestamp '2026-07-28 00:00:00'
+      then null
+      else c.inicio_da_ilha
+    end
+  from por_chave c
+  order by c.market, c.outcome, c.line_value;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_fixture_disponivel_desde(bigint) TO anon, authenticated, service_role;


### PR DESCRIPTION
Closes #300

A pergunta que o usuário faz é "desde quando isso está aqui?", e a tela respondia com a janela de odds, que é outra coisa. Foi o que originou a investigação AE #120/#121.

## Decisão de escopo: RPC própria

A issue deixa em aberto se entra como coluna nova numa RPC ou como RPC própria, e avisa para **não empilhar com outra mudança de contrato na mesma janela**. A migration 112 já troca a assinatura de `get_futebol_fixture_value` na virada do Score de contexto — então empilhar aqui trocaria dois diagnósticos por um.

Função nova não altera contrato de ninguém, o que tem um bônus: esta entrega não depende da janela e pode subir sozinha.

## As três formas de o campo mentir

Todas endereçadas, e a issue as lista:

1. **Não é o mínimo da chave**, que dataria o primeiro nascimento de sempre e ignoraria reativação. A conta é de ilhas e buracos: versões contíguas são atualização, buraco é reativação e reinicia o relógio
2. **Não é a janela de odds**
3. **Vem vazio** para chave anterior à estreia do snapshot, onde o horário dataria a estreia e não a publicação

## Os três critérios de aceite, conferidos contra o banco

Apliquei a função no dev e verifiquei com dado real, não com fixture:

- **o caso medido:** fixture 1570342, Over 3,5 → **25/08/2026 15:03:09 BRT**. Bate com a issue
- **reativação:** achei uma chave nascida em 27/07, na estreia do snapshot, e reativada depois. A função devolve **03/08**, o início da corrida atual, e não o primeiro nascimento
- **chave da estreia:** duas conferidas, ambas vazias

## Achados do code review

**O campo afirmaria disponibilidade de saída já retirada do board.** Procede. Mas a correção sugerida — restringir a função a versões abertas — apagaria justamente o caso de aceite, porque o jogo de 25/08 já encerrou e sua última versão está fechada. A trava certa é na tela: a frase só aparece quando existe oportunidade publicada para aquela saída. Em jogo encerrado isso continua verdadeiro, porque o detalhe lê a foto do apito. A mesma trava resolve o segundo achado, de arrastar a régua até uma parada sem cotação.

**O terceiro achado questionava a premissa inteira:** se o snapshot não fechasse a linha quando a oportunidade sai, não haveria buraco nenhum, toda chave teria uma ilha só, e o campo degeneraria no mínimo da chave — a forma 1 de mentir. Medi no dev: das 284 chaves, **276 têm a última versão fechada** e há **74 chaves com reativação**. O fechamento acontece. A medição ficou escrita na migration, com a data, para o próximo leitor não precisar refazê-la.

## Verificação

331 testes, 7 novos. Build, lint e typecheck sem nada novo.

A função já está aplicada no dev, porque foi assim que conferi os critérios. Ela não altera contrato nenhum e não interfere na janela da spec #301.
