### PR TITLE
fix(futebol): a home pede o calendário pelo catálogo, e o resumo conta o que não liquidou

### DIFF
--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -4,13 +4,13 @@ import { Zap, ArrowRight, Check, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Seo } from '@/components/Seo';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useFutebolFixturesMulti, useFutebolValueBoard, useFutebolValueHistory, useFutebolAlertedPicks, useFutebolFixtureReasonContract, useFutebolAccess, useVitrine } from '@/hooks/use-futebol-data';
+import { useFutebolFixturesMulti, useFutebolValueBoard, useFutebolValueHistory, useFutebolAlertedPicks, useFutebolFixtureReasonContract, useFutebolAccess, useVitrine, useFutebolCompetitions } from '@/hooks/use-futebol-data';
 import FutebolDayStepper from '@/components/FutebolDayStepper';
 import { Blur, FutebolAccessBanner } from '@/components/futebol/FutebolGate';
 import { AjudaCampo } from '@/components/futebol/AjudaCampo';
 import { textoDoScore, TEXTO_CHANCE, TEXTO_ODD, TEXTO_VALOR } from '@/utils/futebol-ajuda-copy';
 import { getFutebolTeamLogoUrl } from '@/utils/futebol-logos';
-import { competitionLabel, ALL_COMPETITIONS } from '@/utils/futebol-competitions';
+import { competitionLabel, fixtureScopesFor } from '@/utils/futebol-competitions';
 import {
   pickLabel, marketLabel, fmtEdgeScore, groupBoardByFixture,
   faixaBadgeCls, faixaWord, faixaTone, topEvidencia, chancePct, ehDestaque, compararOportunidades, versaoDaJanela,
@@ -25,7 +25,7 @@ import { useDemoFutebolBoard } from '@/components/onboarding/demo/use-demo-futeb
 // Aritmética de fuso vem de um lugar só. As cópias locais que existiam aqui
 // eram idênticas às de futebol-datas.ts, e duas cópias da mesma conta de fuso é
 // como se erra fuso — foi por isso que Oportunidades removeu as dela no PR #259.
-import { SAO_PAULO_TZ, parseUtc, brtDateStr, brtDayOf, fmtTime, isFinished } from '@/utils/futebol-datas';
+import { SAO_PAULO_TZ, parseUtc, brtDateStr, brtDayOf, fmtTime, isFinished, addDays } from '@/utils/futebol-datas';
 import { mergeBoardAndHistory } from '@/utils/futebol-history';
 import { mercadoEstaOculto } from '@/utils/futebol-mercados-ocultos';
 import { oportunidadesDoDia, type OppLike } from '@/utils/futebol-registradas';
@@ -289,21 +289,34 @@ function GameRailRow({ f, best, onClick }: { f: FutebolFixture & { competition?:
 
 export default function FutebolHoje() {
   const navigate = useNavigate();
-  // Todas as ligas do mart (data-driven), não mais um allowlist de 3. Aqui a
-  // temporada segue única de propósito: esta tela só olha o dia corrente, então
-  // não tem a virada de temporada que o histórico de Oportunidades enfrenta.
+  // UM instante para a tela inteira, e ele anda: o seletor de dias, o corte de
+  // "já começou" e a janela do calendário têm que concordar sobre que horas são.
+  const agora = useNow();
+  const todayStr = brtDateStr(new Date(agora));
+  const { data: catalog } = useFutebolCompetitions();
+  // As ligas saem do catálogo do mart, não de uma lista escrita à mão (#323).
+  // Pedir o calendário pela lista fixa deixava pick publicado em liga de fora
+  // sem fixture — e sem fixture não há horário, placar nem liquidação: a linha
+  // aparecia na tela e era incapaz de fechar. Medido em produção em 02/09/2026:
+  // 5 dos 23 picks dos últimos 90 dias estavam em ligas de fora.
+  //
+  // A temporada também sai da janela em vez de cravada. O comentário que estava
+  // aqui defendia cravar 2026 alegando que esta tela só olha o dia corrente —
+  // ela olha até DAY_WINDOW dias à frente, e manter a mesma regra dos dois lados
+  // custa menos que uma exceção que precisa ser defendida a cada leitura.
+  const janelaDeFixtures = useMemo(
+    () => ({ from: todayStr, to: addDays(todayStr, DAY_WINDOW) }),
+    [todayStr],
+  );
   const fixtureScopes = useMemo(
-    () => ALL_COMPETITIONS.map((competition) => ({ competition, season: 2026 })),
-    [],
+    () => fixtureScopesFor(catalog, janelaDeFixtures, Number(todayStr.slice(0, 4))),
+    [catalog, janelaDeFixtures, todayStr],
   );
   const { data: allGames, isLoading: lFix } = useFutebolFixturesMulti(fixtureScopes);
   const { data: boardRows, isLoading: l3 } = useFutebolValueBoard();
   const { data: histRows, isLoading: lHist } = useFutebolValueHistory();
   const { data: alertedRaw, isLoading: lReg } = useFutebolAlertedPicks();
   const { ocultos, isLoading: lVitrine } = useVitrine();
-  // UM instante para a tela inteira, e ele anda: o seletor de dias e o corte de
-  // "já começou" têm que concordar sobre que horas são.
-  const agora = useNow();
   // O acesso ENTRA no gate: enquanto ele não chega, `locked` é verdadeiro e o
   // conteúdo renderiza borrado, desborrando quando a resposta volta. Para quem
   // paga, isso é o mesmo defeito do card de motivos, num lugar diferente.
@@ -318,7 +331,6 @@ export default function FutebolHoje() {
   // ele mesmo inventou, que era o defeito.
   const locked = isDemo ? false : !access?.unlocked;
 
-  const todayStr = brtDateStr(new Date(agora));
   const [day, setDay] = useState<string | null>(null);
 
   // dias (BRT) com jogos ainda não começados — base da navegação por dias.

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect } from 'react';
+import { usePostHog } from '@posthog/react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronRight, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
@@ -197,6 +198,7 @@ function ResultBadge({ r }: { r: BetResult }) {
 
 export default function FutebolOportunidades() {
   const navigate = useNavigate();
+  const posthog = usePostHog();
   const { data: rows, isLoading: lBoard } = useFutebolValueBoard();
   // A vitrine entra no gate de carregamento (#324): sem ela a lista renderiza
   // sem filtro e o mercado escondido aparece por um instante antes de sumir. O
@@ -470,11 +472,29 @@ export default function FutebolOportunidades() {
   // num dia de seis, com as três sem fixture saindo da conta em silêncio (#323).
   const resumo = useMemo(
     () => (isPastDay
-      ? resumoDoDia(comValor.map((o) => ({ kickoff_utc: o.kickoff_utc, resultado: resultOf(o) })))
+      ? resumoDoDia(comValor.map((o) => ({
+        // Quem sabe se o fixture veio é o mapa, não o `kickoff_utc`: a linha do
+        // board traz horário mesmo quando o calendário não trouxe o jogo.
+        temFixture: fixtureMap.has(o.fixture_id),
+        resultado: resultOf(o),
+      })))
       : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isPastDay, comValor, goalsMap],
+    [isPastDay, comValor, goalsMap, fixtureMap],
   );
+
+  // Pick publicado num jogo que o calendário não trouxe é anomalia de catálogo,
+  // e some do histórico sem barulho — foi assim que a #323 passou despercebida
+  // até alguém conferir a mão. A tela mostra a pendência para quem está olhando
+  // aquele dia; este evento é para quem não está.
+  useEffect(() => {
+    if (!resumo || resumo.semFixture === 0) return;
+    posthog?.capture('futebol_pick_sem_fixture', {
+      dia: selectedDay,
+      sem_fixture: resumo.semFixture,
+      publicadas: resumo.total,
+    });
+  }, [resumo, selectedDay, posthog]);
 
   // Esta tela lista uma linha por SAÍDA, não por mercado, e há jogos com duas
   // saídas cotadas no mesmo mercado. Navegando só com o id do jogo, clicar no card
@@ -514,7 +534,7 @@ export default function FutebolOportunidades() {
             {/* Entra também quando NADA liquidou mas houve pendência: senão o
                 dia em que todas ficam sem fixture não mostra nada, que é o pior
                 caso do defeito e não o caso benigno. */}
-            {isPastDay && resumo && (resumo.settled > 0 || resumo.semFixture > 0) ? (
+            {isPastDay && resumo && (resumo.settled > 0 || resumo.pendentes > 0) ? (
               <>
                 {resumo.settled > 0 ? (
                   <>
@@ -526,10 +546,15 @@ export default function FutebolOportunidades() {
                 )}
                 {/* A pendência aparece em vez de encolher o denominador. Dizer
                     "2 de 3" num dia de seis não é arredondamento: é a tela
-                    escondendo justamente a linha que não fechou (#323). */}
-                {resumo.semFixture > 0 ? (
+                    escondendo justamente a linha que não fechou (#323).
+                    Vale para as DUAS causas: contar só a falta de fixture
+                    deixava o jogo adiado invisível, com o mesmo efeito. */}
+                {resumo.pendentes > 0 ? (
                   <p className="text-[12px] mt-1 text-amber-2">
-                    {resumo.semFixture} de {resumo.total} sem resultado — o jogo não foi encontrado no calendário
+                    {resumo.pendentes} de {resumo.total} sem resultado
+                    {resumo.semFixture > 0
+                      ? ` · ${resumo.semFixture} sem jogo no calendário`
+                      : ' · jogo adiado ou ainda sem placar'}
                   </p>
                 ) : null}
               </>

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -20,7 +20,7 @@ import {
   opcoesDeFaixa, passaNoFiltroDeFaixas, versaoDaJanela, ehDestaque, compararOportunidades,
   FAIXAS_FILTRO_PADRAO, type Faixa,
 } from '@/utils/futebol-score';
-import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
+import { settleFutebol, resultBadge, resumoDoDia, type BetResult } from '@/utils/futebol-settlement';
 import { mercadoEstaOculto } from '@/utils/futebol-mercados-ocultos';
 import { mergeBoardAndHistory, historyWindow, HISTORY_WINDOW_DAYS } from '@/utils/futebol-history';
 import { oppKey, oportunidadesDoDia, type OppLike } from '@/utils/futebol-registradas';
@@ -465,21 +465,16 @@ export default function FutebolOportunidades() {
     return out;
   }, [allRows, registradasAll]);
 
-  // Resumo do dia passado: quantas das "com valor" bateram.
-  const resumo = useMemo(() => {
-    if (!isPastDay) return null;
-    let hit = 0, miss = 0, push = 0, settled = 0;
-    comValor.forEach((o) => {
-      const r = resultOf(o);
-      if (!r) return;
-      settled++;
-      if (r === 'push') push++;
-      else if (isHit(r)) hit++;
-      else miss++;
-    });
-    return { hit, miss, push, settled };
+  // Resumo do dia passado. O denominador é o que foi PUBLICADO, e não o que
+  // liquidou: contar só a linha com resultado fazia a manchete dizer "2 de 3"
+  // num dia de seis, com as três sem fixture saindo da conta em silêncio (#323).
+  const resumo = useMemo(
+    () => (isPastDay
+      ? resumoDoDia(comValor.map((o) => ({ kickoff_utc: o.kickoff_utc, resultado: resultOf(o) })))
+      : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPastDay, comValor, goalsMap]);
+    [isPastDay, comValor, goalsMap],
+  );
 
   // Esta tela lista uma linha por SAÍDA, não por mercado, e há jogos com duas
   // saídas cotadas no mesmo mercado. Navegando só com o id do jogo, clicar no card
@@ -516,10 +511,27 @@ export default function FutebolOportunidades() {
         <div className="max-w-[1480px] w-full mx-auto px-4 md:px-6 py-5 md:py-6 flex flex-col items-stretch gap-4 sm:flex-row sm:items-end sm:justify-between">
           <div className="w-full min-w-0 sm:w-auto">
             <div className={`${LABEL} flex items-center gap-2`}>{isPastDay ? 'Histórico' : 'Oportunidades'}{isDemo && <DemoBadge />}</div>
-            {isPastDay && resumo && resumo.settled > 0 ? (
+            {/* Entra também quando NADA liquidou mas houve pendência: senão o
+                dia em que todas ficam sem fixture não mostra nada, que é o pior
+                caso do defeito e não o caso benigno. */}
+            {isPastDay && resumo && (resumo.settled > 0 || resumo.semFixture > 0) ? (
               <>
-                <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{resumo.hit} de {resumo.settled} deram green</h1>
-                <p className="text-[13px] mt-1 text-ink-2">Resultado das oportunidades com valor deste dia{resumo.push > 0 ? ` · ${resumo.push} anulada${resumo.push === 1 ? '' : 's'}` : ''}</p>
+                {resumo.settled > 0 ? (
+                  <>
+                    <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{resumo.hit} de {resumo.settled} deram green</h1>
+                    <p className="text-[13px] mt-1 text-ink-2">Resultado das oportunidades com valor deste dia{resumo.push > 0 ? ` · ${resumo.push} anulada${resumo.push === 1 ? '' : 's'}` : ''}</p>
+                  </>
+                ) : (
+                  <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">Nenhuma oportunidade deste dia liquidou</h1>
+                )}
+                {/* A pendência aparece em vez de encolher o denominador. Dizer
+                    "2 de 3" num dia de seis não é arredondamento: é a tela
+                    escondendo justamente a linha que não fechou (#323). */}
+                {resumo.semFixture > 0 ? (
+                  <p className="text-[12px] mt-1 text-amber-2">
+                    {resumo.semFixture} de {resumo.total} sem resultado — o jogo não foi encontrado no calendário
+                  </p>
+                ) : null}
               </>
             ) : (
               <>

--- a/src/utils/futebol-escopo-de-ligas.test.ts
+++ b/src/utils/futebol-escopo-de-ligas.test.ts
@@ -21,39 +21,94 @@ import { resolve } from 'node:path';
 // de unidade pegou isso. A guarda vale para a próxima tela também.
 // ============================================================================
 
-const PAGINAS = resolve(__dirname, '../pages');
+const RAIZ_SRC = resolve(__dirname, '..');
 
-/** `ALL_COMPETITIONS.map(...)`, em qualquer espaçamento ou quebra de linha. */
-const USADA_COMO_ESCOPO = /ALL_COMPETITIONS\s*\.\s*map\s*\(/;
+/**
+ * A lista fixa sendo percorrida para virar escopo. Não é só `.map`: qualquer
+ * iteração serve para montar a lista de pares liga/temporada, e prender a
+ * guarda a um método deixaria `flatMap`, `forEach` e spread passarem.
+ *
+ * `fixtureScopesFor` usa `ALL_COMPETITIONS.map` por dentro, e é o único lugar
+ * onde isso é legítimo — por isso a varredura pula o próprio módulo.
+ */
+const USADA_COMO_ESCOPO = /ALL_COMPETITIONS\s*(\.\s*(map|flatMap|forEach|reduce|filter)\s*\(|\])|\.\.\.\s*ALL_COMPETITIONS|of\s+ALL_COMPETITIONS/;
 
-function paginasDoFutebol(): { nome: string; fonte: string }[] {
-  return readdirSync(PAGINAS)
-    .filter((f) => f.startsWith('Futebol') && f.endsWith('.tsx'))
-    .map((nome) => ({ nome, fonte: readFileSync(resolve(PAGINAS, nome), 'utf8') }));
+/** A CHAMADA de `fixtureScopesFor`, não a menção do nome num comentário. */
+const CHAMA_O_CATALOGO = /fixtureScopesFor\s*\(/;
+
+/** A CHAMADA do hook de calendário multi-liga. */
+const PEDE_CALENDARIO = /useFutebolFixturesMulti\s*\(/;
+
+/** Onde `fixtureScopesFor` mora — o único lugar que pode usar a lista fixa. */
+const DONO_DA_LISTA = 'futebol-competitions.ts';
+
+/**
+ * O código sem os comentários.
+ *
+ * Sem isto a guarda lê prosa: o serviço documenta "useFutebolFixturesMulti (uma
+ * por liga, temporada inteira)" e o parêntese da explicação vira uma chamada aos
+ * olhos do regex. Guarda que acusa comentário ensina a apagar comentário, que é
+ * o oposto do que este repositório quer.
+ */
+function semComentarios(fonte: string): string {
+  return fonte.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+}
+
+/**
+ * Todo `.ts`/`.tsx` de `src`, não só as páginas que começam com "Futebol".
+ * Restringir a guarda ao nome do arquivo era prometer mais do que ela cobria:
+ * um componente, ou uma página chamada `PainelFutebol.tsx`, escapava.
+ *
+ * Fora ficam os dois donos: o módulo que exporta a lista fixa e o que exporta o
+ * hook. Neles as duas coisas são definição, não uso.
+ */
+function fontesDoApp(dir = RAIZ_SRC): { nome: string; fonte: string }[] {
+  const saida: { nome: string; fonte: string }[] = [];
+  for (const entrada of readdirSync(dir, { withFileTypes: true })) {
+    const caminho = resolve(dir, entrada.name);
+    if (entrada.isDirectory()) {
+      saida.push(...fontesDoApp(caminho));
+      continue;
+    }
+    if (!/\.tsx?$/.test(entrada.name) || /\.test\.tsx?$/.test(entrada.name)) continue;
+    if (entrada.name === DONO_DA_LISTA) continue;
+    const fonte = semComentarios(readFileSync(caminho, 'utf8'));
+    if (/export\s+function\s+useFutebolFixturesMulti/.test(fonte)) continue;
+    saida.push({ nome: entrada.name, fonte });
+  }
+  return saida;
 }
 
 describe('escopo de calendário das telas de futebol', () => {
-  it('nenhuma página monta escopo a partir da lista fixa', () => {
-    const infratoras = paginasDoFutebol()
+  it('ninguém fora do módulo dono percorre a lista fixa', () => {
+    const infratoras = fontesDoApp()
       .filter((p) => USADA_COMO_ESCOPO.test(p.fonte))
       .map((p) => p.nome);
 
     expect(infratoras).toEqual([]);
   });
 
-  it('toda página que pede calendário multi-liga passa pelo catálogo', () => {
+  it('quem pede calendário multi-liga passa pelo catálogo', () => {
     // `useFutebolFixturesMulti` é o consumo de escopo. Quem chama precisa ter
-    // derivado esse escopo de `fixtureScopesFor`, não de uma lista própria.
-    //
-    // Exige a CHAMADA, com o parêntese: a FutebolJogos cita o nome do hook num
-    // comentário, explicando o que ela deixou de usar, e casar com a prosa
-    // acusaria uma página que não pede calendário nenhum.
-    const CHAMA_O_HOOK = /useFutebolFixturesMulti\s*\(/;
-    const semCatalogo = paginasDoFutebol()
-      .filter((p) => CHAMA_O_HOOK.test(p.fonte))
-      .filter((p) => !p.fonte.includes('fixtureScopesFor'))
+    // CHAMADO `fixtureScopesFor` — as duas checagens exigem o parêntese, e não
+    // a presença do nome: a FutebolJogos cita `useFutebolFixturesMulti` num
+    // comentário explicando o que deixou de usar, e casar com a prosa acusaria
+    // uma página que não pede calendário nenhum. A assimetria inversa era pior:
+    // bastaria citar `fixtureScopesFor` num comentário para a guarda calar.
+    const semCatalogo = fontesDoApp()
+      .filter((p) => PEDE_CALENDARIO.test(p.fonte))
+      .filter((p) => !CHAMA_O_CATALOGO.test(p.fonte))
       .map((p) => p.nome);
 
     expect(semCatalogo).toEqual([]);
+  });
+
+  it('a varredura enxerga as páginas que deveria — a guarda não é vazia', () => {
+    // Sem isto, um erro de caminho ou de filtro deixaria a lista de arquivos
+    // vazia e os dois testes acima passariam sem olhar nada.
+    const nomes = fontesDoApp().map((p) => p.nome);
+    expect(nomes).toContain('FutebolHoje.tsx');
+    expect(nomes).toContain('FutebolOportunidades.tsx');
+    expect(nomes.length).toBeGreaterThan(50);
   });
 });

--- a/src/utils/futebol-escopo-de-ligas.test.ts
+++ b/src/utils/futebol-escopo-de-ligas.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ============================================================================
+// A lista fixa de ligas é fallback, nunca escopo (issue #323)
+// ============================================================================
+// `ALL_COMPETITIONS` são oito slugs escritos à mão. Usá-la para pedir o
+// calendário deixa pick publicado em liga de fora sem fixture — e sem fixture
+// não há horário, placar nem liquidação: a linha aparece na tela e é incapaz de
+// fechar. Medido em produção em 02/09/2026: 5 dos 23 picks dos últimos 90 dias
+// estavam em ligas de fora (Primeira Liga, Ligue 1, Champions, Bundesliga).
+//
+// Quem sabe montar escopo é `fixtureScopesFor`, que lê o catálogo do mart e
+// resolve a temporada pela janela. A lista fixa sobrevive lá dentro, como
+// fallback enquanto a consulta não chegou.
+//
+// Este teste é de ARQUIVO, no mesmo espírito do shape-file-futebol.test.ts,
+// porque o defeito não é comportamento de função — é fiação. A Oportunidades
+// foi corrigida e a home ficou para trás com o padrão idêntico, e nenhum teste
+// de unidade pegou isso. A guarda vale para a próxima tela também.
+// ============================================================================
+
+const PAGINAS = resolve(__dirname, '../pages');
+
+/** `ALL_COMPETITIONS.map(...)`, em qualquer espaçamento ou quebra de linha. */
+const USADA_COMO_ESCOPO = /ALL_COMPETITIONS\s*\.\s*map\s*\(/;
+
+function paginasDoFutebol(): { nome: string; fonte: string }[] {
+  return readdirSync(PAGINAS)
+    .filter((f) => f.startsWith('Futebol') && f.endsWith('.tsx'))
+    .map((nome) => ({ nome, fonte: readFileSync(resolve(PAGINAS, nome), 'utf8') }));
+}
+
+describe('escopo de calendário das telas de futebol', () => {
+  it('nenhuma página monta escopo a partir da lista fixa', () => {
+    const infratoras = paginasDoFutebol()
+      .filter((p) => USADA_COMO_ESCOPO.test(p.fonte))
+      .map((p) => p.nome);
+
+    expect(infratoras).toEqual([]);
+  });
+
+  it('toda página que pede calendário multi-liga passa pelo catálogo', () => {
+    // `useFutebolFixturesMulti` é o consumo de escopo. Quem chama precisa ter
+    // derivado esse escopo de `fixtureScopesFor`, não de uma lista própria.
+    //
+    // Exige a CHAMADA, com o parêntese: a FutebolJogos cita o nome do hook num
+    // comentário, explicando o que ela deixou de usar, e casar com a prosa
+    // acusaria uma página que não pede calendário nenhum.
+    const CHAMA_O_HOOK = /useFutebolFixturesMulti\s*\(/;
+    const semCatalogo = paginasDoFutebol()
+      .filter((p) => CHAMA_O_HOOK.test(p.fonte))
+      .filter((p) => !p.fonte.includes('fixtureScopesFor'))
+      .map((p) => p.nome);
+
+    expect(semCatalogo).toEqual([]);
+  });
+});

--- a/src/utils/futebol-registradas.test.ts
+++ b/src/utils/futebol-registradas.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { oportunidadesDoDia, oppFromAlerted, oppKey, type OppLike } from './futebol-registradas';
+import { settleFutebol } from './futebol-settlement';
 import type { FutebolAlertedPick, FutebolFixture } from '@/services/futebol-data.service';
 
 function registrada(over: Partial<FutebolAlertedPick> = {}): FutebolAlertedPick {
@@ -215,5 +216,30 @@ describe('oportunidade registrada em liga fora da lista fixa', () => {
     expect(doDia).toHaveLength(1);
     expect(doDia[0].competition).toBe('ligue_1');
     expect(doDia[0].status_short).toBe('FT');
+  });
+
+  it('com o calendário carregado, a linha LIQUIDA de verdade', () => {
+    // O aceite da issue pede horário, placar E liquidação. As asserções acima
+    // param no horário; esta fecha o ciclo, porque é a liquidação que o
+    // histórico de 29/08 não conseguiu fazer nas três linhas órfãs.
+    const linha = oppFromAlerted(strasbourg, fixtureDoStrasbourg);
+    const resultado = settleFutebol(
+      linha,
+      fixtureDoStrasbourg.goals_home!,
+      fixtureDoStrasbourg.goals_away!,
+    );
+
+    // Strasbourg 2 × 1 Lens, pick no mandante: green.
+    expect(resultado).toBe('won');
+  });
+
+  it('sem o calendário, não há placar para liquidar', () => {
+    const linha = oppFromAlerted(strasbourg, undefined);
+
+    // Este é o defeito inteiro em uma linha: o placar vem do fixture, e sem
+    // fixture não existe par de gols para passar ao liquidador. A linha fica
+    // na tela sem nunca fechar, e o resumo do dia a omitia da conta.
+    expect(linha.status_short).toBeNull();
+    expect(fixtureDoStrasbourg.goals_home).toBe(2); // o placar EXISTIA no banco
   });
 });

--- a/src/utils/futebol-registradas.test.ts
+++ b/src/utils/futebol-registradas.test.ts
@@ -145,3 +145,75 @@ describe('oportunidadesDoDia', () => {
     expect(oppKey(1, 'over_under', 'Over', 2.5)).not.toBe(oppKey(1, 'over_under', 'Over', 3.5));
   });
 });
+
+// ============================================================================
+// Pick em liga fora da antiga lista fixa (issue #323)
+// ============================================================================
+// O caso relatado: 29/08/2026, seis oportunidades na tela e três sem horário,
+// sem placar e sem resultado — Strasbourg × Lens e Arouca × Marítimo, de Ligue 1
+// e Primeira Liga. Os fixtures existiam no banco; o que faltava era a tela
+// PEDIR o calendário dessas ligas, porque o escopo vinha de uma lista fixa de
+// oito slugs.
+//
+// Este teste fixa o efeito: com o fixture no mapa, a linha registrada nasce
+// liquidável; sem ele, nasce cega. É o que separa "2 de 3 deram green" de
+// "2 de 6", e por isso o escopo tem de vir do catálogo do mart.
+// ============================================================================
+
+describe('oportunidade registrada em liga fora da lista fixa', () => {
+  const strasbourg = registrada({
+    fixture_id: 1552745,
+    league: 'ligue_1',
+    match_description: 'Strasbourg × Lens',
+    outcome: 'Home',
+  });
+
+  const fixtureDoStrasbourg: FutebolFixture = {
+    fixture_id: 1552745,
+    home_team_id: 95,
+    away_team_id: 116,
+    home_team_name: 'Strasbourg',
+    away_team_name: 'Lens',
+    kickoff_utc: '2026-08-29T15:15:00Z',
+    status_short: 'FT',
+    goals_home: 2,
+    goals_away: 1,
+  } as FutebolFixture;
+
+  it('com o calendário da liga carregado, a linha tem horário e placar', () => {
+    const linha = oppFromAlerted(strasbourg, fixtureDoStrasbourg);
+
+    expect(linha.kickoff_utc).toBe('2026-08-29T15:15:00Z');
+    expect(linha.status_short).toBe('FT');
+    expect(linha.home_team_name).toBe('Strasbourg');
+    expect(linha.away_team_name).toBe('Lens');
+    expect(linha.home_team_id).toBe(95);
+  });
+
+  it('sem o calendário da liga, a linha aparece mas é incapaz de liquidar', () => {
+    // O defeito, fixado: ela NÃO some da lista — some do resultado. Sem
+    // `status_short` finalizado e sem placar, nada a liquida, e o resumo do dia
+    // encolhia o denominador em silêncio. Ver `resumoDoDia`.
+    const linha = oppFromAlerted(strasbourg, undefined);
+
+    expect(linha.kickoff_utc).toBeNull();
+    expect(linha.status_short).toBeNull();
+    // O nome sai da descrição do pick, então a linha ainda se identifica —
+    // é por isso que ela aparece na tela em vez de sumir.
+    expect(linha.home_team_name).toBe('Strasbourg');
+    expect(linha.home_team_id).toBe(0);
+  });
+
+  it('a linha registrada entra no dia mesmo em liga que o board não trouxe', () => {
+    const doDia = oportunidadesDoDia({
+      doBoard: [],
+      registradas: [strasbourg],
+      dia: '2026-08-29',
+      fixturePorId: new Map([[1552745, fixtureDoStrasbourg]]),
+    });
+
+    expect(doDia).toHaveLength(1);
+    expect(doDia[0].competition).toBe('ligue_1');
+    expect(doDia[0].status_short).toBe('FT');
+  });
+});

--- a/src/utils/futebol-resumo-do-dia.test.ts
+++ b/src/utils/futebol-resumo-do-dia.test.ts
@@ -6,23 +6,23 @@ import { resumoDoDia } from './futebol-settlement';
 // ============================================================================
 // Em 29/08/2026 a tela publicou seis oportunidades e a manchete disse "2 de 3
 // deram green". As outras três não estavam erradas nem certas: sumiram. O
-// resumo só contava linha com resultado, então oportunidade sem fixture — logo
-// sem placar — desaparecia da conta sem deixar rastro.
+// resumo só contava linha com resultado, então oportunidade sem placar
+// desaparecia da conta sem deixar rastro.
 //
 // A causa de fundo (a lista fixa de ligas) foi corrigida. Isto cobre o resíduo:
-// quando ainda assim faltar fixture, a conta precisa dizer, em vez de encolher
-// o denominador em silêncio.
+// quando ainda assim faltar resultado — por falta de fixture OU por jogo adiado
+// —, a conta precisa dizer, em vez de encolher o denominador em silêncio.
 // ============================================================================
 
 const liquidada = (resultado: 'won' | 'lost' | 'push' | 'half_won' | 'half_lost') =>
-  ({ kickoff_utc: '2026-08-29T14:30:00Z', resultado } as const);
-const aguardando = { kickoff_utc: '2026-08-29T14:30:00Z', resultado: null } as const;
-const semFixture = { kickoff_utc: null, resultado: null } as const;
+  ({ temFixture: true, resultado } as const);
+const aguardando = { temFixture: true, resultado: null } as const;
+const semFixture = { temFixture: false, resultado: null } as const;
 
 describe('resumoDoDia', () => {
   it('conta acerto, erro e anulada como antes', () => {
     const r = resumoDoDia([liquidada('won'), liquidada('half_won'), liquidada('lost'), liquidada('push')]);
-    expect(r).toMatchObject({ hit: 2, miss: 1, push: 1, settled: 4 });
+    expect(r).toMatchObject({ hit: 2, miss: 1, push: 1, settled: 4, pendentes: 0 });
   });
 
   it('o total é o que foi publicado, não o que liquidou', () => {
@@ -33,29 +33,46 @@ describe('resumoDoDia', () => {
     ]);
     expect(r.settled).toBe(3);
     expect(r.total).toBe(6);
+    expect(r.pendentes).toBe(3);
     expect(r.semFixture).toBe(3);
   });
 
-  it('separa quem espera o jogo de quem não tem jogo', () => {
-    // As duas não liquidaram, mas só uma é anomalia: a linha sem fixture aponta
-    // pick publicado num jogo que o calendário não trouxe. A outra é só o
-    // relógio.
+  it('separa a causa: quem espera o jogo e quem não tem jogo', () => {
     const r = resumoDoDia([aguardando, semFixture]);
     expect(r.aguardando).toBe(1);
     expect(r.semFixture).toBe(1);
     expect(r.settled).toBe(0);
   });
 
+  it('jogo adiado também conta como pendente, e não some da conta', () => {
+    // O defeito recriado com outra causa: num dia passado, jogo adiado tem
+    // fixture e não tem resultado. Contar só `semFixture` faria a manchete
+    // dizer "2 de 2" num dia de três — o mesmo denominador encolhido.
+    const r = resumoDoDia([liquidada('won'), liquidada('lost'), aguardando]);
+    expect(r.settled).toBe(2);
+    expect(r.total).toBe(3);
+    expect(r.pendentes).toBe(1);
+    expect(r.semFixture).toBe(0);
+  });
+
   it('não sobra nem falta linha na conta', () => {
     const linhas = [liquidada('won'), liquidada('lost'), aguardando, semFixture];
     const r = resumoDoDia(linhas);
-    expect(r.settled + r.aguardando + r.semFixture).toBe(r.total);
+    expect(r.settled + r.pendentes).toBe(r.total);
+    expect(r.aguardando + r.semFixture).toBe(r.pendentes);
     expect(r.total).toBe(linhas.length);
+  });
+
+  it('linha sem fixture que por algum motivo tem resultado conta como liquidada', () => {
+    // Defensivo: o que manda é ter resultado. Se um dia o placar vier por outra
+    // via, a linha liquidou — não é pendência.
+    const r = resumoDoDia([{ temFixture: false, resultado: 'won' }]);
+    expect(r).toMatchObject({ hit: 1, settled: 1, pendentes: 0, semFixture: 0 });
   });
 
   it('dia vazio não inventa pendência', () => {
     expect(resumoDoDia([])).toMatchObject({
-      hit: 0, miss: 0, push: 0, settled: 0, aguardando: 0, semFixture: 0, total: 0,
+      hit: 0, miss: 0, push: 0, settled: 0, aguardando: 0, semFixture: 0, pendentes: 0, total: 0,
     });
   });
 });

--- a/src/utils/futebol-resumo-do-dia.test.ts
+++ b/src/utils/futebol-resumo-do-dia.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { resumoDoDia } from './futebol-settlement';
+
+// ============================================================================
+// O resumo do dia conta o que NÃO liquidou (issue #323)
+// ============================================================================
+// Em 29/08/2026 a tela publicou seis oportunidades e a manchete disse "2 de 3
+// deram green". As outras três não estavam erradas nem certas: sumiram. O
+// resumo só contava linha com resultado, então oportunidade sem fixture — logo
+// sem placar — desaparecia da conta sem deixar rastro.
+//
+// A causa de fundo (a lista fixa de ligas) foi corrigida. Isto cobre o resíduo:
+// quando ainda assim faltar fixture, a conta precisa dizer, em vez de encolher
+// o denominador em silêncio.
+// ============================================================================
+
+const liquidada = (resultado: 'won' | 'lost' | 'push' | 'half_won' | 'half_lost') =>
+  ({ kickoff_utc: '2026-08-29T14:30:00Z', resultado } as const);
+const aguardando = { kickoff_utc: '2026-08-29T14:30:00Z', resultado: null } as const;
+const semFixture = { kickoff_utc: null, resultado: null } as const;
+
+describe('resumoDoDia', () => {
+  it('conta acerto, erro e anulada como antes', () => {
+    const r = resumoDoDia([liquidada('won'), liquidada('half_won'), liquidada('lost'), liquidada('push')]);
+    expect(r).toMatchObject({ hit: 2, miss: 1, push: 1, settled: 4 });
+  });
+
+  it('o total é o que foi publicado, não o que liquidou', () => {
+    // O caso de 29/08: seis publicadas, três com placar.
+    const r = resumoDoDia([
+      liquidada('won'), liquidada('won'), liquidada('lost'),
+      semFixture, semFixture, semFixture,
+    ]);
+    expect(r.settled).toBe(3);
+    expect(r.total).toBe(6);
+    expect(r.semFixture).toBe(3);
+  });
+
+  it('separa quem espera o jogo de quem não tem jogo', () => {
+    // As duas não liquidaram, mas só uma é anomalia: a linha sem fixture aponta
+    // pick publicado num jogo que o calendário não trouxe. A outra é só o
+    // relógio.
+    const r = resumoDoDia([aguardando, semFixture]);
+    expect(r.aguardando).toBe(1);
+    expect(r.semFixture).toBe(1);
+    expect(r.settled).toBe(0);
+  });
+
+  it('não sobra nem falta linha na conta', () => {
+    const linhas = [liquidada('won'), liquidada('lost'), aguardando, semFixture];
+    const r = resumoDoDia(linhas);
+    expect(r.settled + r.aguardando + r.semFixture).toBe(r.total);
+    expect(r.total).toBe(linhas.length);
+  });
+
+  it('dia vazio não inventa pendência', () => {
+    expect(resumoDoDia([])).toMatchObject({
+      hit: 0, miss: 0, push: 0, settled: 0, aguardando: 0, semFixture: 0, total: 0,
+    });
+  });
+});

--- a/src/utils/futebol-settlement.ts
+++ b/src/utils/futebol-settlement.ts
@@ -87,3 +87,55 @@ export function resultBadge(r: BetResult): { label: string; tone: 'won' | 'lost'
 export function isHit(r: BetResult): boolean {
   return r === 'won' || r === 'half_won';
 }
+
+/**
+ * Uma linha do dia, do ponto de vista da liquidação: quando o jogo é, e o que
+ * deu. `kickoff_utc` nulo significa que o calendário não trouxe o fixture —
+ * então não há nem horário nem placar para liquidar.
+ */
+export type LinhaLiquidavel = {
+  kickoff_utc: string | null;
+  resultado: BetResult | null;
+};
+
+export type ResumoDoDia = {
+  hit: number;
+  miss: number;
+  push: number;
+  /** Linhas com resultado. `hit + miss + push`. */
+  settled: number;
+  /** Tem fixture, ainda sem resultado: o jogo não acabou (ou foi adiado). */
+  aguardando: number;
+  /** Não tem fixture. Pick publicado num jogo que o calendário não trouxe. */
+  semFixture: number;
+  /** O que foi PUBLICADO no dia. É o denominador honesto. */
+  total: number;
+};
+
+/**
+ * O resumo do dia, contando também o que não liquidou.
+ *
+ * A manchete dizia "2 de 3 deram green" num dia de seis oportunidades: o resumo
+ * só somava linha com resultado, então quem não tinha fixture saía da conta sem
+ * deixar rastro — e a taxa de acerto ficava sobre um denominador que encolheu
+ * sozinho. Ver #323.
+ *
+ * `aguardando` e `semFixture` são separados de propósito. O primeiro é o
+ * relógio e se resolve sozinho; o segundo é anomalia — pick publicado num jogo
+ * que o calendário não trouxe — e é o que merece aparecer na tela e virar
+ * sinal, em vez de sumir.
+ */
+export function resumoDoDia(linhas: readonly LinhaLiquidavel[]): ResumoDoDia {
+  let hit = 0, miss = 0, push = 0, aguardando = 0, semFixture = 0;
+  for (const l of linhas) {
+    if (l.resultado == null) {
+      if (l.kickoff_utc == null) semFixture++;
+      else aguardando++;
+      continue;
+    }
+    if (l.resultado === 'push') push++;
+    else if (isHit(l.resultado)) hit++;
+    else miss++;
+  }
+  return { hit, miss, push, settled: hit + miss + push, aguardando, semFixture, total: linhas.length };
+}

--- a/src/utils/futebol-settlement.ts
+++ b/src/utils/futebol-settlement.ts
@@ -89,12 +89,16 @@ export function isHit(r: BetResult): boolean {
 }
 
 /**
- * Uma linha do dia, do ponto de vista da liquidação: quando o jogo é, e o que
- * deu. `kickoff_utc` nulo significa que o calendário não trouxe o fixture —
- * então não há nem horário nem placar para liquidar.
+ * Uma linha do dia, do ponto de vista da liquidação.
+ *
+ * `temFixture` é dito pelo chamador, que tem o mapa de fixtures — e não
+ * inferido de `kickoff_utc` nulo. A inferência parecia equivalente e não é:
+ * linha vinda do board sempre traz `kickoff_utc`, mesmo quando o calendário não
+ * trouxe aquele jogo, então ela cairia em "aguardando" e a anomalia nunca
+ * acenderia. Só a registrada nasce com o campo nulo.
  */
 export type LinhaLiquidavel = {
-  kickoff_utc: string | null;
+  temFixture: boolean;
   resultado: BetResult | null;
 };
 
@@ -104,10 +108,12 @@ export type ResumoDoDia = {
   push: number;
   /** Linhas com resultado. `hit + miss + push`. */
   settled: number;
-  /** Tem fixture, ainda sem resultado: o jogo não acabou (ou foi adiado). */
+  /** Tem fixture, ainda sem resultado: jogo por acabar, adiado ou sem placar. */
   aguardando: number;
   /** Não tem fixture. Pick publicado num jogo que o calendário não trouxe. */
   semFixture: number;
+  /** Tudo que não liquidou. É o que a tela precisa dizer em vez de omitir. */
+  pendentes: number;
   /** O que foi PUBLICADO no dia. É o denominador honesto. */
   total: number;
 };
@@ -120,22 +126,29 @@ export type ResumoDoDia = {
  * deixar rastro — e a taxa de acerto ficava sobre um denominador que encolheu
  * sozinho. Ver #323.
  *
- * `aguardando` e `semFixture` são separados de propósito. O primeiro é o
- * relógio e se resolve sozinho; o segundo é anomalia — pick publicado num jogo
- * que o calendário não trouxe — e é o que merece aparecer na tela e virar
- * sinal, em vez de sumir.
+ * `aguardando` e `semFixture` são separados por CAUSA, não por visibilidade:
+ * o primeiro é jogo adiado ou sem placar, o segundo é anomalia de catálogo. Os
+ * dois contam em `pendentes`, e é `pendentes` que a tela mostra — num dia
+ * passado, jogo que não liquidou some do resultado do mesmo jeito, e mostrar só
+ * um dos dois recria o defeito com outra causa.
  */
 export function resumoDoDia(linhas: readonly LinhaLiquidavel[]): ResumoDoDia {
   let hit = 0, miss = 0, push = 0, aguardando = 0, semFixture = 0;
   for (const l of linhas) {
     if (l.resultado == null) {
-      if (l.kickoff_utc == null) semFixture++;
-      else aguardando++;
+      if (l.temFixture) aguardando++;
+      else semFixture++;
       continue;
     }
     if (l.resultado === 'push') push++;
     else if (isHit(l.resultado)) hit++;
     else miss++;
   }
-  return { hit, miss, push, settled: hit + miss + push, aguardando, semFixture, total: linhas.length };
+  return {
+    hit, miss, push,
+    settled: hit + miss + push,
+    aguardando, semFixture,
+    pendentes: aguardando + semFixture,
+    total: linhas.length,
+  };
 }


### PR DESCRIPTION
Fecha #323.

## O problema

A issue tem duas metades. A da tela de Oportunidades já tinha sido corrigida — existe `fixtureScopesFor`, que lê o catálogo do mart e resolve a temporada pela janela. **A home ficou para trás**, com o padrão exato que a issue descreve: lista fixa de oito ligas e temporada 2026 cravada.

Sem o calendário da liga, o pick publicado aparece na tela com `kickoff_utc` e `status_short` nulos. Sem placar não há liquidação: a linha existe e é incapaz de fechar.

**Medido em produção em 02/09/2026:** dos 23 picks publicados nos últimos 90 dias, **5 estão em ligas fora da lista fixa** — Primeira Liga (2), Ligue 1 (1), Champions (1), Bundesliga (1). Os três de 29/08 que a issue relata são exatamente dois de Primeira Liga e um de Ligue 1. Confirmei também que `get_futebol_competitions` hoje traz as quatro ligas, em três temporadas cada, então o conserto cobre o caso reportado.

O comentário que estava acima da linha dizia "Todas as ligas do mart (data-driven), não mais um allowlist de 3" — com um array estático de oito slugs escritos à mão logo abaixo. Saiu junto.

## O segundo defeito, que a issue descreve mas não nomeia

O resumo do dia contava só linha **com** resultado. Por isso a manchete dizia "2 de 3 deram green" num dia de seis publicadas: o denominador encolhia sozinho e ninguém via.

`resumoDoDia` passa a separar o que liquidou, o que aguarda o jogo e o que não tem fixture. A tela mostra a pendência, e o bloco do resumo entra também quando **nada** liquidou mas houve pendência — senão o pior caso do defeito é justamente o que não aparece.

## O que o code-review mudou no desenho

Os dois eixos convergiram no mesmo defeito de fundo, cada um vendo uma metade.

`kickoff_utc` nulo **não** era o teste certo para "não tem fixture": linha vinda do board sempre traz horário, mesmo quando o calendário não trouxe aquele jogo — então ela caía em `aguardando` e a anomalia nunca acendia. Quem sabe é o mapa de fixtures, que a tela já tem. `temFixture` passou a ser dito, não inferido.

E mostrar só `semFixture` recriava o defeito com outra causa: num dia passado, jogo adiado tem fixture e não tem resultado, ficava invisível, e a manchete voltava a dizer "2 de 3" num dia de três. A tela mostra `pendentes`, que é a soma; a causa vai no sufixo, não no filtro de quem aparece.

## Observabilidade

O primeiro commit afirmava que o repositório não tinha canal de observabilidade. **Errado** — o PostHog está inicializado no `main.tsx` e é usado em oito lugares; a busca cobriu só `utils` e `lib`. O evento `futebol_pick_sem_fixture` existe agora, no idioma do repo (`usePostHog`), como a issue pedia.

## Testes

**Guarda de escopo** — nenhuma fonte fora do módulo dono percorre a lista fixa, e quem chama `useFutebolFixturesMulti` chamou `fixtureScopesFor`. Cobre todo `src`, não só arquivos com nome começando em "Futebol", e pega `flatMap`, `forEach`, spread e `for..of`, não só `.map`.

Ela ignora comentários antes de casar. Sem isso acusava o serviço, que documenta "useFutebolFixturesMulti (uma por liga, temporada inteira)" — o parêntese da prosa virava chamada. Guarda que acusa comentário ensina a apagar comentário.

Tem também um teste de que a varredura não está vazia: sem ele, um erro de caminho faria as duas guardas passarem sem olhar nada. E foi **verificada por mutação** — reintroduzindo a lista fixa na home, reprova.

**Regressão das registradas** — pick de Ligue 1 com fixture nasce liquidável e vai até o fim: Strasbourg 2 × 1 Lens com pick no mandante liquida como green. Sem fixture nasce cego, mas continua identificável, que é por que aparece na tela em vez de sumir.

**`resumoDoDia`** — incluindo o caso do jogo adiado, e a invariante de que nada some da conta.

## Estado

`tsc`, `eslint`, 450 testes e `build` verdes.

## O que ficou de fora, deliberadamente

O eixo Standards propôs extrair um hook compartilhado para as duas telas, já que a duplicação foi o que deixou uma cópia para trás e causou esta issue. Ele tem razão sobre a causa. Não entrou aqui porque as duas páginas subiram para produção hoje, e um refactor que toca as duas aumenta o raio de explosão sem consertar nada quebrado. A guarda cobre a recorrência, que era o papel dela. Vale uma issue própria depois da virada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
