### PR TITLE
refactor(futebol): as premissas acesas da leitura, num lugar só

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ CLAUDE.md
 
 # Cache do tsc --noEmit; muda a cada checagem local.
 *.tsbuildinfo
+
+# Artefatos de trabalho entre sessoes (handoff, rascunho de spec)
+.scratch/

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,22 @@ _Avoid_: Candidata, linha cotada
 O momento em que uma oportunidade passa a estar disponível no painel para o usuário. Não significa envio de notificação, e não garante exibição: uma oportunidade de mercado fora da **vitrine** é publicada e não aparece.
 _Avoid_: Alerta, envio, publicação no Telegram
 
+**Motivo**:
+Uma premissa que o backend agrupou como **A favor** ou **Contra** de uma saída publicada. O agrupamento é decisão do backend; a tela só traduz o slug para texto. Não existe motivo que a tela conclua sozinha.
+_Avoid_: Razão, justificativa
+
+**Porquê**:
+O mesmo que **motivo a favor** — é o nome que a tela usa quando mostra só o lado positivo.
+_Avoid_: Tratar como conceito separado de motivo
+
+**O que o jogo mostra**:
+As premissas acesas de uma **linha analisada** sem preço. Não é motivo, porque sem preço não há aposta a favor de quê. Tem nome próprio na tela justamente para não ser lido como razão de apostar.
+_Avoid_: Motivo, porquê
+
+**Evidência**:
+O número que embasa uma premissa: a média, o histórico, o placar que sustenta a frase. Ela acompanha a premissa e não a substitui — sem evidência a premissa continua verdadeira, só fica sem lastro na tela.
+_Avoid_: Motivo, prova, justificativa
+
 **Board**:
 O conjunto do que o backend publica — tudo que passou nas portas de qualidade de dado, gravado no funil e no histórico. É o universo, não o que está na tela.
 _Avoid_: Painel, vitrine, lista

--- a/src/components/futebol/JogoResumo.tsx
+++ b/src/components/futebol/JogoResumo.tsx
@@ -13,8 +13,9 @@ import {
   pesoForte,
   premissaDe,
 } from '@/utils/futebol-premissas';
-import { evidenciaDe, ladoDaSaida, manchete } from '@/utils/futebol-evidencias';
+import { ladoDaSaida, manchete } from '@/utils/futebol-evidencias';
 import { melhorLeitura, resumoDosMercados, type MercadoResumo } from '@/utils/futebol-leitura';
+import { premissasAcesasDaLeitura } from '@/utils/futebol-motivos';
 import { fmtDayShort, isFinished } from '@/utils/futebol-datas';
 import { settleFutebol, resultBadge, isHit } from '@/utils/futebol-settlement';
 import { ehDestaque, ehFaixaAlta, faixaWord } from '@/utils/futebol-score';
