### PR TITLE
fix(futebol): a demonstração do onboarding herda a escala do produto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ CLAUDE.md
 
 # Artefatos de trabalho entre sessoes (handoff, rascunho de spec)
 .scratch/
+
+# Worktrees do Claude Code — repositórios à parte, não conteúdo deste
+.claude/worktrees/

--- a/src/components/onboarding/demo/futebol-escala.test.ts
+++ b/src/components/onboarding/demo/futebol-escala.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { demoFutebolBoard, demoFixtureValueRows } from './futebol';
+import { versaoDaJanela, opcoesDeFaixa } from '@/utils/futebol-score';
+
+// ============================================================================
+// A demonstração herda a escala do produto (#333)
+// ============================================================================
+// Ela cravava `contexto_v1`. Como a legenda deriva a escala das linhas que estão
+// na tela, e no tour as linhas são as da demonstração, o onboarding anunciava as
+// fronteiras novas enquanto o board real, ainda em `legacy`, anunciava as
+// antigas. O assinante aprendia uma régua e encontrava outra.
+//
+// Cravar `legacy` "consertaria" hoje e teria de ser desfeito no dia da virada.
+// Herdar fica certo dos dois lados sem ninguém tocar de novo.
+// ============================================================================
+
+describe('a escala da demonstração', () => {
+  it('segue a que o produto está usando: legacy', () => {
+    expect(versaoDaJanela(demoFutebolBoard('legacy'))).toBe('legacy');
+  });
+
+  it('segue a que o produto está usando: contexto_v1', () => {
+    expect(versaoDaJanela(demoFutebolBoard('contexto_v1'))).toBe('contexto_v1');
+  });
+
+  // Quando o produto não declara escala — board vazio, por exemplo —, a
+  // demonstração não inventa uma. A legenda já sabe não cravar número nesse
+  // caso, e é a mesma regra.
+  it('não crava escala quando o produto não declarou', () => {
+    expect(versaoDaJanela(demoFutebolBoard('indefinida'))).toBe('indefinida');
+  });
+
+  it('vale também para as linhas do detalhe do jogo', () => {
+    expect(versaoDaJanela(demoFixtureValueRows('legacy'))).toBe('legacy');
+    expect(versaoDaJanela(demoFixtureValueRows('contexto_v1'))).toBe('contexto_v1');
+  });
+});
+
+describe('a legenda do tour concorda com a do produto', () => {
+  it('em legacy, anuncia os cortes antigos', () => {
+    const selos = opcoesDeFaixa(versaoDaJanela(demoFutebolBoard('legacy'))).map((o) => o.selo);
+    expect(selos).toEqual(['60+', '40+', '<40']);
+  });
+
+  it('em contexto_v1, anuncia os cortes novos', () => {
+    const selos = opcoesDeFaixa(versaoDaJanela(demoFutebolBoard('contexto_v1'))).map((o) => o.selo);
+    expect(selos).toEqual(['60+', '30+', '<30']);
+  });
+});
+
+// O tour ensina a classificação, então os pares nota/faixa precisam ser
+// verdadeiros NAS DUAS escalas — senão a demonstração rotula errado assim que a
+// escala vira, e ninguém percebe porque é dado de mentira.
+describe('os pares nota e faixa são coerentes nas duas escalas', () => {
+  const fronteiras = {
+    legacy: { media: 40, alta: 60 },
+    contexto_v1: { media: 30, alta: 60 },
+  } as const;
+
+  for (const escala of ['legacy', 'contexto_v1'] as const) {
+    it(`em ${escala}`, () => {
+      const { media, alta } = fronteiras[escala];
+      for (const linha of demoFutebolBoard(escala)) {
+        const esperada = linha.score >= alta ? 'Alta' : linha.score >= media ? 'Média' : 'Baixa';
+        expect(`${linha.score} → ${linha.faixa}`).toBe(`${linha.score} → ${esperada}`);
+      }
+    });
+  }
+});

--- a/src/components/onboarding/demo/futebol-escala.test.ts
+++ b/src/components/onboarding/demo/futebol-escala.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { demoFutebolBoard, demoFixtureValueRows } from './futebol';
-import { versaoDaJanela, opcoesDeFaixa } from '@/utils/futebol-score';
+import { versaoDaJanela, opcoesDeFaixa, fronteirasDoScore } from '@/utils/futebol-score';
 
 // ============================================================================
 // A demonstração herda a escala do produto (#333)
@@ -23,13 +23,6 @@ describe('a escala da demonstração', () => {
     expect(versaoDaJanela(demoFutebolBoard('contexto_v1'))).toBe('contexto_v1');
   });
 
