### PR TITLE
Futebol · As fronteiras de faixa passam a ser 30 e 60

### DIFF
--- a/src/components/futebol/FaixasLegenda.test.tsx
+++ b/src/components/futebol/FaixasLegenda.test.tsx
@@ -15,16 +15,16 @@ describe('FaixasLegenda', () => {
   it('acompanha a virada sozinha quando o board declara a escala nova', () => {
     render(<FaixasLegenda opcoes={opcoesDeFaixa('contexto_v1')} />);
 
-    expect(screen.getByText('55+', { exact: true })).toHaveClass('bg-forest');
-    expect(screen.getByText('25+', { exact: true })).toHaveClass('bg-amber/15');
-    expect(screen.getByText('<25', { exact: true })).toHaveClass('bg-canvas-2');
+    expect(screen.getByText('60+', { exact: true })).toHaveClass('bg-forest');
+    expect(screen.getByText('30+', { exact: true })).toHaveClass('bg-amber/15');
+    expect(screen.getByText('<30', { exact: true })).toHaveClass('bg-canvas-2');
   });
 
   it('omite o selo na janela indefinida, em vez de cravar um corte errado', () => {
     render(<FaixasLegenda opcoes={opcoesDeFaixa('indefinida')} />);
 
     expect(screen.queryByText('60+', { exact: true })).toBeNull();
-    expect(screen.queryByText('55+', { exact: true })).toBeNull();
+    expect(screen.queryByText('60+', { exact: true })).toBeNull();
     expect(screen.getByText(/^Alta,/)).toBeInTheDocument();
     expect(screen.getByText(/^Média,/)).toBeInTheDocument();
     expect(screen.getByText(/^Baixa,/)).toBeInTheDocument();

--- a/src/utils/futebol-faixas.test.ts
+++ b/src/utils/futebol-faixas.test.ts
@@ -23,23 +23,23 @@ import {
 
 describe('fronteiras da faixa', () => {
   it('pertencem à faixa de cima', () => {
-    // Uma nota exatamente 25 é Média; exatamente 55 é Alta.
-    expect(FAIXA_MEDIA_MIN).toBe(25);
-    expect(FAIXA_ALTA_MIN).toBe(55);
+    // Uma nota exatamente 30 é Média; exatamente 60 é Alta.
+    expect(FAIXA_MEDIA_MIN).toBe(30);
+    expect(FAIXA_ALTA_MIN).toBe(60);
   });
 
   it('a legenda descreve as três faixas sem furo nem sobreposição', () => {
     const [alta, media, baixa] = opcoesDeFaixa('contexto_v1');
-    expect(alta).toEqual({ tone: 'alta', rotulo: 'Alta', selo: '55+' });
-    expect(media).toEqual({ tone: 'media', rotulo: 'Média', selo: '25+' });
-    expect(baixa).toEqual({ tone: 'baixa', rotulo: 'Baixa', selo: '<25' });
+    expect(alta).toEqual({ tone: 'alta', rotulo: 'Alta', selo: '60+' });
+    expect(media).toEqual({ tone: 'media', rotulo: 'Média', selo: '30+' });
+    expect(baixa).toEqual({ tone: 'baixa', rotulo: 'Baixa', selo: '<30' });
   });
 
   it('na escala antiga a legenda mostra os números antigos', () => {
     // Entre esta entrega e a troca do mart o board ainda vem em legacy. Anunciar
-    // 55+ ali classificaria errado: uma nota legacy de 57 é Média.
+    // 60+ ali classificaria errado: uma nota legacy de 57 é Média.
     expect(fronteirasDoScore('legacy')).toEqual({ media: 40, alta: 60 });
-    expect(fronteirasDoScore('contexto_v1')).toEqual({ media: 25, alta: 55 });
+    expect(fronteirasDoScore('contexto_v1')).toEqual({ media: 30, alta: 60 });
     expect(opcoesDeFaixa('legacy').map((o) => o.selo)).toEqual(['60+', '40+', '<40']);
   });
 });

--- a/src/utils/futebol-historico-escalas.test.ts
+++ b/src/utils/futebol-historico-escalas.test.ts
@@ -62,7 +62,7 @@ describe('a legenda não afirma número quando as escalas convivem', () => {
   });
 
   it('nas janelas de uma escala só, o número aparece', () => {
-    expect(opcoesDeFaixa('contexto_v1').map((o) => o.selo)).toEqual(['55+', '25+', '<25']);
+    expect(opcoesDeFaixa('contexto_v1').map((o) => o.selo)).toEqual(['60+', '30+', '<30']);
     expect(opcoesDeFaixa('legacy').map((o) => o.selo)).toEqual(['60+', '40+', '<40']);
   });
 });

--- a/src/utils/futebol-score.ts
+++ b/src/utils/futebol-score.ts
@@ -138,14 +138,27 @@ export function bestOf(rows: FutebolFixtureValueRow[]): FutebolFixtureValueRow |
 
 /**
  * Fronteiras do Score de contexto (spec #301). As duas pertencem à faixa de
- * cima: 25 é Média, 55 é Alta.
+ * cima: 30 é Média, 60 é Alta.
  *
  * Elas existem aqui para a LEGENDA declarar o número certo, e para mais nada.
  * Quem classifica é o backend: a faixa chega pronta na resposta, e o front que
- * recalcula é o front que discorda da metodologia sem saber.
+ * recalcula é o front que discorda da metodologia sem saber. Por isso estes
+ * números têm de ser os MESMOS do `CASE` das faixas no mart — se divergirem, a
+ * legenda mente em cima de um rótulo correto.
+ *
+ * ⚠️ Eram 25 e 55, medidos pela #107. Viraram 30 e 60 por DECISÃO DE PRODUTO em
+ * 01/09/2026, registrada na `analytics-engineering#109`, e não por leitura de
+ * evidência: a #107 concluiu que nenhum par da grade discrimina — os oito
+ * passam nas restrições de forma e nenhum separa Alta de Baixa além de um
+ * erro-padrão. O 30/60 está na mesma grade medida, então não é número novo.
+ *
+ * O que ele compra, contra o 25/55: a faixa Alta deixa de ser a segunda melhor
+ * e passa a ser a melhor (ROI −3,6 contra −4,6), e o board padrão encolhe de
+ * 63,5% para 52,8% do total. O que ele não conserta: a Média segue sendo o
+ * fundo, igual ao 25/55 — faixa é rótulo, não porta.
  */
-export const FAIXA_MEDIA_MIN = 25;
-export const FAIXA_ALTA_MIN = 55;
+export const FAIXA_MEDIA_MIN = 30;
+export const FAIXA_ALTA_MIN = 60;
 
 /**
  * As fronteiras da escala em que a nota foi calculada.


### PR DESCRIPTION
Metade do app da decisão registrada na [`analytics-engineering#109`](https://github.com/tech-lamjav/analytics-engineering/issues/109#issuecomment-5501616097).

**Baixa < 30 · Média 30–60 · Alta ≥ 60**, com a fronteira pertencendo à faixa de cima nas duas: nota exatamente 30 é Média, exatamente 60 é Alta.

## ⚠️ É decisão de produto, não leitura de evidência

Registrando com todas as letras para não ser lido errado depois: **os dados não apontaram o 30/60**. A #107 concluiu que nenhum par da grade discrimina — os oito passam nas restrições de forma e nenhum separa `Alta` de `Baixa` além de um erro-padrão. A escolha é sobre **quanto rotular como Alta**.

O 30/60 está na grade que a #107 mediu, então não é número inventado fora do conjunto testado.

## Por que este par

| par | Baixa | Média | Alta | a Alta é |
|---|---|---|---|---|
| 25/55 (estava no aceite) | 36,4% · −2,6 | 30,3% · −8,4 | 33,2% · −4,6 | a 2ª melhor |
| **30/60** | 47,2% · −4,1 | 25,9% · −8,1 | **26,9% · −3,6** | **a melhor** |
| 40/70 (avaliado) | 56,3% · −5,5 | 25,7% · −3,1 | 18,0% · **−6,3** | a **pior** |

O 40/70 foi considerado e descartado: ele corta mais volume, mas faz da `Alta` a pior faixa das três — chamar de "Alta confiança" o grupo que mede pior é constrangedor de sustentar.

O que o 30/60 **não** conserta: a `Média` segue sendo o fundo, exatamente como no 25/55. Faixa é rótulo e não porta, e a #107 é explícita que ela não precisa de ROI monotônico para existir.

Em volume, sobre a previsão de 10 a 20 por dia: a visão padrão (`Alta` + `Média`) sai de 6–13 para 5–11.

## Escopo: só exibição

Quem carimba a `faixa` é o mart. Estes números alimentam **a legenda e o tracinho da barra de Score**, e nada mais — o front que recalculasse faixa seria o front discordando da metodologia sem saber.

Por isso eles têm de ser os mesmos do `CASE` das faixas no mart. **A PR do lado do backend está pedida na `analytics-engineering#109`** e ainda não subiu. Se os dois divergirem, a legenda mente em cima de um rótulo correto.

**Seguro subir antes da virada:** o `fronteirasDoScore` só devolve os números novos quando a linha chega como `contexto_v1`. Enquanto o mart estiver `legacy`, a legenda segue mostrando 40 e 60. Nada muda para o assinante hoje.

## Verificação

- `npx vitest run` — **389 passando**, 1 pulado, 40 arquivos
- `npx tsc --noEmit -p tsconfig.app.json` — limpo no módulo futebol
- `npx eslint` nos arquivos tocados — zero erros, zero avisos
- Varredura por 25/55 como fronteira em `CONTEXT.md`, `docs/` e `migrations/`: **nada desatualizado** — os números não estavam documentados fora do código
- Demo do onboarding conferida: os pares score/faixa seguem coerentes nas três escalas (18–21 `Baixa`, 43–51 `Média`, 63 e 74 `Alta`)

## Review

Mudança de duas constantes mais os testes que as travam. Não passou pelo review de dois eixos em paralelo, que seria desproporcional aqui; passou pela checagem que o review anterior mostrou ser a que morde nesta base — documentação e testes que ficam mentindo depois da mudança. Os três arquivos de teste que cravavam 25/55 foram atualizados no mesmo commit.

## Antes da janela

Isto **tem de entrar antes da virada**. Depois dela a `faixa` fica carimbada na série nova junto do `score_versao`, e mudar significaria duas escalas de rótulo dentro da mesma série — exatamente o que o `score_versao` existe para impedir.
