### PR TITLE
feat(futebol): uma resposta só para "por que essa aposta"

### DIFF
--- a/src/components/futebol/JogoResumo.tsx
+++ b/src/components/futebol/JogoResumo.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Blur } from '@/components/futebol/FutebolGate';
 import { RegistrarApostaCTA } from '@/components/futebol/RegistrarAposta';
-import { useFutebolFixturePremissas, useFutebolFixtureNumeros, useVitrine } from '@/hooks/use-futebol-data';
+import { useFutebolFixturePremissas, useFutebolFixtureNumeros, useFutebolFixtureReasonContract, useVitrine } from '@/hooks/use-futebol-data';
 import type {
   FutebolFixtureValueRow,
   FutebolInjury,
@@ -15,7 +15,7 @@ import {
 } from '@/utils/futebol-premissas';
 import { ladoDaSaida, manchete } from '@/utils/futebol-evidencias';
 import { melhorLeitura, resumoDosMercados, type MercadoResumo } from '@/utils/futebol-leitura';
-import { premissasAcesasDaLeitura } from '@/utils/futebol-motivos';
+import { estadoDosMotivos, explicacaoDaLeitura } from '@/utils/futebol-motivos';
 import { fmtDayShort, isFinished } from '@/utils/futebol-datas';
 import { settleFutebol, resultBadge, isHit } from '@/utils/futebol-settlement';
 import { ehDestaque, ehFaixaAlta, faixaWord } from '@/utils/futebol-score';
@@ -74,27 +74,46 @@ export function HeroLeitura({
   retro?: string | null;
 }) {
   const { data: numeros } = useFutebolFixtureNumeros(jogo.fixtureId);
+  // O contrato de motivos, a mesma fonte da home e da bancada (#334). O
+  // isLoading importa: sem ele a tela não distingue 'ainda carregando' de
+  // 'carregou e não tem motivo', e conclui cedo demais.
+  const { data: contrato, isLoading: contratoCarregando } = useFutebolFixtureReasonContract(jogo.fixtureId);
   if (!top) return null;
   const lado = ladoDaSaida(top.mercado.slug, top.candidato.outcome);
   const pick = outcomeLabel(top.candidato, jogo.home, jogo.away);
 
-  // Os porquês, montados pela mesma função que o painel da lista usa (#332).
-  // Os parâmetros preservam exatamente o que esta tela fazia: corte em três,
-  // premissa de peso zero incluída, e sem cair no histórico do time.
-  const porques = premissasAcesasDaLeitura(
+  // A resposta a "por que essa aposta", da mesma fonte que a home e a bancada
+  // usam (#334): com preço, quem agrupa é o backend; sem preço, seguem as
+  // premissas acesas, e o rótulo muda para não prometer aposta onde não há.
+  const explicacao = explicacaoDaLeitura(
     {
       mercado: top.mercado.slug,
-      acesas: top.candidato.acesas,
+      candidato: top.candidato,
+      temPreco: top.value != null,
+      contrato,
       numeros,
       historico: undefined,
       lado,
-      linha: null,
     },
+    // Sem `maxContra`: esta tela é a leitura rápida e mostra só o lado
+    // positivo. Os dois lados vivem na bancada de mercados.
     { max: 3, incluirPesoZero: true },
-  ).map(({ premissa, evidencia }) =>
+  );
+
+  // Esta tela mostra só o lado positivo: ela é a leitura rápida, e os dois lados
+  // vivem na bancada de mercados.
+  const porques = explicacao.itens.map(({ premissa, evidencia }) =>
     evidencia
       ? `${premissa.label}: ${evidencia.texto.charAt(0).toLowerCase()}${evidencia.texto.slice(1)}.`
       : `${premissa.label}.`,
+  );
+
+  // Só o caminho do contrato espera rede. Sem preço, os itens vêm das premissas
+  // que já estão em mão, e não há o que carregar.
+  const estadoDoBloco = estadoDosMotivos(
+    explicacao.itens,
+    explicacao.contra,
+    top.value != null && contratoCarregando,
   );
 
   const fim = isFinished(jogo.statusShort);
@@ -166,14 +185,31 @@ export function HeroLeitura({
           </div>
         )}
 
-        {!compacto && porques.length > 0 && (
-          <div className="mt-4 pt-4 border-t border-white/15 flex flex-col gap-2">
-            {porques.map((t) => (
-              <div key={t} className="flex gap-2 items-start text-[12.5px] leading-relaxed text-white/80">
-                <span className="w-[5px] h-[5px] rounded-full mt-[7px] shrink-0" style={{ background: '#fbbf24' }} />
-                <span>{t}</span>
+        {/* O rótulo carrega a diferença que a fonte faz: com preço é "Por quê",
+            e é o backend quem agrupou; sem preço é "O que o jogo mostra", e ali
+            não há aposta a favor de quê. Um bloco só, e o rótulo muda (#334). */}
+        {!compacto && estadoDoBloco !== 'sem_motivos' && (
+          <div className="mt-4 pt-4 border-t border-white/15">
+            <div className="text-[10px] uppercase tracking-[0.16em] font-semibold text-white/50">
+              {explicacao.rotulo}
+            </div>
+            {estadoDoBloco === 'carregando' ? (
+              // Esqueleto, e não o bloco vazio: enquanto o contrato não chega, a
+              // tela não conclui que não há motivo.
+              <div className="mt-2.5 flex flex-col gap-2" aria-hidden>
+                <Skeleton className="h-[18px] w-full bg-white/15" />
+                <Skeleton className="h-[18px] w-4/5 bg-white/15" />
               </div>
-            ))}
+            ) : (
+              <div className="mt-2.5 flex flex-col gap-2">
+                {porques.map((t) => (
+                  <div key={t} className="flex gap-2 items-start text-[12.5px] leading-relaxed text-white/80">
+                    <span className="w-[5px] h-[5px] rounded-full mt-[7px] shrink-0" style={{ background: '#fbbf24' }} />
+                    <span>{t}</span>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -9,14 +9,15 @@ import {
   useFutebolFixtureNumeros,
   useFutebolFixtureInjuries,
   useFutebolFixtureHistorico,
+  useFutebolFixtureReasonContract,
   useVitrine,
 } from '@/hooks/use-futebol-data';
 import { fmtDayChip, fmtTime, isFinished, isLive } from '@/utils/futebol-datas';
 import { chancePct, pickLabel } from '@/utils/futebol-score';
 import { marketShort, rotuloDaFaixa } from '@/utils/futebol-score';
-import { contaQueValem, premissaDe, rotuloPremissa, pesoForte } from '@/utils/futebol-premissas';
+import { contaQueValem, rotuloPremissa, pesoForte } from '@/utils/futebol-premissas';
 import { melhorLeitura, resumoDosMercados } from '@/utils/futebol-leitura';
-import { premissasAcesasDaLeitura } from '@/utils/futebol-motivos';
+import { estadoDosMotivos, explicacaoDaLeitura } from '@/utils/futebol-motivos';
 import { ladoDaSaida } from '@/utils/futebol-evidencias';
 import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 import { settleFutebol, isHit } from '@/utils/futebol-settlement';
@@ -103,6 +104,11 @@ export function JogoResumoPanel({
   const numeros = demo?.numeros ?? numerosReais;
   const { data: injuries } = useFutebolFixtureInjuries(fixture.fixture_id);
   const { data: historico } = useFutebolFixtureHistorico(fixture.fixture_id);
+  // O contrato de motivos (#334). No tour os dados são de mentira, então não há
+  // o que buscar.
+  const { data: contrato, isLoading: contratoCarregando } = useFutebolFixtureReasonContract(
+    demo ? undefined : fixture.fixture_id,
+  );
 
   const fim = isFinished(fixture.status_short);
   const live = isLive(fixture.status_short);
@@ -142,31 +148,53 @@ export function JogoResumoPanel({
   const lado = cand ? ladoDaSaida(mercadoLeitura!, cand.outcome) : null;
   const nValem = cand && mercadoLeitura ? contaQueValem(mercadoLeitura, cand.acesas) : 0;
 
-  // Os porquês, montados pela mesma função que o resumo do jogo usa (#332).
-  // Os parâmetros preservam exatamente o que esta tela fazia: corte em quatro,
-  // premissa de peso zero excluída, e com fallback para o histórico do time.
-  const porques = premissasAcesasDaLeitura(
+  // A resposta a "por que essa aposta", da mesma fonte que a home, o resumo do
+  // jogo e a bancada usam (#334). Com preço quem agrupa é o backend; sem preço
+  // seguem as premissas acesas, e o rótulo muda.
+  const explicacao = explicacaoDaLeitura(
     {
       mercado: mercadoLeitura ?? '',
-      acesas: cand?.acesas,
+      candidato: cand,
+      temPreco: !!best,
+      contrato,
       numeros,
       historico,
       lado,
-      linha: cand?.line_value ?? null,
     },
-    { max: 4, incluirPesoZero: false },
+    { max: 4, incluirPesoZero: false, maxContra: 2 },
+  );
+  const porques = explicacao.itens;
+
+  // O contrato entra no que a tela espera antes de concluir. Sem isto o painel
+  // afirmava "0 premissas a favor" enquanto a consulta voava — o mesmo defeito
+  // que o card da home levou um ticket inteiro para consertar.
+  const estadoDaExplicacao = estadoDosMotivos(
+    explicacao.itens,
+    explicacao.contra,
+    !demo && !!best && contratoCarregando,
   );
 
-  // O que pesou contra: as premissas do lado que NÃO aconteceram.
-  const contra = topo && cand && mercadoLeitura
-    ? (() => {
-        const acesas = new Set(cand.acesas);
-        const faltou = topo.mercado.premissas
-          .filter((p) => !acesas.has(p.slug) && p.peso != null && p.peso > 0)
-          .slice(0, 2)
-          .map((p) => rotuloPremissa(p, lado, true).toLowerCase());
-        return faltou.length ? `${faltou.length} ${faltou.length === 1 ? 'pesou' : 'pesaram'} contra: ${faltou.join(' e ')}.` : null;
-      })()
+  // Com preço são motivos, e motivo tem lado. Sem preço são premissas acesas, e
+  // não há lado — o sufixo não pode prometer o que o rótulo acabou de tirar.
+  const sufixoDaExplicacao =
+    explicacao.rotulo === 'Por quê'
+      ? explicacao.total === 1
+        ? 'premissa a favor'
+        : 'premissas a favor'
+      : explicacao.total === 1
+        ? 'premissa acesa'
+        : 'premissas acesas';
+
+  // O que pesou contra, AGORA DO CONTRATO.
+  //
+  // Antes era fabricado por negação: pegava as premissas do mercado que não
+  // acenderam e negava cada uma, sem filtrar se ela se aplica à saída escolhida.
+  // Num Over isso listava como contra uma premissa que só existe para o Under —
+  // o defeito que o aceite da virada proíbe com esse exemplo literal.
+  const contra = explicacao.contra.length
+    ? `${explicacao.contra.length} ${explicacao.contra.length === 1 ? 'pesou' : 'pesaram'} contra: ${explicacao.contra
+        .map(({ premissa }) => rotuloPremissa(premissa, lado, true).toLowerCase())
+        .join(' e ')}.`
     : null;
 
   const casa = numeros?.find((n) => n.side === 'home');
@@ -285,8 +313,19 @@ export function JogoResumoPanel({
         {temLeitura ? (
           <div>
             <div className="text-[10px] uppercase tracking-[0.16em] font-bold" style={{ color: '#8d8672' }}>
-              Por que · {nValem} {nValem === 1 ? 'premissa a favor' : 'premissas a favor'}
+              {/* O sufixo acompanha o rótulo. Dizer "a favor" sob "O que o jogo
+                  mostra" seria a mesma promessa que o rótulo acabou de tirar:
+                  sem preço não há aposta a favor de quê. */}
+              {explicacao.rotulo} · {explicacao.total} {sufixoDaExplicacao}
             </div>
+            {/* Enquanto o contrato voa, esqueleto — e não a lista vazia, que
+                afirmaria "não há motivo" antes de saber. */}
+            {estadoDaExplicacao === 'carregando' && (
+              <div className="mt-2.5 flex flex-col gap-2.5" aria-hidden>
+                <Skeleton className="h-[16px] w-full" />
+                <Skeleton className="h-[16px] w-4/5" />
+              </div>
+            )}
             <div className="mt-2.5 flex flex-col gap-2.5">
               {porques.map(({ premissa: p, evidencia: ev }) => (
                 <div key={p.slug} className="flex gap-2.5 items-start">

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -28,9 +28,9 @@ import { SAO_PAULO_TZ, parseUtc, brtDateStr, brtDayOf, fmtTime, isFinished } fro
 import { mergeBoardAndHistory } from '@/utils/futebol-history';
 import { mercadoEstaOculto } from '@/utils/futebol-mercados-ocultos';
 import { oportunidadesDoDia, type OppLike } from '@/utils/futebol-registradas';
-import { estadoDosMotivos, separarMotivosDoContrato, type MotivoExibivel as Motivo } from '@/utils/futebol-motivos';
+import { estadoDosMotivos, explicacaoDaLeitura, type MotivoExibivel as Motivo } from '@/utils/futebol-motivos';
 import { ladoDaSaida } from '@/utils/futebol-evidencias';
-import { premissaDe, rotuloPremissa } from '@/utils/futebol-premissas';
+import { rotuloPremissa } from '@/utils/futebol-premissas';
 import { useNow } from '@/hooks/use-now';
 // Quantos dias futuros (com jogos) o navegador mostra — janela curta, não a temporada toda.
 const DAY_WINDOW = 8;
@@ -443,22 +443,39 @@ export default function FutebolHoje() {
     useFutebolFixtureReasonContract(heroOpp?.fixture_id);
   const { favor: heroFavor, contra: heroContra } = useMemo(() => {
     const vazio = { favor: [] as Motivo[], contra: [] as Motivo[] };
-    if (!heroOpp || !contratoMotivos?.length) return vazio;
-    const linha = contratoMotivos.find(
-      (r) => r.market === heroOpp.market && r.outcome === heroOpp.outcome
-        && (r.line_value ?? null) === (heroOpp.line_value ?? null),
-    );
-    if (!linha) return vazio;
+    if (!heroOpp) return vazio;
     const lado = ladoDaSaida(heroOpp.market, heroOpp.outcome);
-    const traduzir = (itens: typeof linha.favor, negativo: boolean) =>
-      separarMotivosDoContrato(itens)
-        .slugsDePremissas.map((slug) => ({ slug, prem: premissaDe(heroOpp.market, slug) }))
-        .filter((x): x is { slug: string; prem: NonNullable<typeof x.prem> } => x.prem != null)
-        .map(({ slug, prem }) => ({ slug, texto: rotuloPremissa(prem, lado, negativo) }));
-    return {
+
+    // A MESMA função que o resumo do jogo e o painel da lista usam (#334). Antes
+    // esta tela casava a linha do contrato por conta própria, com `===` estrito
+    // — e a linha vem em float, então ela podia não casar e cair no texto de
+    // fallback em vez dos motivos. Também não ordenava por peso nem excluía
+    // premissa de peso zero, então as três telas diziam coisas diferentes sobre
+    // a mesma oportunidade.
+    const explicacao = explicacaoDaLeitura(
+      {
+        mercado: heroOpp.market,
+        candidato: heroOpp,
+        // O destaque da home é sempre uma oportunidade publicada, logo tem preço.
+        temPreco: true,
+        contrato: contratoMotivos,
+        numeros: undefined,
+        historico: undefined,
+        lado,
+      },
       // Três e duas: o card tem altura fixa e a leitura tem que caber de relance.
-      favor: traduzir(linha.favor, false).slice(0, 3),
-      contra: traduzir(linha.contra, true).slice(0, 2),
+      { max: 3, incluirPesoZero: false, maxContra: 2 },
+    );
+
+    const traduzir = (itens: typeof explicacao.itens, negativo: boolean) =>
+      itens.map(({ premissa }) => ({
+        slug: premissa.slug,
+        texto: rotuloPremissa(premissa, lado, negativo),
+      }));
+
+    return {
+      favor: traduzir(explicacao.itens, false),
+      contra: traduzir(explicacao.contra, true),
     };
   }, [heroOpp, contratoMotivos]);
   // A escala da janela, e não a da linha: a registrada não declara versão.

--- a/src/utils/futebol-explicacao-da-leitura.test.ts
+++ b/src/utils/futebol-explicacao-da-leitura.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import { explicacaoDaLeitura } from './futebol-motivos';
+
+// ============================================================================
+// Uma resposta só para "por que essa aposta" (#334)
+// ============================================================================
+// Antes, o resumo do jogo e o painel da lista concluíam motivo sozinhos, a
+// partir das premissas acesas. A home e a bancada liam o contrato do backend.
+// Duas respostas para a mesma pergunta, que hoje concordam por acaso e param de
+// concordar na virada — o contrato muda e o caminho das premissas não.
+//
+// Agora: leitura COM preço lê o contrato; leitura SEM preço continua nas
+// premissas, mas com nome próprio, porque sem preço não há aposta a favor de
+// quê. Ver o glossário: motivo · porquê · o que o jogo mostra.
+// ============================================================================
+
+const GOLS = 'goals_over_under';
+
+const candidato = (acesas: string[], linha: number | null = 2.5) =>
+  ({
+    market: GOLS,
+    outcome: 'Over',
+    line_value: linha,
+    pts_premissas: 20,
+    penalidades_pts: 0,
+    acesas,
+    apagadas: [],
+    penalidades: [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+
+const linhaDoContrato = (favor: string[], contra: string[] = [], linha: number | null = 2.5) =>
+  ({
+    market: GOLS,
+    outcome: 'Over',
+    line_value: linha,
+    score: 55,
+    favor: favor.map((id) => ({ id, tipo: 'premissa' })),
+    contra: contra.map((id) => ({ id, tipo: 'premissa' })),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+
+const semContexto = { numeros: undefined, historico: undefined, lado: null };
+const opcoes = { max: 3, incluirPesoZero: false, maxContra: 2 };
+
+const slugs = (itens: { premissa: { slug: string } }[]) => itens.map((i) => i.premissa.slug);
+
+describe('explicacaoDaLeitura', () => {
+  describe('leitura COM preço lê o contrato', () => {
+    it('os itens saem do lado A favor do contrato, e não das premissas acesas', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato(['ataques_fracos']), // acesa, mas o contrato não lista
+          temPreco: true,
+          contrato: [linhaDoContrato(['defesas_firmes', 'xg_baixo_combinado'])],
+          ...semContexto,
+        },
+        opcoes,
+      );
+
+      expect(slugs(r.itens)).toEqual(['defesas_firmes', 'xg_baixo_combinado']);
+      expect(slugs(r.itens)).not.toContain('ataques_fracos');
+    });
+
+    it('o rótulo é "Por quê"', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato(['defesas_firmes']),
+          temPreco: true,
+          contrato: [linhaDoContrato(['defesas_firmes'])],
+          ...semContexto,
+        },
+        opcoes,
+      );
+      expect(r.rotulo).toBe('Por quê');
+    });
+
+    // O contrato antigo ainda manda preço junto do cenário, e ele continua no ar
+    // até a virada. Componente de preço não é motivo.
+    it('componente de preço presente no contrato não vira motivo', () => {
+      const contrato = [
+        {
+          market: GOLS,
+          outcome: 'Over',
+          line_value: 2.5,
+          score: 55,
+          favor: [
+            { id: 'defesas_firmes', tipo: 'premissa' },
+            { id: 'valor_de_mercado', tipo: 'componente_score' },
+          ],
+          contra: [],
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+      ];
+
+      const r = explicacaoDaLeitura(
+        { mercado: GOLS, candidato: candidato([]), temPreco: true, contrato, ...semContexto },
+        opcoes,
+      );
+
+      expect(slugs(r.itens)).toEqual(['defesas_firmes']);
+    });
+
+    it('o contra vem do contrato, e não de negar premissa que não acendeu', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato(['defesas_vazaveis']),
+          temPreco: true,
+          contrato: [linhaDoContrato(['defesas_vazaveis'], ['ataque_combinado'])],
+          ...semContexto,
+        },
+        opcoes,
+      );
+
+      expect(slugs(r.contra)).toEqual(['ataque_combinado']);
+    });
+
+    // Degradação deliberada. O contrato CHEGOU e não tem linha para esta saída:
+    // some com o bloco seria pior, porque antes desta mudança a tela sempre
+    // tinha o que dizer. Ela cai nas premissas acesas com o rótulo mais fraco —
+    // e é o rótulo que impede isso de virar motivo inventado.
+    it('contrato sem a linha desta saída cai no rótulo fraco, e não inventa motivo', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato(['defesas_firmes'], 3.5),
+          temPreco: true,
+          contrato: [linhaDoContrato(['ataque_combinado'], ['xg_baixo_combinado'], 2.5)],
+          ...semContexto,
+        },
+        opcoes,
+      );
+
+      expect(r.rotulo).toBe('O que o jogo mostra');
+      expect(slugs(r.itens)).toEqual(['defesas_firmes']);
+      // Nada do contrato de outra linha vaza para cá.
+      expect(slugs(r.itens)).not.toContain('ataque_combinado');
+      expect(r.contra).toEqual([]);
+    });
+
+    it('contrato ainda não chegou não é o mesmo que contrato sem motivo', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato(['defesas_firmes']),
+          temPreco: true,
+          contrato: undefined,
+          ...semContexto,
+        },
+        opcoes,
+      );
+
+      expect(r.itens).toEqual([]);
+      expect(r.rotulo).toBe('Por quê');
+    });
+  });
+
+  describe('leitura SEM preço continua nas premissas', () => {
+    it('os itens saem das premissas acesas', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato(['defesas_firmes', 'xg_baixo_combinado']),
+          temPreco: false,
+          contrato: [linhaDoContrato(['ataque_combinado'])],
+          ...semContexto,
+        },
+        opcoes,
+      );
+
+      expect(slugs(r.itens)).toEqual(['defesas_firmes', 'xg_baixo_combinado']);
+    });
+
+    it('o rótulo tem nome próprio, porque sem preço não há aposta a favor de quê', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato(['defesas_firmes'], null),
+          temPreco: false,
+          contrato: undefined,
+          ...semContexto,
+        },
+        opcoes,
+      );
+
+      expect(r.rotulo).toBe('O que o jogo mostra');
+    });
+
+    it('não tem contra: sem preço, não há o que pesar contra', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato(['defesas_firmes']),
+          temPreco: false,
+          contrato: [linhaDoContrato(['defesas_firmes'], ['ataque_combinado'])],
+          ...semContexto,
+        },
+        opcoes,
+      );
+
+      expect(r.contra).toEqual([]);
+    });
+  });
+
+  describe('regras que valem nos dois caminhos', () => {
+    it('premissa de peso zero fica de fora quando a tela não a pede', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato([]),
+          temPreco: true,
+          contrato: [linhaDoContrato(['ritmo_alto', 'defesas_firmes'])],
+          ...semContexto,
+        },
+        opcoes,
+      );
+
+      expect(slugs(r.itens)).toEqual(['defesas_firmes']);
+    });
+
+    it('respeita o corte pedido pela tela', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato([]),
+          temPreco: true,
+          contrato: [
+            linhaDoContrato([
+              'defesas_firmes',
+              'defesas_vazaveis',
+              'ataque_combinado',
+              'xg_baixo_combinado',
+            ]),
+          ],
+          ...semContexto,
+        },
+        { max: 2, incluirPesoZero: false, maxContra: 2 },
+      );
+
+      expect(r.itens).toHaveLength(2);
+    });
+
+    it('ordena por peso, para o item mais forte aparecer primeiro', () => {
+      const r = explicacaoDaLeitura(
+        {
+          mercado: GOLS,
+          candidato: candidato([]),
+          temPreco: true,
+          contrato: [linhaDoContrato(['ataques_fracos', 'defesas_firmes'])],
+          ...semContexto,
+        },
+        opcoes,
+      );
+
+      expect(slugs(r.itens)).toEqual(['defesas_firmes', 'ataques_fracos']);
+    });
+  });
+});

--- a/src/utils/futebol-explicacao-da-leitura.test.ts
+++ b/src/utils/futebol-explicacao-da-leitura.test.ts
@@ -259,3 +259,41 @@ describe('explicacaoDaLeitura', () => {
     });
   });
 });
