### PR TITLE
Futebol · O Handicap sai da vitrine sem sair do board (#324)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,8 +21,20 @@ Uma candidata aprovada pelas regras de publicação vigentes.
 _Avoid_: Candidata, linha cotada
 
 **Publicação no painel**:
-O momento em que uma oportunidade passa a estar disponível no painel para o usuário. Não significa envio de notificação.
+O momento em que uma oportunidade passa a estar disponível no painel para o usuário. Não significa envio de notificação, e não garante exibição: uma oportunidade de mercado fora da **vitrine** é publicada e não aparece.
 _Avoid_: Alerta, envio, publicação no Telegram
+
+**Board**:
+O conjunto do que o backend publica — tudo que passou nas portas de qualidade de dado, gravado no funil e no histórico. É o universo, não o que está na tela.
+_Avoid_: Painel, vitrine, lista
+
+**Vitrine**:
+O recorte do board que o assinante de fato vê, no painel e nas DMs. Um mercado pode sair da vitrine sem sair do board: ele continua publicado e medido, e só deixa de ser exibido e alertado. A lista mora no banco (`futebol_mercados_ocultos`), não em código, porque devolver um mercado à tela é um UPDATE e não um release.
+_Avoid_: Gate, porta, filtro de faixa
+
+**Mercado oculto**:
+Mercado retirado da vitrine por decisão de produto, com data e motivo registrados. Não é porta de publicação: nada muda no gate, no mart nem nas RPCs. O histórico de dias passados continua mostrando o mercado, porque é registro do que foi publicado e visto.
+_Avoid_: Mercado desativado, mercado removido
 
 **Alerta de publicação**:
 O aviso enviado no Telegram quando uma oportunidade é publicada no painel, para que o usuário possa vê-la antes do jogo.

--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -2756,6 +2756,54 @@ grant execute on function public.get_futebol_publication_alert_recipients() to s
 revoke all on function public.claim_futebol_publication_alert_deliveries() from public, anon, authenticated;
 grant execute on function public.claim_futebol_publication_alert_deliveries() to service_role;
 
+-- ── Vitrine do produto: mercado fora da tela (migration 116, issue #324) ────
+-- Um mercado pode sair da VITRINE sem sair do BOARD: o backend continua
+-- publicando e gravando no histórico, e só o que o assinante vê muda. Parar de
+-- publicar pararia de medir, e é a medição que decide quando o mercado volta.
+--
+-- A lista mora aqui e não em constante porque são dois consumidores em runtimes
+-- diferentes — o painel (browser) e as DMs do Telegram (edge functions, Deno) —
+-- e devolver o mercado à tela tem de ser um UPDATE, não um release.
+create table if not exists public.futebol_mercados_ocultos (
+  market text primary key,
+  -- A linha sobrevive a "oculto = false": ela é o registro de que o mercado JÁ
+  -- esteve fora, e "oculto_desde" diz desde quando. É o que torna o antes/depois
+  -- comparável quando ele voltar.
+  oculto boolean not null default true,
+  oculto_desde timestamptz not null default now(),
+  motivo text not null
+);
+
+-- RLS ligada e SEM policy, no mesmo padrão da futebol_premissa_copy: nada lê a
+-- tabela direto, só a RPC security definer abaixo.
+alter table public.futebol_mercados_ocultos enable row level security;
+
+comment on table public.futebol_mercados_ocultos is
+  'Mercados retirados da vitrine do produto. Não é gate: o board continua publicando.';
+
+create or replace function public.get_futebol_mercados_ocultos()
+returns text[]
+ language sql
+ stable
+ security definer
+ set search_path to ''
+as $function$
+  select coalesce(array_agg(market order by market), array[]::text[])
+    from public.futebol_mercados_ocultos
+   where oculto;
+$function$;
+
+grant execute on function public.get_futebol_mercados_ocultos() to anon, authenticated, service_role;
+
+insert into public.futebol_mercados_ocultos (market, oculto, oculto_desde, motivo)
+values (
+  'asian_handicap',
+  true,
+  timestamptz '2026-09-01 00:00:00+00',
+  'ROI -48,4 em 23 linhas publicadas (EP 16,5), contra +22,3 do Gols. Investigacao na B3 (ClickUp wdx6zev656). Decisao do PM em 31/08/2026, prop-play-predictor#324.'
+)
+on conflict (market) do nothing;
+
 -- ── 7. Reverse trial (7 dias, sem cartão) — colunas no public.users ──────────
 alter table public.users add column if not exists futebol_trial_started_at timestamptz;
 alter table public.users add column if not exists futebol_subscription_status text not null default 'free';

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -3,6 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Blur } from '@/components/futebol/FutebolGate';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
 import {
+  useFutebolMercadosOcultos,
   useFutebolFixturePremissas,
   useFutebolFixtureNumeros,
   useFutebolFixtureHistorico,
@@ -33,6 +34,7 @@ import { avisoSemDado } from '@/utils/futebol-sem-dado';
 import { valueDoCandidato, resumoDosMercados, mesmaLinha, type SaidaPreferida } from '@/utils/futebol-leitura';
 import { ehDestaque, ehFaixaAlta, rotuloDaFaixa, fronteirasDoScore } from '@/utils/futebol-score';
 import { leituraDaCotacao } from '@/utils/futebol-cotacao';
+import { filtrarCatalogoDeMercados } from '@/utils/futebol-mercados-ocultos';
 import { disponivelDesdeDaSaida, rotuloDisponivelDesde } from '@/utils/futebol-disponibilidade';
 import { separarMotivosDoContrato } from '@/utils/futebol-motivos';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
@@ -260,11 +262,29 @@ export function BancadaMercados({
   const fim = isFinished(jogo.statusShort);
   const jogoJaComecou = useJogoJaComecou(jogo.kickoffUtc);
   const placar = fim ? { home: jogo.goalsHome, away: jogo.goalsAway } : null;
-  const mercado: MercadoInfo = MERCADOS.find((m) => m.slug === mercadoAtivo) ?? MERCADOS[0];
+  // A vitrine (#324). Sem ela a prateleira sairia do catálogo inteiro, e o
+  // mercado escondido voltaria como chip — com barra de Score e sem odd.
+  const { data: mercadosOcultos } = useFutebolMercadosOcultos();
+  // Memoizado porque `?? []` cria array novo a cada render e envenenaria as
+  // dependências dos useMemo abaixo.
+  const ocultos = useMemo(() => mercadosOcultos ?? [], [mercadosOcultos]);
+  const mercadosVisiveis = useMemo(
+    () => filtrarCatalogoDeMercados(MERCADOS, ocultos),
+    [ocultos],
+  );
+
+  // `mercadoAtivo` vem de fora e pode apontar para um mercado que saiu da
+  // vitrine (link antigo, estado guardado). O fallback é o primeiro VISÍVEL, e
+  // não `MERCADOS[0]`, senão a aba ressuscitaria o que a lista escondeu.
+  const mercado: MercadoInfo =
+    mercadosVisiveis.find((m) => m.slug === mercadoAtivo) ?? mercadosVisiveis[0] ?? MERCADOS[0];
   const ehLinha = TIPO_LINHA.has(mercado.slug);
   const ehAH = mercado.slug === 'asian_handicap';
 
-  const resumos = useMemo(() => resumoDosMercados(rows, valueRows, preferida), [rows, valueRows, preferida]);
+  const resumos = useMemo(
+    () => resumoDosMercados(rows, valueRows, preferida, ocultos),
+    [rows, valueRows, preferida, ocultos],
+  );
   const mercadosCotados = useMemo(
     () => resumos.filter((r) => leituraDaCotacao(
       r.mercado.slug,
@@ -631,7 +651,10 @@ export function BancadaMercados({
       <div data-tour="fut-jogo-mercados" className="min-w-0 xl:col-start-1 xl:row-start-1 xl:border-r" style={{ borderColor: '#ded2b6', background: '#fdfbf6' }}>
         <div className="px-5 pt-4 pb-3.5" style={{ borderBottom: '1px solid #f1e9d6' }}>
           <div className="text-[10px] uppercase tracking-[0.18em] font-bold" style={{ color: '#8d8672' }}>
-            Os 5 mercados
+            {/* Conta o que a VITRINE mostra, não o catálogo: com um mercado
+                escondido (#324) o rótulo fixo "Os 5 mercados" mentiria em cima
+                de uma lista de quatro. */}
+            {resumos.length === 1 ? 'O mercado' : `Os ${resumos.length} mercados`}
           </div>
           <div className="mt-1 text-[11.5px] leading-relaxed" style={{ color: '#6b6350' }}>
             {/* A frase conta só os mercados COTADOS. `passa` também é verdadeiro

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -416,3 +416,22 @@ export function useFutebolMatchupMarkets(
     refetchOnWindowFocus: false,
   });
 }
+
+/**
+ * Os mercados fora da VITRINE — não fora do board.
+ *
+ * A lista vem do banco para que devolver um mercado à tela seja um UPDATE e não
+ * um release. Fica aqui, e não em constante, porque o detalhe do jogo monta a
+ * prateleira a partir do CATÁLOGO de mercados e não do board: sem esta lista o
+ * mercado escondido continuaria como chip, com barra de Score e sem odd, que é
+ * pior do que não ter escondido. Ver prop-play-predictor#324.
+ */
+export function useFutebolMercadosOcultos() {
+  return useQuery<string[]>({
+    queryKey: ['futebol', 'mercados-ocultos'],
+    queryFn: () => futebolDataService.getMercadosOcultos(),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 15 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -4,7 +4,7 @@ import { Zap, ArrowRight, Check, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Seo } from '@/components/Seo';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useFutebolFixturesMulti, useFutebolValueBoard, useFutebolValueHistory, useFutebolAlertedPicks, useFutebolFixtureReasonContract, useFutebolAccess } from '@/hooks/use-futebol-data';
+import { useFutebolFixturesMulti, useFutebolValueBoard, useFutebolValueHistory, useFutebolAlertedPicks, useFutebolFixtureReasonContract, useFutebolAccess, useFutebolMercadosOcultos } from '@/hooks/use-futebol-data';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
 import { AjudaCampo } from '@/components/futebol/AjudaCampo';
@@ -26,6 +26,7 @@ import { demoFutebolBoard, demoFutebolFixtures } from '@/components/onboarding/d
 // como se erra fuso — foi por isso que Oportunidades removeu as dela no PR #259.
 import { SAO_PAULO_TZ, parseUtc, brtDateStr, brtDayOf, fmtTime, isFinished } from '@/utils/futebol-datas';
 import { mergeBoardAndHistory } from '@/utils/futebol-history';
+import { mercadoEstaOculto } from '@/utils/futebol-mercados-ocultos';
 import { oportunidadesDoDia, type OppLike } from '@/utils/futebol-registradas';
 import { separarMotivosDoContrato } from '@/utils/futebol-motivos';
 import { ladoDaSaida } from '@/utils/futebol-evidencias';
@@ -331,17 +332,26 @@ export default function FutebolHoje() {
   // O que mudou foi tirar o corte de "só jogo que ainda não começou", que era
   // exclusivo desta tela: ele zerava a home toda noite, num dia que teve
   // oportunidades. Quem quer só o que dá para acompanhar tem o filtro no painel.
+  // A vitrine (#324). O board já vem filtrado do service, mas a fusão reabre o
+  // dia corrente pela linha do histórico, que não é filtrado de propósito.
+  const { data: mercadosOcultos } = useFutebolMercadosOcultos();
+  const ocultos = useMemo(() => mercadosOcultos ?? [], [mercadosOcultos]);
   const valueRows = useMemo(
-    () => mergeBoardAndHistory(boardRows ?? [], histRows ?? [], agora),
-    [boardRows, histRows, agora],
+    () => mergeBoardAndHistory(boardRows ?? [], histRows ?? [], agora, ocultos),
+    [boardRows, histRows, agora, ocultos],
   );
   // As oportunidades REGISTRADAS entram aqui pelo mesmo motivo que entram no
   // painel: elas existiram no dia e o board não as tem mais, porque o mart é
   // full-refresh. Sem elas a home mostrava três num dia de seis, e as duas telas
   // contavam histórias diferentes do mesmo dia.
+  // A home mostra o dia corrente, então aqui a vitrine (#324) vale sem exceção:
+  // não há linha de dia passado a preservar como registro.
   const registradasAll = useMemo(
-    () => (alertedRaw ?? []).filter((a) => !!a.market && !!a.outcome),
-    [alertedRaw],
+    () =>
+      (alertedRaw ?? []).filter(
+        (a) => !!a.market && !!a.outcome && !mercadoEstaOculto(a.market, ocultos),
+      ),
+    [alertedRaw, ocultos],
   );
   const fixturePorId = useMemo(() => {
     const m = new Map<number, FutebolFixture>();

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { ChevronRight, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useFutebolValueBoard, useFutebolValueHistory, useFutebolAccess, useFutebolFixturesMulti, useFutebolAlertedPicks, useFutebolCompetitions } from '@/hooks/use-futebol-data';
+import { useFutebolValueBoard, useFutebolValueHistory, useFutebolAccess, useFutebolFixturesMulti, useFutebolAlertedPicks, useFutebolCompetitions, useFutebolMercadosOcultos } from '@/hooks/use-futebol-data';
 import { useFutebolPublicationAlerts } from '@/hooks/use-futebol-publication-alerts';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
@@ -21,6 +21,7 @@ import {
   FAIXAS_FILTRO_PADRAO, type Faixa,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
+import { mercadoEstaOculto } from '@/utils/futebol-mercados-ocultos';
 import { mergeBoardAndHistory, historyWindow, HISTORY_WINDOW_DAYS } from '@/utils/futebol-history';
 import { oppKey, oportunidadesDoDia, type OppLike } from '@/utils/futebol-registradas';
 import { parseUtc, brtDayOf, brtDateStr, fmtTime, hasKickoffPassed, addDays } from '@/utils/futebol-datas';
@@ -268,9 +269,14 @@ export default function FutebolOportunidades() {
     [catalog, janelaDeFixtures, hoje],
   );
   const { data: fixtures } = useFutebolFixturesMulti(fixtureScopes);
+  // A vitrine (#324): board e detalhe já vêm filtrados do service, mas a fusão
+  // com o histórico reabre o dia corrente — jogo que já começou hoje vence pela
+  // linha do histórico, que NÃO é filtrado de propósito.
+  const { data: mercadosOcultos } = useFutebolMercadosOcultos();
+  const ocultos = useMemo(() => mercadosOcultos ?? [], [mercadosOcultos]);
   const allRows = useMemo<FutebolValueBoardRow[]>(
-    () => mergeBoardAndHistory(rows ?? [], histRows ?? [], agora),
-    [rows, histRows, agora]
+    () => mergeBoardAndHistory(rows ?? [], histRows ?? [], agora, ocultos),
+    [rows, histRows, agora, ocultos]
   );
 
   // Placar por fixture (pra liquidar os jogos já encerrados = histórico "bateu/não").
@@ -304,8 +310,18 @@ export default function FutebolOportunidades() {
   // Sem market/outcome não há como casar com o board nem liquidar (linhas
   // anteriores ao 091 podem vir sem).
   const registradasAll = useMemo(
-    () => (alertedRaw ?? []).filter((a) => !!a.market && !!a.outcome),
-    [alertedRaw]
+    () =>
+      (alertedRaw ?? []).filter(
+        (a) =>
+          !!a.market &&
+          !!a.outcome &&
+          // A vitrine (#324) vale de hoje para a frente. Dia passado é registro
+          // do que foi enviado e visto, e some-lo reescreveria o que o
+          // assinante recebeu. Sem este corte, um Handicap alertado ANTES de o
+          // mercado sair da vitrine voltava como linha do painel de hoje.
+          (a.game_day < hoje || !mercadoEstaOculto(a.market, ocultos)),
+      ),
+    [alertedRaw, hoje, ocultos]
   );
 
   // Dias no stepper: dias COM oportunidade (board = passado + presente) + dias

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -4,6 +4,14 @@ import {
   normalizeFutebolValueBoardRows,
   type FutebolScoreVersion,
 } from './futebol-score-contract';
+import { filtrarMercadosOcultos } from '@/utils/futebol-mercados-ocultos';
+
+// A vitrine muda por UPDATE no banco, não por release, então a lista não pode
+// ser lida uma vez e congelada pela vida da aba. Cinco minutos é curto o
+// bastante para devolver um mercado sem pedir refresh, e longo o bastante para
+// não somar uma chamada a cada carga do board.
+const MERCADOS_OCULTOS_TTL_MS = 5 * 60 * 1000;
+let mercadosOcultosCache: { valor: string[]; expiraEm: number } | null = null;
 
 // As RPCs de futebol ainda não estão nos tipos gerados do Supabase (existem
 // só no dev, lendo BigQuery via FDW no schema bq_futebol). Cast pra any, mesmo
@@ -894,11 +902,44 @@ export const futebolDataService = {
     });
   },
 
+  /**
+   * Os mercados que estão fora da VITRINE — não fora do board.
+   *
+   * A lista vem do banco (migration 116) e não de constante, porque devolver um
+   * mercado à tela tem de ser um UPDATE e não um release, e porque o Telegram
+   * roda em outro runtime e precisa ler a MESMA fonte.
+   *
+   * ⚠️ Falha em silêncio, de propósito. O `withRetry` trata "função não existe"
+   * como erro definitivo, então um front publicado antes da migration mataria o
+   * board inteiro por causa de uma leitura de configuração. Sem a lista o
+   * comportamento é o de hoje — nada escondido —, que é degradação e não
+   * regressão. Ver prop-play-predictor#324.
+   */
+  async getMercadosOcultos(): Promise<string[]> {
+    const agora = Date.now();
+    if (mercadosOcultosCache && agora < mercadosOcultosCache.expiraEm) {
+      return mercadosOcultosCache.valor;
+    }
+    try {
+      const { data, error } = await supabaseClient.rpc('get_futebol_mercados_ocultos');
+      if (error) throw error;
+      const valor = (data || []) as string[];
+      mercadosOcultosCache = { valor, expiraEm: agora + MERCADOS_OCULTOS_TTL_MS };
+      return valor;
+    } catch {
+      // Sem cache válido e sem resposta: nada escondido, board vivo.
+      return mercadosOcultosCache?.valor ?? [];
+    }
+  },
+
   async getValueBoard(): Promise<FutebolValueBoardRow[]> {
     return withRetry(async () => {
-      const { data, error } = await supabaseClient.rpc('get_futebol_value_board');
+      const [{ data, error }, ocultos] = await Promise.all([
+        supabaseClient.rpc('get_futebol_value_board'),
+        this.getMercadosOcultos(),
+      ]);
       if (error) throw error;
-      return normalizeFutebolValueBoardRows(data || []);
+      return filtrarMercadosOcultos(normalizeFutebolValueBoardRows(data || []), ocultos);
     });
   },
 
@@ -919,6 +960,12 @@ export const futebolDataService = {
    * colunas na mesma ordem, então a tela não precisa saber de onde veio a linha.
    *
    * Datas em `YYYY-MM-DD`, dia BRT, inclusivas nas duas pontas.
+   *
+   * ⚠️ NÃO aplica `filtrarMercadosOcultos`, e isso é decisão, não esquecimento.
+   * O histórico é o registro do que foi PUBLICADO e visto: até o Handicap sair
+   * da vitrine ele apareceu na tela, e o assinante pode ter apostado nele.
+   * Escondê-lo aqui reescreveria o passado dele e mudaria a performance exibida.
+   * Ver prop-play-predictor#324.
    */
   async getValueHistory(from: string, to: string): Promise<FutebolValueBoardRow[]> {
     return withRetry(async () => {
@@ -949,11 +996,12 @@ export const futebolDataService = {
 
   async getFixtureValue(fixtureId: number): Promise<FutebolFixtureValueRow[]> {
     return withRetry(async () => {
-      const { data, error } = await supabaseClient.rpc('get_futebol_fixture_value', {
-        p_fixture_id: fixtureId,
-      });
+      const [{ data, error }, ocultos] = await Promise.all([
+        supabaseClient.rpc('get_futebol_fixture_value', { p_fixture_id: fixtureId }),
+        this.getMercadosOcultos(),
+      ]);
       if (error) throw error;
-      return normalizeFutebolFixtureValueRows(data || []);
+      return filtrarMercadosOcultos(normalizeFutebolFixtureValueRows(data || []), ocultos);
     });
   },
 

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -4,7 +4,7 @@ import {
   normalizeFutebolValueBoardRows,
   type FutebolScoreVersion,
 } from './futebol-score-contract';
-import { filtrarMercadosOcultos } from '@/utils/futebol-mercados-ocultos';
+import { filtrarMercadosOcultos, VITRINE_FALLBACK } from '@/utils/futebol-mercados-ocultos';
 
 // A vitrine muda por UPDATE no banco, não por release, então a lista não pode
 // ser lida uma vez e congelada pela vida da aba. Cinco minutos é curto o
@@ -927,8 +927,11 @@ export const futebolDataService = {
       mercadosOcultosCache = { valor, expiraEm: agora + MERCADOS_OCULTOS_TTL_MS };
       return valor;
     } catch {
-      // Sem cache válido e sem resposta: nada escondido, board vivo.
-      return mercadosOcultosCache?.valor ?? [];
+      // No escuro vale o último valor bom; sem ele, o fallback. Cair para lista
+      // vazia mostraria na tela o que o produto tirou da prateleira, e a janela
+      // realista de escuro é justamente a de antes da migration — quando
+      // esconder já é o comportamento decidido.
+      return mercadosOcultosCache?.valor ?? [...VITRINE_FALLBACK];
     }
   },
 

--- a/src/utils/futebol-history.ts
+++ b/src/utils/futebol-history.ts
@@ -22,6 +22,7 @@
 // ============================================================================
 import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
 import { parseUtc, brtDateStr, brtDayOf, addDays } from '@/utils/futebol-datas';
+import { mercadoEstaOculto } from '@/utils/futebol-mercados-ocultos';
 
 /** Quantos dias o Histórico navega para trás. */
 export const HISTORY_WINDOW_DAYS = 30;
@@ -72,6 +73,13 @@ export function mergeBoardAndHistory(
   board: FutebolValueBoardRow[],
   history: FutebolValueBoardRow[],
   nowMs: number,
+  // Os mercados fora da vitrine (#324). Valem para o DIA CORRENTE e não para o
+  // passado, e a distinção é a decisão de produto inteira: a linha de dia
+  // passado é registro do que foi publicado e visto, e escondê-la reescreveria
+  // o que o assinante viu; a linha de hoje é a lista de hoje, mesmo quando quem
+  // ganha o desempate é o histórico. Sem esta divisão o mercado escondido
+  // voltava pela porta dos fundos assim que o jogo começava.
+  ocultos: readonly string[] = [],
 ): FutebolValueBoardRow[] {
   const today = brtDateStr(new Date(nowMs));
   const out: FutebolValueBoardRow[] = [];
@@ -82,7 +90,9 @@ export function mergeBoardAndHistory(
     const d = brtDayOf(r.kickoff_utc);
     if (!d) continue;
     if (d < today) out.push(r);
-    else if (d === today) hojeHist.set(opportunityKey(r), r);
+    else if (d === today && !mercadoEstaOculto(r.market, ocultos)) {
+      hojeHist.set(opportunityKey(r), r);
+    }
     // d > today: a RPC não devolve; se um dia devolver, o board manda.
   }
 

--- a/src/utils/futebol-leitura.ts
+++ b/src/utils/futebol-leitura.ts
@@ -1,4 +1,5 @@
 import type { FutebolFixturePremissas, FutebolFixtureValueRow } from '@/services/futebol-data.service';
+import { filtrarCatalogoDeMercados } from '@/utils/futebol-mercados-ocultos';
 import { ehDestaque } from '@/utils/futebol-score';
 import type { Saida } from '@/utils/futebol-saida';
 import {
@@ -126,9 +127,13 @@ export function resumoDosMercados(
   rows: FutebolFixturePremissas[] | null | undefined,
   valueRows: FutebolFixtureValueRow[] | null | undefined,
   preferida?: SaidaPreferida | null,
+  // Os mercados fora da vitrine (#324). A prateleira do detalhe sai do CATÁLOGO
+  // e não do board, então filtrar as linhas do board não bastava: o mercado
+  // escondido continuava como chip, com barra de Score e sem odd.
+  ocultos: readonly string[] = [],
 ): MercadoResumo[] {
   if (!rows?.length) return [];
-  return MERCADOS.flatMap((m) => {
+  return filtrarCatalogoDeMercados(MERCADOS, ocultos).flatMap((m) => {
     // Com preço coletado quem representa o mercado é a saída do melhor Score; sem
     // preço, a saída com mais premissas. Rótulo e números na MESMA saída, sempre.
     //

--- a/src/utils/futebol-mercados-ocultos-paridade.test.ts
+++ b/src/utils/futebol-mercados-ocultos-paridade.test.ts
@@ -74,3 +74,16 @@ describe('as duas cópias da vitrine concordam', () => {
     }
   });
 });
+
+describe('o fallback da vitrine é o mesmo dos dois lados', () => {
+  // Se as duas listas se afastarem, o painel e a DM discordam exatamente na
+  // janela em que ninguém está olhando: a de antes da migration. É a mesma
+  // classe de defeito das 27 divergências de copy da issue #272.
+  it('VITRINE_FALLBACK bate', () => {
+    expect([...notificacao.VITRINE_FALLBACK]).toEqual([...painel.VITRINE_FALLBACK]);
+  });
+
+  it('o fallback esconde alguma coisa — lista vazia derrotaria o propósito', () => {
+    expect(painel.VITRINE_FALLBACK.length).toBeGreaterThan(0);
+  });
+});

--- a/src/utils/futebol-mercados-ocultos-paridade.test.ts
+++ b/src/utils/futebol-mercados-ocultos-paridade.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import * as painel from './futebol-mercados-ocultos';
+import * as notificacao from '../../supabase/functions/shared/mercados-ocultos';
+
+// ============================================================================
+// A guarda que impede as duas cópias da vitrine de divergirem (#324)
+// ============================================================================
+// A regra "este mercado sai da tela" existe DUAS vezes, e tem de existir: o
+// painel roda no browser e as DMs rodam em Deno, que não alcança o `src/`. É a
+// mesma fronteira do `shared/faixa.ts`.
+//
+// A diferença é que ali a cópia é inevitável e inofensiva, e aqui ela seria um
+// bug com cara de nada: o painel esconde o mercado, a DM continua mandando, e o
+// assinante recebe no celular o que sumiu da tela. Ninguém veria, porque tela e
+// DM são lidas por pessoas diferentes em momentos diferentes — que é exatamente
+// como as 27 divergências de copy sobreviveram até a guarda da issue #272.
+//
+// Esta guarda compara COMPORTAMENTO, caso a caso, e não texto. Se alguém mexer
+// numa cópia e esquecer a outra, o PR quebra aqui.
+// ============================================================================
+
+const CASOS: { nome: string; linhas: { market: string }[]; ocultos: string[] }[] = [
+  { nome: 'lista vazia', linhas: [{ market: 'goals_over_under' }], ocultos: [] },
+  {
+    nome: 'esconde um',
+    linhas: [{ market: 'goals_over_under' }, { market: 'asian_handicap' }],
+    ocultos: ['asian_handicap'],
+  },
+  {
+    nome: 'esconde vários',
+    linhas: [{ market: 'btts' }, { market: 'asian_handicap' }, { market: 'double_chance' }],
+    ocultos: ['asian_handicap', 'btts'],
+  },
+  {
+    nome: 'esconde tudo',
+    linhas: [{ market: 'asian_handicap' }, { market: 'asian_handicap' }],
+    ocultos: ['asian_handicap'],
+  },
+  { nome: 'sem linhas', linhas: [], ocultos: ['asian_handicap'] },
+  {
+    nome: 'mercado oculto que não aparece nas linhas',
+    linhas: [{ market: 'match_winner' }],
+    ocultos: ['btts'],
+  },
+];
+
+describe('as duas cópias da vitrine concordam', () => {
+  it.each(CASOS)('filtrarMercadosOcultos · $nome', ({ linhas, ocultos }) => {
+    expect(notificacao.filtrarMercadosOcultos(linhas, ocultos)).toEqual(
+      painel.filtrarMercadosOcultos(linhas, ocultos),
+    );
+  });
+
+  it.each([
+    ['asian_handicap', ['asian_handicap']],
+    ['goals_over_under', ['asian_handicap']],
+    ['asian_handicap', []],
+    ['btts', ['asian_handicap', 'btts']],
+  ] as const)('mercadoEstaOculto · %s', (market, ocultos) => {
+    expect(notificacao.mercadoEstaOculto(market, [...ocultos])).toBe(
+      painel.mercadoEstaOculto(market, [...ocultos]),
+    );
+  });
+
+  // Os dois conjuntos de exports NÃO são iguais, e não deveriam ser: a leitura
+  // da RPC mora no `carregarMercadosOcultos` do lado Deno e no service do lado
+  // do painel, e o `filtrarCatalogoDeMercados` só existe no painel, porque só
+  // ele monta prateleira a partir do catálogo. O que tem de existir dos dois
+  // lados é o PAR DE PREDICADOS — é ele que decide o que o assinante vê.
+  it('os dois predicados existem dos dois lados', () => {
+    for (const nome of ['mercadoEstaOculto', 'filtrarMercadosOcultos'] as const) {
+      expect(typeof painel[nome]).toBe('function');
+      expect(typeof notificacao[nome]).toBe('function');
+    }
+  });
+});

--- a/src/utils/futebol-mercados-ocultos.test.ts
+++ b/src/utils/futebol-mercados-ocultos.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { filtrarMercadosOcultos, mercadoEstaOculto } from './futebol-mercados-ocultos';
+
+const linha = (market: string, id: number) => ({ market, fixture_id: id });
+
+describe('mercadoEstaOculto', () => {
+  it('reconhece o mercado que está na lista', () => {
+    expect(mercadoEstaOculto('asian_handicap', ['asian_handicap'])).toBe(true);
+  });
+
+  it('não esconde mercado fora da lista', () => {
+    expect(mercadoEstaOculto('goals_over_under', ['asian_handicap'])).toBe(false);
+  });
+
+  it('com a lista vazia nada está oculto', () => {
+    expect(mercadoEstaOculto('asian_handicap', [])).toBe(false);
+  });
+});
+
+describe('filtrarMercadosOcultos', () => {
+  it('remove as linhas do mercado oculto', () => {
+    const linhas = [
+      linha('goals_over_under', 1),
+      linha('asian_handicap', 2),
+      linha('match_winner', 3),
+      linha('asian_handicap', 4),
+    ];
+
+    expect(filtrarMercadosOcultos(linhas, ['asian_handicap'])).toEqual([
+      linha('goals_over_under', 1),
+      linha('match_winner', 3),
+    ]);
+  });
+
+  it('preserva a ordem das linhas que ficam', () => {
+    const linhas = [linha('btts', 1), linha('asian_handicap', 2), linha('double_chance', 3)];
+
+    expect(filtrarMercadosOcultos(linhas, ['asian_handicap']).map((l) => l.fixture_id)).toEqual([
+      1, 3,
+    ]);
+  });
+
+  it('esconde mais de um mercado quando a lista tem mais de um', () => {
+    const linhas = [linha('goals_over_under', 1), linha('asian_handicap', 2), linha('btts', 3)];
+
+    expect(filtrarMercadosOcultos(linhas, ['asian_handicap', 'btts'])).toEqual([
+      linha('goals_over_under', 1),
+    ]);
+  });
+
+  it('devolve tudo quando não há mercado oculto', () => {
+    const linhas = [linha('goals_over_under', 1), linha('asian_handicap', 2)];
+
+    expect(filtrarMercadosOcultos(linhas, [])).toEqual(linhas);
+  });
+
+  it('não muda o array recebido', () => {
+    const linhas = [linha('goals_over_under', 1), linha('asian_handicap', 2)];
+
+    filtrarMercadosOcultos(linhas, ['asian_handicap']);
+
+    expect(linhas).toHaveLength(2);
+  });
+});

--- a/src/utils/futebol-mercados-ocultos.ts
+++ b/src/utils/futebol-mercados-ocultos.ts
@@ -15,6 +15,25 @@
 // só a regra, pura, para poder ser testada sem rede.
 // ============================================================
 
+/**
+ * O que vale quando a lista do banco não pode ser lida.
+ *
+ * NÃO é a fonte da verdade — o banco é. Isto é só o que fazer no escuro, e a
+ * única janela realista de escuro é entre o deploy deste código e a aplicação
+ * da migration 116: depois dela, é uma RPC minúscula no mesmo banco que acabou
+ * de servir o board.
+ *
+ * Nessa janela, esconder o Handicap já é o comportamento decidido — o SQL é que
+ * não subiu ainda. Cair para lista vazia mostraria na tela e mandaria na DM
+ * exatamente o que o produto tirou da prateleira.
+ *
+ * ⚠️ Quando um mercado voltar à vitrine pelo UPDATE, TIRE-O DAQUI TAMBÉM. Se
+ * ficar, uma falha de leitura o esconde de novo — o banco vence sempre que
+ * responde, mas o escuro passaria a mentir. A guarda de paridade obriga as duas
+ * cópias (esta e a de `supabase/functions/shared/`) a andarem juntas.
+ */
+export const VITRINE_FALLBACK: readonly string[] = ['asian_handicap'];
+
 /** O mercado está fora da vitrine? */
 export function mercadoEstaOculto(
   market: string,

--- a/src/utils/futebol-mercados-ocultos.ts
+++ b/src/utils/futebol-mercados-ocultos.ts
@@ -1,0 +1,57 @@
+// ============================================================
+// futebol-mercados-ocultos.ts — o mercado sai da vitrine, não do board
+// ============================================================
+// O backend continua publicando, gravando no funil e no histórico. O que esta
+// regra faz é decidir o que o ASSINANTE vê. Isso é de propósito: um mercado
+// retirado do board pararia de ser medido, e é justamente a medição que decide
+// quando ele volta.
+//
+// Primeiro caso: `asian_handicap`. Os números que motivaram estão na migration
+// 116 e em nenhum outro lugar — repeti-los aqui é como eles divergem, e já
+// divergiram uma vez dentro deste mesmo PR.
+//
+// A lista NÃO mora aqui. Ela vem do banco (`get_futebol_mercados_ocultos`), para
+// que devolver um mercado à tela seja um UPDATE e não um release. Este módulo é
+// só a regra, pura, para poder ser testada sem rede.
+// ============================================================
+
+/** O mercado está fora da vitrine? */
+export function mercadoEstaOculto(
+  market: string,
+  ocultos: readonly string[],
+): boolean {
+  return ocultos.includes(market);
+}
+
+/**
+ * Tira do conjunto as linhas dos mercados ocultos.
+ *
+ * Genérica em cima de `market` de propósito: board, detalhe do jogo e a fila do
+ * Telegram carregam formas diferentes, e a regra é a mesma nos três. Aplicar no
+ * ponto em que os dados entram no app é o que faz lista, contador e resumo
+ * concordarem sem que cada tela precise lembrar do filtro.
+ */
+export function filtrarMercadosOcultos<T extends { market: string }>(
+  linhas: readonly T[],
+  ocultos: readonly string[],
+): T[] {
+  if (!ocultos.length) return [...linhas];
+  return linhas.filter((linha) => !mercadoEstaOculto(linha.market, ocultos));
+}
+
+/**
+ * A mesma regra sobre o CATÁLOGO de mercados, que chaveia por `slug`.
+ *
+ * Existe separada porque o detalhe do jogo não monta a prateleira a partir do
+ * board: ele itera o catálogo dos cinco mercados e busca preço para cada um.
+ * Filtrar só as linhas do board deixaria o mercado escondido como chip, com
+ * barra de Score e mapa de premissas, e agora sem odd — pior do que não ter
+ * escondido. Foi o que o review da #324 pegou.
+ */
+export function filtrarCatalogoDeMercados<T extends { slug: string }>(
+  mercados: readonly T[],
+  ocultos: readonly string[],
+): T[] {
+  if (!ocultos.length) return [...mercados];
+  return mercados.filter((mercado) => !mercadoEstaOculto(mercado.slug, ocultos));
+}

--- a/src/utils/futebol-vitrine-aceite.test.ts
+++ b/src/utils/futebol-vitrine-aceite.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { mergeBoardAndHistory } from './futebol-history';
+import { resumoDosMercados } from './futebol-leitura';
+import { filtrarCatalogoDeMercados } from './futebol-mercados-ocultos';
+import { MERCADOS } from './futebol-premissas';
+
+// ============================================================================
+// O aceite da #324, no nível do comportamento
+// ============================================================================
+// O primeiro teste que eu escrevi cobria só o predicado puro sobre arrays
+// literais, e o code review mostrou por que isso não bastava: o predicado
+// passava e o mercado continuava na tela, porque a prateleira do detalhe sai do
+// CATÁLOGO e a lista de hoje pode vir do HISTÓRICO. Estes casos travam os dois
+// caminhos que o review encontrou.
+// ============================================================================
+
+const OCULTOS = ['asian_handicap'];
+
+const linhaDoBoard = (market: string, kickoff: string) => ({
+  fixture_id: 1,
+  home_team_id: 1,
+  away_team_id: 2,
+  home_team_name: 'Casa',
+  away_team_name: 'Fora',
+  competition: 'brasileirao',
+  kickoff_utc: kickoff,
+  status_short: 'NS',
+  market,
+  outcome: 'Home',
+  line_value: -0.5,
+  edge: 0.03,
+  best_odd: 1.9,
+  best_book: 'X',
+  avg_odd: 1.85,
+  n_casas: 8,
+  janela_usada: 't1h',
+  prob_justa_fechamento: 0.55,
+  pts_premissas: 30,
+  penalidades: 0,
+  score: 50,
+  faixa: 'Média',
+  evidencias: [],
+  premissas_sem_dado: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+}) as any;
+
+describe('a prateleira do detalhe respeita a vitrine', () => {
+  it('o catálogo perde o mercado escondido', () => {
+    const visiveis = filtrarCatalogoDeMercados(MERCADOS, OCULTOS);
+    expect(visiveis.map((m) => m.slug)).not.toContain('asian_handicap');
+    expect(visiveis).toHaveLength(MERCADOS.length - 1);
+  });
+
+  it('resumoDosMercados não devolve o mercado escondido', () => {
+    // Uma linha de premissas por mercado, com a primeira premissa acesa — o
+    // bastante para o mercado aparecer na prateleira se nada o esconder.
+    const premissas = MERCADOS.map((m) => ({
+      market: m.slug,
+      outcome: 'Home',
+      line_value: null,
+      pts_premissas: 10,
+      penalidades_pts: 0,
+      acesas: m.premissas.length ? [m.premissas[0].slug] : [],
+      apagadas: [],
+      penalidades: [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    })) as any;
+
+    const comVitrine = resumoDosMercados(premissas, [], null, OCULTOS).map((r) => r.mercado.slug);
+    const semVitrine = resumoDosMercados(premissas, [], null, []).map((r) => r.mercado.slug);
+
+    expect(semVitrine).toContain('asian_handicap');
+    expect(comVitrine).not.toContain('asian_handicap');
+    expect(comVitrine).toHaveLength(semVitrine.length - 1);
+  });
+});
+
+describe('a lista de hoje não reabre o mercado pelo histórico', () => {
+  // 2026-09-01 12:00 BRT. O jogo das 10h já começou: nesse caso a linha do
+  // HISTÓRICO vence o desempate, e era por aí que o mercado voltava.
+  const agora = Date.parse('2026-09-01T15:00:00Z');
+  const jogoDeHoje = '2026-09-01T13:00:00';
+  const jogoDeOntem = '2026-08-31T13:00:00';
+
+  it('esconde o mercado quando quem vence o desempate é o histórico', () => {
+    const hist = [linhaDoBoard('asian_handicap', jogoDeHoje)];
+    const saida = mergeBoardAndHistory([], hist, agora, OCULTOS);
+    expect(saida).toHaveLength(0);
+  });
+
+  it('mantém o mercado no dia passado, que é registro do que foi visto', () => {
+    const hist = [linhaDoBoard('asian_handicap', jogoDeOntem)];
+    const saida = mergeBoardAndHistory([], hist, agora, OCULTOS);
+    expect(saida).toHaveLength(1);
+    expect(saida[0].market).toBe('asian_handicap');
+  });
+
+  it('não mexe nos outros mercados de hoje', () => {
+    const hist = [linhaDoBoard('goals_over_under', jogoDeHoje)];
+    const saida = mergeBoardAndHistory([], hist, agora, OCULTOS);
+    expect(saida.map((r) => r.market)).toEqual(['goals_over_under']);
+  });
+
+  it('sem vitrine configurada, nada muda', () => {
+    const hist = [linhaDoBoard('asian_handicap', jogoDeHoje)];
+    expect(mergeBoardAndHistory([], hist, agora, [])).toHaveLength(1);
+  });
+});

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -30,6 +30,7 @@ import { generateTraceId, trackEvent } from "../shared/posthog.ts";
 import { esc } from "../shared/format.ts";
 import { trackedUrl } from "../shared/links.ts";
 import { ehFaixaPublicavel } from "../shared/faixa.ts";
+import { carregarMercadosOcultos, filtrarMercadosOcultos } from "../shared/mercados-ocultos.ts";
 import { logMessageRun } from "../shared/runs.ts";
 
 const TELEGRAM_BOT_TOKEN = Deno.env.get("TELEGRAM_BOT_TOKEN") || "";
@@ -207,9 +208,14 @@ serve(async (req) => {
     const { data: board, error: bErr } = await supabase.rpc("get_futebol_value_board");
     if (bErr) throw bErr;
 
+    // 1b) a vitrine — MESMA fonte que o painel lê (migration 116). Sem isto o
+    // alerta vaza: o painel esconde o mercado e a DM continua mandando.
+    const mercadosOcultos = await carregarMercadosOcultos(supabase);
+
     const now = new Date();
     const today = brtDay(now);
-    const todayRows = ((board ?? []) as BoardRow[]).filter((r) => {
+    const naVitrine = filtrarMercadosOcultos((board ?? []) as BoardRow[], mercadosOcultos);
+    const todayRows = naVitrine.filter((r) => {
       const k = kickoffDate(r.kickoff_utc);
       return k.getTime() > now.getTime() && brtDay(k) === today && ehFaixaPublicavel(r.faixa);
     });

--- a/supabase/functions/notify-opportunities/index.ts
+++ b/supabase/functions/notify-opportunities/index.ts
@@ -210,7 +210,8 @@ serve(async (req) => {
 
     // 1b) a vitrine — MESMA fonte que o painel lê (migration 116). Sem isto o
     // alerta vaza: o painel esconde o mercado e a DM continua mandando.
-    const mercadosOcultos = await carregarMercadosOcultos(supabase);
+    const vitrine = await carregarMercadosOcultos(supabase);
+    const mercadosOcultos = vitrine.mercados;
 
     const now = new Date();
     const today = brtDay(now);
@@ -240,6 +241,11 @@ serve(async (req) => {
     if (mode === "report") {
       return json({
         ok: true, mode,
+        // `origem: "fallback"` significa que a lista do banco não respondeu e a
+        // mensagem saiu pela lista embutida. Não é erro — a DM sai correta —,
+        // mas é o sinal de que a vitrine pode estar desatualizada, e sem ele
+        // isso sobreviveria em silêncio.
+        vitrine: { origem: vitrine.origem, ocultos: mercadosOcultos },
         picks: picks.map((p) => ({
           jogo: `${p.home_team_name} × ${p.away_team_name}`,
           pick: pickLabel(p.market, p.outcome, p.line_value, p.home_team_name, p.away_team_name),

--- a/supabase/functions/notify-published-opportunities/index.ts
+++ b/supabase/functions/notify-published-opportunities/index.ts
@@ -360,7 +360,8 @@ serve(async (req) => {
     // A vitrine, da MESMA fonte que o painel lê (migration 116). Este é o
     // segundo canal de alerta: esconder o mercado só no `notify-opportunities`
     // deixaria o alerta de publicação continuar mandando. Ver #324.
-    const mercadosOcultos = await carregarMercadosOcultos(supabase);
+    const vitrine = await carregarMercadosOcultos(supabase);
+    const mercadosOcultos = vitrine.mercados;
     const now = new Date();
     const { data: existing, error: existingError } = await supabase
       .from("futebol_publication_alerts")

--- a/supabase/functions/notify-published-opportunities/index.ts
+++ b/supabase/functions/notify-published-opportunities/index.ts
@@ -14,6 +14,7 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 import { trackedUrl } from "../shared/links.ts";
 import { generateTraceId, trackEvent } from "../shared/posthog.ts";
 import { logMessageRun } from "../shared/runs.ts";
+import { carregarMercadosOcultos, filtrarMercadosOcultos } from "../shared/mercados-ocultos.ts";
 import { planPublicationBatch, type PublicationBoardRow } from "./planner.ts";
 import {
   type PublishedMessageOpportunity,
@@ -356,6 +357,10 @@ serve(async (req) => {
       "get_futebol_value_board",
     );
     if (boardError) throw boardError;
+    // A vitrine, da MESMA fonte que o painel lê (migration 116). Este é o
+    // segundo canal de alerta: esconder o mercado só no `notify-opportunities`
+    // deixaria o alerta de publicação continuar mandando. Ver #324.
+    const mercadosOcultos = await carregarMercadosOcultos(supabase);
     const now = new Date();
     const { data: existing, error: existingError } = await supabase
       .from("futebol_publication_alerts")
@@ -366,7 +371,7 @@ serve(async (req) => {
       alreadyAlerted: new Set(
         (existing ?? []).map((row: any) => row.opportunity_key as string),
       ),
-      board: (board ?? []) as BoardRow[],
+      board: filtrarMercadosOcultos((board ?? []) as BoardRow[], mercadosOcultos),
     });
 
     const { data: recipients, error: recipientsError } = await supabase.rpc(

--- a/supabase/functions/shared/mercados-ocultos.ts
+++ b/supabase/functions/shared/mercados-ocultos.ts
@@ -1,0 +1,67 @@
+/**
+ * A vitrine do produto, do lado das notificações.
+ *
+ * Um mercado pode sair da VITRINE sem sair do BOARD: o backend segue publicando
+ * e gravando no funil e no histórico, e o que muda é só o que o assinante vê.
+ * Parar de publicar pararia de medir, e é a medição que decide quando o mercado
+ * volta. Os números que motivaram estão na migration 116, e só lá. Ver `prop-play-predictor#324`.
+ *
+ * ⚠️ A lista mora no BANCO, não em constante, e é isto que impede o vazamento
+ * mais provável: o painel esconder o mercado e a DM continuar mandando. O painel
+ * roda no browser e isto roda em Deno, então não há módulo compartilhado entre
+ * os dois — só o banco é fonte comum. É o mesmo argumento do `faixa.ts` ao lado,
+ * com uma diferença: ali a cópia é inevitável, aqui ela seria um bug.
+ *
+ * Esta é a única cópia deste lado da fronteira: as duas funções de notificação
+ * importam daqui.
+ */
+
+/**
+ * Mesmo predicado do painel (`src/utils/futebol-mercados-ocultos.ts`).
+ *
+ * A guarda `src/utils/futebol-mercados-ocultos-paridade.test.ts` compara as duas
+ * cópias caso a caso e quebra o PR quando elas se afastam — mesmo padrão da
+ * guarda de copy das premissas, que nasceu de 27 divergências que ninguém viu.
+ */
+export function mercadoEstaOculto(
+  market: string,
+  ocultos: readonly string[],
+): boolean {
+  return ocultos.includes(market);
+}
+
+export function filtrarMercadosOcultos<T extends { market: string }>(
+  linhas: readonly T[],
+  ocultos: readonly string[],
+): T[] {
+  if (!ocultos.length) return [...linhas];
+  return linhas.filter((linha) => !mercadoEstaOculto(linha.market, ocultos));
+}
+
+/**
+ * O cliente Supabase, no mínimo que esta função usa.
+ *
+ * `PromiseLike` e não `Promise` porque o `rpc()` do supabase-js devolve um
+ * builder que é thenable, não uma Promise — tipar como Promise faz o
+ * `deno check` recusar a chamada real.
+ */
+// deno-lint-ignore no-explicit-any
+type ClienteRpc = { rpc: (nome: string, ...args: any[]) => PromiseLike<any> };
+
+/**
+ * Lê a vitrine, e NUNCA lança.
+ *
+ * Configuração indisponível não pode derrubar o envio do dia — nem quando a RPC
+ * ainda não existe, que é o estado entre o deploy do código e a aplicação da
+ * migration. Sem a lista o comportamento é o de antes, nada escondido: é
+ * degradação, não regressão.
+ */
+export async function carregarMercadosOcultos(supabase: ClienteRpc): Promise<string[]> {
+  try {
+    const { data, error } = await supabase.rpc("get_futebol_mercados_ocultos");
+    if (error) return [];
+    return Array.isArray(data) ? (data as string[]) : [];
+  } catch (_) {
+    return [];
+  }
+}

--- a/supabase/functions/shared/mercados-ocultos.ts
+++ b/supabase/functions/shared/mercados-ocultos.ts
@@ -49,19 +49,34 @@ export function filtrarMercadosOcultos<T extends { market: string }>(
 type ClienteRpc = { rpc: (nome: string, ...args: any[]) => PromiseLike<any> };
 
 /**
+ * O que vale quando a lista do banco não pode ser lida. Cópia do
+ * `VITRINE_FALLBACK` do painel — a guarda de paridade obriga as duas a andarem
+ * juntas, e é lá que está o comentário inteiro, inclusive o aviso de tirar o
+ * mercado daqui quando ele voltar à vitrine.
+ */
+export const VITRINE_FALLBACK: readonly string[] = ["asian_handicap"];
+
+/**
  * Lê a vitrine, e NUNCA lança.
  *
- * Configuração indisponível não pode derrubar o envio do dia — nem quando a RPC
- * ainda não existe, que é o estado entre o deploy do código e a aplicação da
- * migration. Sem a lista o comportamento é o de antes, nada escondido: é
- * degradação, não regressão.
+ * Configuração indisponível não pode derrubar o envio do dia. Mas cair para
+ * lista vazia mandaria na DM exatamente o que o produto tirou da prateleira —
+ * então o escuro cai para o `VITRINE_FALLBACK`, e a mensagem sai SEM o mercado
+ * escondido em vez de sair errada ou não sair.
+ *
+ * Devolve a origem para o chamador poder registrar o estado degradado: silêncio
+ * aqui é como uma vitrine desatualizada sobreviveria sem ninguém notar.
  */
-export async function carregarMercadosOcultos(supabase: ClienteRpc): Promise<string[]> {
+export async function carregarMercadosOcultos(
+  supabase: ClienteRpc,
+): Promise<{ mercados: string[]; origem: "banco" | "fallback" }> {
   try {
     const { data, error } = await supabase.rpc("get_futebol_mercados_ocultos");
-    if (error) return [];
-    return Array.isArray(data) ? (data as string[]) : [];
+    if (error || !Array.isArray(data)) {
+      return { mercados: [...VITRINE_FALLBACK], origem: "fallback" };
+    }
+    return { mercados: data as string[], origem: "banco" };
   } catch (_) {
-    return [];
+    return { mercados: [...VITRINE_FALLBACK], origem: "fallback" };
   }
 }

--- a/supabase/functions/tests/mercados-ocultos.test.ts
+++ b/supabase/functions/tests/mercados-ocultos.test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from "./_assert.ts";
 import {
   carregarMercadosOcultos,
   filtrarMercadosOcultos,
+  VITRINE_FALLBACK,
 } from "../shared/mercados-ocultos.ts";
 
 const linha = (market: string, id: number) => ({ market, fixture_id: id });
@@ -40,24 +41,36 @@ Deno.test("carrega a lista da RPC", async () => {
       return Promise.resolve({ data: ["asian_handicap"], error: null });
     },
   };
-  assertEquals(await carregarMercadosOcultos(supabase), ["asian_handicap"]);
+  assertEquals(await carregarMercadosOcultos(supabase), {
+    mercados: ["asian_handicap"],
+    origem: "banco",
+  });
 });
 
-Deno.test("RPC com erro não derruba o envio: devolve lista vazia", async () => {
+Deno.test("RPC com erro cai para o fallback, e a mensagem sai SEM o mercado escondido", async () => {
   const supabase = {
     rpc: () => Promise.resolve({ data: null, error: { message: "boom" } }),
   };
-  assertEquals(await carregarMercadosOcultos(supabase), []);
+  assertEquals(await carregarMercadosOcultos(supabase), {
+    mercados: [...VITRINE_FALLBACK],
+    origem: "fallback",
+  });
 });
 
-Deno.test("RPC inexistente (front antes da migration) devolve lista vazia", async () => {
+Deno.test("RPC inexistente (código antes da migration) cai para o fallback", async () => {
   const supabase = {
     rpc: () => Promise.reject(new Error("function does not exist")),
   };
-  assertEquals(await carregarMercadosOcultos(supabase), []);
+  assertEquals(await carregarMercadosOcultos(supabase), {
+    mercados: [...VITRINE_FALLBACK],
+    origem: "fallback",
+  });
 });
 
-Deno.test("resposta nula vira lista vazia", async () => {
+Deno.test("resposta sem array cai para o fallback", async () => {
   const supabase = { rpc: () => Promise.resolve({ data: null, error: null }) };
-  assertEquals(await carregarMercadosOcultos(supabase), []);
+  assertEquals(await carregarMercadosOcultos(supabase), {
+    mercados: [...VITRINE_FALLBACK],
+    origem: "fallback",
+  });
 });

--- a/supabase/functions/tests/mercados-ocultos.test.ts
+++ b/supabase/functions/tests/mercados-ocultos.test.ts
@@ -1,0 +1,63 @@
+// A vitrine do produto, do lado das notificações. Um mercado escondido no
+// painel e não no Telegram é o vazamento que esta regra existe para impedir:
+// o assinante recebe no celular o que sumiu da tela.
+import { assertEquals } from "./_assert.ts";
+import {
+  carregarMercadosOcultos,
+  filtrarMercadosOcultos,
+} from "../shared/mercados-ocultos.ts";
+
+const linha = (market: string, id: number) => ({ market, fixture_id: id });
+
+Deno.test("filtra as linhas do mercado oculto", () => {
+  const linhas = [
+    linha("goals_over_under", 1),
+    linha("asian_handicap", 2),
+    linha("match_winner", 3),
+  ];
+  assertEquals(filtrarMercadosOcultos(linhas, ["asian_handicap"]), [
+    linha("goals_over_under", 1),
+    linha("match_winner", 3),
+  ]);
+});
+
+Deno.test("sem mercado oculto devolve tudo", () => {
+  const linhas = [linha("goals_over_under", 1), linha("asian_handicap", 2)];
+  assertEquals(filtrarMercadosOcultos(linhas, []), linhas);
+});
+
+Deno.test("esconde mais de um mercado", () => {
+  const linhas = [linha("btts", 1), linha("asian_handicap", 2), linha("double_chance", 3)];
+  assertEquals(filtrarMercadosOcultos(linhas, ["asian_handicap", "btts"]), [
+    linha("double_chance", 3),
+  ]);
+});
+
+Deno.test("carrega a lista da RPC", async () => {
+  const supabase = {
+    rpc: (nome: string) => {
+      assertEquals(nome, "get_futebol_mercados_ocultos");
+      return Promise.resolve({ data: ["asian_handicap"], error: null });
+    },
+  };
+  assertEquals(await carregarMercadosOcultos(supabase), ["asian_handicap"]);
+});
+
+Deno.test("RPC com erro não derruba o envio: devolve lista vazia", async () => {
+  const supabase = {
+    rpc: () => Promise.resolve({ data: null, error: { message: "boom" } }),
+  };
+  assertEquals(await carregarMercadosOcultos(supabase), []);
+});
+
+Deno.test("RPC inexistente (front antes da migration) devolve lista vazia", async () => {
+  const supabase = {
+    rpc: () => Promise.reject(new Error("function does not exist")),
+  };
+  assertEquals(await carregarMercadosOcultos(supabase), []);
+});
+
+Deno.test("resposta nula vira lista vazia", async () => {
+  const supabase = { rpc: () => Promise.resolve({ data: null, error: null }) };
+  assertEquals(await carregarMercadosOcultos(supabase), []);
+});

--- a/supabase/migrations/20260901200000_116_futebol_mercados_ocultos.sql
+++ b/supabase/migrations/20260901200000_116_futebol_mercados_ocultos.sql
@@ -1,0 +1,80 @@
+-- 20260901200000_116_futebol_mercados_ocultos
+--
+-- Um mercado pode sair da VITRINE sem sair do BOARD.
+--
+-- Decisão do PM em 31/08/2026 (prop-play-predictor#324, registrada também na
+-- analytics-engineering#109): o `asian_handicap` deixa de ser exibido ao
+-- assinante no lançamento do Score de contexto, mas CONTINUA sendo publicado,
+-- gravado no funil e no histórico. Parar de publicar pararia de medir, e é a
+-- medição que decide quando o mercado volta.
+--
+-- O número que motivou, do board efetivamente publicado (kickoff 27/07 a
+-- 31/08/2026, liquidado nos 90 minutos, erro-padrão agrupado por fixture):
+--
+--   goals_over_under   50 linhas   ROI +22,3   EP 17,4   31 acertos
+--   asian_handicap     23 linhas   ROI −48,4   EP 16,5    6 acertos
+--
+-- Os dois quase se anulam em unidades (+11,13 contra −11,14), ou seja: o
+-- produto empata porque o Gols paga o Handicap. E o buraco é anterior ao
+-- redesenho do Score — aparece igual nas duas metodologias.
+--
+-- A investigação do mercado corre na B3 (ClickUp `wdx6zev656`) e não bloqueia
+-- o lançamento.
+--
+-- ⚠️ POR QUE TABELA E NÃO CONSTANTE NO CÓDIGO
+-- Devolver o Handicap à tela precisa ser um UPDATE, não um release. São dois
+-- consumidores em runtimes diferentes — o painel (browser) e a DM do Telegram
+-- (edge function, Deno) — e eles não compartilham módulo. A tabela é a única
+-- fonte que os dois leem, então não há como um voltar sem o outro.
+--
+-- Conferência depois de aplicar:
+--   select * from public.get_futebol_mercados_ocultos();  -- espera {asian_handicap}
+
+-- ── A vitrine ───────────────────────────────────────────────────────────────
+create table if not exists public.futebol_mercados_ocultos (
+  market text primary key,
+  -- A linha existe mesmo com `oculto = false`: ela é o registro de que o
+  -- mercado JÁ esteve fora, e `desde` diz desde quando. Apagar a linha para
+  -- devolver o mercado perderia essa data, que é o que torna o antes/depois
+  -- comparável quando ele voltar.
+  oculto boolean not null default true,
+  oculto_desde timestamptz not null default now(),
+  motivo text not null
+);
+
+-- RLS ligada e SEM policy, de propósito, no mesmo padrão da
+-- `futebol_premissa_copy` (migration 106): nada lê esta tabela direto. A RPC
+-- abaixo é SECURITY DEFINER e lê como dono, então a ausência de policy é o que
+-- garante que ninguém leia por fora.
+alter table public.futebol_mercados_ocultos enable row level security;
+
+comment on table public.futebol_mercados_ocultos is
+  'Mercados retirados da vitrine do produto. Não é gate: o board continua publicando.';
+
+-- ── A leitura ───────────────────────────────────────────────────────────────
+-- Devolve `text[]` e não `setof` porque os dois consumidores querem a lista
+-- inteira de uma vez, e um array evita o caso de "zero linhas" ter de ser
+-- tratado como erro em dois lugares diferentes.
+create or replace function public.get_futebol_mercados_ocultos()
+returns text[]
+language sql
+stable
+security definer
+set search_path to ''
+as $function$
+  select coalesce(array_agg(market order by market), array[]::text[])
+    from public.futebol_mercados_ocultos
+   where oculto;
+$function$;
+
+grant execute on function public.get_futebol_mercados_ocultos() to anon, authenticated, service_role;
+
+-- ── O primeiro caso ─────────────────────────────────────────────────────────
+insert into public.futebol_mercados_ocultos (market, oculto, oculto_desde, motivo)
+values (
+  'asian_handicap',
+  true,
+  timestamptz '2026-09-01 00:00:00+00',
+  'ROI -48,4 em 23 linhas publicadas (EP 16,5), contra +22,3 do Gols. Investigacao na B3 (ClickUp wdx6zev656). Decisao do PM em 31/08/2026, prop-play-predictor#324.'
+)
+on conflict (market) do nothing;


### PR DESCRIPTION
Fecha #324.

## O que muda

O `asian_handicap` deixa de ser **exibido** ao assinante. Ele **continua sendo publicado**, gravado no funil e no histórico — parar de publicar pararia de medir, e é a medição que decide quando ele volta.

Nada muda no gate, no mart ou nas RPCs de valor.

**A lista mora no banco** (migration 116), não em constante: são dois consumidores em runtimes diferentes — painel no browser, DMs em Deno — e devolver o mercado à tela tem de ser um `UPDATE`, não um release.

## Onde o mercado some

| superfície | como |
|---|---|
| Home, Oportunidades | board filtrado no service + fusão com histórico + picks já alertados |
| Lista de jogos, Campeonato | de graça, pelo mesmo service |
| Detalhe do jogo | linhas de valor, prateleira dos 5 mercados, contador, rótulo e fallback do mercado ativo |
| Telegram | os **dois** canais: resumo diário e alerta de publicação |

**Onde ele NÃO some, de propósito:** o histórico e os dias passados. É registro do que foi publicado e visto — o assinante pode ter apostado naquilo, e escondê-lo reescreveria o passado dele e mudaria a performance exibida.

## O que motivou

Board efetivamente publicado, kickoff de 27/07 a 31/08, liquidado nos 90 minutos, erro-padrão agrupado por fixture:

| mercado | linhas | acerto | equilíbrio | ROI | EP | unidades |
|---|---:|---:|---:|---:|---:|---:|
| `goals_over_under` | 50 | 62% | 47% | +22,3 | 17,4 | +11,13 |
| `asian_handicap` | 23 | **26%** | 52% | **−48,4** | 16,5 | **−11,14** |

Os dois quase se anulam: o produto empata porque o Gols paga o Handicap. E o buraco **é anterior ao redesenho do Score** — aparece igual nas duas metodologias. Até 07/08 foram **zero acertos em 12 linhas**.

A investigação do mercado corre na B3 (ClickUp `wdx6zev656`) e não bloqueia o lançamento.

## O que o code review corrigiu, e não era pouco

A primeira versão filtrava só as linhas do board. Três buracos:

1. **A prateleira do detalhe sai do CATÁLOGO, não do board.** O chip "Handicap asiático" continuava lá, com barra de Score e **agora sem odd** — pior do que não ter escondido.
2. **A fusão com o histórico reabria o dia corrente.** Jogo que já começou hoje vence pela linha do histórico, que não é filtrada. A distinção que resolveu: a vitrine vale **de hoje para a frente**; dia passado é registro.
3. **Picks já alertados voltavam** pelo mesmo caminho.

E dois de padrão: o `CONTEXT.md` tinha ficado **falso** (ele define "publicação no painel" como o momento em que a oportunidade fica disponível, e agora existe linha publicada que nunca fica), e faltava a guarda de paridade entre as duas cópias do predicado.

## A decisão do escuro

Se a leitura da vitrine falhar, a mensagem sai **sem** o mercado escondido — não "manda tudo" nem "não manda nada".

A única janela realista de escuro é entre o deploy deste código e a aplicação da migration: depois dela é uma RPC minúscula no mesmo banco que acabou de servir o board. E nessa janela esconder já é o comportamento decidido — o que não subiu foi o SQL, não a decisão.

`carregarMercadosOcultos` devolve a origem (`banco` | `fallback`) e o `mode=report` da função diária publica isso, para vitrine desatualizada não sobreviver em silêncio.

> ⚠️ **Quando o Handicap voltar à vitrine pelo `UPDATE`, tire-o do `VITRINE_FALLBACK` também**, nas duas cópias. Se ficar, uma falha de leitura o esconde de novo. A guarda de paridade obriga as duas a andarem juntas, mas não sabe da decisão de produto.

## Deploy

- [ ] Aplicar a **migration 116** (`futebol_mercados_ocultos` + RPC). Antes dela o fallback é que segura.
- [ ] Registrar na #324 a **data real** em que o Handicap sai da tela — é item do aceite, e o `oculto_desde` deve refletir o deploy.
- [ ] Smoke test: home, oportunidades, lista de jogos, campeonato, detalhe do jogo, e um `mode=report` em cada função de notificação.

**Efeito visível esperado:** jogo cuja única oportunidade era Handicap perde o selo na lista de jogos e no campeonato. É o efeito pretendido, mas num dia de Série B pode esvaziar bastante a lista.

## Verificação

- `npx vitest run` — **389 passando**, 1 pulado, 40 arquivos
- `npx tsc --noEmit -p tsconfig.app.json` — limpo no módulo futebol
- `npx eslint` nos arquivos tocados — zero erros (2 avisos de `any` pré-existentes, linhas 19 e 28 do service)
- `npm run build` — ok
- ⚠️ Os testes Deno das edge functions **não rodaram nesta máquina** (Deno não instalado). São gate no CI.

## Fora de escopo

Filtrar por lado (favorito ou azarão): das 13 linhas publicadas em que uma premissa do lado azarão acendeu, **9 têm handicap negativo com odd média 1,68** — premissa de azarão em cima do favorito. Enquanto a B3 não responder a classificação de lado, um filtro por lado esconde o lado errado.

O `MapaPremissas.tsx` tem os mesmos defeitos de contador e prateleira e **não foi tocado**: nada o importa, é órfão.
