### PR TITLE
Futebol · As telas esperam a leitura em vez de negá-la

### DIFF
--- a/src/components/futebol/FaixaPartida.test.tsx
+++ b/src/components/futebol/FaixaPartida.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FaixaPartida } from './FaixaPartida';
+import type { JogoInfo } from './JogoResumo';
+
+// ============================================================================
+// Os três estados da leitura na faixa da partida
+// ============================================================================
+// "Sem leitura ainda" é uma CONCLUSÃO: significa que as duas fontes chegaram e
+// nenhuma delas sustenta uma linha. Enquanto elas estão em voo, a resposta certa
+// é o esqueleto, não a conclusão — senão a tela afirma um vazio que ela ainda
+// não sabe se é verdade.
+//
+// Regra para quem mexer aqui depois (issue #310): nenhum teste deste arquivo
+// afirma número de Score, peso de premissa ou slug. Eles só distinguem os três
+// estados, e por isso atravessam a virada do contrato sem precisar de ajuste.
+// ============================================================================
+
+const jogo: JogoInfo = {
+  fixtureId: 1,
+  home: 'Palmeiras',
+  away: 'Flamengo',
+  competition: 'brasileirao',
+  season: 2026,
+  kickoffUtc: '2026-09-05T22:00:00Z',
+  statusShort: 'NS',
+  goalsHome: null,
+  goalsAway: null,
+};
+
+function renderFaixa(props: Partial<Parameters<typeof FaixaPartida>[0]> = {}) {
+  return render(
+    <FaixaPartida
+      jogo={jogo}
+      premissas={[]}
+      valueRows={[]}
+      leituraCarregando={false}
+      locked={false}
+      rodada="Rodada 24"
+      estadio="Allianz Parque"
+      quando="sáb 19:00"
+      formHome={[]}
+      formAway={[]}
+      homeTeamId={10}
+      awayTeamId={20}
+      onAbrirMercado={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe('FaixaPartida · estado da leitura', () => {
+  it('mostra o esqueleto, e não a conclusão, enquanto a leitura carrega', () => {
+    renderFaixa({ leituraCarregando: true });
+
+    expect(screen.getByTestId('faixa-leitura-carregando')).toBeInTheDocument();
+    expect(screen.queryByText('Sem leitura ainda')).not.toBeInTheDocument();
+  });
+
+  it('o confronto aparece na hora, sem esperar a leitura', () => {
+    // O cabeçalho vem da lista de jogos e não depende das duas queries. Segurá-lo
+    // atrás do carregando trocaria uma piscada por outra, e essa apagaria da tela
+    // informação que já estava disponível.
+    renderFaixa({ leituraCarregando: true });
+
+    expect(screen.getByText('Palmeiras')).toBeInTheDocument();
+    expect(screen.getByText('Flamengo')).toBeInTheDocument();
+    expect(screen.getByText('sáb 19:00')).toBeInTheDocument();
+    expect(screen.getByText('Allianz Parque')).toBeInTheDocument();
+  });
+
+  it('só conclui "Sem leitura ainda" depois que as duas fontes chegaram', () => {
+    renderFaixa({ leituraCarregando: false, premissas: [], valueRows: [] });
+
+    expect(screen.queryByTestId('faixa-leitura-carregando')).not.toBeInTheDocument();
+    expect(screen.getByText('Sem leitura ainda')).toBeInTheDocument();
+  });
+});

--- a/src/components/futebol/FaixaPartida.tsx
+++ b/src/components/futebol/FaixaPartida.tsx
@@ -3,8 +3,8 @@ import { MapPin } from 'lucide-react';
 import { Blur } from '@/components/futebol/FutebolGate';
 import { Crest } from '@/components/futebol/Crest';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
-import { useFutebolFixturePremissas } from '@/hooks/use-futebol-data';
-import type { FutebolFixtureValueRow, FutebolFormResult } from '@/services/futebol-data.service';
+
+import type { FutebolFixturePremissas, FutebolFixtureValueRow, FutebolFormResult } from '@/services/futebol-data.service';
 import { melhorLeitura, resumoDosMercados, type SaidaPreferida } from '@/utils/futebol-leitura';
 import { rotuloDaFaixa } from '@/utils/futebol-score';
 import { outcomeLabel, contaQueValem, PORTA_PREMISSAS } from '@/utils/futebol-premissas';
@@ -47,7 +47,9 @@ function Forma({ form, alinhar }: { form: FutebolFormResult[]; alinhar?: 'fim' }
 
 export function FaixaPartida({
   jogo,
+  premissas,
   valueRows,
+  leituraCarregando,
   locked,
   rodada,
   estadio,
@@ -60,7 +62,17 @@ export function FaixaPartida({
   preferida,
 }: {
   jogo: JogoInfo;
+  /** As premissas do jogo. Vêm da página: ela já faz essa query e é a dona do estado. */
+  premissas: FutebolFixturePremissas[] | null | undefined;
   valueRows: FutebolFixtureValueRow[] | null | undefined;
+  /**
+   * Alguma das duas fontes da leitura ainda está em voo.
+   *
+   * "Sem leitura ainda" é uma conclusão: só cabe quando as duas chegaram e
+   * nenhuma sustenta uma linha. Enquanto carregam, a faixa mostra o esqueleto,
+   * senão a tela afirma um vazio que ela ainda não sabe se é verdade.
+   */
+  leituraCarregando: boolean;
   locked: boolean;
   rodada: string;
   estadio: string | null;
@@ -74,8 +86,7 @@ export function FaixaPartida({
   /** A saída que o usuário clicou em Oportunidades, quando ele veio de lá. */
   preferida?: SaidaPreferida | null;
 }) {
-  const { data: rows } = useFutebolFixturePremissas(jogo.fixtureId);
-  const resumos = useMemo(() => resumoDosMercados(rows, valueRows, preferida), [rows, valueRows, preferida]);
+  const resumos = useMemo(() => resumoDosMercados(premissas, valueRows, preferida), [premissas, valueRows, preferida]);
   const top = useMemo(() => melhorLeitura(resumos), [resumos]);
   const fim = isFinished(jogo.statusShort);
   // A faixa conhecia dois estados, encerrado e "não começou", então o jogo EM
@@ -175,6 +186,22 @@ export function FaixaPartida({
             Funcionava por acaso, porque o CTA chama stopPropagation. O Score ficou
             fora da área clicável de propósito: ele é leitura, não controle, e é o
             vizinho do botão de registrar. */}
+        {leituraCarregando ? (
+          // O esqueleto ocupa a mesma caixa da leitura pronta, para a faixa não
+          // saltar de altura quando o dado chega. Tons de branco, não o Skeleton
+          // padrão: aqui o fundo é o forest, e o cinza dele sumiria.
+          <div data-testid="faixa-leitura-carregando" className="flex items-center gap-5 min-w-0" aria-busy="true">
+            <div className="flex-1 min-w-0">
+              <div className="text-[10px] uppercase tracking-[0.16em] text-white/45">Melhor leitura do jogo</div>
+              <div className="mt-2 h-[26px] w-[68%] rounded bg-white/15 animate-pulse" />
+              <div className="mt-3 h-[16px] w-[45%] rounded bg-white/10 animate-pulse" />
+            </div>
+            <div className="text-center shrink-0">
+              <div className="h-[44px] w-[62px] rounded bg-white/15 animate-pulse" />
+              <div className="mt-2 h-[10px] w-[62px] rounded bg-white/10 animate-pulse" />
+            </div>
+          </div>
+        ) : (
         <div className="flex items-center gap-5 min-w-0">
           <button
             type="button"
@@ -249,6 +276,7 @@ export function FaixaPartida({
             )}
           </div>
         </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/futebol/FixtureRow.test.tsx
+++ b/src/components/futebol/FixtureRow.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { FixtureRow } from './FixtureRow';
+import type { FutebolFixture } from '@/services/futebol-data.service';
+
+// ============================================================================
+// Os três estados da leitura na linha da agenda
+// ============================================================================
+// Mesma regra da faixa do detalhe: "sem leitura ainda" é uma CONCLUSÃO, e só
+// cabe depois que o board respondeu. Enquanto ele está em voo a linha mostra o
+// esqueleto, senão a agenda afirma um vazio que ainda não sabe se é verdade.
+//
+// Regra para quem mexer aqui depois (issue #310): nenhum teste deste arquivo
+// afirma número de Score, peso de premissa ou slug — só distingue os estados.
+// ============================================================================
+
+const jogo = {
+  fixture_id: 1,
+  home_team_id: 10,
+  away_team_id: 20,
+  home_team_name: 'Londrina',
+  away_team_name: 'Juventude',
+  kickoff_utc: '2026-09-01T22:30:00Z',
+  status_short: 'NS',
+  goals_home: null,
+  goals_away: null,
+} as unknown as FutebolFixture;
+
+function renderLinha(props: Partial<Parameters<typeof FixtureRow>[0]> = {}) {
+  return render(
+    <FixtureRow fixture={jogo} best={null} leituraCarregando={false} onClick={vi.fn()} {...props} />,
+  );
+}
+
+describe('FixtureRow · estado da leitura', () => {
+  it('mostra o esqueleto, e não a conclusão, enquanto o board carrega', () => {
+    renderLinha({ leituraCarregando: true });
+
+    expect(screen.getByTestId('linha-leitura-carregando')).toBeInTheDocument();
+    expect(screen.queryByText(/sem leitura/i)).not.toBeInTheDocument();
+  });
+
+  it('o jogo aparece na hora, sem esperar a leitura', () => {
+    renderLinha({ leituraCarregando: true });
+
+    expect(screen.getByText('Londrina')).toBeInTheDocument();
+    expect(screen.getByText('Juventude')).toBeInTheDocument();
+  });
+
+  it('o selo do Score não mostra o traço de "não tem" enquanto carrega', () => {
+    // O travessão é a mesma conclusão em forma de símbolo: ele diz que não há
+    // Score. Enquanto o board não respondeu, não há o que afirmar.
+    renderLinha({ leituraCarregando: true });
+
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+    expect(screen.getByTestId('linha-selo-carregando')).toBeInTheDocument();
+  });
+
+  it('só conclui "sem leitura ainda" depois que o board respondeu', () => {
+    renderLinha({ leituraCarregando: false, best: null });
+
+    expect(screen.queryByTestId('linha-leitura-carregando')).not.toBeInTheDocument();
+    expect(screen.getAllByText(/sem leitura/i).length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/futebol/FixtureRow.tsx
+++ b/src/components/futebol/FixtureRow.tsx
@@ -1,4 +1,5 @@
 import { Crest } from './Crest';
+import { Skeleton } from '@/components/ui/skeleton';
 import { fmtTime, isFinished, isLive } from '@/utils/futebol-datas';
 import { chancePct, ehDestaque, ehFaixaAlta, marketShort, pickLabel } from '@/utils/futebol-score';
 import { settleFutebol, isHit } from '@/utils/futebol-settlement';
@@ -18,15 +19,31 @@ import type { FutebolFixture, FutebolValueBoardRow } from '@/services/futebol-da
  *
  * Em jogo encerrado o vencedor fica em destaque e o perdedor recua, pra varredura
  * ficar mais rápida do que ler dois placares.
+ *
+ * O confronto nunca espera pela leitura: ele vem da agenda do dia e não depende
+ * do board. Quem espera é só a coluna da direita e o selo — ver
+ * `leituraCarregando`.
  */
 export function FixtureRow({
   fixture,
   best,
+  leituraCarregando,
   selected = false,
   onClick,
 }: {
   fixture: FutebolFixture;
   best: FutebolValueBoardRow | null;
+  /**
+   * O board ainda está em voo.
+   *
+   * "Sem leitura ainda" é uma conclusão, e só cabe depois que ele respondeu.
+   * Sem isto a linha nasce negando: `best` chega nulo enquanto a consulta corre,
+   * e a agenda inteira afirma um vazio que ela ainda não sabe se é verdade.
+   *
+   * Obrigatória de propósito: com valor padrão, um consumidor novo herda o bug
+   * por esquecimento, e o compilador não avisa.
+   */
+  leituraCarregando: boolean;
   selected?: boolean;
   onClick: () => void;
 }) {
@@ -90,10 +107,23 @@ export function FixtureRow({
         </div>
       </div>
 
-      {/* A leitura da linha. No celular cabe o pick e a odd; o rótulo do mercado e a
-          chance ficam para o desktop. Sem odds coletadas não existe pick, e a linha
-          diz isso em cinza em vez de inventar um. */}
+      {/* A leitura da linha, em três estados. Enquanto o board não respondeu, o
+          esqueleto; com odds coletadas, o pick; sem elas, a frase em cinza em vez
+          de um pick inventado. No celular cabem o pick e a odd, e o rótulo do
+          mercado e a chance ficam para o desktop. */}
       <div className="w-[96px] sm:w-[160px] shrink-0 text-right min-w-0">
+        {leituraCarregando ? (
+          // No desktop a leitura pronta ocupa três linhas (mercado, pick, odd) e
+          // aqui vão três barras. No celular o rótulo do mercado não existe e a
+          // negação ocupa uma linha só, então a primeira barra some junto: é o
+          // que mantém a altura igual nos dois tamanhos.
+          <div data-testid="linha-leitura-carregando" aria-busy="true" className="flex flex-col items-end gap-1">
+            <Skeleton className="hidden sm:block h-[9px] w-[52px] bg-canvas-2" />
+            <Skeleton className="hidden sm:block h-[12px] w-[74px] bg-canvas-2" />
+            <Skeleton className="h-[11px] w-[56px] bg-canvas-2" />
+          </div>
+        ) : (
+        <>
         <span className="hidden sm:block text-[9px] uppercase tracking-[0.14em] font-semibold" style={{ color: '#8d8672' }}>
           {best ? marketShort(best.market) : fim ? 'sem leitura' : 'sem leitura ainda'}
         </span>
@@ -114,8 +144,20 @@ export function FixtureRow({
             <span className="hidden sm:inline">{fim ? 'não teve odds coletadas' : 'odds entram perto do jogo'}</span>
           </span>
         )}
+        </>
+        )}
       </div>
 
+      {leituraCarregando ? (
+        // Mesmo tamanho do selo pronto: o travessão é a conclusão "não tem
+        // Score" em forma de símbolo, e ela ainda não pode ser afirmada.
+        <Skeleton
+          data-testid="linha-selo-carregando"
+          aria-busy="true"
+          className="shrink-0 w-8 h-8 sm:w-[38px] sm:h-[38px] bg-canvas-2"
+          style={{ borderRadius: 11 }}
+        />
+      ) : (
       <div
         className="shrink-0 grid place-items-center tabular-nums font-bold w-8 h-8 sm:w-[38px] sm:h-[38px] text-[13px] sm:text-[14px]"
         style={
@@ -135,6 +177,7 @@ export function FixtureRow({
       >
         {!best ? '—' : bateu != null ? (bateu ? '✓' : '✕') : best.score}
       </div>
+      )}
     </button>
   );
 }

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -1,3 +1,4 @@
+import { Skeleton } from '@/components/ui/skeleton';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { ArrowRight, X, Minus } from 'lucide-react';
@@ -35,6 +36,10 @@ import type {
  * mesmo. A maioria dos jogos legitimamente não tem oportunidade, e um painel em
  * branco lê como defeito.
  *
+ * Mas "sem leitura" só é dito depois que as fontes responderam. Enquanto elas
+ * carregam entra o esqueleto: afirmar a ausência cedo demais é o mesmo erro,
+ * com a agravante de aparecer em tamanho grande ao lado da lista.
+ *
  * Três queries por jogo aberto (premissas, números e desfalques), todas leves e
  * compartilhadas com a tela de jogo: abrir o painel aquece a análise completa. A
  * `fixture_detail` saiu junto com o bloco de stats, que este desenho não tem mais.
@@ -67,11 +72,19 @@ function Forma({ forma }: { forma: string | null | undefined }) {
 export function JogoResumoPanel({
   fixture,
   best,
+  leituraCarregando,
   onClose,
   demo,
 }: {
   fixture: FutebolFixtureByDay;
   best: FutebolValueBoardRow | null;
+  /**
+   * O board da página ainda está em voo. Somado ao carregando das premissas
+   * daqui, decide se o painel pode concluir "Sem leitura para este jogo" — ela
+   * é uma conclusão, e no desktop aparece em tamanho grande ao lado da linha
+   * que ainda está em esqueleto.
+   */
+  leituraCarregando: boolean;
   onClose: () => void;
   /**
    * Premissas e números de exemplo, usados só enquanto o tour roda. O jogo do
@@ -80,7 +93,9 @@ export function JogoResumoPanel({
    */
   demo?: { premissas: FutebolFixturePremissas[]; numeros: FutebolFixtureNumeros[] };
 }) {
-  const { data: premissasReais } = useFutebolFixturePremissas(demo ? undefined : fixture.fixture_id);
+  const { data: premissasReais, isLoading: premissasCarregando } = useFutebolFixturePremissas(
+    demo ? undefined : fixture.fixture_id,
+  );
   const { data: numerosReais } = useFutebolFixtureNumeros(demo ? undefined : fixture.fixture_id);
   const premissas = demo?.premissas ?? premissasReais;
   const numeros = demo?.numeros ?? numerosReais;
@@ -117,6 +132,8 @@ export function JogoResumoPanel({
       ? pickLabel(topo.candidato, fixture.home_team_name, fixture.away_team_name)
       : null;
 
+  // No tour os dados são de mentira e chegam prontos: não há espera a mostrar.
+  const carregandoLeitura = demo ? false : leituraCarregando || premissasCarregando;
   const temLeitura = !!best || (topo != null && topo.nValem > 0);
   const lado = cand ? ladoDaSaida(mercadoLeitura!, cand.outcome) : null;
   const nValem = cand && mercadoLeitura ? contaQueValem(mercadoLeitura, cand.acesas) : 0;
@@ -289,6 +306,19 @@ export function JogoResumoPanel({
                 <span className="text-[12px] leading-relaxed" style={{ color: '#6b6350' }}>{contra}</span>
               </div>
             )}
+          </div>
+        ) : carregandoLeitura ? (
+          // Nem "tem leitura" nem "não tem": ainda não dá para dizer. O bloco
+          // ocupa a mesma caixa da negação, que é a maior das duas.
+          <div
+            data-testid="painel-leitura-carregando"
+            aria-busy="true"
+            className="px-4 py-3.5 rounded-[14px] flex flex-col gap-2"
+            style={{ background: 'var(--canvas-2)', border: '1px solid #e5d9bd' }}
+          >
+            <Skeleton className="h-[13px] w-[60%] bg-line/60" />
+            <Skeleton className="h-[12px] w-[85%] bg-line/60" />
+            <Skeleton className="h-[12px] w-[70%] bg-line/60" />
           </div>
         ) : (
           <div className="px-4 py-3.5 rounded-[14px]" style={{ background: 'var(--canvas-2)', border: '1px solid #e5d9bd' }}>

--- a/src/pages/FutebolCampeonato.tsx
+++ b/src/pages/FutebolCampeonato.tsx
@@ -19,6 +19,7 @@ import {
 import type { Competition, FutebolFixture, FutebolValueBoardRow } from '@/services/futebol-data.service';
 import { brtDayOf, fmtDayHeader, isFinished } from '@/utils/futebol-datas';
 import { groupBoardByFixture } from '@/utils/futebol-score';
+import { sufixoDeLeitura } from '@/utils/futebol-leitura';
 import { settleFutebol, isHit } from '@/utils/futebol-settlement';
 import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
 import { ChaveamentoBracket } from '@/components/futebol/ChaveamentoBracket';
@@ -114,7 +115,9 @@ export default function FutebolCampeonato() {
   const { data: fixtures, isLoading, isError } = useFutebolFixtures(competition, season);
   const { data: standings, isLoading: loadingStandings } = useFutebolStandings(competition, season, true);
   const { data: leaders, isLoading: loadingLeaders } = useFutebolLeaders(competition, season, true);
-  const { data: board } = useFutebolValueBoard();
+  // Mesma regra da agenda: enquanto o board não respondeu, a linha não conclui
+  // "sem leitura ainda" e o contador não afirma um total.
+  const { data: board, isLoading: leituraCarregando } = useFutebolValueBoard();
 
   const bestByFixture = useMemo(() => {
     const m = new Map<number, FutebolValueBoardRow>();
@@ -210,6 +213,12 @@ export default function FutebolCampeonato() {
     const encerrada = jogosDaRodada.length > 0 && jogosDaRodada.every((f) => isFinished(f.status_short));
     const rotulo = encerrada ? (porPontos ? 'Rodada encerrada' : 'Fase encerrada') : porPontos ? 'Nesta rodada' : 'Nesta fase';
 
+    // Enquanto o board não respondeu, `bestByFixture` está vazio e "sem leitura
+    // nesta rodada" seria a mesma conclusão prematura que a linha evita. "Sem
+    // jogos" não: essa não depende do board, e a rodada vazia é vazia agora.
+    if (leituraCarregando && jogosDaRodada.length) {
+      return { rotulo, valor: '', texto: 'carregando…' };
+    }
     if (!comLeitura.length) {
       return {
         rotulo,
@@ -231,7 +240,7 @@ export default function FutebolCampeonato() {
       valor: String(comLeitura.length),
       texto: melhor ? `com leitura · melhor Score ${melhor}` : 'com leitura',
     };
-  }, [jogosDaRodada, bestByFixture, porPontos]);
+  }, [jogosDaRodada, bestByFixture, porPontos, leituraCarregando]);
 
   const nTimes = standings?.length ?? new Set((fixtures ?? []).map((f) => f.home_team_id)).size;
   const ondeEstamos = currentRound
@@ -295,7 +304,8 @@ export default function FutebolCampeonato() {
                   {fmtDayHeader(day)}
                 </span>
                 <span className="text-[10.5px]" style={{ color: '#8d8672' }}>
-                  {games.length} {games.length === 1 ? 'jogo' : 'jogos'} · {comLeitura} com leitura
+                  {games.length} {games.length === 1 ? 'jogo' : 'jogos'}
+                  {sufixoDeLeitura(leituraCarregando, comLeitura)}
                 </span>
               </div>
               {games.map((f) => (
@@ -303,6 +313,7 @@ export default function FutebolCampeonato() {
                   key={f.fixture_id}
                   fixture={f}
                   best={bestByFixture.get(f.fixture_id) ?? null}
+                  leituraCarregando={leituraCarregando}
                   onClick={() => navigate(`/futebol/jogo/${f.fixture_id}`)}
                 />
               ))}

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -301,7 +301,7 @@ export default function FutebolJogo() {
     return computeMatchupTendencies(tend.home, tend.away, fixture.home_team_name, fixture.away_team_name);
   }, [tend, fixture]);
   // Score vem PRONTO do backend (fact_value_opportunities). 1X2 por enquanto.
-  const { data: realValueRows } = useFutebolFixtureValue(fid);
+  const { data: realValueRows, isLoading: valorCarregando } = useFutebolFixtureValue(fid);
   const valueRows = isDemo ? demoFixtureValueRows : realValueRows;
   const { data: access } = useFutebolAccess();
   const locked = isDemo ? false : !access?.unlocked;
@@ -377,7 +377,12 @@ export default function FutebolJogo() {
   // O tour fala do que está montado: a régua só existe nos mercados de linha, e
   // as premissas só quando a coleta trouxe alguma para este jogo. A query é a
   // mesma da bancada, então sai do cache do react-query, sem ida extra à rede.
-  const { data: premissasDoJogo } = useFutebolFixturePremissas(fid);
+  const { data: premissasDoJogo, isLoading: premissasCarregando } = useFutebolFixturePremissas(fid);
+  // A leitura da faixa se apoia em DUAS fontes: as premissas e as linhas de
+  // valor. Enquanto qualquer uma está em voo a faixa não tem como concluir
+  // "Sem leitura ainda", então ela mostra o esqueleto. No tour não há espera:
+  // os dados são de mentira e chegam prontos.
+  const leituraCarregando = isDemo ? false : premissasCarregando || valorCarregando;
   const jogoSteps = useMemo(
     () =>
       makeFutebolJogoSteps({
@@ -529,7 +534,9 @@ export default function FutebolJogo() {
                 {isDemo && <div className="mb-2"><DemoBadge /></div>}
                 <FaixaPartida
                   jogo={jogoInfo}
+                  premissas={premissasDoJogo}
                   valueRows={valueRows}
+                  leituraCarregando={leituraCarregando}
                   locked={locked}
                   rodada={prettyRound(fixture.round)}
                   estadio={fixture.venue_name ? `${fixture.venue_name}${fixture.venue_city ? `, ${fixture.venue_city}` : ''}` : null}

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -10,6 +10,7 @@ import { useFutebolFixturesByDay, useFutebolFixtureDays, useFutebolValueBoard } 
 import type { FutebolFixtureByDay, FutebolValueBoardRow } from '@/services/futebol-data.service';
 import { addDays, brtToday, fmtDayHeader } from '@/utils/futebol-datas';
 import { groupBoardByFixture } from '@/utils/futebol-score';
+import { sufixoDeLeitura } from '@/utils/futebol-leitura';
 import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
@@ -83,10 +84,16 @@ export default function FutebolJogos() {
   const { from, to } = useMemo(() => monthRange(dia), [dia]);
   const { data: fixtures, isLoading, isError } = useFutebolFixturesByDay(dia);
   const { data: dias } = useFutebolFixtureDays(from, to);
-  const { data: board } = useFutebolValueBoard();
+  // O carregando do board é separado do carregando dos jogos do dia: a agenda
+  // consegue listar o confronto antes de saber se ele tem leitura, e é isso que
+  // ela deve fazer. O que ela não pode é contar "0 com leitura" nem escrever
+  // "sem leitura ainda" enquanto a resposta não chegou — isso é conclusão.
+  const { data: board, isLoading: boardCarregando } = useFutebolValueBoard();
 
   const jogosTour = useOnboardingTour(FUT_JOGOS_TOUR_ID, { enabled: !isLoading && !isError });
   const isDemo = jogosTour.run;
+  // No tour os dados são de mentira e chegam prontos: não há espera a mostrar.
+  const leituraCarregando = isDemo ? false : boardCarregando;
 
   const effFixtures = useMemo<FutebolFixtureByDay[]>(
     () => (isDemo ? makeDemoAgenda(dia) : (fixtures ?? [])),
@@ -219,7 +226,7 @@ export default function FutebolJogos() {
               ? 'carregando…'
               : total === 0
                 ? 'nenhum jogo neste dia'
-                : `${total} ${total === 1 ? 'jogo' : 'jogos'} · ${grupos.length} ${grupos.length === 1 ? 'campeonato' : 'campeonatos'} · ${comLeitura} com leitura`}
+                : `${total} ${total === 1 ? 'jogo' : 'jogos'} · ${grupos.length} ${grupos.length === 1 ? 'campeonato' : 'campeonatos'}${sufixoDeLeitura(leituraCarregando, comLeitura)}`}
           </span>
           <div className="ml-auto min-w-0" data-tour="fut-jogos-datas">
             <AgendaDateStrip selectedDay={dia} onSelectDay={selectDay} jogosPorDia={jogosPorDia} />
@@ -306,8 +313,11 @@ export default function FutebolJogos() {
                             <ArrowUpRight className="w-3.5 h-3.5" />
                           </Link>
                           <span className="ml-auto text-[10.5px] shrink-0 tabular-nums" style={{ color: '#8d8672' }}>
-                            {jogos.length} {jogos.length === 1 ? 'jogo' : 'jogos'} ·{' '}
-                            {jogos.filter((j) => bestByFixture.has(j.fixture_id)).length} com leitura
+                            {jogos.length} {jogos.length === 1 ? 'jogo' : 'jogos'}
+                            {sufixoDeLeitura(
+                              leituraCarregando,
+                              jogos.filter((j) => bestByFixture.has(j.fixture_id)).length,
+                            )}
                           </span>
                         </div>
                         {!recolhido &&
@@ -316,6 +326,7 @@ export default function FutebolJogos() {
                               key={f.fixture_id}
                               fixture={f}
                               best={bestByFixture.get(f.fixture_id) ?? null}
+                              leituraCarregando={leituraCarregando}
                               selected={f.fixture_id === jogoParam}
                               onClick={() => openJogo(f)}
                             />
@@ -334,6 +345,7 @@ export default function FutebolJogos() {
                   <JogoResumoPanel
                     fixture={selected}
                     best={bestByFixture.get(selected.fixture_id) ?? null}
+                    leituraCarregando={leituraCarregando}
                     onClose={closePanel}
                     demo={
                       isDemo ? { premissas: demoFutebolPremissas, numeros: demoFutebolNumeros } : undefined

--- a/src/utils/futebol-leitura.test.ts
+++ b/src/utils/futebol-leitura.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resumoDosMercados, melhorLeitura } from './futebol-leitura';
+import { resumoDosMercados, melhorLeitura, sufixoDeLeitura } from './futebol-leitura';
 import type { FutebolFixturePremissas, FutebolFixtureValueRow } from '@/services/futebol-data.service';
 
 // O caso é o Independ. Rivadavia x Fluminense (fixture 1547770, staging): o mart
@@ -198,5 +198,19 @@ describe('melhorLeitura', () => {
     expect(top.candidato.outcome).toBe('Over');
     expect(top.candidato.line_value).toBe(top.value!.line_value);
     expect(top.candidato.outcome).toBe(top.value!.outcome);
+  });
+});
+
+describe('sufixoDeLeitura', () => {
+  it('não afirma um total enquanto o board não respondeu', () => {
+    // Zero aqui seria a mesma mentira que "sem leitura ainda" na linha: a tela
+    // ainda não tem do que contar.
+    expect(sufixoDeLeitura(true, 0)).toBe('');
+    expect(sufixoDeLeitura(true, 3)).toBe('');
+  });
+
+  it('conta depois que o board respondeu, inclusive quando o total é zero', () => {
+    expect(sufixoDeLeitura(false, 0)).toBe(' · 0 com leitura');
+    expect(sufixoDeLeitura(false, 2)).toBe(' · 2 com leitura');
   });
 });

--- a/src/utils/futebol-leitura.ts
+++ b/src/utils/futebol-leitura.ts
@@ -165,3 +165,16 @@ export function melhorLeitura(resumos: MercadoResumo[]): MercadoResumo | null {
   if (comValor.length) return [...comValor].sort((a, b) => (b.value!.score) - (a.value!.score))[0];
   return [...resumos].sort((a, b) => b.nValem - a.nValem)[0];
 }
+
+/**
+ * O sufixo "· N com leitura" dos contadores da agenda e do campeonato.
+ *
+ * Vazio enquanto o board não respondeu. Contar leituras a partir de um mapa
+ * ainda vazio faz a tela afirmar "0 com leitura" antes de existir resposta — a
+ * mesma conclusão prematura que o esqueleto da linha evita, só que em número.
+ * Some em vez de mostrar zero: um contador que aparece atrasado é menos errado
+ * do que um que mente e depois se corrige.
+ */
+export function sufixoDeLeitura(carregando: boolean, comLeitura: number): string {
+  return carregando ? '' : ` · ${comLeitura} com leitura`;
+}


### PR DESCRIPTION
## O problema

Ao abrir um jogo ou a agenda, a tela escrevia **"sem leitura ainda"** antes de qualquer consulta terminar. Isso é uma conclusão, não um estado de espera: ela só cabe quando as fontes já responderam e nenhuma sustenta uma leitura.

O efeito é a piscada — a negação aparece, some, e a leitura entra no lugar. Em jogo que de fato não tem leitura, a negação nunca era falsa no fim, mas o caminho até ela sempre foi.

## O que muda

**Detalhe do jogo.** A faixa da partida mostra esqueleto enquanto as duas fontes da leitura — premissas e linhas de valor — estão em voo. O cabeçalho não espera: times, horário, escudos, placar e estádio vêm da lista e não dependem dessas consultas.

**Agenda e campeonato.** A linha mostra esqueleto na coluna da leitura e no selo do Score. O travessão do selo era a mesma negação em forma de símbolo.

**Contadores.** "0 com leitura" some em vez de ser afirmado antes da resposta. Um contador que aparece atrasado é menos errado que um que mente e depois se corrige.

**Card "Nesta rodada"** do campeonato e **painel lateral** da agenda, que diziam "sem leitura nesta rodada" e "Sem leitura para este jogo" pelo mesmo motivo. O painel era o pior caso: no desktop a negação aparecia em tamanho grande ao lado da linha que ainda estava em esqueleto.

## Desenho

A busca das premissas subiu da `FaixaPartida` para a página, que já fazia a mesma consulta para outra coisa. Some uma busca duplicada, some uma dependência escondida do componente, e a página volta a ser a única dona do estado.

A prop `leituraCarregando` é obrigatória de propósito. Com valor padrão, um consumidor novo herdaria o bug por esquecimento e o compilador não avisaria.

Os esqueletos usam o `Skeleton` do repo com `bg-canvas-2`. A faixa do detalhe desvia disso porque o fundo dela é forest e o cinza sumiria; nas linhas o fundo é creme e o motivo não se aplica.

O sufixo dos contadores virou `sufixoDeLeitura`, função pura testada, no lugar de três trechos repetidos em duas formas diferentes.

## Testes

Sete testes novos, em três arquivos. Eles distinguem apenas os estados — carregando, sem leitura, leitura pronta — e **não afirmam Score, peso de premissa nem slug**, para atravessarem a virada de contrato da #310 sem ajuste. A regra está escrita no topo de cada arquivo.

## Verificação

Rebaseado em cima da develop atual (9bccf10), depois do Handicap fora da vitrine e das fronteiras 30/60.

- `npx vitest run` — 398 passando, 1 pulado, 42 arquivos
- `npm run lint` — zero erros, zero avisos nos arquivos tocados
- `npx tsc --noEmit -p tsconfig.app.json` — limpo nos arquivos tocados
- `npm run build` — ok

## O que fica para depois

**Erro do board não é resposta.** Nenhum consumidor olha `isError`. Se a RPC falhar, o carregando vira falso com dado indefinido e as telas voltam a afirmar a ausência — a mesma conclusão sem base, por outro caminho. Não entrou aqui porque dizer "não foi possível carregar a leitura" é texto novo na tela, decisão de produto, e não apenas segurar uma conclusão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yS66fTymj6PcpvKGpxLn4