+
+describe('a linha casa com folga, porque ela vem em float', () => {
+  // A home comparava a linha do contrato com `===` estrito. Linha vem em float,
+  // e 2.5 de uma fonte não é necessariamente 2.5 da outra: a tela podia não
+  // casar e mostrar o texto de fallback em vez dos motivos. Era bug vivo até
+  // ela passar a usar esta função, que compara com folga.
+  it('casa apesar do resíduo de ponto flutuante', () => {
+    const r = explicacaoDaLeitura(
+      {
+        mercado: GOLS,
+        candidato: candidato(['defesas_firmes'], 0.1 + 0.2), // 0.30000000000000004
+        temPreco: true,
+        contrato: [linhaDoContrato(['ataque_combinado'], [], 0.3)],
+        ...semContexto,
+      },
+      opcoes,
+    );
+
+    expect(r.rotulo).toBe('Por quê');
+    expect(slugs(r.itens)).toEqual(['ataque_combinado']);
+  });
+
+  it('não casa linhas que são de fato diferentes', () => {
+    const r = explicacaoDaLeitura(
+      {
+        mercado: GOLS,
+        candidato: candidato(['defesas_firmes'], 2.5),
+        temPreco: true,
+        contrato: [linhaDoContrato(['ataque_combinado'], [], 3.5)],
+        ...semContexto,
+      },
+      opcoes,
+    );
+
+    expect(r.rotulo).toBe('O que o jogo mostra');
+    expect(slugs(r.itens)).toEqual(['defesas_firmes']);
+  });
+});

