### PR TITLE
Futebol: a home e o painel contam o mesmo dia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ CLAUDE.md
 /*.jpeg
 /*.webp
 .playwright-mcp/
+
+# Cache do tsc --noEmit; muda a cada checagem local.
+*.tsbuildinfo

--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -2696,7 +2696,14 @@ AS $function$
         partition by h.opportunity_key order by h.dbt_valid_from
       ) as fim_da_anterior
     from futebol.fact_value_opportunities_hist h
+    join futebol.fact_fixtures fx on fx.fixture_id = h.fixture_id
+    -- Só versões anteriores ao apito. O mart é full-refresh e continua
+    -- reescrevendo o jogo depois de encerrado — medido: 97% das versões nascem
+    -- DEPOIS do apito, em média 668h depois. Sem este corte, uma chave fechada
+    -- e reaberta no dia seguinte faria a tela dizer "disponível desde" um
+    -- horário posterior ao fim da partida.
     where h.fixture_id = p_fixture_id
+      and h.dbt_valid_from < fx.kickoff_utc
   ), ilhas as (
     select
       v.*,

--- a/src/components/futebol/AjudaCampo.tsx
+++ b/src/components/futebol/AjudaCampo.tsx
@@ -1,0 +1,62 @@
+import { Info } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+/**
+ * O rótulo de um número com um (i) que explica o que ele é.
+ *
+ * Popover e não tooltip: tooltip abre no hover, e metade do público lê isto no
+ * celular, onde hover não existe. Aqui o toque abre, o Esc e o toque fora
+ * fecham, e o teclado alcança o botão.
+ *
+ * As explicações moram neste arquivo, e não soltas na tela, porque os mesmos
+ * quatro números aparecem no destaque da home, nos cards e no painel — três
+ * cópias da mesma frase é como a copy diverge (foi o que aconteceu com a copy
+ * das premissas, issue #272).
+ */
+
+export function AjudaCampo({
+  rotulo,
+  titulo,
+  texto,
+  escuro,
+}: {
+  rotulo: string;
+  titulo: string;
+  texto: string;
+  /** No fundo forest do destaque; no card claro fica false. */
+  escuro?: boolean;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        className={`text-[9px] uppercase tracking-[0.14em] font-semibold ${escuro ? '' : 'text-ink-3'}`}
+        style={escuro ? { color: 'rgba(255,255,255,0.5)' } : undefined}
+      >
+        {rotulo}
+      </span>
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={`O que é ${titulo}`}
+            className={`grid h-4 w-4 place-items-center rounded-full transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 ${
+              escuro ? 'hover:bg-white/15' : 'hover:bg-canvas-2'
+            }`}
+            style={escuro ? { color: 'rgba(255,255,255,0.5)', outlineColor: '#fbbf24' } : undefined}
+          >
+            <Info className={`h-3 w-3 ${escuro ? '' : 'text-ink-3'}`} />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="w-64 rounded-rebrand-md border border-line bg-white p-3.5 text-ink shadow-lg"
+        >
+          {/* Forest, e não o cinza de rótulo: dentro do cartão branco o cinza
+              somia contra o texto e o título deixava de ancorar a leitura. */}
+          <div className="text-[10px] uppercase tracking-[0.14em] font-bold text-forest">{titulo}</div>
+          <p className="mt-1.5 text-[12.5px] leading-relaxed text-ink-2">{texto}</p>
+        </PopoverContent>
+      </Popover>
+    </span>
+  );
+}

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -4,40 +4,36 @@ import { Zap, ArrowRight, Check, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Seo } from '@/components/Seo';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useFutebolFixturesMulti, useFutebolValueBoard, useFutebolFixtureValue, useFutebolAccess } from '@/hooks/use-futebol-data';
+import { useFutebolFixturesMulti, useFutebolValueBoard, useFutebolValueHistory, useFutebolAlertedPicks, useFutebolFixtureReasonContract, useFutebolAccess } from '@/hooks/use-futebol-data';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
+import { AjudaCampo } from '@/components/futebol/AjudaCampo';
+import { textoDoScore, TEXTO_CHANCE, TEXTO_ODD, TEXTO_VALOR } from '@/utils/futebol-ajuda-copy';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
 import { competitionLabel, ALL_COMPETITIONS } from '@/utils/futebol-competitions';
 import {
-  pickLabel, marketLabel, fmtEdgeScore, freqEmDez, groupBoardByFixture,
-  faixaBadgeCls, faixaWord, faixaTone, topEvidencia, chancePct, ehDestaque,
+  pickLabel, marketLabel, fmtEdgeScore, groupBoardByFixture,
+  faixaBadgeCls, faixaWord, faixaTone, topEvidencia, chancePct, ehDestaque, compararOportunidades, versaoDaJanela,
 } from '@/utils/futebol-score';
-import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
+import type { FutebolValueBoardRow, FutebolFixture } from '@/services/futebol-data.service';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
 import { FUTEBOL_TOUR_ID, makeFutebolSteps } from '@/components/onboarding/tours';
 import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
 import { demoFutebolBoard, demoFutebolFixtures } from '@/components/onboarding/demo/futebol';
-
-const SAO_PAULO_TZ = 'America/Sao_Paulo';
+// Aritmética de fuso vem de um lugar só. As cópias locais que existiam aqui
+// eram idênticas às de futebol-datas.ts, e duas cópias da mesma conta de fuso é
+// como se erra fuso — foi por isso que Oportunidades removeu as dela no PR #259.
+import { SAO_PAULO_TZ, parseUtc, brtDateStr, brtDayOf, fmtTime, isFinished } from '@/utils/futebol-datas';
+import { mergeBoardAndHistory } from '@/utils/futebol-history';
+import { oportunidadesDoDia, type OppLike } from '@/utils/futebol-registradas';
+import { separarMotivosDoContrato } from '@/utils/futebol-motivos';
+import { ladoDaSaida } from '@/utils/futebol-evidencias';
+import { premissaDe, rotuloPremissa } from '@/utils/futebol-premissas';
+import { useNow } from '@/hooks/use-now';
 // Quantos dias futuros (com jogos) o navegador mostra — janela curta, não a temporada toda.
 const DAY_WINDOW = 8;
 