@@ -77,16 +78,24 @@ export function HeroLeitura({
   const lado = ladoDaSaida(top.mercado.slug, top.candidato.outcome);
   const pick = outcomeLabel(top.candidato, jogo.home, jogo.away);
 
-  // Os porquês: a evidência das acesas de maior peso, no máximo 3.
-  const porques = top.candidato.acesas
-    .map((s) => premissaDe(top.mercado.slug, s))
-    .filter((p): p is NonNullable<typeof p> => p != null)
-    .sort((a, b) => (b.peso ?? 0) - (a.peso ?? 0))
-    .slice(0, 3)
-    .map((p) => {
-      const ev = evidenciaDe(p.slug, numeros, lado);
-      return ev ? `${p.label}: ${ev.texto.charAt(0).toLowerCase()}${ev.texto.slice(1)}.` : `${p.label}.`;
-    });
+  // Os porquês, montados pela mesma função que o painel da lista usa (#332).
+  // Os parâmetros preservam exatamente o que esta tela fazia: corte em três,
+  // premissa de peso zero incluída, e sem cair no histórico do time.
+  const porques = premissasAcesasDaLeitura(
+    {
+      mercado: top.mercado.slug,
+      acesas: top.candidato.acesas,
+      numeros,
+      historico: undefined,
+      lado,
+      linha: null,
+    },
+    { max: 3, incluirPesoZero: true },
+  ).map(({ premissa, evidencia }) =>
+    evidencia
+      ? `${premissa.label}: ${evidencia.texto.charAt(0).toLowerCase()}${evidencia.texto.slice(1)}.`
+      : `${premissa.label}.`,
+  );
 
   const fim = isFinished(jogo.statusShort);
   const res = fim ? settleFutebol(top.candidato, jogo.goalsHome, jogo.goalsAway) : null;

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -16,7 +16,8 @@ import { chancePct, pickLabel } from '@/utils/futebol-score';
 import { marketShort, rotuloDaFaixa } from '@/utils/futebol-score';
 import { contaQueValem, premissaDe, rotuloPremissa, pesoForte } from '@/utils/futebol-premissas';
 import { melhorLeitura, resumoDosMercados } from '@/utils/futebol-leitura';
-import { evidenciaDe, ladoDaSaida } from '@/utils/futebol-evidencias';
+import { premissasAcesasDaLeitura } from '@/utils/futebol-motivos';
+import { ladoDaSaida } from '@/utils/futebol-evidencias';
 import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 import { settleFutebol, isHit } from '@/utils/futebol-settlement';
 import type {
@@ -141,18 +142,20 @@ export function JogoResumoPanel({
   const lado = cand ? ladoDaSaida(mercadoLeitura!, cand.outcome) : null;
   const nValem = cand && mercadoLeitura ? contaQueValem(mercadoLeitura, cand.acesas) : 0;
 
-  // Os porquês: premissas acesas que valem, com o número que as embasa.
-  const porques = (cand?.acesas ?? [])
-    .map((s) => premissaDe(mercadoLeitura!, s))
-    .filter((p): p is NonNullable<typeof p> => p != null && (p.peso == null || p.peso > 0))
-    .sort((a, b) => (b.peso ?? 0) - (a.peso ?? 0))
-    .slice(0, 4)
-    .map((p) => ({
-      p,
-      ev:
-        evidenciaDe(p.slug, numeros, lado, true, cand?.line_value ?? null) ??
-        evidenciaDoHistorico(p.slug, historico, lado, cand?.line_value ?? null),
-    }));
+  // Os porquês, montados pela mesma função que o resumo do jogo usa (#332).
+  // Os parâmetros preservam exatamente o que esta tela fazia: corte em quatro,
+  // premissa de peso zero excluída, e com fallback para o histórico do time.
+  const porques = premissasAcesasDaLeitura(
+    {
+      mercado: mercadoLeitura ?? '',
+      acesas: cand?.acesas,
+      numeros,
+      historico,
+      lado,
+      linha: cand?.line_value ?? null,
+    },
+    { max: 4, incluirPesoZero: false },
+  );
 
   // O que pesou contra: as premissas do lado que NÃO aconteceram.
   const contra = topo && cand && mercadoLeitura
@@ -285,7 +288,7 @@ export function JogoResumoPanel({
               Por que · {nValem} {nValem === 1 ? 'premissa a favor' : 'premissas a favor'}
             </div>
             <div className="mt-2.5 flex flex-col gap-2.5">
-              {porques.map(({ p, ev }) => (
+              {porques.map(({ premissa: p, evidencia: ev }) => (
                 <div key={p.slug} className="flex gap-2.5 items-start">
                   <span
                     className="shrink-0 mt-0.5 h-[18px] px-1.5 rounded inline-flex items-center text-[9px] font-bold uppercase tracking-[0.08em]"

--- a/src/utils/futebol-motivos.ts
+++ b/src/utils/futebol-motivos.ts
@@ -1,5 +1,12 @@
-import type { FutebolFixtureReasonItem } from '@/services/futebol-data.service';
-import { PREMISSAS_OCULTAS } from '@/utils/futebol-premissas';
+import type {
+  FutebolFixtureHistorico,
+  FutebolFixtureNumeros,
+  FutebolFixturePremissas,
+  FutebolFixtureReasonItem,
+} from '@/services/futebol-data.service';
+import { PREMISSAS_OCULTAS, premissaDe, type Premissa } from '@/utils/futebol-premissas';
+import { evidenciaDe, type Evidencia } from '@/utils/futebol-evidencias';
+import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 
 /**
  * Um item do contrato que não é razão de contexto e por isso não vai para a
@@ -77,4 +84,79 @@ export function estadoDosMotivos(
 ): EstadoDosMotivos {
   if (favor.length > 0 || contra.length > 0) return 'motivos';
   return carregando ? 'carregando' : 'sem_motivos';
+}
+
+/** Uma premissa acesa com o número que a embasa, quando existe. */
+export type PremissaComEvidencia = { premissa: Premissa; evidencia: Evidencia | null };
+
+/** O que cada tela pede de diferente. */
+export type OpcoesDasPremissasAcesas = {
+  /** Quantas exibir. Resumo do jogo pede 3; painel da lista pede 4. */
+  max: number;
+  /**
+   * Premissa de peso zero entra na lista?
+   *
+   * Peso zero não é premissa quebrada: é premissa que a recalibragem tirou da
+   * conta e manteve visível, porque ela descreve o jogo mesmo sem pontuar.
+   * O resumo mostra; o painel não.
+   */
+  incluirPesoZero: boolean;
+};
+
+/**
+ * As premissas acesas de uma leitura, ordenadas por peso e prontas para a tela.
+ *
+ * ⚠️ O nome diz o que ela faz, e não o que a tela chama o resultado, de
+ * propósito. Pelo glossário, **motivo** é o que o backend agrupou — "não existe
+ * motivo que a tela conclua sozinha" —, e esta função monta a lista aqui, a
+ * partir das premissas acesas. Chamá-la de motivo seria o código contradizer o
+ * vocabulário.
+ *
+ * Depois do #334 ela fica só para **linha analisada sem preço**, onde o que a
+ * tela mostra tem nome próprio: "o que o jogo mostra". Leitura com preço passa a
+ * ler o contrato.
+ *
+ * O que ela faz existir agora é o lugar: enquanto a montagem viveu dentro de
+ * duas telas, elas divergiram sem ninguém ver.
+ *
+ * A evidência do histórico do time é tentada sempre. Não é opção porque não é
+ * observável: quem não a quer passa `historico` vazio, e aí ela é nula de
+ * qualquer jeito.
+ */
+export function premissasAcesasDaLeitura(
+  entrada: {
+    /** Slug do mercado da leitura. */
+    mercado: string;
+    /** Slugs das premissas que acenderam para a saída escolhida. */
+    acesas: readonly string[] | null | undefined;
+    numeros: FutebolFixtureNumeros[] | undefined;
+    historico: FutebolFixtureHistorico[] | undefined;
+    lado: 'home' | 'away' | null;
+    /**
+     * A linha da saída, quando o texto da evidência depende dela.
+     *
+     * ⚠️ Vem separada de propósito, e não derivada do candidato. As duas telas
+     * divergem aqui: o painel passa a linha e o resumo não, e o resumo tem
+     * candidato com linha — derivar mudaria o texto dele. Enquanto o #332
+     * promete comportamento idêntico, a divergência fica explícita. Ela some no
+     * #334, junto com as outras.
+     */
+    linha: number | null;
+  },
+  opcoes: OpcoesDasPremissasAcesas,
+): PremissaComEvidencia[] {
+  const { mercado, acesas, numeros, historico, lado, linha } = entrada;
+
+  return (acesas ?? [])
+    .map((slug) => premissaDe(mercado, slug))
+    .filter((p): p is Premissa => p != null)
+    .filter((p) => opcoes.incluirPesoZero || p.peso == null || p.peso > 0)
+    .sort((a, b) => (b.peso ?? 0) - (a.peso ?? 0))
+    .slice(0, opcoes.max)
+    .map((premissa) => ({
+      premissa,
+      evidencia:
+        evidenciaDe(premissa.slug, numeros, lado, true, linha) ??
+        evidenciaDoHistorico(premissa.slug, historico, lado, linha),
+    }));
 }

--- a/src/utils/futebol-premissas-acesas.test.ts
+++ b/src/utils/futebol-premissas-acesas.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import { premissasAcesasDaLeitura } from './futebol-motivos';
+
+// ============================================================================
+// O lado positivo dos motivos, num lugar só (#332)
+// ============================================================================
+// O resumo do jogo e o painel da lista montavam esta lista cada um por conta, e
+// NÃO do mesmo jeito: cortes diferentes, filtro de peso diferente, um com
+// fallback de histórico e outro sem. Não era duplicação — eram dois
+// comportamentos.
+//
+// A diferença vira PARÂMETRO aqui, de propósito. Ela desaparece sozinha no #334,
+// quando o contrato virar a fonte e os itens passarem a ser os mesmos nos dois
+// lugares. Unificar agora seria mudar tela dentro de um ticket que promete não
+// mudar nada.
+//
+// Os pesos usados nos casos são os reais do catálogo de Gols, para o teste
+// quebrar se alguém recalibrar sem olhar aqui:
+//   defesas_firmes 14 · defesas_vazaveis 12 · ataque_combinado 12
+//   xg_baixo_combinado 10 · ataques_fracos 3 · ambos_vazam 0 · ritmo_alto 0
+// ============================================================================
+
+const GOLS = 'goals_over_under';
+
+/** Como o resumo do jogo chama hoje. */
+const COMO_O_RESUMO = { max: 3, incluirPesoZero: true };
+
+/** Como o painel da lista chama hoje. */
+const COMO_O_PAINEL = { max: 4, incluirPesoZero: false };
+
+const semContexto = {
+  numeros: undefined,
+  historico: undefined,
+  lado: null,
+  linha: null,
+};
+
+const slugs = (itens: { premissa: { slug: string } }[]) => itens.map((i) => i.premissa.slug);
+
+describe('premissasAcesasDaLeitura', () => {
+  it('sem premissa acesa, não devolve item nenhum', () => {
+    expect(
+      premissasAcesasDaLeitura({ mercado: GOLS, acesas: [], ...semContexto }, COMO_O_RESUMO),
+    ).toEqual([]);
+  });
+
+  it('ordena por peso, do maior para o menor', () => {
+    const itens = premissasAcesasDaLeitura(
+      {
+        mercado: GOLS,
+        acesas: ['ataques_fracos', 'defesas_firmes', 'xg_baixo_combinado'],
+        ...semContexto,
+      },
+      COMO_O_RESUMO,
+    );
+
+    expect(slugs(itens)).toEqual(['defesas_firmes', 'xg_baixo_combinado', 'ataques_fracos']);
+  });
+
+  it('corta no máximo pedido, mantendo os de maior peso', () => {
+    const itens = premissasAcesasDaLeitura(
+      {
+        mercado: GOLS,
+        acesas: ['defesas_firmes', 'defesas_vazaveis', 'xg_baixo_combinado', 'ataques_fracos'],
+        ...semContexto,
+      },
+      COMO_O_RESUMO,
+    );
+
+    expect(slugs(itens)).toEqual(['defesas_firmes', 'defesas_vazaveis', 'xg_baixo_combinado']);
+  });
+
+  it('com menos acesas que o corte, devolve todas', () => {
+    const itens = premissasAcesasDaLeitura(
+      { mercado: GOLS, acesas: ['defesas_firmes'], ...semContexto },
+      COMO_O_RESUMO,
+    );
+
+    expect(slugs(itens)).toEqual(['defesas_firmes']);
+  });
+
+  it('ignora slug que não existe no catálogo daquele mercado', () => {
+    const itens = premissasAcesasDaLeitura(
+      { mercado: GOLS, acesas: ['nao_existe', 'defesas_firmes'], ...semContexto },
+      COMO_O_RESUMO,
+    );
+
+    expect(slugs(itens)).toEqual(['defesas_firmes']);
+  });
+
+  // A diferença que existe hoje entre as duas telas, e que o #334 dissolve.
+  describe('premissa de peso zero', () => {
+    const acesas = ['ambos_vazam', 'ritmo_alto', 'defesas_firmes'];
+
+    it('entra quando a tela pede, como o resumo do jogo faz', () => {
+      const itens = premissasAcesasDaLeitura({ mercado: GOLS, acesas, ...semContexto }, COMO_O_RESUMO);
+      expect(slugs(itens)).toContain('ambos_vazam');
+    });
+
+    it('fica de fora quando a tela não pede, como o painel da lista faz', () => {
+      const itens = premissasAcesasDaLeitura({ mercado: GOLS, acesas, ...semContexto }, COMO_O_PAINEL);
+      expect(slugs(itens)).toEqual(['defesas_firmes']);
+    });
+  });
+
+  describe('evidência', () => {
+    it('vem nula quando não há número nem histórico', () => {
+      const [item] = premissasAcesasDaLeitura(
+        { mercado: GOLS, acesas: ['defesas_firmes'], ...semContexto },
+        COMO_O_RESUMO,
+      );
+      expect(item.evidencia).toBeNull();
+    });
+
+    // Sem número do jogo, a evidência cai no histórico do time. Isto é sempre
+    // tentado, e não uma opção: quem não a quer passa histórico vazio, e aí ela
+    // é nula de qualquer jeito. A primeira versão deste teste passava histórico
+    // VAZIO e afirmava que "não caía" — passaria com a opção ligada ou
+    // desligada, e não testava nada.
+    it('cai no histórico do time quando não há número do jogo', () => {
+      const jogo = (side: 'home' | 'away', xg: number) =>
+        ({
+          side,
+          em_casa: side === 'home',
+          xg,
+          xg_contra: null,
+          team_name: side === 'home' ? 'Casa' : 'Fora',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any;
+
+      const [item] = premissasAcesasDaLeitura(
+        {
+          mercado: GOLS,
+          acesas: ['xg_baixo_combinado'],
+          numeros: undefined,
+          historico: [jogo('home', 0.5), jogo('home', 0.5), jogo('away', 0.6), jogo('away', 0.6)],
+          lado: 'home',
+          linha: null,
+        },
+        COMO_O_RESUMO,
+      );
+
+      expect(item.evidencia).not.toBeNull();
+      expect(item.evidencia?.texto).toContain('gols esperados');
+    });
+
+    it('com histórico vazio, a evidência segue nula', () => {
+      const [item] = premissasAcesasDaLeitura(
+        {
+          mercado: GOLS,
+          acesas: ['xg_baixo_combinado'],
+          numeros: undefined,
+          historico: [],
+          lado: 'home',
+          linha: null,
+        },
+        COMO_O_RESUMO,
+      );
+      expect(item.evidencia).toBeNull();
+    });
+  });
+
+  it('o item devolve a premissa inteira, para a tela decidir como escrever', () => {
+    const [item] = premissasAcesasDaLeitura(
+      { mercado: GOLS, acesas: ['defesas_firmes'], ...semContexto },
+      COMO_O_RESUMO,
+    );
+
+    expect(item.premissa.slug).toBe('defesas_firmes');
+    expect(item.premissa.label).toBe('Defesas firmes dos dois lados');
+  });
+});


### PR DESCRIPTION
Fecha #332. Filho de #331.

## ⚠️ O que validar aqui: idealmente nada

A promessa inteira deste PR é **nada mudar na tela**. Ele tira de dentro de duas telas uma montagem que estava copiada e coloca num lugar só. Se alguma coisa mudou visualmente, é bug.

O eixo Spec do review comparou linha a linha contra a `develop` e aprovou a paridade — mas isso é leitura de código, não tela renderizada. Vale um minuto de olho no preview:

| onde | o que conferir |
|---|---|
| aba **Resumo** da tela de jogo | o card verde do topo, lista de bolinhas âmbar: **no máximo 3** itens, formato "Premissa: o número que embasa." |
| **painel** da lista de jogos (`/futebol/jogos`, clicar num jogo) | bloco de porquês com etiqueta Forte/Médio: **no máximo 4** itens |

**O que denunciaria regressão é quantidade e ordem.** Corte e ordenação por peso são exatamente os dois pontos onde as telas divergiam e que viraram parâmetro.

Um detalhe fácil de inverter sem perceber: premissa de **peso zero** não deve aparecer no painel, mas **deve** aparecer no resumo do jogo.

## Por que este PR existe

As duas telas montavam essa lista cada uma por conta, e **não do mesmo jeito**. Não era duplicação — eram dois comportamentos:

| | resumo do jogo | painel da lista |
|---|---|---|
| corte | 3 | 4 |
| premissa de peso zero | entra | é excluída |
| fallback do histórico do time | não tem | tem |
| linha da aposta no texto | não entra | entra |

A diferença virou **parâmetro**, de propósito. Ela desaparece sozinha no #334, quando o contrato virar a fonte e os itens passarem a ser os mesmos nos dois lugares. Unificar agora seria mudar tela dentro de um PR que promete não mudar nada.

## O que o code review corrigiu, e o principal foi grave

**O código contradizia o glossário escrito no mesmo diff.** O verbete diz que **motivo** é o que o backend agrupou e que "não existe motivo que a tela conclua sozinha" — e a função, chamada `motivosPositivos`, montava a lista **na tela**, a partir das premissas acesas. Agora ela se chama `premissasAcesasDaLeitura`, que é o que ela faz. No #334 ela vira o caminho do "o que o jogo mostra".

**A opção de fallback do histórico era inobservável.** Quem não a quer já passa histórico vazio, e a evidência histórica devolve nulo para lista vazia — a flag não mudava nada, e o teste dela passava ligada ou desligada. Testava nada. Saiu, e no lugar entrou um caso com histórico de verdade produzindo evidência, que é o que o aceite pedia.

**Três contradições no glossário, todas minhas:** `Motivo` mandava evitar "Porquê" enquanto o verbete seguinte consagrava "Porquê"; os dois mandavam evitar "evidência", que é tipo exportado e usado no diff; e os verbetes entraram no meio da sequência do pipeline. Agora `Evidência` tem verbete próprio e o bloco está depois de "Publicação no painel".

Mais três imports mortos, dois `import type` do mesmo módulo, e o remapeamento `{ p, ev }` que só existia para o JSX.

## Uma sugestão do review que eu recusei

Ele propôs receber o candidato em vez de `acesas` e `linha` soltos, para dissolver o data clump. **Quebraria a paridade:** o resumo passa linha nula hoje e o candidato dele *tem* linha, então o texto da evidência mudaria. Enquanto este ticket promete comportamento idêntico, a divergência fica explícita e comentada no código. Ela some no #334 com as outras.

## Achado para o #334, não deste PR

O resumo do jogo monta a **manchete** — a frase grande do topo — por um caminho próprio, também a partir das premissas acesas. Quando os motivos vierem do contrato, ela pode passar a discordar da lista logo abaixo dela.

## Verificação

- `npx vitest run` — **414 passando**, 1 pulado, 43 arquivos
- `npx tsc --noEmit -p tsconfig.app.json` — limpo no módulo futebol
- `npx eslint` nos arquivos tocados — zero erros, zero avisos
- `npm run build` — ok