--- a/src/utils/futebol-motivos.ts
+++ b/src/utils/futebol-motivos.ts
@@ -192,10 +192,25 @@ export function premissasAcesasDaLeitura(
  * degradação: cabe ao chamador não concluir nada enquanto isso, com
  * `estadoDosMotivos`.
  */
+export type SaidaExplicavel = {
+  market: string;
+  outcome: string;
+  line_value: number | null;
+  /** As premissas acesas, quando a tela as tem. A home lê do board e não tem. */
+  acesas?: readonly string[];
+};
+
 export function explicacaoDaLeitura(
   entrada: {
     mercado: string;
-    candidato: FutebolFixturePremissas | null | undefined;
+    /**
+     * A saída escolhida, no mínimo que a explicação precisa dela.
+     *
+     * Estrutural de propósito: o resumo e o painel passam a linha de premissas,
+     * e a home passa a linha do board — que não tem `acesas`, e nem precisa,
+     * porque lá sempre há preço e a fonte é o contrato.
+     */
+    candidato: SaidaExplicavel | null | undefined;
     /** A leitura tem preço coletado? É o que decide a fonte e o rótulo. */
     temPreco: boolean;
     contrato: FutebolFixtureReasonContractRow[] | undefined;

--- a/src/utils/futebol-motivos.ts
+++ b/src/utils/futebol-motivos.ts
@@ -2,11 +2,13 @@ import type {
   FutebolFixtureHistorico,
   FutebolFixtureNumeros,
   FutebolFixturePremissas,
+  FutebolFixtureReasonContractRow,
   FutebolFixtureReasonItem,
 } from '@/services/futebol-data.service';
 import { PREMISSAS_OCULTAS, premissaDe, type Premissa } from '@/utils/futebol-premissas';
 import { evidenciaDe, type Evidencia } from '@/utils/futebol-evidencias';
 import { evidenciaDoHistorico } from '@/utils/futebol-historico';
+import { mesmaLinha } from '@/utils/futebol-leitura';
 
 /**
  * Um item do contrato que não é razão de contexto e por isso não vai para a
@@ -77,9 +79,9 @@ export type EstadoDosMotivos = 'motivos' | 'carregando' | 'sem_motivos';
 /** Um motivo já traduzido para exibição, com o slug preservado como chave. */
 export type MotivoExibivel = { slug: string; texto: string };
 
-export function estadoDosMotivos(
-  favor: readonly MotivoExibivel[],
-  contra: readonly MotivoExibivel[],
+export function estadoDosMotivos<T>(
+  favor: readonly T[],
+  contra: readonly T[],
   carregando: boolean,
 ): EstadoDosMotivos {
   if (favor.length > 0 || contra.length > 0) return 'motivos';
@@ -91,8 +93,13 @@ export type PremissaComEvidencia = { premissa: Premissa; evidencia: Evidencia | 
 
 /** O que cada tela pede de diferente. */
 export type OpcoesDasPremissasAcesas = {
-  /** Quantas exibir. Resumo do jogo pede 3; painel da lista pede 4. */
-  max: number;
+  /**
+   * Quantas exibir. Ausente = sem corte, e quem chama fatia.
+   *
+   * `explicacaoDaLeitura` pede sem corte porque precisa contar quantas existem
+   * antes de fatiar — o rótulo do painel anuncia o total, não o que coube.
+   */
+  max?: number;
   /**
    * Premissa de peso zero entra na lista?
    *
@@ -159,4 +166,105 @@ export function premissasAcesasDaLeitura(
         evidenciaDe(premissa.slug, numeros, lado, true, linha) ??
         evidenciaDoHistorico(premissa.slug, historico, lado, linha),
     }));
+}
+
+
+/**
+ * O que a tela mostra para explicar uma leitura, e sob que rótulo.
+ *
+ * **Com preço**, os itens são **motivos**: quem agrupa em A favor e Contra é o
+ * backend, e a tela só traduz o slug. É o mesmo contrato que a home e a bancada
+ * leem, então as telas passam a dizer a mesma coisa.
+ *
+ * **Sem preço** não existe contrato — ele só é emitido para linha cotada. Os
+ * itens são as premissas acesas e o rótulo muda para **"O que o jogo mostra"**,
+ * porque sem preço não há aposta a favor de quê. Por isso o retorno chama-se
+ * `itens`, e não `aFavor`: metade das vezes eles não são motivo, e o glossário é
+ * explícito que motivo é o que o backend agrupou.
+ *
+ * ⚠️ **Degradação deliberada:** com preço, se o contrato chegou e não tem linha
+ * para aquela saída, cai nas premissas acesas com o rótulo do sem-preço. Some do
+ * bloco seria pior — antes desta mudança a tela sempre tinha o que dizer, e
+ * sumir com a explicação inteira por falha de uma consulta é regressão. O rótulo
+ * mais fraco é o que mantém a tela honesta.
+ *
+ * `contrato: undefined` (ainda em voo) devolve listas vazias e **não** cai na
+ * degradação: cabe ao chamador não concluir nada enquanto isso, com
+ * `estadoDosMotivos`.
+ */
+export function explicacaoDaLeitura(
+  entrada: {
+    mercado: string;
+    candidato: FutebolFixturePremissas | null | undefined;
+    /** A leitura tem preço coletado? É o que decide a fonte e o rótulo. */
+    temPreco: boolean;
+    contrato: FutebolFixtureReasonContractRow[] | undefined;
+    numeros: FutebolFixtureNumeros[] | undefined;
+    historico: FutebolFixtureHistorico[] | undefined;
+    lado: 'home' | 'away' | null;
+  },
+  opcoes: OpcoesDasPremissasAcesas & {
+    /** Quantos itens de Contra exibir. Ausente = a tela não mostra contra. */
+    maxContra?: number;
+  },
+): {
+  rotulo: 'Por quê' | 'O que o jogo mostra';
+  itens: PremissaComEvidencia[];
+  contra: PremissaComEvidencia[];
+  /**
+   * Quantos itens existem ANTES do corte da tela.
+   *
+   * O rótulo do painel anuncia um número, e ele é quantos existem e não quantos
+   * couberam — senão a tela diria sempre o mesmo número assim que houvesse itens
+   * demais.
+   */
+  total: number;
+} {
+  const { mercado, candidato, temPreco, contrato, numeros, historico, lado } = entrada;
+  const linha = candidato?.line_value ?? null;
+
+  // Sem corte: quem corta é quem chama, e o total precisa ser contado antes.
+  const monta = (slugs: readonly string[]) =>
+    premissasAcesasDaLeitura(
+      { mercado, acesas: slugs, numeros, historico, lado, linha },
+      { incluirPesoZero: opcoes.incluirPesoZero },
+    );
+
+  const semPreco = () => {
+    const todos = monta(candidato?.acesas ?? []);
+    return {
+      rotulo: 'O que o jogo mostra' as const,
+      itens: todos.slice(0, opcoes.max),
+      // Sem preço não há aposta, e sem aposta não há o que pesar contra.
+      contra: [],
+      total: todos.length,
+    };
+  };
+
+  if (!temPreco) return semPreco();
+
+  const doContrato = (contrato ?? []).find(
+    (r) =>
+      r.market === candidato?.market &&
+      r.outcome === candidato?.outcome &&
+      mesmaLinha(r.line_value, linha),
+  );
+
+  // Chegou e não tem linha para esta saída: melhor o rótulo mais fraco que o
+  // bloco vazio. Ainda em voo (`contrato` indefinido) NÃO cai aqui.
+  if (contrato != null && doContrato == null) return semPreco();
+
+  const todos = monta(separarMotivosDoContrato(doContrato?.favor ?? []).slugsDePremissas);
+  return {
+    rotulo: 'Por quê',
+    itens: todos.slice(0, opcoes.max),
+    contra:
+      opcoes.maxContra == null
+        ? []
+        : monta(separarMotivosDoContrato(doContrato?.contra ?? []).slugsDePremissas).slice(
+            0,
+            opcoes.maxContra,
+          ),
+    total: todos.length,
+  };
 }


### PR DESCRIPTION
Fecha #334. Filho de #331. **Este PR muda tela** — vale abrir o preview.

## O que muda para o assinante

**Com preço**, os motivos passam a vir do **contrato do backend** — os mesmos que a home e a bancada já usam. A tela deixa de concluir motivo sozinha.

**Sem preço**, seguem as premissas acesas, sob o rótulo **"O que o jogo mostra"**. Sem preço não há aposta a favor de quê, e o rótulo para de prometer o que não existe. É um bloco só, e o rótulo carrega a diferença.

O **resumo do jogo ganhou rótulo** naquele bloco — ele não tinha nenhum, era só uma lista de bolinhas. Como a decisão inteira depende do rótulo carregar a diferença, ele passou a existir.

## O "pesaram contra" fabricado morreu

O painel derivava contra **por negação**: pegava as premissas do mercado que não acenderam e negava cada uma, **sem filtrar se ela se aplica à saída escolhida**. Num Over listava como contra uma premissa que só existe para o Under.

É o defeito que o aceite da virada proíbe com esse exemplo literal:

> Contra considera apenas premissas **aplicáveis à saída escolhida** e que não aconteceram. Premissa do lado oposto nunca vira Contra por negação — foi o que produziu "As defesas não são firmes" e "Os dois criam bastante chance de gol" como contras de um Over.

O bloco continua na tela; o conteúdo agora vem do contrato.

## ⚠️ O segundo commit: três bugs na home que ninguém tinha visto

Achados pelo code review, e **nenhum deles estava no escopo do #334**:

**1. A home casava a linha do contrato com `===` estrito.** A linha vem em float, e 2,5 de uma fonte não é necessariamente 2,5 da outra. Quando não casava, **o card mais visível do produto mostrava o texto de fallback em vez dos motivos**. Existe um `mesmaLinha` exportado e documentado exatamente por isso, e a home não usava.

**2. Não ordenava por peso.** As outras telas ordenam, então as três diziam a mesma coisa em ordem diferente — o mesmo modo de falha que a copy das premissas corrigiu na migration 106.

**3. Não excluía premissa de peso zero**, que o aceite da virada proíbe com todas as letras.

O conserto foi fazer a home usar a **mesma função**. Os três somem juntos, e some a **quarta cópia** do casamento de linha — que era o que permitia elas divergirem. Teste de regressão trava `0.1 + 0.2` contra `0.3`.

## O que o code review corrigiu antes do commit

| achado | correção |
|---|---|
| o painel exibiria "**O que o jogo mostra · 3 premissas a favor**" — troquei o rótulo e esqueci o sufixo | sufixo acompanha: "premissas acesas" quando não há preço |
| o nome contradizia o glossário **de novo** (`motivosDaLeitura` devolvendo `aFavor` no ramo sem preço) | virou `explicacaoDaLeitura`, devolvendo `itens` |
| o painel ficou **sem estado de carregamento** e afirmava "Por quê · 0 premissas a favor" com o contrato em voo | usa o mesmo `estadoDosMotivos` do card da home |
| com contrato indisponível o bloco do resumo **sumia inteiro** | cai nas premissas com o rótulo fraco; em voo continua esqueleto |
| `fonte` era idêntico ao `temPreco` que o chamador já passa | removido |
| `maxContra: 0` era supressão vestida de corte | virou opcional ausente |

## Verificado contra a produção, não suposto

O review levantou que descartar itens do contrato **com texto próprio** faria o painel mostrar menos que a bancada. Consultei um jogo real: dos 6 itens, o único com texto é `valor_de_mercado` — componente de **preço**, filtrado de propósito. A lacuna é teórica hoje. Se o backend passar a mandar item textual que não seja preço, ele seria descartado: **limitação conhecida**.

## O que validar no preview

| onde | o que conferir |
|---|---|
| aba **Resumo** do jogo | o rótulo troca entre "Por quê" (com preço) e "O que o jogo mostra" (sem) |
| **painel** da lista de jogos | o sufixo acompanha o rótulo: "a favor" vs "acesas" |
| bloco **"pesaram contra"** | continua lá; num Over não deve listar premissa que só existe para Under |
| **home** | se algum jogo mostrava o texto do "~X% de chance" e agora mostra motivos, era o bug do float |
| rede lenta no DevTools | **esqueleto** enquanto o contrato não chega; nunca "0 premissas" nem fallback |

## Fora de escopo

A bancada de mercados **não muda** — ela já lê o contrato; o que ela tem de diferente é a UI, com os dois lados e drilldown. O resumo do jogo continua **sem contra**, porque lá ele nunca existiu.

## Verificação

- `npx vitest run` — **428 passando**, 1 pulado, 44 arquivos
- `npx tsc --noEmit -p tsconfig.app.json` — limpo no módulo futebol
- `npx eslint` nos arquivos tocados — zero erros, zero avisos
- `npm run build` — ok