-function parseUtc(raw: string | null): Date | null {
-  if (!raw) return null;
-  const iso = raw.includes('T') ? raw : `${raw}T00:00:00`;
-  const d = new Date(/[Z]|[+-]\d{2}:?\d{2}$/.test(iso) ? iso : `${iso}Z`);
-  return isNaN(d.getTime()) ? null : d;
-}
-function brtDateStr(d: Date): string {
-  return new Intl.DateTimeFormat('en-CA', { timeZone: SAO_PAULO_TZ, year: 'numeric', month: '2-digit', day: '2-digit' }).format(d);
-}
-function fmtTime(raw: string | null): string {
-  const d = parseUtc(raw);
-  if (!d) return '';
-  return new Intl.DateTimeFormat('pt-BR', { timeZone: SAO_PAULO_TZ, hour: '2-digit', minute: '2-digit' }).format(d);
-}
 function fmtDayTime(raw: string | null): string {
   const d = parseUtc(raw);
   if (!d) return '—';
@@ -48,9 +44,6 @@ function fmtTodayHeader(d: Date): string {
   const s = new Intl.DateTimeFormat('pt-BR', { timeZone: SAO_PAULO_TZ, weekday: 'long', day: '2-digit', month: 'long' }).format(d);
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
-function isFinished(s: string | null): boolean {
-  return s === 'FT' || s === 'AET' || s === 'PEN';
-}
 function crestInitials(name: string): string {
   return name.replace(/[^A-Za-zÀ-ÿ\s]/g, '').trim().slice(0, 3).toUpperCase() || '?';
 }
@@ -60,6 +53,9 @@ function Crest({ teamId, name, size = 24 }: { teamId: number; name: string; size
   if (logo && !err) return <img src={logo} alt={name} onError={() => setErr(true)} style={{ width: size, height: size }} className="object-contain shrink-0" loading="lazy" />;
   return <div style={{ width: size, height: size }} className="rounded-full bg-canvas-2 border border-line grid place-items-center text-[9px] font-bold text-ink-2 shrink-0">{crestInitials(name)}</div>;
 }
+
+/** Um motivo do contrato, com o slug preservado para servir de chave. */
+type Motivo = { slug: string; texto: string };
 
 const CARD = 'bg-white border border-line rounded-rebrand-md';
 const LABEL = 'text-[10px] uppercase tracking-[0.16em] font-semibold text-ink-3';
@@ -79,11 +75,13 @@ function Kpi({ label, value, sub, tone = 'ink', anchor }: { label: string; value
 }
 
 // Número do hero (Chance / Odd / Se paga em / Valor)
-function HeroStat({ label, value, dark, locked }: { label: string; value: string; dark?: boolean; locked?: boolean }) {
+function HeroStat({ label, value, dark, locked, ajuda }: { label: string; value: string; dark?: boolean; locked?: boolean; ajuda?: string }) {
   return (
     <div>
       <div className="text-[9px] uppercase tracking-[0.14em] font-semibold" style={{ color: dark ? 'rgba(255,255,255,0.5)' : undefined }}>
-        <span className={dark ? '' : 'text-ink-3'}>{label}</span>
+        {ajuda
+          ? <AjudaCampo rotulo={label} titulo={label} texto={ajuda} escuro={dark} />
+          : <span className={dark ? '' : 'text-ink-3'}>{label}</span>}
       </div>
       <div className={`text-[20px] font-bold tabular-nums leading-none mt-1 ${dark ? '' : 'text-ink'}`}><Blur active={!!locked}>{value}</Blur></div>
     </div>
@@ -92,14 +90,14 @@ function HeroStat({ label, value, dark, locked }: { label: string; value: string
 
 // ── Hero: melhor valor do dia — 3 colunas (pick · por quê · confiab). ────────
 // Alta = gradiente forest (texto branco); Média = card claro com acento âmbar.
-function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow; onClick: () => void; atencao?: string | null; locked?: boolean }) {
+function TopValueHero({ o, onClick, favor, contra, textoScore, locked }: { o: FutebolValueBoardRow; onClick: () => void; favor: Motivo[]; contra: Motivo[]; textoScore: string; locked?: boolean }) {
   const pick = pickLabel(o, o.home_team_name, o.away_team_name);
   const ev = topEvidencia(o.evidencias);
   const d = true; // hero sempre no fundo forest (mockup); a faixa vai no selo, não na cor do card
   const chance = chancePct(o.prob_justa_fechamento);
   const porque = chance != null
     ? <>O mercado dá <b className={d ? 'text-white' : 'text-ink'}>~{chance}% de chance</b>; na odd <b className={d ? 'text-white' : 'text-ink'}>{o.best_odd.toFixed(2)}</b> isso paga acima do risco real — é aí que está o valor.</>
-    : <>Na odd <b className={d ? 'text-white' : 'text-ink'}>{o.best_odd.toFixed(2)}</b>, se paga se acontecer ~{freqEmDez(o.best_odd)} em cada 10 vezes ou mais — e a leitura do jogo aponta nessa direção.</>;
+    : <>Na odd <b className={d ? 'text-white' : 'text-ink'}>{o.best_odd.toFixed(2)}</b>, a aposta se paga a partir de <b className={d ? 'text-white' : 'text-ink'}>{Math.round(100 / o.best_odd)}%</b> de acerto — e a leitura do jogo aponta nessa direção.</>;
 
   return (
     <div className={`rounded-2xl overflow-hidden relative ${d ? 'text-white' : 'bg-white border border-line border-l-4 border-l-amber'}`}
@@ -115,11 +113,16 @@ function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow
           </span>
           <div className={`text-[11px] uppercase tracking-[0.16em] font-semibold mt-5 ${d ? 'text-white/50' : 'text-ink-3'}`}>{marketLabel(o.market)} · {competitionLabel(o.competition)}</div>
           <div className={`text-[28px] md:text-[32px] font-bold tracking-tight leading-[1.1] mt-2 ${d ? '' : 'text-ink'}`}><Blur active={!!locked} strength={9}>{pick}</Blur></div>
-          <div className={`flex items-center gap-1.5 text-[13px] mt-2 ${d ? 'text-white/70' : 'text-ink-2'}`}>
-            <Crest teamId={o.home_team_id} name={o.home_team_name} size={18} />
-            <span>{o.home_team_name} × {o.away_team_name}</span>
-            <Crest teamId={o.away_team_id} name={o.away_team_name} size={18} />
-            <span className="opacity-70">· {fmtDayTime(o.kickoff_utc)}</span>
+          {/* No celular a data desce para a própria linha. Tudo numa fileira só,
+              os nomes quebravam no meio e o escudo do visitante ficava órfão
+              entre 'Bournemouth ×' e 'Everton'. No desktop cabe e segue inline. */}
+          <div className={`text-[13px] mt-2 flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-1.5 ${d ? 'text-white/70' : 'text-ink-2'}`}>
+            <span className="flex items-center gap-1.5">
+              <Crest teamId={o.home_team_id} name={o.home_team_name} size={18} />
+              <span>{o.home_team_name} × {o.away_team_name}</span>
+              <Crest teamId={o.away_team_id} name={o.away_team_name} size={18} />
+            </span>
+            <span className="opacity-70"><span className="hidden sm:inline">· </span>{fmtDayTime(o.kickoff_utc)}</span>
           </div>
           <button onClick={onClick} className={`h-11 px-5 mt-5 w-fit rounded-md text-[13px] font-semibold inline-flex items-center gap-2 ${d ? '' : 'bg-ink text-canvas hover:bg-ink-2'} transition`}
             style={d ? { background: '#fbbf24', color: '#1a1d1a' } : undefined}>
@@ -127,31 +130,56 @@ function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow
           </button>
         </div>
 
-        {/* Meio — por quê + ponto de atenção */}
-        <div className="md:col-span-5 flex flex-col">
-          <div className={`text-[11px] uppercase tracking-[0.18em] font-semibold ${d ? 'text-white/50' : 'text-ink-3'}`}>Por quê</div>
-          <p className={`text-[17px] md:text-[19px] leading-[1.4] font-medium tracking-tight mt-2 ${d ? 'text-white/95' : 'text-ink'}`} style={{ textWrap: 'pretty' }}><Blur active={!!locked}>{porque}</Blur></p>
-          {ev && (
-            <p className={`flex items-start gap-1.5 text-[12px] mt-3 ${d ? 'text-white/80' : 'text-ink-2'}`}>
-              <Check className={`w-3.5 h-3.5 mt-0.5 shrink-0 ${d ? 'text-emerald-300' : 'text-status-success'}`} /><span>{ev}</span>
-            </p>
+        {/* Meio — o que sustenta e o que pesa contra.
+
+            Antes era uma frase sobre chance e odd. Ela repetia os números da
+            coluna da direita e não dava argumento nenhum: as premissas do jogo
+            é que explicam a leitura, e são elas que a tela de detalhe mostra.
+            Vêm do mesmo contrato do backend, então as duas telas concordam. */}
+        <div className="md:col-span-5 flex flex-col gap-4">
+          {favor.length > 0 && (
+            <div>
+              <div className={`text-[11px] uppercase tracking-[0.18em] font-semibold ${d ? 'text-white/50' : 'text-ink-3'}`}>A favor</div>
+              <ul className="mt-2 flex flex-col gap-1.5">
+                {favor.map((m) => (
+                  <li key={m.slug} className={`flex items-start gap-2 text-[14px] leading-snug ${d ? 'text-white/90' : 'text-ink'}`}>
+                    <Check className={`w-4 h-4 mt-0.5 shrink-0 ${d ? 'text-emerald-300' : 'text-status-success'}`} />
+                    <span><Blur active={!!locked}>{m.texto}</Blur></span>
+                  </li>
+                ))}
+              </ul>
+            </div>
           )}
-          {atencao && (
-            <div className="mt-4 rounded-lg p-3 flex items-start gap-2"
-              style={d ? { background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.1)' } : { background: '#fef7df', border: '1px solid #fde68a' }}>
-              <span style={{ color: d ? '#fde68a' : '#9a6c00' }} className="mt-0.5 shrink-0"><AlertTriangle className="w-3.5 h-3.5" /></span>
-              <div className={`text-[12px] leading-relaxed ${d ? 'text-white/80' : ''}`} style={d ? undefined : { color: '#5a3c00' }}>
-                <span className="font-semibold" style={{ color: d ? '#fde68a' : '#9a6c00' }}>Ponto de atenção · </span>{atencao}
-              </div>
+
+          {contra.length > 0 && (
+            <div>
+              <div className={`text-[11px] uppercase tracking-[0.18em] font-semibold ${d ? 'text-white/50' : 'text-ink-3'}`}>Contra</div>
+              <ul className="mt-2 flex flex-col gap-1.5">
+                {contra.map((m) => (
+                  <li key={m.slug} className={`flex items-start gap-2 text-[14px] leading-snug ${d ? 'text-white/70' : 'text-ink-2'}`}>
+                    <AlertTriangle className={`w-4 h-4 mt-0.5 shrink-0 ${d ? '' : 'text-amber-2'}`} style={d ? { color: '#fde68a' } : undefined} />
+                    <span><Blur active={!!locked}>{m.texto}</Blur></span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {favor.length === 0 && contra.length === 0 && (
+            <div>
+              <div className={`text-[11px] uppercase tracking-[0.18em] font-semibold ${d ? 'text-white/50' : 'text-ink-3'}`}>Por quê</div>
+              <p className={`text-[17px] md:text-[19px] leading-[1.4] font-medium tracking-tight mt-2 ${d ? 'text-white/95' : 'text-ink'}`} style={{ textWrap: 'pretty' }}><Blur active={!!locked}>{porque}</Blur></p>
             </div>
           )}
         </div>
 
-        {/* Direita — confiabilidade + números */}
-        <div className={`md:col-span-3 flex flex-col justify-between md:pl-6 ${d ? '' : 'md:border-l md:border-line'}`}
-          style={d ? { borderLeft: '1px solid rgba(255,255,255,0.1)' } : undefined}>
+        {/* Direita — Score + números */}
+        {/* A divisória é do layout de DUAS colunas. No celular elas viram uma
+            pilha, e a borda sobrava como um risco solto ao lado do Score. Ela
+            era estilo inline, que não aceita breakpoint — virou classe md:. */}
+        <div className={`md:col-span-3 flex flex-col justify-between md:pl-6 md:border-l ${d ? 'md:border-white/10' : 'md:border-line'}`}>
           <div>
-            <div className={`text-[10px] uppercase tracking-[0.16em] font-semibold ${d ? 'text-white/50' : 'text-ink-3'}`}>Confiabilidade</div>
+            <AjudaCampo rotulo="Score" titulo="Score" texto={textoScore} escuro={d} />
             <div className="flex items-baseline gap-1.5 mt-1">
               <span className={`text-[56px] md:text-[64px] font-bold tabular-nums leading-none ${d ? '' : 'text-amber-2'}`} style={d ? { color: '#fbbf24' } : undefined}>{o.score}</span>
               <span className={`text-[16px] ${d ? 'text-white/40' : 'text-ink-3'}`}>/100</span>
@@ -160,11 +188,13 @@ function TopValueHero({ o, onClick, atencao, locked }: { o: FutebolValueBoardRow
               style={d ? { background: 'rgba(220,239,226,0.15)', color: '#dcefe2' } : undefined}>
               <span className="w-1.5 h-1.5 rounded-full" style={{ background: d ? '#fbbf24' : 'var(--amber)' }} />Faixa {faixaWord(o.faixa)}
             </span>
-            <div className="grid grid-cols-2 gap-x-5 gap-y-3 mt-5">
-              {chance != null && <HeroStat label="Chance" value={`${chance}%`} dark={d} locked={locked} />}
-              <HeroStat label="Odd" value={o.best_odd.toFixed(2)} dark={d} locked={locked} />
-              <HeroStat label="Se paga em" value={`~${freqEmDez(o.best_odd)}/10`} dark={d} locked={locked} />
-              <HeroStat label="Valor" value={fmtEdgeScore(o.edge)} dark={d} locked={locked} />
+            {/* Os três numa linha só: eles são a mesma leitura — a chance
+                estimada, o preço e a diferença entre os dois — e lidos em
+                sequência dizem mais do que empilhados. */}
+            <div className="grid grid-cols-3 gap-x-3 gap-y-3 mt-5">
+              {chance != null && <HeroStat label="Chance" value={`${chance}%`} dark={d} locked={locked} ajuda={TEXTO_CHANCE} />}
+              <HeroStat label="Odd" value={o.best_odd.toFixed(2)} dark={d} locked={locked} ajuda={TEXTO_ODD} />
+              <HeroStat label="Valor" value={fmtEdgeScore(o.edge)} dark={d} locked={locked} ajuda={TEXTO_VALOR} />
             </div>
           </div>
         </div>
@@ -242,46 +272,101 @@ export default function FutebolHoje() {
   const navigate = useNavigate();
   // Todas as ligas do mart (data-driven), não mais um allowlist de 3.
   const { data: allGames, isLoading: lFix } = useFutebolFixturesMulti(ALL_COMPETITIONS, 2026);
-  const { data: valueRows, isLoading: l3 } = useFutebolValueBoard();
+  const { data: boardRows, isLoading: l3 } = useFutebolValueBoard();
+  const { data: histRows, isLoading: lHist } = useFutebolValueHistory();
+  const { data: alertedRaw, isLoading: lReg } = useFutebolAlertedPicks();
+  // UM instante para a tela inteira, e ele anda: o seletor de dias e o corte de
+  // "já começou" têm que concordar sobre que horas são.
+  const agora = useNow();
   const { data: access } = useFutebolAccess();
-  const loading = lFix || l3;
+  const loading = lFix || l3 || lHist || lReg;
   const futebolTour = useOnboardingTour(FUTEBOL_TOUR_ID, { enabled: !loading });
   const isDemo = futebolTour.run; // durante o tour, preenche a tela com exemplo
   const locked = isDemo ? false : !access?.unlocked;
 
-  const todayStr = brtDateStr(new Date());
+  const todayStr = brtDateStr(new Date(agora));
   const [day, setDay] = useState<string | null>(null);
 
   // dias (BRT) com jogos ainda não começados — base da navegação por dias.
   // Limita aos próximos dias (não varre a temporada inteira do Brasileirão).
   const days = useMemo(() => {
-    const now = Date.now();
+    const now = agora;
+    const hoje = brtDateStr(new Date(now));
     const set = new Set<string>();
     allGames.forEach((f) => {
       const d = parseUtc(f.kickoff_utc || f.date_utc);
       const t = d?.getTime();
-      if (d && t != null && t > now && !isFinished(f.status_short)) set.add(brtDateStr(d));
+      if (!d || t == null) return;
+      const dia = brtDateStr(d);
+      // HOJE fica no seletor o dia inteiro, mesmo depois de o último jogo entrar
+      // em campo. Antes o dia só entrava se tivesse jogo por começar, e por volta
+      // das 21h — quando o último começa — hoje sumia da lista e a tela pulava
+      // sozinha para amanhã, com quem estava lendo junto.
+      if (dia === hoje || (t > now && !isFinished(f.status_short))) set.add(dia);
     });
     return [...set].sort().slice(0, DAY_WINDOW);
-  }, [allGames]);
+  }, [allGames, agora]);
   const selectedDay = (day && days.includes(day)) ? day : (days.includes(todayStr) ? todayStr : days[0] ?? todayStr);
   const selectedDate = new Date(`${selectedDay}T12:00:00Z`);
   const isToday = selectedDay === todayStr;
 
   // oportunidades (value rows) do dia selecionado, ainda não começadas. O Score já
   // vem pronto do backend (fact_value_opportunities); aqui só filtramos e ranqueamos.
-  const dayRows = useMemo(() => {
-    if (!valueRows?.length) return [];
-    const now = Date.now();
-    return valueRows.filter((r) => {
-      const d = parseUtc(r.kickoff_utc);
-      const t = d?.getTime();
-      return d != null && t! > now && brtDateStr(d) === selectedDay && !isFinished(r.status_short);
-    });
-  }, [valueRows, selectedDay]);
+  // TODAS as oportunidades do dia, tenham os jogos começado ou não. Esta tela é
+  // o retrato do dia, e antes ela escondia o que já tinha entrado em campo: numa
+  // noite de sábado com sete oportunidades publicadas, mostrava zero.
+  //
+  // Quem quiser só o que ainda dá para acompanhar tem o filtro na tela de
+  // Oportunidades.
+  // MESMA fonte da tela de Oportunidades, de propósito: as duas telas falam da
+  // mesma lista, e divergir aqui seria o produto contando duas histórias.
+  // A regra da fusão vive em futebol-history.ts, testada.
+  //
+  // O que mudou foi tirar o corte de "só jogo que ainda não começou", que era
+  // exclusivo desta tela: ele zerava a home toda noite, num dia que teve
+  // oportunidades. Quem quer só o que dá para acompanhar tem o filtro no painel.
+  const valueRows = useMemo(
+    () => mergeBoardAndHistory(boardRows ?? [], histRows ?? [], agora),
+    [boardRows, histRows, agora],
+  );
+  // As oportunidades REGISTRADAS entram aqui pelo mesmo motivo que entram no
+  // painel: elas existiram no dia e o board não as tem mais, porque o mart é
+  // full-refresh. Sem elas a home mostrava três num dia de seis, e as duas telas
+  // contavam histórias diferentes do mesmo dia.
+  const registradasAll = useMemo(
+    () => (alertedRaw ?? []).filter((a) => !!a.market && !!a.outcome),
+    [alertedRaw],
+  );
+  const fixturePorId = useMemo(() => {
+    const m = new Map<number, FutebolFixture>();
+    (allGames ?? []).forEach((f) => m.set(f.fixture_id, f));
+    return m;
+  }, [allGames]);
+
+  const dayRows = useMemo<OppLike[]>(
+    () => oportunidadesDoDia({
+      doBoard: valueRows.filter((r) => brtDayOf(r.kickoff_utc) === selectedDay),
+      registradas: registradasAll,
+      dia: selectedDay,
+      fixturePorId,
+    }),
+    [valueRows, selectedDay, registradasAll, fixturePorId],
+  );
+
+  // Os blocos visuais precisam de Score e faixa para existir. A oportunidade
+  // registrada ANTES da migration 091 não guardou esses números, então ela conta
+  // no total do dia — que é o que o painel também conta — mas não vira card com
+  // número inventado.
+  const comNumeros = useMemo(
+    () => dayRows.filter(
+      (r): r is FutebolValueBoardRow =>
+        r.score != null && r.faixa != null && r.edge != null && r.prob_justa_fechamento != null,
+    ),
+    [dayRows],
+  );
 
   // melhor oportunidade por jogo, ordenado por Score
-  const board = useMemo(() => groupBoardByFixture(dayRows), [dayRows]);
+  const board = useMemo(() => groupBoardByFixture(comNumeros), [comNumeros]);
   const bestByFixture = useMemo(() => {
     const m = new Map<number, FutebolValueBoardRow>();
     if (isDemo) { demoFutebolBoard.forEach((r) => m.set(r.fixture_id, r)); return m; }
@@ -299,21 +384,48 @@ export default function FutebolHoje() {
       .sort((a, b) => (parseUtc(a.kickoff_utc)?.getTime() ?? 0) - (parseUtc(b.kickoff_utc)?.getTime() ?? 0));
   }, [allGames, selectedDay]);
 
-  const realOppsByFixture = useMemo(() => board.map((bf) => bf.best), [board]);
-  const oppsByFixture = isDemo ? demoFutebolBoard : realOppsByFixture;
+  // Uma linha por OPORTUNIDADE, não por jogo. Colapsar por jogo escondia a
+  // segunda linha do mesmo confronto — num dia com duas oportunidades no
+  // Bournemouth × Everton, a lista mostrava uma e sumia com a outra. A grade de
+  // jogos ao lado continua com uma linha por partida, que é o papel dela.
+  const realOpps = useMemo(
+    () => [...comNumeros].sort((a, b) => compararOportunidades(a, b)),
+    [comNumeros],
+  );
+  const oppsByFixture = isDemo ? demoFutebolBoard : realOpps;
   // O destaque é a primeira em faixa Alta ou Média, e não necessariamente a de
   // maior Score: faixa não é função pura do Score, porque as portas de odd por
   // mercado podem deixar a linha mais bem pontuada fora do destaque. Testar só a
   // posição zero fazia o bloco sumir num dia que tinha destaque.
   const heroOpp = oppsByFixture.find((o) => ehDestaque(o.faixa)) ?? null;
-  // "Ponto de atenção" do hero: vem do detalhe (contras/avisos) do jogo em destaque
-  const { data: heroRows } = useFutebolFixtureValue(heroOpp?.fixture_id);
-  const heroAtencao = useMemo(() => {
-    if (!heroOpp || !heroRows?.length) return null;
-    const row = heroRows.find((r) => r.market === heroOpp.market && r.outcome === heroOpp.outcome && (r.line_value ?? null) === (heroOpp.line_value ?? null));
-    const list = row ? [...(row.contras ?? []), ...(row.avisos ?? [])] : [];
-    return list[0] ?? null;
-  }, [heroOpp, heroRows]);
+  // A favor e Contra do destaque, do MESMO contrato que a tela de detalhe usa.
+  // O backend decide o grupo de cada motivo; aqui só se traduz o slug pelo
+  // catálogo e se corta a lista no que cabe no card.
+  const { data: contratoMotivos } = useFutebolFixtureReasonContract(heroOpp?.fixture_id);
+  const { favor: heroFavor, contra: heroContra } = useMemo(() => {
+    const vazio = { favor: [] as Motivo[], contra: [] as Motivo[] };
+    if (!heroOpp || !contratoMotivos?.length) return vazio;
+    const linha = contratoMotivos.find(
+      (r) => r.market === heroOpp.market && r.outcome === heroOpp.outcome
+        && (r.line_value ?? null) === (heroOpp.line_value ?? null),
+    );
+    if (!linha) return vazio;
+    const lado = ladoDaSaida(heroOpp.market, heroOpp.outcome);
+    const traduzir = (itens: typeof linha.favor, negativo: boolean) =>
+      separarMotivosDoContrato(itens)
+        .slugsDePremissas.map((slug) => ({ slug, prem: premissaDe(heroOpp.market, slug) }))
+        .filter((x): x is { slug: string; prem: NonNullable<typeof x.prem> } => x.prem != null)
+        .map(({ slug, prem }) => ({ slug, texto: rotuloPremissa(prem, lado, negativo) }));
+    return {
+      // Três e duas: o card tem altura fixa e a leitura tem que caber de relance.
+      favor: traduzir(linha.favor, false).slice(0, 3),
+      contra: traduzir(linha.contra, true).slice(0, 2),
+    };
+  }, [heroOpp, contratoMotivos]);
+  // A escala da janela, e não a da linha: a registrada não declara versão.
+  const textoScore = textoDoScore(
+    versaoDaJanela(dayRows) === 'contexto_v1' ? 'contexto_v1' : 'legacy',
+  );
   const moreOpps = oppsByFixture.filter((o) => o !== heroOpp && ehDestaque(o.faixa)).slice(0, 4);
   const nOpps = isDemo ? demoFutebolBoard.length : dayRows.length;
   const gameList = isDemo ? demoFutebolFixtures : dayGames;
@@ -384,7 +496,7 @@ export default function FutebolHoje() {
         {loading ? (
           <Skeleton className="h-64 w-full bg-canvas-2 rounded-2xl" />
         ) : heroOpp ? (
-          <TopValueHero o={heroOpp} atencao={heroAtencao} onClick={() => navigate(`/futebol/jogo/${heroOpp.fixture_id}`)} locked={locked} />
+          <TopValueHero o={heroOpp} favor={heroFavor} contra={heroContra} textoScore={textoScore} onClick={() => navigate(`/futebol/jogo/${heroOpp.fixture_id}`)} locked={locked} />
         ) : (
           <div className={`${CARD} p-6 flex items-start gap-3`}>
             <Zap className="w-5 h-5 text-ink-3 mt-0.5 shrink-0" />

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -20,8 +20,9 @@ import {
   FAIXA_FILTRO_PADRAO, type FaixaFilter,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
-import { mergeBoardAndHistory, opportunityKey } from '@/utils/futebol-history';
-import { parseUtc, brtDayOf, brtDateStr, fmtTime } from '@/utils/futebol-datas';
+import { mergeBoardAndHistory } from '@/utils/futebol-history';
+import { oppKey, oportunidadesDoDia, type OppLike } from '@/utils/futebol-registradas';
+import { parseUtc, brtDayOf, brtDateStr, fmtTime, hasKickoffPassed } from '@/utils/futebol-datas';
 import { onboardingHref, ONBOARDING_SRC_ALERTAS_FUTEBOL } from '@/utils/onboarding-return';
 import { useNow } from '@/hooks/use-now';
 import type { FutebolValueBoardRow, FutebolAlertedPick, FutebolFixture } from '@/services/futebol-data.service';
@@ -32,76 +33,6 @@ import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
 import { demoFutebolBoard } from '@/components/onboarding/demo/futebol';
 
 const FINISHED_STATUS = new Set(['FT', 'AET', 'PEN']);
-
-/**
- * Linha da lista. O board (mart) sempre traz Score, faixa, chance e valor; uma
- * oportunidade REGISTRADA (que existiu no dia e o board não tem mais, porque o
- * mart é full-refresh e re-escolhe a janela de odds) pode não ter esses números
- * do instante em que era oportunidade — nas enviadas antes da migration 091 não
- * foram guardados. Ela continua sendo oportunidade do dia; só esses campos ficam
- * vazios. FutebolValueBoardRow é atribuível a isto (number → number | null).
- */
-type OppLike = Omit<FutebolValueBoardRow, 'score' | 'faixa' | 'edge' | 'prob_justa_fechamento' | 'score_versao'> & {
-  score: number | null;
-  faixa: string | null;
-  edge: number | null;
-  prob_justa_fechamento: number | null;
-  /**
-   * Ausente na oportunidade registrada: a tabela de picks nunca guardou versão,
-   * e carimbá-la de legacy faria a legenda achar que toda janela é mista.
-   */
-  score_versao?: FutebolValueBoardRow['score_versao'];
-};
-
-/**
- * Chave de uma oportunidade — casa board, histórico e registro do que foi
- * enviado. Reexportada de `futebol-history.ts` com a forma que esta tela usa
- * (argumentos soltos em vez de objeto): eram duas funções produzindo string
- * byte a byte idêntica, e duas chaves que "por acaso" batem é o tipo de coisa
- * que só quebra depois que alguém mexe numa delas.
- */
-const oppKey = (fixtureId: number, market: string | null, outcome: string | null, line: number | null) =>
-  opportunityKey({ fixture_id: fixtureId, market, outcome, line_value: line });
-
-/**
- * Monta a linha de uma oportunidade registrada (enviada no daily) com os valores
- * do momento do envio. Sem fixture casado, cai pro "Casa × Fora" do registro:
- * é melhor manter a oportunidade na lista sem escudo do que perder o registro.
- */
-function oppFromAlerted(a: FutebolAlertedPick, fx?: FutebolFixture): OppLike {
-  const [rawHome, rawAway] = a.match_description.split('×');
-  return {
-    fixture_id: a.fixture_id,
-    home_team_id: fx?.home_team_id ?? 0,
-    away_team_id: fx?.away_team_id ?? 0,
-    home_team_name: fx?.home_team_name ?? (rawHome?.trim() || 'Casa'),
-    away_team_name: fx?.away_team_name ?? (rawAway?.trim() || 'Fora'),
-    competition: a.league ?? '',
-    kickoff_utc: fx?.kickoff_utc ?? null,
-    status_short: fx?.status_short ?? null,
-    market: a.market!,
-    outcome: a.outcome!,
-    line_value: a.line_value,
-    best_odd: Number(a.odds),
-    best_book: '',
-    avg_odd: Number(a.odds),
-    n_casas: 0,
-    janela_usada: a.janela_usada ?? '',
-    pts_valor: 0,
-    pts_premissas: 0,
-    pts_corroboracao: 0,
-    penalidades: 0,
-    evidencias: [],
-    premissas_sem_dado: 0,
-    // Números do instante em que era oportunidade. Null nas enviadas antes da
-    // migration 091 (o pipeline sobrescreve a janela e destrói chance/valor/Score
-    // da manhã); daí em diante vêm preenchidos e a linha fica igual à do board.
-    score: a.score,
-    faixa: a.faixa,
-    edge: a.edge,
-    prob_justa_fechamento: a.prob_justa_fechamento,
-  };
-}
 
 // O `kickoffMs`, o `brtDayStr` e o `TODAY_BRT` que moravam aqui eram cópia
 // literal do que `futebol-datas.ts` já exporta como `parseUtc`, `brtDayOf` e
@@ -346,6 +277,10 @@ export default function FutebolOportunidades() {
   const locked = isDemo ? false : !access?.unlocked;
   const [mercado, setMercado] = useState<MarketFilter>('all');
   const [faixa, setFaixa] = useState<FaixaFilter>(FAIXA_FILTRO_PADRAO);
+  // Desligado por padrão: a lista é o retrato do dia, e esconder o que já entrou
+  // em campo apagaria metade dele numa noite de sábado. Quem está caçando aposta
+  // agora liga e vê só o que dá para acompanhar.
+  const [soEmAberto, setSoEmAberto] = useState(false);
   const [comp, setComp] = useState<CompFilter>('all');
   const [day, setDay] = useState<string | null>(null);
 
@@ -478,15 +413,15 @@ export default function FutebolOportunidades() {
   // Lista do dia = board + oportunidades registradas que o board não tem mais.
   // Uma lista só: as duas são oportunidade daquele dia, a diferença é de onde
   // veio o número, não de natureza.
-  const dayRows = useMemo<OppLike[]>(() => {
-    const board: OppLike[] = allRows.filter((r) => brtDayOf(r.kickoff_utc) === selectedDay);
-    const noBoard = new Set(board.map((r) => oppKey(r.fixture_id, r.market, r.outcome, r.line_value)));
-    const registradas = registradasAll
-      .filter((a) => a.game_day === selectedDay)
-      .filter((a) => !noBoard.has(oppKey(a.fixture_id, a.market, a.outcome, a.line_value)))
-      .map((a) => oppFromAlerted(a, fixtureMap.get(a.fixture_id)));
-    return [...board, ...registradas];
-  }, [allRows, selectedDay, registradasAll, fixtureMap]);
+  const dayRows = useMemo<OppLike[]>(
+    () => oportunidadesDoDia({
+      doBoard: allRows.filter((r) => brtDayOf(r.kickoff_utc) === selectedDay),
+      registradas: registradasAll,
+      dia: selectedDay,
+      fixturePorId: fixtureMap,
+    }),
+    [allRows, selectedDay, registradasAll, fixtureMap],
+  );
 
   const filtered = useMemo(
     () => dayRows.filter((r) => {
@@ -494,9 +429,18 @@ export default function FutebolOportunidades() {
       // Sem faixa não dá pra classificar, então o filtro de faixa a esconde.
       if (!passaNoFiltroDeFaixa(faixa, r.faixa)) return false;
       if (comp !== 'all' && r.competition !== comp) return false;
+      // Em aberto = o apito inicial ainda não soou. O status vem depois, e às
+      // vezes atrasado, então quem manda é o relógio (ver futebol-datas.ts).
+      if (
+        soEmAberto &&
+        (r.kickoff_utc == null ||
+          hasKickoffPassed(r.kickoff_utc, new Date(agora)) ||
+          FINISHED_STATUS.has(r.status_short ?? ''))
+      )
+        return false;
       return true;
     }),
-    [dayRows, mercado, faixa, comp]
+    [dayRows, mercado, faixa, comp, soEmAberto, agora]
   );
 
   // Uma linha por oportunidade (sem colapsar por jogo), ranqueado por Score.
@@ -659,6 +603,20 @@ export default function FutebolOportunidades() {
           {/* `flex-wrap`: os dois filtros somam ~294px e não cabem lado a lado
               abaixo de ~340px. Sem isso a linha `shrink-0` estourava a página. */}
           <div className="flex flex-wrap items-center gap-2 sm:flex-nowrap sm:shrink-0">
+            {/* Chip em vez de mais um dropdown: é liga-desliga, e o estado tem
+                que ser legível sem abrir nada. */}
+            <button
+              type="button"
+              aria-pressed={soEmAberto}
+              onClick={() => setSoEmAberto((v) => !v)}
+              className={`h-9 px-3 rounded-rebrand-sm text-[12px] font-semibold border transition-colors shrink-0 ${
+                soEmAberto
+                  ? 'bg-forest text-canvas border-forest'
+                  : 'bg-white text-ink-2 border-line hover:bg-canvas-2 hover:text-ink'
+              }`}
+            >
+              Só jogos em aberto
+            </button>
             <FilterSelect label="Faixa" value={faixa} options={faixaOptions} onChange={(v) => setFaixa(v as FaixaFilter)} />
             <FilterSelect label="Competição" value={comp} options={compOptions} onChange={(v) => setComp(v as CompFilter)} />
           </div>
@@ -679,7 +637,7 @@ export default function FutebolOportunidades() {
             </p>
             <p className="text-xs text-ink-3 mt-1">
               {escondidasPeloFiltro > 0
-                ? `Este dia tem ${escondidasPeloFiltro} ${escondidasPeloFiltro === 1 ? 'oportunidade' : 'oportunidades'} em outra faixa ou mercado. Troque o filtro para ver.`
+                ? `Este dia tem ${escondidasPeloFiltro} ${escondidasPeloFiltro === 1 ? 'oportunidade' : 'oportunidades'}${soEmAberto ? ' de jogos que já começaram ou em outro filtro. Desligue "Só jogos em aberto" para ver.' : ' em outra faixa ou mercado. Troque o filtro para ver.'}`
                 : isPastDay ? 'Só listamos aqui as apostas que sinalizamos com valor.'
                 : isFutureDay ? 'As odds costumam ser coletadas a partir de ~24h antes do jogo — as oportunidades aparecem aqui quando chegarem.'
                 : 'As oportunidades aparecem quando há odds coletadas antes do jogo.'}

--- a/src/pages/Onboarding.test.tsx
+++ b/src/pages/Onboarding.test.tsx
@@ -59,6 +59,15 @@ describe('Onboarding', { timeout: 20_000 }, () => {
     expect(screen.getByRole('button', { name: /Conectar meu Telegram/i })).toBeInTheDocument();
   });
 
+  it('o carrossel tem seta para os dois lados, além dos pontos', async () => {
+    // Sem elas, quem quer rever um slide precisa esperar o autoplay dar a volta.
+    renderOnboarding();
+
+    expect(await screen.findByRole('button', { name: 'Slide anterior' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Próximo slide' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Ir para o slide 1' })).toBeInTheDocument();
+  });
+
   it('sem origem, mantém o onboarding genérico', async () => {
     renderOnboarding();
 

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -10,6 +10,8 @@ import {
   Check,
   Loader2,
   ArrowRight,
+  ChevronLeft,
+  ChevronRight,
   RefreshCw,
   Image as ImageIcon,
   Flame,
@@ -190,6 +192,16 @@ function BetinhoCarousel() {
     emblaApi?.scrollTo(i);
     play();
   };
+  // As setas reiniciam pelo mesmo motivo: quem navegou na mão não quer o
+  // carrossel pulando sozinho meio segundo depois.
+  const anterior = () => {
+    emblaApi?.scrollPrev();
+    play();
+  };
+  const proximo = () => {
+    emblaApi?.scrollNext();
+    play();
+  };
 
   return (
     <div className="w-full max-w-[380px]">
@@ -207,16 +219,39 @@ function BetinhoCarousel() {
         {SLIDES[selected]?.label}
       </p>
 
-      <div className="mt-2 flex justify-center gap-2">
-        {SLIDES.map((s, i) => (
-          <button
-            key={s.key}
-            type="button"
-            aria-label={`Ir para o slide ${i + 1}`}
-            onClick={() => goTo(i)}
-            className={`h-2 rounded-full transition-all ${i === selected ? 'w-6 bg-amber' : 'w-2 bg-white/30'}`}
-          />
-        ))}
+      {/* As setas ficam na mesma linha dos pontos, e não sobrepostas ao card:
+          ali elas não cobrem o conteúdo do slide nem competem com o CTA, e no
+          celular continuam alcançáveis pelo polegar. */}
+      <div className="mt-2 flex items-center justify-center gap-4">
+        <button
+          type="button"
+          aria-label="Slide anterior"
+          onClick={anterior}
+          className="grid h-8 w-8 place-items-center rounded-full bg-white/10 text-white/70 transition-colors hover:bg-white/20 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+
+        <div className="flex items-center gap-2">
+          {SLIDES.map((s, i) => (
+            <button
+              key={s.key}
+              type="button"
+              aria-label={`Ir para o slide ${i + 1}`}
+              onClick={() => goTo(i)}
+              className={`h-2 rounded-full transition-all ${i === selected ? 'w-6 bg-amber' : 'w-2 bg-white/30'}`}
+            />
+          ))}
+        </div>
+
+        <button
+          type="button"
+          aria-label="Próximo slide"
+          onClick={proximo}
+          className="grid h-8 w-8 place-items-center rounded-full bg-white/10 text-white/70 transition-colors hover:bg-white/20 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
       </div>
     </div>
   );

--- a/src/utils/futebol-ajuda-copy.test.ts
+++ b/src/utils/futebol-ajuda-copy.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { textoDoScore } from './futebol-ajuda-copy';
+
+describe('textoDoScore', () => {
+  it('na escala nova, diz que o Score não olha o preço', () => {
+    const texto = textoDoScore('contexto_v1');
+
+    expect(texto).toMatch(/não olha o preço/i);
+    expect(texto).not.toMatch(/odd paga acima/i);
+  });
+
+  it('na escala antiga, continua dizendo que o preço entra na conta', () => {
+    // A virada é coordenada com o mart (spec #301). Explicar a metodologia nova
+    // antes da hora descreveria um número que a tela ainda não está mostrando.
+    expect(textoDoScore('legacy')).toMatch(/odd paga acima/i);
+  });
+
+  it('sem versão declarada, mantém a explicação da escala em vigor hoje', () => {
+    expect(textoDoScore(undefined)).toBe(textoDoScore('legacy'));
+  });
+
+  it('nunca promete chance de acerto', () => {
+    // O erro de leitura mais caro da tela: tratar Score como probabilidade.
+    for (const t of [textoDoScore('legacy'), textoDoScore('contexto_v1')]) {
+      expect(t).toMatch(/não é chance de acerto/i);
+    }
+  });
+});

--- a/src/utils/futebol-ajuda-copy.ts
+++ b/src/utils/futebol-ajuda-copy.ts
@@ -1,0 +1,23 @@
+import type { FutebolScoreVersion } from '@/services/futebol-score-contract';
+
+/**
+ * As definições dos quatro números da leitura.
+ *
+ * O texto do Score depende da escala: até a virada ele soma preço e contexto;
+ * depois passa a medir só o contexto (spec #301). Escrever a versão nova antes
+ * da hora faria a tela explicar uma metodologia que ainda não está rodando.
+ */
+export function textoDoScore(versao: FutebolScoreVersion | undefined): string {
+  return versao === 'contexto_v1'
+    ? 'Mede quanto do cenário favorável aparece nesta linha: ataque, defesa, mando, forma, histórico do confronto. Não é chance de acerto, e não olha o preço — a odd e o valor aparecem ao lado, separados.'
+    : 'Mede a confiabilidade da leitura, de 0 a 100. Junta o cenário do jogo com o quanto a odd paga acima do risco estimado. Não é chance de acerto.';
+}
+
+export const TEXTO_CHANCE =
+  'A probabilidade que o mercado atribui a esta saída, depois de tirar a margem da casa. Não é a nossa estimativa: é a leitura das cotações.';
+
+export const TEXTO_ODD =
+  'A melhor cotação encontrada entre as casas acompanhadas, no momento da coleta. É ela que define o retorno se a aposta acontecer.';
+
+export const TEXTO_VALOR =
+  'A diferença entre o que a odd paga e o que a chance justifica. Positivo significa preço acima do risco estimado. Zero ou negativo é informação sobre o preço, não defeito da leitura.';

--- a/src/utils/futebol-registradas.test.ts
+++ b/src/utils/futebol-registradas.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { oportunidadesDoDia, oppFromAlerted, oppKey, type OppLike } from './futebol-registradas';
+import type { FutebolAlertedPick, FutebolFixture } from '@/services/futebol-data.service';
+
+function registrada(over: Partial<FutebolAlertedPick> = {}): FutebolAlertedPick {
+  return {
+    game_day: '2026-08-29',
+    fixture_id: 1,
+    market: 'match_winner',
+    outcome: 'Home',
+    line_value: null,
+    bet_description: 'Coritiba vence',
+    betting_market: 'Resultado',
+    league: 'brasileirao-b',
+    match_description: 'Coritiba × Palmeiras',
+    odds: 2.1,
+    janela_usada: 'manha',
+    score: 62,
+    faixa: 'alta',
+    edge: 0.08,
+    prob_justa_fechamento: 0.52,
+    sent_at: '2026-08-29T11:00:00Z',
+    ...over,
+  };
+}
+
+function doBoard(over: Partial<OppLike> = {}): OppLike {
+  return {
+    fixture_id: 1,
+    home_team_id: 10,
+    away_team_id: 20,
+    home_team_name: 'Coritiba',
+    away_team_name: 'Palmeiras',
+    competition: 'brasileirao-b',
+    kickoff_utc: '2026-08-29T22:00:00Z',
+    status_short: 'NS',
+    market: 'match_winner',
+    outcome: 'Home',
+    line_value: null,
+    best_odd: 2.1,
+    best_book: 'bet365',
+    avg_odd: 2.05,
+    n_casas: 4,
+    janela_usada: 'manha',
+    pts_valor: 20,
+    pts_premissas: 30,
+    pts_corroboracao: 5,
+    penalidades: 0,
+    evidencias: [],
+    premissas_sem_dado: 0,
+    score: 62,
+    faixa: 'alta',
+    edge: 0.08,
+    prob_justa_fechamento: 0.52,
+    ...over,
+  };
+}
+
+const semFixtures = new Map<number, FutebolFixture>();
+
+describe('oportunidadesDoDia', () => {
+  it('soma a registrada que o board não tem mais', () => {
+    // O bug que originou este módulo: num sábado de seis oportunidades a home
+    // mostrava três, porque só a outra tela somava as registradas.
+    const lista = oportunidadesDoDia({
+      doBoard: [doBoard()],
+      registradas: [registrada({ fixture_id: 2, match_description: 'Sport × Goiás' })],
+      dia: '2026-08-29',
+      fixturePorId: semFixtures,
+    });
+
+    expect(lista).toHaveLength(2);
+    expect(lista[1].home_team_name).toBe('Sport');
+  });
+
+  it('não duplica a oportunidade que já está no board', () => {
+    const lista = oportunidadesDoDia({
+      doBoard: [doBoard()],
+      registradas: [registrada()],
+      dia: '2026-08-29',
+      fixturePorId: semFixtures,
+    });
+
+    expect(lista).toHaveLength(1);
+  });
+
+  it('a mesma partida com outra aposta entra como linha própria', () => {
+    // A chave é jogo + mercado + saída + linha: dois palpites no mesmo jogo são
+    // duas oportunidades, e colapsá-los esconderia uma.
+    const lista = oportunidadesDoDia({
+      doBoard: [doBoard()],
+      registradas: [registrada({ market: 'over_under', outcome: 'Over', line_value: 2.5 })],
+      dia: '2026-08-29',
+      fixturePorId: semFixtures,
+    });
+
+    expect(lista).toHaveLength(2);
+  });
+
+  it('registrada de outro dia fica de fora', () => {
+    const lista = oportunidadesDoDia({
+      doBoard: [],
+      registradas: [registrada({ game_day: '2026-08-28' })],
+      dia: '2026-08-29',
+      fixturePorId: semFixtures,
+    });
+
+    expect(lista).toHaveLength(0);
+  });
+
+  it('com o jogo casado, usa os nomes e o horário do fixture', () => {
+    const fx = {
+      fixture_id: 7,
+      home_team_id: 33,
+      away_team_id: 44,
+      home_team_name: 'Athletico-PR',
+      away_team_name: 'Vila Nova',
+      kickoff_utc: '2026-08-29T19:30:00Z',
+      status_short: 'FT',
+    } as FutebolFixture;
+
+    const linha = oppFromAlerted(registrada({ fixture_id: 7, match_description: 'CAP × VIL' }), fx);
+
+    expect(linha.home_team_name).toBe('Athletico-PR');
+    expect(linha.kickoff_utc).toBe('2026-08-29T19:30:00Z');
+    expect(linha.status_short).toBe('FT');
+  });
+
+  it('sem jogo casado, mantém a oportunidade com os nomes do registro', () => {
+    // Perder o escudo é aceitável; perder a oportunidade da lista não é.
+    const linha = oppFromAlerted(registrada({ match_description: 'Ceará × Bahia' }));
+
+    expect(linha.home_team_name).toBe('Ceará');
+    expect(linha.away_team_name).toBe('Bahia');
+    expect(linha.kickoff_utc).toBeNull();
+  });
+
+  it('a registrada não declara versão de escala', () => {
+    // Carimbá-la de legacy faria a legenda achar que toda janela é mista.
+    expect(oppFromAlerted(registrada()).score_versao).toBeUndefined();
+  });
+
+  it('a chave ignora campos que não identificam a aposta', () => {
+    expect(oppKey(1, 'over_under', 'Over', 2.5)).toBe(oppKey(1, 'over_under', 'Over', 2.5));
+    expect(oppKey(1, 'over_under', 'Over', 2.5)).not.toBe(oppKey(1, 'over_under', 'Over', 3.5));
+  });
+});

--- a/src/utils/futebol-registradas.ts
+++ b/src/utils/futebol-registradas.ts
@@ -1,0 +1,117 @@
+import type {
+  FutebolAlertedPick,
+  FutebolFixture,
+  FutebolValueBoardRow,
+} from '@/services/futebol-data.service';
+import { opportunityKey } from '@/utils/futebol-history';
+
+/**
+ * A lista de oportunidades de um dia, como as telas a montam.
+ *
+ * Esta função mora aqui, e não dentro de uma tela, porque a home e o painel
+ * precisam mostrar a MESMA lista. Enquanto ela era privada do painel, a home
+ * somava só o board e o histórico: num sábado com seis oportunidades, mostrava
+ * três, e as duas telas contavam histórias diferentes do mesmo dia.
+ */
+
+/**
+ * Linha da lista. O board sempre traz Score, faixa, chance e valor; uma
+ * oportunidade REGISTRADA (que existiu no dia e o board não tem mais, porque o
+ * mart é full-refresh e re-escolhe a janela de odds) pode não ter esses números
+ * do instante em que era oportunidade — nas enviadas antes da migration 091 não
+ * foram guardados. Ela continua sendo oportunidade do dia; só esses campos ficam
+ * vazios. FutebolValueBoardRow é atribuível a isto (number → number | null).
+ */
+export type OppLike = Omit<
+  FutebolValueBoardRow,
+  'score' | 'faixa' | 'edge' | 'prob_justa_fechamento' | 'score_versao'
+> & {
+  score: number | null;
+  faixa: string | null;
+  edge: number | null;
+  prob_justa_fechamento: number | null;
+  /**
+   * Ausente na oportunidade registrada: a tabela de picks nunca guardou versão,
+   * e carimbá-la de legacy faria a legenda achar que toda janela é mista.
+   */
+  score_versao?: FutebolValueBoardRow['score_versao'];
+};
+
+/**
+ * Chave de uma oportunidade — casa board, histórico e registro do que foi
+ * enviado. Reexportada de `futebol-history.ts` com a forma que as telas usam
+ * (argumentos soltos em vez de objeto): eram duas funções produzindo string
+ * byte a byte idêntica, e duas chaves que "por acaso" batem é o tipo de coisa
+ * que só quebra depois que alguém mexe numa delas.
+ */
+export const oppKey = (
+  fixtureId: number,
+  market: string | null,
+  outcome: string | null,
+  line: number | null,
+) => opportunityKey({ fixture_id: fixtureId, market, outcome, line_value: line });
+
+/**
+ * Monta a linha de uma oportunidade registrada (enviada no daily) com os valores
+ * do momento do envio. Sem fixture casado, cai pro "Casa × Fora" do registro:
+ * é melhor manter a oportunidade na lista sem escudo do que perder o registro.
+ */
+export function oppFromAlerted(a: FutebolAlertedPick, fx?: FutebolFixture): OppLike {
+  const [rawHome, rawAway] = a.match_description.split('×');
+  return {
+    fixture_id: a.fixture_id,
+    home_team_id: fx?.home_team_id ?? 0,
+    away_team_id: fx?.away_team_id ?? 0,
+    home_team_name: fx?.home_team_name ?? (rawHome?.trim() || 'Casa'),
+    away_team_name: fx?.away_team_name ?? (rawAway?.trim() || 'Fora'),
+    competition: a.league ?? '',
+    kickoff_utc: fx?.kickoff_utc ?? null,
+    status_short: fx?.status_short ?? null,
+    market: a.market!,
+    outcome: a.outcome!,
+    line_value: a.line_value,
+    best_odd: Number(a.odds),
+    best_book: '',
+    avg_odd: Number(a.odds),
+    n_casas: 0,
+    janela_usada: a.janela_usada ?? '',
+    pts_valor: 0,
+    pts_premissas: 0,
+    pts_corroboracao: 0,
+    penalidades: 0,
+    evidencias: [],
+    premissas_sem_dado: 0,
+    // Números do instante em que era oportunidade. Null nas enviadas antes da
+    // migration 091 (o pipeline sobrescreve a janela e destrói chance/valor/Score
+    // da manhã); daí em diante vêm preenchidos e a linha fica igual à do board.
+    score: a.score,
+    faixa: a.faixa,
+    edge: a.edge,
+    prob_justa_fechamento: a.prob_justa_fechamento,
+  };
+}
+
+/**
+ * As oportunidades de um dia: o que o board e o histórico têm, mais o que foi
+ * enviado no daily e o board não tem mais.
+ */
+export function oportunidadesDoDia({
+  doBoard,
+  registradas,
+  dia,
+  fixturePorId,
+}: {
+  doBoard: OppLike[];
+  registradas: readonly FutebolAlertedPick[];
+  dia: string;
+  fixturePorId: Map<number, FutebolFixture>;
+}): OppLike[] {
+  const jaNaLista = new Set(
+    doBoard.map((r) => oppKey(r.fixture_id, r.market, r.outcome, r.line_value)),
+  );
+  const soRegistradas = registradas
+    .filter((a) => a.game_day === dia)
+    .filter((a) => !jaNaLista.has(oppKey(a.fixture_id, a.market, a.outcome, a.line_value)))
+    .map((a) => oppFromAlerted(a, fixturePorId.get(a.fixture_id)));
+  return [...doBoard, ...soRegistradas];
+}

--- a/supabase/migrations/20260829210000_115_futebol_disponivel_desde_antes_do_apito.sql
+++ b/supabase/migrations/20260829210000_115_futebol_disponivel_desde_antes_do_apito.sql
@@ -1,0 +1,98 @@
+-- 20260829210000_115_futebol_disponivel_desde_antes_do_apito
+--
+-- Corrige a migration 114: "Disponível desde" podia devolver um horário
+-- POSTERIOR ao fim da partida.
+--
+-- A migration 114 monta as ilhas de disponibilidade sobre todas as versões do
+-- snapshot, sem limite superior. Só que o mart é full-refresh e continua
+-- reescrevendo o jogo depois de encerrado — medido no dev em 29/08/2026: 97%
+-- das versões nascem DEPOIS do apito, em média 668h depois. Numa chave fechada
+-- e reaberta no dia seguinte, a ilha mais recente começa no dia seguinte, e a
+-- tela dizia que a oportunidade estava disponível desde depois do jogo.
+--
+-- O corte é o apito inicial: só conta como disponibilidade o que existiu antes
+-- de a bola rolar, que é o único período em que dava para apostar.
+--
+-- Efeito medido no dev, com a função corrigida:
+--   - fixture 1570342 (caso de aceite da issue #300): segue 25/08/2026 15:03:09
+--     BRT, 56 minutos antes do apito.
+--   - fixtures 1489381 e 1489391 (apitos de 17/06 e 19/06, cuja única versão no
+--     snapshot nasce em 27/07): passam a não devolver nada, em vez de dizerem
+--     "disponível desde 03/08" — um mês depois do jogo.
+--
+-- Sem DROP: a assinatura não muda, então CREATE OR REPLACE preserva as grants.
+
+CREATE OR REPLACE FUNCTION public.get_futebol_fixture_disponivel_desde(p_fixture_id bigint)
+RETURNS TABLE(
+  market text,
+  outcome text,
+  line_value double precision,
+  disponivel_desde timestamp without time zone
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+  -- Ilhas e buracos sobre as versões do snapshot. Versões contíguas
+  -- (dbt_valid_to de uma = dbt_valid_from da seguinte) são ATUALIZAÇÃO da mesma
+  -- disponibilidade; um buraco entre elas é REATIVAÇÃO, e reinicia o relógio.
+  with versoes as (
+    select
+      h.opportunity_key,
+      h.market,
+      h.outcome,
+      h.line_value,
+      h.dbt_valid_from,
+      lag(h.dbt_valid_to) over (
+        partition by h.opportunity_key order by h.dbt_valid_from
+      ) as fim_da_anterior
+    from futebol.fact_value_opportunities_hist h
+    join futebol.fact_fixtures fx on fx.fixture_id = h.fixture_id
+    where h.fixture_id = p_fixture_id
+      -- Só versões anteriores ao apito (ver o cabeçalho).
+      and h.dbt_valid_from < fx.kickoff_utc
+  ), ilhas as (
+    select
+      v.*,
+      -- Cada vez que o fim da versão anterior não encosta no início desta,
+      -- começa uma ilha nova. A primeira versão sempre abre uma.
+      count(*) filter (where v.fim_da_anterior is distinct from v.dbt_valid_from) over (
+        partition by v.opportunity_key
+        order by v.dbt_valid_from
+        rows between unbounded preceding and current row
+      ) as ilha
+    from versoes v
+  ), por_chave as (
+    select distinct on (i.opportunity_key)
+      i.opportunity_key,
+      i.market,
+      i.outcome,
+      i.line_value,
+      -- Início da ilha da versão MAIS RECENTE: a disponibilidade atual.
+      min(i.dbt_valid_from) over (partition by i.opportunity_key, i.ilha) as inicio_da_ilha,
+      -- Primeira versão que o snapshot tem desta chave, para detectar o caso 3.
+      min(i.dbt_valid_from) over (partition by i.opportunity_key) as primeira_versao
+    from ilhas i
+    order by i.opportunity_key, i.dbt_valid_from desc
+  )
+  select
+    c.market,
+    c.outcome,
+    c.line_value,
+    -- Vazio quando a corrida atual começa na primeira versão que o snapshot tem
+    -- E essa versão está na estreia dele: aí o horário é a data em que o
+    -- snapshot passou a existir, não a hora em que a oportunidade foi publicada.
+    -- Uma reativação POSTERIOR à estreia continua confiável, e por isso a
+    -- comparação é com o início da ilha, não com a chave inteira.
+    case
+      when c.inicio_da_ilha = c.primeira_versao
+       and c.primeira_versao < timestamp '2026-07-28 00:00:00'
+      then null
+      else c.inicio_da_ilha
+    end
+  from por_chave c
+  order by c.market, c.outcome, c.line_value;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_futebol_fixture_disponivel_desde(bigint) TO anon, authenticated, service_role;


### PR DESCRIPTION
## O que motivou

A home mostrava três oportunidades num sábado que teve seis. O painel somava as **registradas** (as enviadas no daily que o board não tem mais, porque o mart é full-refresh e re-escolhe a janela de odds) por uma função privada daquela tela; a home somava só o board e o histórico. Duas telas, duas histórias do mesmo dia.

A soma virou um módulo compartilhado, `src/utils/futebol-registradas.ts`, chamado pelas duas telas. É o seam do bug, e é onde estão os testes novos.

## O que mudou

**A contagem do dia**
- Módulo compartilhado para a lista de oportunidades do dia (board + histórico + registradas), com 8 testes.
- A home mostra as oportunidades do dia mesmo com o jogo encerrado — é o retrato do dia.
- Filtro novo no painel: "Só jogos em aberto", desligado por padrão, para quem quer só o que ainda dá para acompanhar.
- O seletor de dias mantém "hoje" o dia inteiro. Ele virava para amanhã às 21h e a pessoa abria a home num dia vazio.

**A leitura dos números**
- Um (i) ao lado de Chance, Odd, Valor e Score, explicando cada um. É popover, e não tooltip: tooltip só abre no hover, e no celular ninguém leria. A copy mora em um arquivo só (`futebol-ajuda-copy.ts`), porque os mesmos quatro números aparecem em três lugares — foi assim que a copy das premissas divergiu na #272.
- O texto do Score muda com a escala (`legacy` x `contexto_v1`, spec #301) e sai da versão da **janela**, não da linha: a registrada não declara versão, e cair no texto legacy faria o card explicar a metodologia antiga depois da virada.
- "Confiabilidade" virou "Score", que é como as outras telas chamam.
- "Se paga em" saiu: era conta de retorno vestida de leitura.
- Chance, odd e valor em três colunas. No celular a data sai da linha dos times (os nomes quebravam) e a divisória vertical do Score some (era herança do desktop).
- O destaque mostra A favor e Contra vindos do contrato de motivos, com o lado calculado por `ladoDaSaida` — na dupla chance 1X é casa e X2 é fora, e derivar isso na mão divergia do detalhe.

**Onboarding**
- Setas no carrossel. Sem elas, rever um slide exigia esperar o autoplay dar a volta.

**Banco**
- Migration 115 corrige a 114: "Disponível desde" podia devolver um horário posterior ao fim da partida, porque o mart continua reescrevendo o jogo depois do apito — medido no dev: 97% das versões nascem depois dele, em média 668h depois. O corte agora é o apito inicial. `CREATE OR REPLACE`, assinatura intacta, sem `DROP`, então as grants ficam.
- Já aplicada no dev. Medido depois da correção: o caso de aceite da issue #300 (fixture 1570342) segue em 25/08/2026 15:03:09 BRT, e os fixtures 1489381 e 1489391 (apitos de 17/06 e 19/06, primeira versão no snapshot em 27/07) param de dizer "disponível desde 03/08".

## Achados do code review corrigidos nesta rodada

1. `get_futebol_fixture_disponivel_desde` sem limite no apito (a migration 115 acima).
2. O lado da aposta derivado na mão no destaque, divergindo do detalhe na dupla chance.
3. O texto do Score caindo em legacy quando a linha não declara versão.
4. A guarda de "linha com números" cobria só score e faixa; sem `edge` o card imprimia "+0.0%" e o KPI de melhor valor virava zero.
5. A chave da lista de motivos saía do texto, e duas premissas compartilham a mesma frase negativa.
6. O `loading` não cobria o histórico nem as registradas, então a tela piscava a nota recalculada antes da foto do apito.
7. `hasKickoffPassed(null)` é `false`, então a registrada sem jogo casado passava pelo filtro de "em aberto".
8. O vazio acusava faixa e mercado mesmo quando quem esvaziou a lista foi o "Só jogos em aberto".

## Checklist para validar em localhost:8080

1. **Home, contagem** — abra a home e o painel no mesmo dia. O número de oportunidades tem que bater.
2. **Home, jogo encerrado** — à noite, com jogos já terminados, a home continua listando as oportunidades do dia.
3. **Painel, filtro novo** — ligue "Só jogos em aberto": some quem já apitou. Se a lista esvaziar, a mensagem tem que falar do filtro de jogos em aberto, não de faixa ou mercado.
4. **Seletor de dias** — depois das 21h, "hoje" continua sendo hoje.
5. **Os (i)** — clique nos quatro no celular e no desktop. Abrem no toque, fecham no Esc e no toque fora, e o título aparece em verde.
6. **Destaque** — A favor e Contra batem com o que o detalhe do mesmo jogo mostra, inclusive numa dupla chance.
7. **Mobile** — nomes de time sem quebra estranha, data em linha própria, sem a linha vertical ao lado do Score.
8. **Onboarding** — as setas do carrossel andam para os dois lados.

## Verificações

- 34 arquivos de teste, 343 testes passando
- `tsc --noEmit` sem erro novo nos arquivos de futebol
- `eslint` limpo nos arquivos tocados
- `npm run build` ok

Não fazer merge antes da validação em localhost.
