### PR TITLE
Futebol · A home para de trocar conteúdo depois de carregado

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Blur } from '@/components/futebol/FutebolGate';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
 import {
-  useFutebolMercadosOcultos,
+  useVitrine,
   useFutebolFixturePremissas,
   useFutebolFixtureNumeros,
   useFutebolFixtureHistorico,
@@ -264,10 +264,7 @@ export function BancadaMercados({
   const placar = fim ? { home: jogo.goalsHome, away: jogo.goalsAway } : null;
   // A vitrine (#324). Sem ela a prateleira sairia do catálogo inteiro, e o
   // mercado escondido voltaria como chip — com barra de Score e sem odd.
-  const { data: mercadosOcultos } = useFutebolMercadosOcultos();
-  // Memoizado porque `?? []` cria array novo a cada render e envenenaria as
-  // dependências dos useMemo abaixo.
-  const ocultos = useMemo(() => mercadosOcultos ?? [], [mercadosOcultos]);
+  const { ocultos } = useVitrine();
   const mercadosVisiveis = useMemo(
     () => filtrarCatalogoDeMercados(MERCADOS, ocultos),
     [ocultos],

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -435,3 +435,19 @@ export function useFutebolMercadosOcultos() {
     refetchOnWindowFocus: false,
   });
 }
+
+/**
+ * A vitrine, do jeito que a tela precisa dela: a lista E se ela já chegou.
+ *
+ * Existe porque as três telas que a consomem repetiam o mesmo par — o hook, o
+ * `?? []` memoizado e o comentário — e porque o `isLoading` importa tanto
+ * quanto a lista: renderizar antes de a vitrine chegar mostra o mercado
+ * escondido por um instante, e ele some depois. Ver prop-play-predictor#324.
+ */
+export function useVitrine(): { ocultos: string[]; isLoading: boolean } {
+  const { data, isLoading } = useFutebolMercadosOcultos();
+  // Memoizado: `?? []` cria array novo a cada render e envenenaria as
+  // dependências de todo useMemo que recebe `ocultos`.
+  const ocultos = useMemo(() => data ?? [], [data]);
+  return { ocultos, isLoading };
+}

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -4,7 +4,7 @@ import { Zap, ArrowRight, Check, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Seo } from '@/components/Seo';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useFutebolFixturesMulti, useFutebolValueBoard, useFutebolValueHistory, useFutebolAlertedPicks, useFutebolFixtureReasonContract, useFutebolAccess, useFutebolMercadosOcultos } from '@/hooks/use-futebol-data';
+import { useFutebolFixturesMulti, useFutebolValueBoard, useFutebolValueHistory, useFutebolAlertedPicks, useFutebolFixtureReasonContract, useFutebolAccess, useVitrine } from '@/hooks/use-futebol-data';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
 import { AjudaCampo } from '@/components/futebol/AjudaCampo';
@@ -28,7 +28,7 @@ import { SAO_PAULO_TZ, parseUtc, brtDateStr, brtDayOf, fmtTime, isFinished } fro
 import { mergeBoardAndHistory } from '@/utils/futebol-history';
 import { mercadoEstaOculto } from '@/utils/futebol-mercados-ocultos';
 import { oportunidadesDoDia, type OppLike } from '@/utils/futebol-registradas';
-import { separarMotivosDoContrato } from '@/utils/futebol-motivos';
+import { estadoDosMotivos, separarMotivosDoContrato, type MotivoExibivel as Motivo } from '@/utils/futebol-motivos';
 import { ladoDaSaida } from '@/utils/futebol-evidencias';
 import { premissaDe, rotuloPremissa } from '@/utils/futebol-premissas';
 import { useNow } from '@/hooks/use-now';
@@ -55,8 +55,6 @@ function Crest({ teamId, name, size = 24 }: { teamId: number; name: string; size
   return <div style={{ width: size, height: size }} className="rounded-full bg-canvas-2 border border-line grid place-items-center text-[9px] font-bold text-ink-2 shrink-0">{crestInitials(name)}</div>;
 }
 
-/** Um motivo do contrato, com o slug preservado para servir de chave. */
-type Motivo = { slug: string; texto: string };
 
 const CARD = 'bg-white border border-line rounded-rebrand-md';
 const LABEL = 'text-[10px] uppercase tracking-[0.16em] font-semibold text-ink-3';
@@ -91,11 +89,12 @@ function HeroStat({ label, value, dark, locked, ajuda }: { label: string; value:
 
 // ── Hero: melhor valor do dia — 3 colunas (pick · por quê · confiab). ────────
 // Alta = gradiente forest (texto branco); Média = card claro com acento âmbar.
-function TopValueHero({ o, onClick, favor, contra, textoScore, locked }: { o: FutebolValueBoardRow; onClick: () => void; favor: Motivo[]; contra: Motivo[]; textoScore: string; locked?: boolean }) {
+function TopValueHero({ o, onClick, favor, contra, textoScore, locked, carregandoMotivos = false }: { o: FutebolValueBoardRow; onClick: () => void; favor: Motivo[]; contra: Motivo[]; textoScore: string; locked?: boolean; carregandoMotivos?: boolean }) {
   const pick = pickLabel(o, o.home_team_name, o.away_team_name);
   const ev = topEvidencia(o.evidencias);
   const d = true; // hero sempre no fundo forest (mockup); a faixa vai no selo, não na cor do card
   const chance = chancePct(o.prob_justa_fechamento);
+  const estado = estadoDosMotivos(favor, contra, carregandoMotivos);
   const porque = chance != null
     ? <>O mercado dá <b className={d ? 'text-white' : 'text-ink'}>~{chance}% de chance</b>; na odd <b className={d ? 'text-white' : 'text-ink'}>{o.best_odd.toFixed(2)}</b> isso paga acima do risco real — é aí que está o valor.</>
     : <>Na odd <b className={d ? 'text-white' : 'text-ink'}>{o.best_odd.toFixed(2)}</b>, a aposta se paga a partir de <b className={d ? 'text-white' : 'text-ink'}>{Math.round(100 / o.best_odd)}%</b> de acerto — e a leitura do jogo aponta nessa direção.</>;
@@ -138,7 +137,7 @@ function TopValueHero({ o, onClick, favor, contra, textoScore, locked }: { o: Fu
             é que explicam a leitura, e são elas que a tela de detalhe mostra.
             Vêm do mesmo contrato do backend, então as duas telas concordam. */}
         <div className="md:col-span-5 flex flex-col gap-4">
-          {favor.length > 0 && (
+          {estado === 'motivos' && favor.length > 0 && (
             <div>
               <div className={`text-[11px] uppercase tracking-[0.18em] font-semibold ${d ? 'text-white/50' : 'text-ink-3'}`}>A favor</div>
               <ul className="mt-2 flex flex-col gap-1.5">
@@ -152,7 +151,7 @@ function TopValueHero({ o, onClick, favor, contra, textoScore, locked }: { o: Fu
             </div>
           )}
 
-          {contra.length > 0 && (
+          {estado === 'motivos' && contra.length > 0 && (
             <div>
               <div className={`text-[11px] uppercase tracking-[0.18em] font-semibold ${d ? 'text-white/50' : 'text-ink-3'}`}>Contra</div>
               <ul className="mt-2 flex flex-col gap-1.5">
@@ -166,7 +165,25 @@ function TopValueHero({ o, onClick, favor, contra, textoScore, locked }: { o: Fu
             </div>
           )}
 
-          {favor.length === 0 && contra.length === 0 && (
+          {/* Enquanto os motivos não chegam, esqueleto — e NÃO o texto do
+              "Por quê". Os motivos vêm de uma segunda consulta que só começa
+              depois de o destaque ser escolhido, então a lista vazia acontece
+              sempre por alguns instantes; mostrar o fallback ali fazia a tela
+              trocar de conteúdo na cara do usuário.
+              As duas barras têm a altura de linha do parágrafo que substituem
+              (17px e 19px vezes o leading de 1,4), para a troca não pular o
+              layout. */}
+          {estado === 'carregando' && (
+            <div>
+              <div className={`text-[11px] uppercase tracking-[0.18em] font-semibold ${d ? 'text-white/50' : 'text-ink-3'}`}>Por quê</div>
+              <div className="mt-2 flex flex-col gap-2" aria-hidden>
+                <Skeleton className={`h-[24px] md:h-[27px] w-full ${d ? 'bg-white/15' : 'bg-canvas-2'}`} />
+                <Skeleton className={`h-[24px] md:h-[27px] w-3/4 ${d ? 'bg-white/15' : 'bg-canvas-2'}`} />
+              </div>
+            </div>
+          )}
+
+          {estado === 'sem_motivos' && (
             <div>
               <div className={`text-[11px] uppercase tracking-[0.18em] font-semibold ${d ? 'text-white/50' : 'text-ink-3'}`}>Por quê</div>
               <p className={`text-[17px] md:text-[19px] leading-[1.4] font-medium tracking-tight mt-2 ${d ? 'text-white/95' : 'text-ink'}`} style={{ textWrap: 'pretty' }}><Blur active={!!locked}>{porque}</Blur></p>
@@ -282,11 +299,17 @@ export default function FutebolHoje() {
   const { data: boardRows, isLoading: l3 } = useFutebolValueBoard();
   const { data: histRows, isLoading: lHist } = useFutebolValueHistory();
   const { data: alertedRaw, isLoading: lReg } = useFutebolAlertedPicks();
+  const { ocultos, isLoading: lVitrine } = useVitrine();
   // UM instante para a tela inteira, e ele anda: o seletor de dias e o corte de
   // "já começou" têm que concordar sobre que horas são.
   const agora = useNow();
-  const { data: access } = useFutebolAccess();
-  const loading = lFix || l3 || lHist || lReg;
+  // O acesso ENTRA no gate: enquanto ele não chega, `locked` é verdadeiro e o
+  // conteúdo renderiza borrado, desborrando quando a resposta volta. Para quem
+  // paga, isso é o mesmo defeito do card de motivos, num lugar diferente.
+  const { data: access, isLoading: lAccess } = useFutebolAccess();
+  // A vitrine entra no gate: sem ela a lista renderiza sem filtro e o mercado
+  // escondido aparece por um instante antes de sumir (#324).
+  const loading = lFix || l3 || lHist || lReg || lVitrine || lAccess;
   const futebolTour = useOnboardingTour(FUTEBOL_TOUR_ID, { enabled: !loading });
   const isDemo = futebolTour.run; // durante o tour, preenche a tela com exemplo
   const locked = isDemo ? false : !access?.unlocked;
@@ -332,10 +355,6 @@ export default function FutebolHoje() {
   // O que mudou foi tirar o corte de "só jogo que ainda não começou", que era
   // exclusivo desta tela: ele zerava a home toda noite, num dia que teve
   // oportunidades. Quem quer só o que dá para acompanhar tem o filtro no painel.
-  // A vitrine (#324). O board já vem filtrado do service, mas a fusão reabre o
-  // dia corrente pela linha do histórico, que não é filtrado de propósito.
-  const { data: mercadosOcultos } = useFutebolMercadosOcultos();
-  const ocultos = useMemo(() => mercadosOcultos ?? [], [mercadosOcultos]);
   const valueRows = useMemo(
     () => mergeBoardAndHistory(boardRows ?? [], histRows ?? [], agora, ocultos),
     [boardRows, histRows, agora, ocultos],
@@ -417,7 +436,11 @@ export default function FutebolHoje() {
   // A favor e Contra do destaque, do MESMO contrato que a tela de detalhe usa.
   // O backend decide o grupo de cada motivo; aqui só se traduz o slug pelo
   // catálogo e se corta a lista no que cabe no card.
-  const { data: contratoMotivos } = useFutebolFixtureReasonContract(heroOpp?.fixture_id);
+  // O isLoading importa: sem ele o card não distingue "ainda carregando" de
+  // "carregou e não tem motivo", e mostra o texto do "Por quê" antes de trocar
+  // por A favor / Contra na cara do usuário.
+  const { data: contratoMotivos, isLoading: carregandoMotivos } =
+    useFutebolFixtureReasonContract(heroOpp?.fixture_id);
   const { favor: heroFavor, contra: heroContra } = useMemo(() => {
     const vazio = { favor: [] as Motivo[], contra: [] as Motivo[] };
     if (!heroOpp || !contratoMotivos?.length) return vazio;
@@ -506,13 +529,13 @@ export default function FutebolHoje() {
           </div>
         </div>
 
-        <FutebolAccessBanner access={access} />
+        {!loading && <FutebolAccessBanner access={access} />}
 
         {/* Hero / sem valor */}
         {loading ? (
           <Skeleton className="h-64 w-full bg-canvas-2 rounded-2xl" />
         ) : heroOpp ? (
-          <TopValueHero o={heroOpp} favor={heroFavor} contra={heroContra} textoScore={textoScore} onClick={() => navigate(`/futebol/jogo/${heroOpp.fixture_id}`)} locked={locked} />
+          <TopValueHero o={heroOpp} favor={heroFavor} contra={heroContra} carregandoMotivos={carregandoMotivos} textoScore={textoScore} onClick={() => navigate(`/futebol/jogo/${heroOpp.fixture_id}`)} locked={locked} />
         ) : (
           <div className={`${CARD} p-6 flex items-start gap-3`}>
             <Zap className="w-5 h-5 text-ink-3 mt-0.5 shrink-0" />

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { ChevronRight, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useFutebolValueBoard, useFutebolValueHistory, useFutebolAccess, useFutebolFixturesMulti, useFutebolAlertedPicks, useFutebolCompetitions, useFutebolMercadosOcultos } from '@/hooks/use-futebol-data';
+import { useFutebolValueBoard, useFutebolValueHistory, useFutebolAccess, useFutebolFixturesMulti, useFutebolAlertedPicks, useFutebolCompetitions, useVitrine } from '@/hooks/use-futebol-data';
 import { useFutebolPublicationAlerts } from '@/hooks/use-futebol-publication-alerts';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
@@ -197,7 +197,13 @@ function ResultBadge({ r }: { r: BetResult }) {
 
 export default function FutebolOportunidades() {
   const navigate = useNavigate();
-  const { data: rows, isLoading } = useFutebolValueBoard();
+  const { data: rows, isLoading: lBoard } = useFutebolValueBoard();
+  // A vitrine entra no gate de carregamento (#324): sem ela a lista renderiza
+  // sem filtro e o mercado escondido aparece por um instante antes de sumir. O
+  // board já vem filtrado do service, mas a fusão com o histórico e os picks
+  // registrados reabrem o dia corrente.
+  const { ocultos, isLoading: lVitrine } = useVitrine();
+  const isLoading = lBoard || lVitrine;
   const { data: catalog } = useFutebolCompetitions();
   const { data: access } = useFutebolAccess();
   const { data: publicationAlerts, acknowledgeOnboarding, isAcknowledging } = useFutebolPublicationAlerts();
@@ -269,11 +275,6 @@ export default function FutebolOportunidades() {
     [catalog, janelaDeFixtures, hoje],
   );
   const { data: fixtures } = useFutebolFixturesMulti(fixtureScopes);
-  // A vitrine (#324): board e detalhe já vêm filtrados do service, mas a fusão
-  // com o histórico reabre o dia corrente — jogo que já começou hoje vence pela
-  // linha do histórico, que NÃO é filtrado de propósito.
-  const { data: mercadosOcultos } = useFutebolMercadosOcultos();
-  const ocultos = useMemo(() => mercadosOcultos ?? [], [mercadosOcultos]);
   const allRows = useMemo<FutebolValueBoardRow[]>(
     () => mergeBoardAndHistory(rows ?? [], histRows ?? [], agora, ocultos),
     [rows, histRows, agora, ocultos]

--- a/src/utils/futebol-motivos.test.ts
+++ b/src/utils/futebol-motivos.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { separarMotivosDoContrato } from './futebol-motivos';
+import { estadoDosMotivos, separarMotivosDoContrato } from './futebol-motivos';
 
 // O contrato SQL em si (quais premissas são aplicáveis a cada saída, e o que
 // não pode virar razão) é guardado por futebol-contrato-score.test.ts. Aqui só
@@ -121,5 +121,37 @@ describe('separarMotivosDoContrato', () => {
     expect(motivosContra.slugsDePremissas).toContain(contra[0].id);
     expect(motivosContra.slugsDePremissas.length + motivosContra.motivosSemDrilldown.length)
       .toBe(contra.length);
+  });
+});
+
+describe('estadoDosMotivos', () => {
+  const m = (slug: string) => ({ slug, texto: slug });
+
+  // O defeito que este seam existe para impedir: o hero colapsava três estados
+  // em dois. "Ainda carregando" e "carregou e não tem motivo" eram os dois
+  // `favor.length === 0`, então a tela mostrava o texto do "Por quê" e trocava
+  // por "A favor / Contra" alguns instantes depois, na cara do usuário.
+  it('carregando e sem motivo ainda: nem motivos, nem o texto de fallback', () => {
+    expect(estadoDosMotivos([], [], true)).toBe('carregando');
+  });
+
+  it('carregou e não veio motivo nenhum: aí sim o fallback', () => {
+    expect(estadoDosMotivos([], [], false)).toBe('sem_motivos');
+  });
+
+  it('com motivo a favor, mostra os motivos', () => {
+    expect(estadoDosMotivos([m('a')], [], false)).toBe('motivos');
+  });
+
+  it('só com motivo contra, mostra os motivos', () => {
+    expect(estadoDosMotivos([], [m('b')], false)).toBe('motivos');
+  });
+
+  // A invariante é do estado, não do hook: quem já tem motivo na tela não pode
+  // perdê-lo porque alguém marcou `carregando`. Com o `isLoading` que o card
+  // passa hoje este caso não acontece, e o teste existe para o dia em que
+  // alguém trocar por `isFetching` ou passar carregamento de outra origem.
+  it('carregando com motivo já em tela: continua mostrando os motivos', () => {
+    expect(estadoDosMotivos([m('a')], [], true)).toBe('motivos');
   });
 });

--- a/src/utils/futebol-motivos.ts
+++ b/src/utils/futebol-motivos.ts
@@ -39,3 +39,42 @@ export function separarMotivosDoContrato(itens: readonly FutebolFixtureReasonIte
       .map((item) => ({ t: item.texto as string, pontos: item.pontos })),
   };
 }
+
+/**
+ * O que o card do destaque deve mostrar no lugar dos motivos.
+ *
+ * São TRÊS estados, e o defeito que esta função existe para impedir é o card
+ * colapsá-los em dois. Os motivos do destaque vêm de uma SEGUNDA consulta
+ * (`get_futebol_fixture_reason_contract`), que só pode começar depois que o
+ * board resolveu e a oportunidade em destaque foi escolhida — ela depende do
+ * `fixture_id` dela. Então a lista vazia acontece sempre, por alguns instantes,
+ * antes de os motivos chegarem.
+ *
+ * Enquanto "ainda carregando" e "carregou e não tem motivo" forem os dois
+ * `favor.length === 0`, a tela mostra o texto do "Por quê" e o troca por
+ * "A favor / Contra" na cara do usuário. Não é corrida nem dado errado: é
+ * estado de carregamento que não existia.
+ *
+ * `motivos` vence `carregando` de propósito. Com o `isLoading` do react-query v5
+ * que o card passa hoje isso é redundante — ele é `isPending && isFetching`, já
+ * falso numa revalidação com dado em mão. A ordem fica assim mesmo porque a
+ * invariante é do estado, não do hook: trocar para `isFetching`, ou passar um
+ * `carregando` de outra origem, não pode apagar motivo que já está na tela.
+ *
+ * Erro de consulta cai em `sem_motivos`, e é degradação deliberada: o texto do
+ * "Por quê" é derivado da própria oportunidade e continua verdadeiro sem o
+ * contrato. Esqueleto eterno seria pior.
+ */
+export type EstadoDosMotivos = 'motivos' | 'carregando' | 'sem_motivos';
+
+/** Um motivo já traduzido para exibição, com o slug preservado como chave. */
+export type MotivoExibivel = { slug: string; texto: string };
+
+export function estadoDosMotivos(
+  favor: readonly MotivoExibivel[],
+  contra: readonly MotivoExibivel[],
+  carregando: boolean,
+): EstadoDosMotivos {
+  if (favor.length > 0 || contra.length > 0) return 'motivos';
+  return carregando ? 'carregando' : 'sem_motivos';
+}


### PR DESCRIPTION
## O relato

> "eu senti uma hora q ele carregou primeiro aquele texto falando tem x% de chance de ganhar e depois virou o a favor e contra"

Confirmado, reproduzível, e **não era corrida nem dado errado**.

## A causa

O card de destaque colapsava **três** estados em dois. "Ainda carregando" e "carregou e não tem motivo" eram os dois `favor.length === 0`.

Os motivos vêm de `get_futebol_fixture_reason_contract`, uma **segunda** consulta que só pode começar depois de o board resolver e o destaque ser escolhido — ela depende do `fixture_id` dele (`enabled: !!fixtureId`). Então a lista vazia acontece **sempre**, por alguns instantes. O fallback pintava e era substituído.

## O seam

`estadoDosMotivos` em `futebol-motivos.ts`: pura, três estados nomeados pela condição (`motivos | carregando | sem_motivos`), testada antes do código.

`motivos` vence `carregando` de propósito — a invariante é do estado e não do hook: quem já tem motivo na tela não pode perdê-lo porque alguém marcou carregando.

Erro de consulta cai em `sem_motivos`. Degradação deliberada: o texto do "Por quê" é derivado da própria oportunidade e continua verdadeiro sem o contrato. Esqueleto eterno seria pior.

## A varredura achou mais dois do mesmo tipo

**A vitrine não estava no gate** (bug meu, do #324). O board já vem filtrado do service, mas a fusão com o histórico e os picks registrados reabrem o dia corrente — o mercado escondido aparecia e sumia.

**O acesso também não estava.** Enquanto ele não chega, `locked` é verdadeiro e o conteúdo renderiza **borrado**, desborrando quando a resposta volta. Para assinante pagante é exatamente o defeito relatado, em outro lugar. E a faixa de acesso injetava uma barra acima do hero, empurrando a página inteira.

Verificados e limpos, todos já dentro do gate: KPIs, `moreOpps`, registradas, `gameList`, day stepper.

## O que o code review corrigiu

| achado | correção |
|---|---|
| union anônimo | tipo exportado, nomeado pela **condição** e não pelo widget, como `LeituraCotacao` ao lado |
| esqueleto à mão | `Skeleton` do repo, com a altura de linha do parágrafo que substitui — o comentário afirmava altura igual e **mentia** (46px contra 53px) |
| `unknown[]` | `MotivoExibivel[]`, tipo que estava duplicado como `Motivo` local na página |
| seam meio aplicado | os **quatro** ramos do card passam pelo `estado`; dois ainda liam os arrays crus |
| shotgun surgery | hook + `?? []` memoizado estavam em **três** cópias → `useVitrine()` |
| doc que não bate | o JSDoc justificava a ordem por `isFetching`, mas o caller passa `isLoading`, que no v5 já é falso na revalidação. Comportamento certo, **razão errada** — razão reescrita, teste rerrotulado |

## Escopo

A tela de **Oportunidades** levou o mesmo conserto de gate. Fora do escopo acordado (que era a home) e declarado como tal: é defeito de uma linha, e deixá-lo sabendo que está lá seria pior.

Efeito colateral aceito: a home espera a consulta da vitrine. Na prática é quase nada — ela dispara em paralelo com o board, é uma lista de `string[]`, e tem cache de 5 minutos. É entrada da mesma fusão cujas outras entradas já estavam no gate.

## Verificação

- `npx vitest run` — **394 passando**, 1 pulado, 40 arquivos
- `npx tsc --noEmit -p tsconfig.app.json` — limpo no módulo futebol. **Ele pegou um erro que a suíte não pega**: vitest não faz typecheck, e a suíte ficou verde com um `Cannot redeclare` no código.
- `npx eslint` nos arquivos tocados — zero erros, zero avisos
- `npm run build` — ok

## O que este PR NÃO faz

Não coloca a home na metodologia nova. Conferi a produção: o board ainda vem com `pts_valor` e sem `score_versao`, e o contrato de motivos ainda devolve `valor_de_mercado` como razão a favor — o front já descarta isso, mas o dado é legacy. Isso só muda na virada (`#309`).