-  // Quando o produto não declara escala — board vazio, por exemplo —, a
-  // demonstração não inventa uma. A legenda já sabe não cravar número nesse
-  // caso, e é a mesma regra.
-  it('não crava escala quando o produto não declarou', () => {
-    expect(versaoDaJanela(demoFutebolBoard('indefinida'))).toBe('indefinida');
-  });
-
   it('vale também para as linhas do detalhe do jogo', () => {
     expect(versaoDaJanela(demoFixtureValueRows('legacy'))).toBe('legacy');
     expect(versaoDaJanela(demoFixtureValueRows('contexto_v1'))).toBe('contexto_v1');
@@ -49,21 +42,45 @@ describe('a legenda do tour concorda com a do produto', () => {
 });
 
 // O tour ensina a classificação, então os pares nota/faixa precisam ser
-// verdadeiros NAS DUAS escalas — senão a demonstração rotula errado assim que a
-// escala vira, e ninguém percebe porque é dado de mentira.
+// verdadeiros NAS DUAS escalas. A demonstração deriva a faixa da nota e da
+// escala justamente por isso: rótulo cravado é insustentável, porque uma nota
+// 35 é Média numa e Baixa na outra.
 describe('os pares nota e faixa são coerentes nas duas escalas', () => {
-  const fronteiras = {
-    legacy: { media: 40, alta: 60 },
-    contexto_v1: { media: 30, alta: 60 },
-  } as const;
+  const esperada = (score: number, escala: 'legacy' | 'contexto_v1') => {
+    const { media, alta } = fronteirasDoScore(escala);
+    return score >= alta ? 'Alta' : score >= media ? 'Média' : 'Baixa';
+  };
 
   for (const escala of ['legacy', 'contexto_v1'] as const) {
-    it(`em ${escala}`, () => {
-      const { media, alta } = fronteiras[escala];
-      for (const linha of demoFutebolBoard(escala)) {
-        const esperada = linha.score >= alta ? 'Alta' : linha.score >= media ? 'Média' : 'Baixa';
-        expect(`${linha.score} → ${linha.faixa}`).toBe(`${linha.score} → ${esperada}`);
+    it(`board, em ${escala}`, () => {
+      for (const l of demoFutebolBoard(escala)) {
+        expect(`${l.score} → ${l.faixa}`).toBe(`${l.score} → ${esperada(l.score, escala)}`);
+      }
+    });
+
+    it(`saídas do jogo, em ${escala}`, () => {
+      for (const l of demoFixtureValueRows(escala)) {
+        expect(`${l.score} → ${l.faixa}`).toBe(`${l.score} → ${esperada(l.score, escala)}`);
       }
     });
   }
+
+  // Sem uma nota no intervalo onde as escalas DISCORDAM, os testes acima
+  // passariam com a fábrica ignorando o argumento. Esta guarda existe para o dia
+  // em que alguém ajustar as notas de exemplo sem perceber que apagou a prova.
+  it('existe nota no intervalo em que as duas escalas discordam', () => {
+    const { media: mediaNova } = fronteirasDoScore('contexto_v1');
+    const { media: mediaVelha } = fronteirasDoScore('legacy');
+    const naFaixaDeDiscordancia = demoFutebolBoard('legacy').filter(
+      (l) => l.score >= mediaNova && l.score < mediaVelha,
+    );
+    expect(naFaixaDeDiscordancia.length).toBeGreaterThan(0);
+  });
+
+  it('e ela é rotulada diferente em cada escala', () => {
+    const nova = demoFutebolBoard('contexto_v1').find((l) => l.score === 35);
+    const velha = demoFutebolBoard('legacy').find((l) => l.score === 35);
+    expect(nova?.faixa).toBe('Média');
+    expect(velha?.faixa).toBe('Baixa');
+  });
 });

--- a/src/components/onboarding/demo/futebol.test.ts
+++ b/src/components/onboarding/demo/futebol.test.ts
@@ -18,8 +18,8 @@ const faixaEsperada = (score: number) =>
 
 describe('dados de demonstração do futebol', () => {
   it.each([
-    ['board do painel', demoFutebolBoard],
-    ['saídas do jogo', demoFixtureValueRows],
+    ['board do painel', demoFutebolBoard('contexto_v1')],
+    ['saídas do jogo', demoFixtureValueRows('contexto_v1')],
   ])('%s: toda linha declara a escala nova', (_nome, linhas) => {
     for (const linha of linhas) {
       expect(linha.score_versao, `${linha.market} ${linha.outcome}`).toBe('contexto_v1');
@@ -27,9 +27,9 @@ describe('dados de demonstração do futebol', () => {
   });
 
   it.each([
-    ['board do painel', demoFutebolBoard],
-    ['saídas do jogo', demoFixtureValueRows],
-  ])('%s: a faixa bate com as fronteiras 25 e 55', (_nome, linhas) => {
+    ['board do painel', demoFutebolBoard('contexto_v1')],
+    ['saídas do jogo', demoFixtureValueRows('contexto_v1')],
+  ])('%s: a faixa bate com as fronteiras do Score de contexto', (_nome, linhas) => {
     for (const linha of linhas) {
       expect(faixaTone(linha.faixa), `${linha.market} ${linha.outcome} · Score ${linha.score}`)
         .toBe(faixaEsperada(linha.score));
@@ -39,14 +39,14 @@ describe('dados de demonstração do futebol', () => {
   it('o board de exemplo continua mostrando as três faixas', () => {
     // A mistura é o ponto da demonstração: sem ela, o filtro de faixa e a
     // legenda não têm o que ensinar.
-    const faixas = new Set(demoFutebolBoard.map((l) => faixaTone(l.faixa)));
+    const faixas = new Set(demoFutebolBoard('contexto_v1').map((l) => faixaTone(l.faixa)));
     expect([...faixas].sort()).toEqual(['alta', 'baixa', 'media']);
   });
 
   it('nenhuma linha de exemplo carrega componente de preço no Score', () => {
     // Os campos continuam no tipo durante a janela de compatibilidade, mas a
     // demonstração não pode sugerir que preço soma na nota.
-    for (const linha of demoFutebolBoard) {
+    for (const linha of demoFutebolBoard('contexto_v1')) {
       expect(linha.pts_valor, `${linha.market} ${linha.outcome}`).toBe(0);
       expect(linha.pts_corroboracao, `${linha.market} ${linha.outcome}`).toBe(0);
     }

--- a/src/components/onboarding/demo/futebol.test.ts
+++ b/src/components/onboarding/demo/futebol.test.ts
@@ -3,7 +3,7 @@ import {
   demoFutebolBoard,
   demoFixtureValueRows,
 } from './futebol';
-import { FAIXA_ALTA_MIN, FAIXA_MEDIA_MIN, faixaTone } from '@/utils/futebol-score';
+import { faixaTone } from '@/utils/futebol-score';
 
 // ============================================================================
 // A demonstração ensina a metodologia vigente (issue #308, spec #301)
@@ -13,29 +13,7 @@ import { FAIXA_ALTA_MIN, FAIXA_MEDIA_MIN, faixaTone } from '@/utils/futebol-scor
 // ninguém percebe, porque dado de demonstração não quebra teste de tela.
 // ============================================================================
 
-const faixaEsperada = (score: number) =>
-  score >= FAIXA_ALTA_MIN ? 'alta' : score >= FAIXA_MEDIA_MIN ? 'media' : 'baixa';
-
 describe('dados de demonstração do futebol', () => {
-  it.each([
-    ['board do painel', demoFutebolBoard('contexto_v1')],
-    ['saídas do jogo', demoFixtureValueRows('contexto_v1')],
-  ])('%s: toda linha declara a escala nova', (_nome, linhas) => {
-    for (const linha of linhas) {
-      expect(linha.score_versao, `${linha.market} ${linha.outcome}`).toBe('contexto_v1');
-    }
-  });
-
-  it.each([
-    ['board do painel', demoFutebolBoard('contexto_v1')],
-    ['saídas do jogo', demoFixtureValueRows('contexto_v1')],
-  ])('%s: a faixa bate com as fronteiras do Score de contexto', (_nome, linhas) => {
-    for (const linha of linhas) {
-      expect(faixaTone(linha.faixa), `${linha.market} ${linha.outcome} · Score ${linha.score}`)
-        .toBe(faixaEsperada(linha.score));
-    }
-  });
-
   it('o board de exemplo continua mostrando as três faixas', () => {
     // A mistura é o ponto da demonstração: sem ela, o filtro de faixa e a
     // legenda não têm o que ensinar.

--- a/src/components/onboarding/demo/futebol.ts
+++ b/src/components/onboarding/demo/futebol.ts
@@ -1,11 +1,29 @@
-import type { VersaoDaJanela } from '@/utils/futebol-score';
+import { fronteirasDoScore, type FutebolScoreVersion } from '@/utils/futebol-score';
 import type { FutebolFixturePremissas, FutebolFixtureNumeros, FutebolValueBoardRow, FutebolFixture, FutebolFixtureByDay, FutebolStandingRow, FutebolLeaders, FutebolTeamProfile, FutebolTeamSeason, FutebolFixtureDetail, FutebolFixtureValueRow } from '@/services/futebol-data.service';
 import { fmtTime, addDays } from '@/utils/futebol-datas';
 
 // Dados de EXEMPLO (fictícios) pro onboarding guiado — usados só enquanto o tour
 // roda, pra a tela nunca ficar vazia. Nada aqui é real. Times/valores ilustrativos.
 
-const base = (versao: VersaoDaJanela, over: Partial<FutebolValueBoardRow>): FutebolValueBoardRow => ({
+/**
+ * A faixa DERIVA da nota e da escala, e não é cravada por linha.
+ *
+ * Cravar era insustentável: uma nota 35 é Média na escala nova (corte 30) e
+ * Baixa na antiga (corte 40), então nenhum rótulo fixo é verdadeiro nos dois
+ * lados. A demonstração só "passava" porque nenhuma nota dela caía entre 30 e
+ * 39 — por acaso, não por desenho. E o teste que afirmava cobrir as duas
+ * escalas passaria com a fábrica ignorando o argumento.
+ *
+ * As fronteiras vêm de `fronteirasDoScore`, que é o único lugar que sabe onde
+ * elas estão. Recopiar aqui seria criar a quarta cópia de um número que já se
+ * moveu uma vez.
+ */
+function faixaDaEscala(score: number, versao: FutebolScoreVersion): string {
+  const { media, alta } = fronteirasDoScore(versao);
+  return score >= alta ? 'Alta' : score >= media ? 'Média' : 'Baixa';
+}
+
+const base = (versao: FutebolScoreVersion, over: Partial<FutebolValueBoardRow>): FutebolValueBoardRow => ({
   fixture_id: 0,
   home_team_id: 0,
   away_team_id: 0,
@@ -35,7 +53,8 @@ const base = (versao: VersaoDaJanela, over: Partial<FutebolValueBoardRow>): Fute
   faixa: 'Média',
   evidencias: [],
   ...over,
-  score_versao: versao === 'indefinida' ? undefined : versao,
+  score_versao: versao,
+  faixa: faixaDaEscala(over.score ?? 50, versao),
   premissas_sem_dado: over.premissas_sem_dado ?? 0,
 });
 
@@ -43,12 +62,12 @@ const base = (versao: VersaoDaJanela, over: Partial<FutebolValueBoardRow>): Fute
 // pra mostrar a classificação do backend. As notas seguem as fronteiras do
 // Score de contexto — 55 para Alta, 25 para Média (spec #301) —, senão a
 // demonstração ensinaria a régua aposentada.
-export const demoFutebolBoard = (versao: VersaoDaJanela): FutebolValueBoardRow[] => [
+export const demoFutebolBoard = (versao: FutebolScoreVersion): FutebolValueBoardRow[] => [
   base(versao, {
     fixture_id: 9001, home_team_id: 121, away_team_id: 127,
     home_team_name: 'Palmeiras', away_team_name: 'Flamengo',
     market: 'match_winner', outcome: 'Home', best_odd: 2.1, avg_odd: 1.98,
-    edge: 0.123, prob_justa_fechamento: 0.52, score: 74, faixa: 'Alta',
+    edge: 0.123, prob_justa_fechamento: 0.52, score: 74,
     kickoff_utc: '2025-08-10T21:30:00Z',
     evidencias: ['Mandante forte em casa e adversário desfalcado no meio-campo.'],
   }),
@@ -56,7 +75,7 @@ export const demoFutebolBoard = (versao: VersaoDaJanela): FutebolValueBoardRow[]
     fixture_id: 9002, home_team_id: 130, away_team_id: 119,
     home_team_name: 'Grêmio', away_team_name: 'Internacional',
     market: 'goals_over_under', outcome: 'Over', line_value: 2.5, best_odd: 1.95, avg_odd: 1.88,
-    edge: 0.081, prob_justa_fechamento: 0.55, score: 63, faixa: 'Alta',
+    edge: 0.081, prob_justa_fechamento: 0.55, score: 63,
     kickoff_utc: '2025-08-10T23:00:00Z',
     evidencias: ['Clássico historicamente aberto, com médias altas de gols dos dois lados.'],
   }),
@@ -64,7 +83,7 @@ export const demoFutebolBoard = (versao: VersaoDaJanela): FutebolValueBoardRow[]
     fixture_id: 9003, home_team_id: 126, away_team_id: 131,
     home_team_name: 'São Paulo', away_team_name: 'Corinthians',
     market: 'match_winner', outcome: 'Draw', best_odd: 3.25, avg_odd: 3.1,
-    edge: 0.056, prob_justa_fechamento: 0.32, score: 51, faixa: 'Média',
+    edge: 0.056, prob_justa_fechamento: 0.32, score: 51,
     kickoff_utc: '2025-08-10T18:30:00Z',
     evidencias: ['Equilíbrio no retrospecto recente e defesas sólidas.'],
   }),
@@ -72,15 +91,26 @@ export const demoFutebolBoard = (versao: VersaoDaJanela): FutebolValueBoardRow[]
     fixture_id: 9004, home_team_id: 120, away_team_id: 124,
     home_team_name: 'Botafogo', away_team_name: 'Fluminense',
     market: 'goals_over_under', outcome: 'Under', line_value: 2.5, best_odd: 1.88, avg_odd: 1.8,
-    edge: 0.031, prob_justa_fechamento: 0.54, score: 43, faixa: 'Média',
+    edge: 0.031, prob_justa_fechamento: 0.54, score: 43,
     kickoff_utc: '2025-08-11T00:00:00Z',
     evidencias: ['Dois times de posse e poucos gols nos últimos confrontos.'],
+  }),
+  // Nota 35 de propósito: é o ÚNICO intervalo onde as duas escalas discordam
+  // (Média na nova, corte 30; Baixa na antiga, corte 40). Sem uma linha aqui, o
+  // teste que promete cobrir as duas passaria com a fábrica ignorando a escala.
+  base(versao, {
+    fixture_id: 9006, home_team_id: 131, away_team_id: 126,
+    home_team_name: 'Atlético-MG', away_team_name: 'Grêmio',
+    market: 'goals_over_under', outcome: 'Over', line_value: 2.5, best_odd: 2.05, avg_odd: 2.0,
+    edge: 0.012, prob_justa_fechamento: 0.49, score: 35,
+    kickoff_utc: '2025-08-11T21:00:00Z',
+    evidencias: ['Ataques irregulares, mas ritmo alto nos últimos jogos.'],
   }),
   base(versao, {
     fixture_id: 9005, home_team_id: 135, away_team_id: 118,
     home_team_name: 'Cruzeiro', away_team_name: 'Bahia',
     market: 'match_winner', outcome: 'Home', best_odd: 1.72, avg_odd: 1.7,
-    edge: -0.008, prob_justa_fechamento: 0.6, score: 18, faixa: 'Baixa',
+    edge: -0.008, prob_justa_fechamento: 0.6, score: 18,
     kickoff_utc: '2025-08-10T19:00:00Z',
     evidencias: [],
   }),
@@ -223,21 +253,22 @@ export const demoFixtureDetail: FutebolFixtureDetail = {
 };
 
 // Oportunidades do jogo (WhatToWatch + Explorar mercados).
-const vr = (versao: VersaoDaJanela, over: Partial<FutebolFixtureValueRow>): FutebolFixtureValueRow => ({
+const vr = (versao: FutebolScoreVersion, over: Partial<FutebolFixtureValueRow>): FutebolFixtureValueRow => ({
   market: 'match_winner', outcome: 'Home', outcome_order: 1, line_value: null,
   edge: 0.05, best_odd: 2, best_book: 'Bet365', avg_odd: 1.95, n_casas: 6, janela_usada: 't1h',
   prob_justa_fechamento: 0.5, pts_valor: 0, pts_premissas: 20, pts_corroboracao: 0,
   penalidades: 0, penalidades_globais_pts: 0, penalidades_especificas_pts: 0,
-  score: 50, faixa: 'Média', modelo_api_concorda: true, linha_sharp_confirma: true,
+  score: 50, modelo_api_concorda: true, linha_sharp_confirma: true,
   evidencias: [], avisos: [], contras: [], ...over,
-  score_versao: versao === 'indefinida' ? undefined : versao,
+  score_versao: versao,
+  faixa: faixaDaEscala(over.score ?? 50, versao),
   premissas_sem_dado: over.premissas_sem_dado ?? 0,
 });
 
-export const demoFixtureValueRows = (versao: VersaoDaJanela): FutebolFixtureValueRow[] => [
+export const demoFixtureValueRows = (versao: FutebolScoreVersion): FutebolFixtureValueRow[] => [
   vr(versao, {
     market: 'match_winner', outcome: 'Home', outcome_order: 1, best_odd: 2.10, avg_odd: 1.98,
-    edge: 0.123, prob_justa_fechamento: 0.52, score: 74, faixa: 'Alta',
+    edge: 0.123, prob_justa_fechamento: 0.52, score: 74,
     evidencias: [
       'Mandante forte em casa (8V em 10 jogos) e melhor ataque do returno.',
       'Adversário sem o titular do meio-campo, criando menos.',
@@ -246,10 +277,10 @@ export const demoFixtureValueRows = (versao: VersaoDaJanela): FutebolFixtureValu
     contras: ['Visitante vem de vitória fora e não sofre gols há 3 jogos.'],
     avisos: [],
   }),
-  vr(versao, { market: 'match_winner', outcome: 'Draw', outcome_order: 2, best_odd: 3.30, avg_odd: 3.2, edge: 0.02, prob_justa_fechamento: 0.28, score: 46, faixa: 'Média' }),
-  vr(versao, { market: 'match_winner', outcome: 'Away', outcome_order: 3, best_odd: 3.60, avg_odd: 3.5, edge: -0.03, prob_justa_fechamento: 0.24, score: 19, faixa: 'Baixa' }),
-  vr(versao, { market: 'goals_over_under', outcome: 'Over', outcome_order: 1, line_value: 2.5, best_odd: 1.95, avg_odd: 1.9, edge: 0.06, prob_justa_fechamento: 0.55, score: 48, faixa: 'Média' }),
-  vr(versao, { market: 'goals_over_under', outcome: 'Under', outcome_order: 2, line_value: 2.5, best_odd: 1.90, avg_odd: 1.85, edge: -0.01, prob_justa_fechamento: 0.45, score: 21, faixa: 'Baixa' }),
+  vr(versao, { market: 'match_winner', outcome: 'Draw', outcome_order: 2, best_odd: 3.30, avg_odd: 3.2, edge: 0.02, prob_justa_fechamento: 0.28, score: 46 }),
+  vr(versao, { market: 'match_winner', outcome: 'Away', outcome_order: 3, best_odd: 3.60, avg_odd: 3.5, edge: -0.03, prob_justa_fechamento: 0.24, score: 19 }),
+  vr(versao, { market: 'goals_over_under', outcome: 'Over', outcome_order: 1, line_value: 2.5, best_odd: 1.95, avg_odd: 1.9, edge: 0.06, prob_justa_fechamento: 0.55, score: 48 }),
+  vr(versao, { market: 'goals_over_under', outcome: 'Under', outcome_order: 2, line_value: 2.5, best_odd: 1.90, avg_odd: 1.85, edge: -0.01, prob_justa_fechamento: 0.45, score: 21 }),
 ];
 
 // Artilheiros de exemplo.

--- a/src/components/onboarding/demo/futebol.ts
+++ b/src/components/onboarding/demo/futebol.ts
@@ -1,10 +1,11 @@
+import type { VersaoDaJanela } from '@/utils/futebol-score';
 import type { FutebolFixturePremissas, FutebolFixtureNumeros, FutebolValueBoardRow, FutebolFixture, FutebolFixtureByDay, FutebolStandingRow, FutebolLeaders, FutebolTeamProfile, FutebolTeamSeason, FutebolFixtureDetail, FutebolFixtureValueRow } from '@/services/futebol-data.service';
 import { fmtTime, addDays } from '@/utils/futebol-datas';
 
 // Dados de EXEMPLO (fictícios) pro onboarding guiado — usados só enquanto o tour
 // roda, pra a tela nunca ficar vazia. Nada aqui é real. Times/valores ilustrativos.
 
-const base = (over: Partial<FutebolValueBoardRow>): FutebolValueBoardRow => ({
+const base = (versao: VersaoDaJanela, over: Partial<FutebolValueBoardRow>): FutebolValueBoardRow => ({
   fixture_id: 0,
   home_team_id: 0,
   away_team_id: 0,
@@ -34,7 +35,7 @@ const base = (over: Partial<FutebolValueBoardRow>): FutebolValueBoardRow => ({
   faixa: 'Média',
   evidencias: [],
   ...over,
-  score_versao: over.score_versao ?? 'contexto_v1',
+  score_versao: versao === 'indefinida' ? undefined : versao,
   premissas_sem_dado: over.premissas_sem_dado ?? 0,
 });
 
@@ -42,8 +43,8 @@ const base = (over: Partial<FutebolValueBoardRow>): FutebolValueBoardRow => ({
 // pra mostrar a classificação do backend. As notas seguem as fronteiras do
 // Score de contexto — 55 para Alta, 25 para Média (spec #301) —, senão a
 // demonstração ensinaria a régua aposentada.
-export const demoFutebolBoard: FutebolValueBoardRow[] = [
-  base({
+export const demoFutebolBoard = (versao: VersaoDaJanela): FutebolValueBoardRow[] => [
+  base(versao, {
     fixture_id: 9001, home_team_id: 121, away_team_id: 127,
     home_team_name: 'Palmeiras', away_team_name: 'Flamengo',
     market: 'match_winner', outcome: 'Home', best_odd: 2.1, avg_odd: 1.98,
@@ -51,7 +52,7 @@ export const demoFutebolBoard: FutebolValueBoardRow[] = [
     kickoff_utc: '2025-08-10T21:30:00Z',
     evidencias: ['Mandante forte em casa e adversário desfalcado no meio-campo.'],
   }),
-  base({
+  base(versao, {
     fixture_id: 9002, home_team_id: 130, away_team_id: 119,
     home_team_name: 'Grêmio', away_team_name: 'Internacional',
     market: 'goals_over_under', outcome: 'Over', line_value: 2.5, best_odd: 1.95, avg_odd: 1.88,
@@ -59,7 +60,7 @@ export const demoFutebolBoard: FutebolValueBoardRow[] = [
     kickoff_utc: '2025-08-10T23:00:00Z',
     evidencias: ['Clássico historicamente aberto, com médias altas de gols dos dois lados.'],
   }),
-  base({
+  base(versao, {
     fixture_id: 9003, home_team_id: 126, away_team_id: 131,
     home_team_name: 'São Paulo', away_team_name: 'Corinthians',
     market: 'match_winner', outcome: 'Draw', best_odd: 3.25, avg_odd: 3.1,
@@ -67,7 +68,7 @@ export const demoFutebolBoard: FutebolValueBoardRow[] = [
     kickoff_utc: '2025-08-10T18:30:00Z',
     evidencias: ['Equilíbrio no retrospecto recente e defesas sólidas.'],
   }),
-  base({
+  base(versao, {
     fixture_id: 9004, home_team_id: 120, away_team_id: 124,
     home_team_name: 'Botafogo', away_team_name: 'Fluminense',
     market: 'goals_over_under', outcome: 'Under', line_value: 2.5, best_odd: 1.88, avg_odd: 1.8,
@@ -75,7 +76,7 @@ export const demoFutebolBoard: FutebolValueBoardRow[] = [
     kickoff_utc: '2025-08-11T00:00:00Z',
     evidencias: ['Dois times de posse e poucos gols nos últimos confrontos.'],
   }),
-  base({
+  base(versao, {
     fixture_id: 9005, home_team_id: 135, away_team_id: 118,
     home_team_name: 'Cruzeiro', away_team_name: 'Bahia',
     market: 'match_winner', outcome: 'Home', best_odd: 1.72, avg_odd: 1.7,
@@ -222,19 +223,19 @@ export const demoFixtureDetail: FutebolFixtureDetail = {
 };
 
 // Oportunidades do jogo (WhatToWatch + Explorar mercados).
-const vr = (over: Partial<FutebolFixtureValueRow>): FutebolFixtureValueRow => ({
+const vr = (versao: VersaoDaJanela, over: Partial<FutebolFixtureValueRow>): FutebolFixtureValueRow => ({
   market: 'match_winner', outcome: 'Home', outcome_order: 1, line_value: null,
   edge: 0.05, best_odd: 2, best_book: 'Bet365', avg_odd: 1.95, n_casas: 6, janela_usada: 't1h',
   prob_justa_fechamento: 0.5, pts_valor: 0, pts_premissas: 20, pts_corroboracao: 0,
   penalidades: 0, penalidades_globais_pts: 0, penalidades_especificas_pts: 0,
   score: 50, faixa: 'Média', modelo_api_concorda: true, linha_sharp_confirma: true,
   evidencias: [], avisos: [], contras: [], ...over,
-  score_versao: over.score_versao ?? 'contexto_v1',
+  score_versao: versao === 'indefinida' ? undefined : versao,
   premissas_sem_dado: over.premissas_sem_dado ?? 0,
 });
 
-export const demoFixtureValueRows: FutebolFixtureValueRow[] = [
-  vr({
+export const demoFixtureValueRows = (versao: VersaoDaJanela): FutebolFixtureValueRow[] => [
+  vr(versao, {
     market: 'match_winner', outcome: 'Home', outcome_order: 1, best_odd: 2.10, avg_odd: 1.98,
     edge: 0.123, prob_justa_fechamento: 0.52, score: 74, faixa: 'Alta',
     evidencias: [
@@ -245,10 +246,10 @@ export const demoFixtureValueRows: FutebolFixtureValueRow[] = [
     contras: ['Visitante vem de vitória fora e não sofre gols há 3 jogos.'],
     avisos: [],
   }),
-  vr({ market: 'match_winner', outcome: 'Draw', outcome_order: 2, best_odd: 3.30, avg_odd: 3.2, edge: 0.02, prob_justa_fechamento: 0.28, score: 46, faixa: 'Média' }),
-  vr({ market: 'match_winner', outcome: 'Away', outcome_order: 3, best_odd: 3.60, avg_odd: 3.5, edge: -0.03, prob_justa_fechamento: 0.24, score: 19, faixa: 'Baixa' }),
-  vr({ market: 'goals_over_under', outcome: 'Over', outcome_order: 1, line_value: 2.5, best_odd: 1.95, avg_odd: 1.9, edge: 0.06, prob_justa_fechamento: 0.55, score: 48, faixa: 'Média' }),
-  vr({ market: 'goals_over_under', outcome: 'Under', outcome_order: 2, line_value: 2.5, best_odd: 1.90, avg_odd: 1.85, edge: -0.01, prob_justa_fechamento: 0.45, score: 21, faixa: 'Baixa' }),
+  vr(versao, { market: 'match_winner', outcome: 'Draw', outcome_order: 2, best_odd: 3.30, avg_odd: 3.2, edge: 0.02, prob_justa_fechamento: 0.28, score: 46, faixa: 'Média' }),
+  vr(versao, { market: 'match_winner', outcome: 'Away', outcome_order: 3, best_odd: 3.60, avg_odd: 3.5, edge: -0.03, prob_justa_fechamento: 0.24, score: 19, faixa: 'Baixa' }),
+  vr(versao, { market: 'goals_over_under', outcome: 'Over', outcome_order: 1, line_value: 2.5, best_odd: 1.95, avg_odd: 1.9, edge: 0.06, prob_justa_fechamento: 0.55, score: 48, faixa: 'Média' }),
+  vr(versao, { market: 'goals_over_under', outcome: 'Under', outcome_order: 2, line_value: 2.5, best_odd: 1.90, avg_odd: 1.85, edge: -0.01, prob_justa_fechamento: 0.45, score: 21, faixa: 'Baixa' }),
 ];
 
 // Artilheiros de exemplo.

--- a/src/components/onboarding/demo/use-demo-futebol.ts
+++ b/src/components/onboarding/demo/use-demo-futebol.ts
@@ -1,0 +1,44 @@
+import { useMemo } from 'react';
+import type {
+  FutebolFixtureValueRow,
+  FutebolValueBoardRow,
+} from '@/services/futebol-data.service';
+import { versaoDaJanela, type FutebolScoreVersion } from '@/utils/futebol-score';
+import { demoFutebolBoard, demoFixtureValueRows } from './futebol';
+
+/**
+ * A escala que o produto está usando, para a demonstração herdar (#333).
+ *
+ * ⚠️ Recebe **a mesma janela que a tela exibe**, e não o board cru. A legenda de
+ * faixas deriva da janela; se a demonstração herdar de outra fonte, o tour volta
+ * a anunciar uma régua diferente da que está ao lado dele — que é o defeito
+ * inteiro, só que mais difícil de ver.
+ *
+ * Janela indeterminada — vazia, ou misturando as duas escalas — resolve em
+ * `legacy`. Não é chute: pelo contrato do repo, linha sem `score_versao` e com
+ * componentes de preço numéricos **é** legacy, e a linha de demonstração tem
+ * exatamente essa forma. Declarar outra coisa seria a demonstração contradizer
+ * o adapter que o resto do app usa para ler o mesmo dado.
+ */
+function useEscalaDoProduto(
+  janela: readonly { score_versao?: FutebolScoreVersion }[] | null | undefined,
+): FutebolScoreVersion {
+  const versao = versaoDaJanela(janela ?? []);
+  return versao === 'contexto_v1' ? 'contexto_v1' : 'legacy';
+}
+
+/** O board de exemplo, na escala que o produto está usando. */
+export function useDemoFutebolBoard(
+  janela: readonly { score_versao?: FutebolScoreVersion }[] | null | undefined,
+): FutebolValueBoardRow[] {
+  const escala = useEscalaDoProduto(janela);
+  return useMemo(() => demoFutebolBoard(escala), [escala]);
+}
+
+/** As saídas de exemplo do detalhe do jogo, na escala que o produto está usando. */
+export function useDemoFixtureValueRows(
+  janela: readonly { score_versao?: FutebolScoreVersion }[] | null | undefined,
+): FutebolFixtureValueRow[] {
+  const escala = useEscalaDoProduto(janela);
+  return useMemo(() => demoFixtureValueRows(escala), [escala]);
+}

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -312,6 +312,11 @@ export default function FutebolHoje() {
   const loading = lFix || l3 || lHist || lReg || lVitrine || lAccess;
   const futebolTour = useOnboardingTour(FUTEBOL_TOUR_ID, { enabled: !loading });
   const isDemo = futebolTour.run; // durante o tour, preenche a tela com exemplo
+  // A demonstração HERDA a escala do produto (#333). Ela é derivada do board
+  // REAL, e não das linhas da própria demo — senão o tour anuncia a régua que
+  // ele mesmo inventou, que era o defeito.
+  const escalaDoProduto = versaoDaJanela(boardRows ?? []);
+  const demoBoard = useMemo(() => demoFutebolBoard(escalaDoProduto), [escalaDoProduto]);
   const locked = isDemo ? false : !access?.unlocked;
 
   const todayStr = brtDateStr(new Date(agora));
@@ -404,10 +409,10 @@ export default function FutebolHoje() {
   const board = useMemo(() => groupBoardByFixture(comNumeros), [comNumeros]);
   const bestByFixture = useMemo(() => {
     const m = new Map<number, FutebolValueBoardRow>();
-    if (isDemo) { demoFutebolBoard.forEach((r) => m.set(r.fixture_id, r)); return m; }
+    if (isDemo) { demoBoard.forEach((r) => m.set(r.fixture_id, r)); return m; }
     board.forEach((bf) => m.set(bf.fixtureId, bf.best));
     return m;
-  }, [board, isDemo]);
+  }, [board, isDemo, demoBoard]);
 
   // agenda do dia selecionado (inclui já iniciados, pra contexto da grade)
   const dayGames = useMemo(() => {
@@ -427,7 +432,7 @@ export default function FutebolHoje() {
     () => [...comNumeros].sort((a, b) => compararOportunidades(a, b)),
     [comNumeros],
   );
-  const oppsByFixture = isDemo ? demoFutebolBoard : realOpps;
+  const oppsByFixture = isDemo ? demoBoard : realOpps;
   // O destaque é a primeira em faixa Alta ou Média, e não necessariamente a de
   // maior Score: faixa não é função pura do Score, porque as portas de odd por
   // mercado podem deixar a linha mais bem pontuada fora do destaque. Testar só a
@@ -483,7 +488,7 @@ export default function FutebolHoje() {
     versaoDaJanela(dayRows) === 'contexto_v1' ? 'contexto_v1' : 'legacy',
   );
   const moreOpps = oppsByFixture.filter((o) => o !== heroOpp && ehDestaque(o.faixa)).slice(0, 4);
-  const nOpps = isDemo ? demoFutebolBoard.length : dayRows.length;
+  const nOpps = isDemo ? demoBoard.length : dayRows.length;
   const gameList = isDemo ? demoFutebolFixtures : dayGames;
   const alta = oppsByFixture.filter((o) => faixaTone(o.faixa) === 'alta').length;
   // melhor valor entre as oportunidades realmente exibidas, não o edge bruto de longshots

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -20,7 +20,8 @@ import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
 import { FUTEBOL_TOUR_ID, makeFutebolSteps } from '@/components/onboarding/tours';
 import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
-import { demoFutebolBoard, demoFutebolFixtures } from '@/components/onboarding/demo/futebol';
+import { demoFutebolFixtures } from '@/components/onboarding/demo/futebol';
+import { useDemoFutebolBoard } from '@/components/onboarding/demo/use-demo-futebol';
 // Aritmética de fuso vem de um lugar só. As cópias locais que existiam aqui
 // eram idênticas às de futebol-datas.ts, e duas cópias da mesma conta de fuso é
 // como se erra fuso — foi por isso que Oportunidades removeu as dela no PR #259.
@@ -315,8 +316,6 @@ export default function FutebolHoje() {
   // A demonstração HERDA a escala do produto (#333). Ela é derivada do board
   // REAL, e não das linhas da própria demo — senão o tour anuncia a régua que
   // ele mesmo inventou, que era o defeito.
-  const escalaDoProduto = versaoDaJanela(boardRows ?? []);
-  const demoBoard = useMemo(() => demoFutebolBoard(escalaDoProduto), [escalaDoProduto]);
   const locked = isDemo ? false : !access?.unlocked;
 
   const todayStr = brtDateStr(new Date(agora));
@@ -392,6 +391,11 @@ export default function FutebolHoje() {
     }),
     [valueRows, selectedDay, registradasAll, fixturePorId],
   );
+
+  // A demonstração herda a escala do produto (#333). A janela passada aqui é a
+  // MESMA que a tela exibe: herdar de outra faz o tour anunciar uma régua e a
+  // legenda ao lado dele anunciar outra, que é o defeito inteiro de volta.
+  const demoBoard = useDemoFutebolBoard(dayRows);
 
   // Os blocos visuais precisam de Score e faixa para existir. A oportunidade
   // registrada ANTES da migration 091 não guardou esses números, então ela conta

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -16,7 +16,7 @@ import {
 import { type SaidaPreferida } from '@/utils/futebol-leitura';
 import {
   pickLabel, marketLabel, valorVerdict, fmtEdgeScore,
-  faixaWord, faixaBadgeCls, chancePct, versaoDaJanela,
+  faixaWord, faixaBadgeCls, chancePct,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { escalacaoExibida, rotuloEscalacao } from '@/utils/futebol-escalacao';
@@ -28,7 +28,8 @@ import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
 import { FUT_JOGO_TOUR_ID, makeFutebolJogoSteps } from '@/components/onboarding/tours';
 import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
-import { demoFixtureDetail, demoFixtureValueRows, demoTeamSeason, demoAwaySeason } from '@/components/onboarding/demo/futebol';
+import { demoFixtureDetail, demoTeamSeason, demoAwaySeason } from '@/components/onboarding/demo/futebol';
+import { useDemoFixtureValueRows } from '@/components/onboarding/demo/use-demo-futebol';
 
 /**
  * A bancada fica lado a lado a partir de 1280px (o breakpoint `xl` do grid). O
@@ -305,10 +306,12 @@ export default function FutebolJogo() {
   // e não tem consulta própria.
   const { ocultos } = useVitrine();
   const { data: realValueRows, isLoading: valorCarregando } = useFutebolFixtureValue(fid);
-  // A demonstração herda a escala do produto (#333), derivada das linhas REAIS.
-  const valueRows = isDemo
-    ? demoFixtureValueRows(versaoDaJanela(realValueRows ?? []))
-    : realValueRows;
+  // A demonstração herda a escala do produto (#333), derivada da MESMA janela
+  // que a tela exibe. Memoizado porque a lista desce para filhos e para
+  // dependências de outros useMemo: recriar o array a cada render invalidaria
+  // todos eles sem que nada tivesse mudado.
+  const demoValueRows = useDemoFixtureValueRows(realValueRows);
+  const valueRows = isDemo ? demoValueRows : realValueRows;
   const { data: access } = useFutebolAccess();
   const locked = isDemo ? false : !access?.unlocked;
   // Perfis (médias da temporada) dos dois times — pra "Estatísticas · temporada"

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -16,7 +16,7 @@ import {
 import { type SaidaPreferida } from '@/utils/futebol-leitura';
 import {
   pickLabel, marketLabel, valorVerdict, fmtEdgeScore,
-  faixaWord, faixaBadgeCls, chancePct,
+  faixaWord, faixaBadgeCls, chancePct, versaoDaJanela,
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { escalacaoExibida, rotuloEscalacao } from '@/utils/futebol-escalacao';
@@ -305,7 +305,10 @@ export default function FutebolJogo() {
   // e não tem consulta própria.
   const { ocultos } = useVitrine();
   const { data: realValueRows, isLoading: valorCarregando } = useFutebolFixtureValue(fid);
-  const valueRows = isDemo ? demoFixtureValueRows : realValueRows;
+  // A demonstração herda a escala do produto (#333), derivada das linhas REAIS.
+  const valueRows = isDemo
+    ? demoFixtureValueRows(versaoDaJanela(realValueRows ?? []))
+    : realValueRows;
   const { data: access } = useFutebolAccess();
   const locked = isDemo ? false : !access?.unlocked;
   // Perfis (médias da temporada) dos dois times — pra "Estatísticas · temporada"

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -9,7 +9,7 @@ import { JogoResumoPanel } from '@/components/futebol/JogoResumoPanel';
 import { useFutebolFixturesByDay, useFutebolFixtureDays, useFutebolValueBoard } from '@/hooks/use-futebol-data';
 import type { FutebolFixtureByDay, FutebolValueBoardRow } from '@/services/futebol-data.service';
 import { addDays, brtToday, fmtDayHeader } from '@/utils/futebol-datas';
-import { groupBoardByFixture } from '@/utils/futebol-score';
+import { groupBoardByFixture, versaoDaJanela } from '@/utils/futebol-score';
 import { sufixoDeLeitura } from '@/utils/futebol-leitura';
 import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
@@ -100,15 +100,18 @@ export default function FutebolJogos() {
     [isDemo, dia, fixtures],
   );
 
+  // A demonstração herda a escala do produto (#333), derivada do board REAL.
+  const demoBoard = useMemo(() => demoFutebolBoard(versaoDaJanela(board ?? [])), [board]);
+
   const bestByFixture = useMemo(() => {
     const m = new Map<number, FutebolValueBoardRow>();
     if (isDemo) {
-      demoFutebolBoard.forEach((r) => m.set(r.fixture_id, r));
+      demoBoard.forEach((r) => m.set(r.fixture_id, r));
       return m;
     }
     groupBoardByFixture(board || []).forEach((bf) => m.set(bf.fixtureId, bf.best));
     return m;
-  }, [board, isDemo]);
+  }, [board, isDemo, demoBoard]);
 
   const jogosPorDia = useMemo(() => {
     const m = new Map<string, number>();

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -9,15 +9,15 @@ import { JogoResumoPanel } from '@/components/futebol/JogoResumoPanel';
 import { useFutebolFixturesByDay, useFutebolFixtureDays, useFutebolValueBoard } from '@/hooks/use-futebol-data';
 import type { FutebolFixtureByDay, FutebolValueBoardRow } from '@/services/futebol-data.service';
 import { addDays, brtToday, fmtDayHeader } from '@/utils/futebol-datas';
-import { groupBoardByFixture, versaoDaJanela } from '@/utils/futebol-score';
+import { groupBoardByFixture } from '@/utils/futebol-score';
 import { sufixoDeLeitura } from '@/utils/futebol-leitura';
 import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
 import { FUT_JOGOS_TOUR_ID, makeFutebolJogosSteps } from '@/components/onboarding/tours';
 import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
+import { useDemoFutebolBoard } from '@/components/onboarding/demo/use-demo-futebol';
 import {
-  demoFutebolBoard,
   demoFutebolNumeros,
   demoFutebolPremissas,
   makeDemoAgenda,
@@ -100,8 +100,10 @@ export default function FutebolJogos() {
     [isDemo, dia, fixtures],
   );
 
-  // A demonstração herda a escala do produto (#333), derivada do board REAL.
-  const demoBoard = useMemo(() => demoFutebolBoard(versaoDaJanela(board ?? [])), [board]);
+  // A demonstração herda a escala do produto (#333). Aqui a janela É o board:
+  // a agenda não recorta por dia o que já veio do dia, e é dele que a leitura
+  // de cada confronto sai.
+  const demoBoard = useDemoFutebolBoard(board);
 
   const bestByFixture = useMemo(() => {
     const m = new Map<number, FutebolValueBoardRow>();

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -32,7 +32,7 @@ import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
 import { FUT_OPP_TOUR_ID, makeFutebolOportunidadesSteps } from '@/components/onboarding/tours';
 import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
-import { demoFutebolBoard } from '@/components/onboarding/demo/futebol';
+import { useDemoFutebolBoard } from '@/components/onboarding/demo/use-demo-futebol';
 
 const FINISHED_STATUS = new Set(['FT', 'AET', 'PEN']);
 
@@ -392,6 +392,11 @@ export default function FutebolOportunidades() {
     [allRows, selectedDay, registradasAll, fixtureMap],
   );
 
+  // A demonstração herda a escala do produto (#333). A janela passada aqui é a
+  // MESMA que a tela exibe: herdar de outra faz o tour anunciar uma régua e a
+  // legenda ao lado dele anunciar outra, que é o defeito inteiro de volta.
+  const demoBoard = useDemoFutebolBoard(dayRows);
+
   const filtered = useMemo(
     () => dayRows.filter((r) => {
       if (mercado !== 'all' && r.market !== mercado) return false;
@@ -420,8 +425,6 @@ export default function FutebolOportunidades() {
     () => [...filtered].sort(compararOportunidades),
     [filtered]
   );
-  // A demonstração herda a escala do produto (#333), derivada do board REAL.
-  const demoBoard = useMemo(() => demoFutebolBoard(versaoDaJanela(rows ?? [])), [rows]);
   const bestRows: OppLike[] = isDemo ? demoBoard : realBestRows;
   // A lista mostra o que o backend publicou. O corte local por número de Score
   // saiu na virada do Score de contexto (spec #301): a régua era calibrada para

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -420,7 +420,9 @@ export default function FutebolOportunidades() {
     () => [...filtered].sort(compararOportunidades),
     [filtered]
   );
-  const bestRows: OppLike[] = isDemo ? demoFutebolBoard : realBestRows;
+  // A demonstração herda a escala do produto (#333), derivada do board REAL.
+  const demoBoard = useMemo(() => demoFutebolBoard(versaoDaJanela(rows ?? [])), [rows]);
+  const bestRows: OppLike[] = isDemo ? demoBoard : realBestRows;
   // A lista mostra o que o backend publicou. O corte local por número de Score
   // saiu na virada do Score de contexto (spec #301): a régua era calibrada para
   // a fórmula antiga e aplicá-la à escala nova classificaria errado.
@@ -430,8 +432,8 @@ export default function FutebolOportunidades() {
   // filtro escondesse a faixa Baixa, que é justamente o padrão.
   // Quantas o dia tem e o filtro escondeu. Serve ao estado vazio: sem isto ele
   // diz "não há oportunidade nesse dia" quando o que houve foi um filtro.
-  const escondidasPeloFiltro = (isDemo ? demoFutebolBoard.length : dayRows.length) - bestRows.length;
-  const distribuicao = isDemo ? demoFutebolBoard : dayRows;
+  const escondidasPeloFiltro = (isDemo ? demoBoard.length : dayRows.length) - bestRows.length;
+  const distribuicao = isDemo ? demoBoard : dayRows;
   const nAlta = distribuicao.filter((o) => faixaTone(o.faixa ?? '') === 'alta' && o.faixa != null).length;
   const nMedia = distribuicao.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'media').length;
   const nBaixa = distribuicao.filter((o) => o.faixa != null && faixaTone(o.faixa) === 'baixa').length;


### PR DESCRIPTION
Fecha #333.

## O problema

A demonstração do tour cravava `contexto_v1`. A legenda de faixas deriva a escala das linhas que estão na tela, e durante o tour as linhas são as da demonstração — então o onboarding anunciava as fronteiras novas (30/60) enquanto o board real, ainda em `legacy`, anunciava as antigas (40/60). Quem entrava aprendia uma régua e encontrava outra.

Cravar `legacy` consertaria hoje e teria de ser desfeito no dia da virada. Herdar fica certo dos dois lados sem ninguém tocar de novo.

## O que mudou

As fábricas (`demoFutebolBoard`, `demoFixtureValueRows`) passam a receber a escala, e a **faixa deriva da nota** via `fronteirasDoScore` em vez de vir cravada linha a linha. Isso não era cosmético: com rótulo fixo, uma nota 35 é impossível de rotular certo nos dois lados, porque é Média na escala nova (corte 30) e Baixa na antiga (corte 40).

`useDemoFutebolBoard` / `useDemoFixtureValueRows` concentram a derivação. As quatro telas passam **a janela que elas próprias exibem** — não o board cru. Isso importa: em Oportunidades a demonstração herdava de `rows` enquanto a legenda lia `dayRows` (recortado pelo dia), e em Hoje era `boardRows` contra `dayRows`. Duas janelas, duas réguas — o mesmo defeito de volta, só que mais difícil de ver.

Janela indeterminada resolve em `legacy`, e não por chute: pelo contrato do adapter, linha sem `score_versao` e com componentes de preço numéricos **é** legacy.

## O que valida isso

O primeiro teste que escrevi passava por acaso — nenhuma nota de exemplo caía entre 30 e 39, então a coerência nota/faixa passaria com a fábrica ignorando o argumento. Entrou uma linha de nota 35 e duas guardas: uma exige que exista nota no intervalo de discordância, outra exige que ela troque de rótulo entre as escalas. Sem elas a prova se apaga em silêncio na próxima vez que alguém mexer nos exemplos.

O teste das três faixas também passou a valer nas duas escalas: mover fronteira pode esvaziar uma faixa e deixar o filtro do tour sem o que filtrar.

Caíram duas tautologias em `futebol.test.ts` (passavam `'contexto_v1'` e afirmavam `'contexto_v1'`).

## Verificação visual

Rode o tour de futebol e confira que a legenda de faixas e os selos das linhas de exemplo dizem a mesma coisa — hoje o produto está em `legacy`, então o tour deve anunciar 60+ / 40+ / <40. No dia da virada, sem tocar em nada, deve passar a anunciar 60+ / 30+ / <30.

## Estado

`tsc`, `eslint`, 435 testes e `build` verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
