### PR TITLE
feat(futebol): navegação por link — clique do meio abre em nova aba

### DIFF
--- a/src/components/futebol/ChaveamentoBracket.tsx
+++ b/src/components/futebol/ChaveamentoBracket.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Maximize2, Minus, Plus, RotateCcw, X } from 'lucide-react';
 import { Crest } from './Crest';
@@ -125,11 +126,11 @@ function LadoDoConfronto({ lado, c }: { lado: Lado; c: Confronto }) {
   );
 }
 
-function CardConfronto({ c, onJogo }: { c: Confronto; onJogo: (id: number) => void }) {
+function CardConfronto({ c, hrefDoJogo }: { c: Confronto; hrefDoJogo: (id: number) => string }) {
   const ultimo = c.jogos[c.jogos.length - 1];
   return (
-    <button
-      onClick={() => ultimo && onJogo(ultimo.fixture_id)}
+    <Link
+      to={ultimo ? hrefDoJogo(ultimo.fixture_id) : '#'}
       className="w-full text-left rounded-rebrand-sm overflow-hidden bg-white hover:shadow-sm transition"
       style={{ border: '1px solid #ded2b6' }}
       title={c.jogos.length > 1 ? 'ida e volta somadas' : undefined}
@@ -137,7 +138,7 @@ function CardConfronto({ c, onJogo }: { c: Confronto; onJogo: (id: number) => vo
       <LadoDoConfronto lado={c.a} c={c} />
       <div style={{ height: 1, background: '#f1e9d6' }} />
       <LadoDoConfronto lado={c.b} c={c} />
-    </button>
+    </Link>
   );
 }
 
@@ -212,11 +213,12 @@ function useArrastarParaRolar() {
 /** A chave em si. Mesma marcação no card e na tela cheia; muda só a largura. */
 function Chave({
   colunas,
-  onJogo,
+  hrefDoJogo,
   largura,
 }: {
   colunas: Coluna[];
-  onJogo: (id: number) => void;
+  /** O endereço da tela do jogo. Destino de link, não ação (#341). */
+  hrefDoJogo: (id: number) => string;
   largura: number;
 }) {
   return (
@@ -233,7 +235,7 @@ function Chave({
             </div>
             <div className="flex-1 flex flex-col justify-around gap-1.5">
               {col.confrontos.map((c) => (
-                <CardConfronto key={c.chave} c={c} onJogo={onJogo} />
+                <CardConfronto key={c.chave} c={c} hrefDoJogo={hrefDoJogo} />
               ))}
               {Array.from({ length: vagos }).map((_, i) => (
                 <CardVago key={i} />
@@ -252,12 +254,13 @@ const MAX_ESCALA = 2.2;
 /** Pop-up com zoom e arrasto, pra chave grande caber no olho. */
 function ChaveExpandida({
   colunas,
-  onJogo,
+  hrefDoJogo,
   onFechar,
   titulo,
 }: {
   colunas: Coluna[];
-  onJogo: (id: number) => void;
+  /** O endereço da tela do jogo. Destino de link, não ação (#341). */
+  hrefDoJogo: (id: number) => string;
   onFechar: () => void;
   titulo: string;
 }) {
@@ -489,7 +492,7 @@ function ChaveExpandida({
           className="p-6 origin-top-left w-max"
           style={{ transform: `translate(${pos.x}px, ${pos.y}px) scale(${escala})` }}
         >
-          <Chave colunas={colunas} onJogo={onJogo} largura={190} />
+          <Chave colunas={colunas} hrefDoJogo={hrefDoJogo} largura={190} />
         </div>
       </div>
       </div>
@@ -502,13 +505,14 @@ export function ChaveamentoBracket({
   rounds,
   idxSelecionado,
   competition,
-  onJogo,
+  hrefDoJogo,
 }: {
   fixtures: FutebolFixture[];
   rounds: string[];
   idxSelecionado: number;
   competition: string;
-  onJogo: (fixtureId: number) => void;
+  /** O endereço da tela do jogo. Destino de link, não ação (#341). */
+  hrefDoJogo: (fixtureId: number) => string;
 }) {
   const [expandido, setExpandido] = useState(false);
   const puxar = useArrastarParaRolar();
@@ -602,7 +606,7 @@ export function ChaveamentoBracket({
               {...puxar.handlers}
               className="p-3 overflow-auto minimal-scrollbar max-h-[460px] cursor-grab active:cursor-grabbing select-none"
             >
-              <Chave colunas={colunas} onJogo={onJogo} largura={158} />
+              <Chave colunas={colunas} hrefDoJogo={hrefDoJogo} largura={158} />
             </div>
             <div
               className="px-4 py-2 text-[10.5px] leading-relaxed"
@@ -616,7 +620,7 @@ export function ChaveamentoBracket({
       </div>
 
       {expandido && (
-        <ChaveExpandida colunas={colunas} onJogo={onJogo} onFechar={() => setExpandido(false)} titulo={titulo} />
+        <ChaveExpandida colunas={colunas} hrefDoJogo={hrefDoJogo} onFechar={() => setExpandido(false)} titulo={titulo} />
       )}
     </>
   );

--- a/src/components/futebol/FixtureRow.test.tsx
+++ b/src/components/futebol/FixtureRow.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
 import { FixtureRow } from './FixtureRow';
 import type { FutebolFixture } from '@/services/futebol-data.service';
 
@@ -26,9 +27,22 @@ const jogo = {
   goals_away: null,
 } as unknown as FutebolFixture;
 
+// A linha virou `<Link>` (#341), para o clique do meio abrir a tela do jogo em
+// outra aba. Isso exige um Router em volta — não é acoplamento novo do
+// componente ao roteador, é o preço de a linha ser um link de verdade em vez de
+// um botão que finge navegar.
 function renderLinha(props: Partial<Parameters<typeof FixtureRow>[0]> = {}) {
   return render(
-    <FixtureRow fixture={jogo} best={null} leituraCarregando={false} onClick={vi.fn()} {...props} />,
+    <MemoryRouter>
+      <FixtureRow
+        fixture={jogo}
+        best={null}
+        leituraCarregando={false}
+        to={`/futebol/jogo/${jogo.fixture_id}`}
+        onClick={vi.fn()}
+        {...props}
+      />
+    </MemoryRouter>,
   );
 }
 

--- a/src/components/futebol/FixtureRow.tsx
+++ b/src/components/futebol/FixtureRow.tsx
@@ -1,6 +1,8 @@
 import { Crest } from './Crest';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Link } from 'react-router-dom';
 import { fmtTime, isFinished, isLive } from '@/utils/futebol-datas';
+import { interceptarCliqueSimples } from '@/utils/navegacao-por-link';
 import { chancePct, ehDestaque, ehFaixaAlta, marketShort, pickLabel } from '@/utils/futebol-score';
 import { settleFutebol, isHit } from '@/utils/futebol-settlement';
 import type { FutebolFixture, FutebolValueBoardRow } from '@/services/futebol-data.service';
@@ -29,6 +31,7 @@ export function FixtureRow({
   best,
   leituraCarregando,
   selected = false,
+  to,
   onClick,
 }: {
   fixture: FutebolFixture;
@@ -45,6 +48,15 @@ export function FixtureRow({
    */
   leituraCarregando: boolean;
   selected?: boolean;
+  /**
+   * Para onde o NAVEGADOR leva: a tela do jogo.
+   *
+   * O clique simples não chega lá — ele é interceptado e abre o painel lateral.
+   * Mas o clique do meio, o Ctrl+clique e o «abrir em nova aba» do botão direito
+   * escapam do intercepto e usam este destino. É o comportamento pedido na #341:
+   * na aba nova o usuário quer o jogo inteiro, não a lista com o painel aberto.
+   */
+  to: string;
   onClick: () => void;
 }) {
   const fim = isFinished(fixture.status_short);
@@ -74,8 +86,9 @@ export function FixtureRow({
   const bateu = liquidacao != null ? isHit(liquidacao) : null;
 
   return (
-    <button
-      onClick={onClick}
+    <Link
+      to={to}
+      onClick={interceptarCliqueSimples(onClick)}
       aria-current={selected ? 'true' : undefined}
       className="w-full text-left px-3 sm:px-4 py-2.5 flex items-center gap-2.5 sm:gap-3.5 transition"
       style={{
@@ -178,6 +191,6 @@ export function FixtureRow({
         {!best ? '—' : bateu != null ? (bateu ? '✓' : '✕') : best.score}
       </div>
       )}
-    </button>
+    </Link>
   );
 }

--- a/src/components/futebol/FixtureRow.tsx
+++ b/src/components/futebol/FixtureRow.tsx
@@ -57,7 +57,15 @@ export function FixtureRow({
    * na aba nova o usuário quer o jogo inteiro, não a lista com o painel aberto.
    */
   to: string;
-  onClick: () => void;
+  /**
+   * O que o clique SIMPLES faz, quando não é ir para `to`.
+   *
+   * Opcional de propósito. Sem ele, o `<Link>` navega sozinho e o clique simples
+   * leva ao mesmo lugar que o clique do meio — que é o caso da maioria das
+   * telas. Passá-lo apontando para o próprio `to` seria cancelar o link para
+   * refazer à mão o que ele já faria.
+   */
+  onClick?: () => void;
 }) {
   const fim = isFinished(fixture.status_short);
   const live = isLive(fixture.status_short);
@@ -88,7 +96,7 @@ export function FixtureRow({
   return (
     <Link
       to={to}
-      onClick={interceptarCliqueSimples(onClick)}
+      onClick={onClick && interceptarCliqueSimples(onClick)}
       aria-current={selected ? 'true' : undefined}
       className="w-full text-left px-3 sm:px-4 py-2.5 flex items-center gap-2.5 sm:gap-3.5 transition"
       style={{

--- a/src/components/futebol/GruposFase.tsx
+++ b/src/components/futebol/GruposFase.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { useMemo } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Crest } from './Crest';
@@ -24,13 +25,14 @@ function nomeDoGrupo(g: string): string {
 export function GruposFase({
   rows,
   loading,
-  onTeam,
+  hrefDoTime,
   /** Quantos passam de fase. Só pinta a barra verde, não inventa critério. */
   classificados = 2,
 }: {
   rows?: FutebolStandingRow[];
   loading: boolean;
-  onTeam: (id: number) => void;
+  /** O endereço da página do time. Destino de link, não ação (#341). */
+  hrefDoTime: (id: number) => string;
   classificados?: number;
 }) {
   const grupos = useMemo(() => {
@@ -103,9 +105,9 @@ export function GruposFase({
               const passa = r.rank <= classificados;
               const sg = r.goals_diff > 0 ? `+${r.goals_diff}` : r.goals_diff < 0 ? `−${Math.abs(r.goals_diff)}` : '0';
               return (
-                <button
+                <Link
                   key={r.team_id}
-                  onClick={() => onTeam(r.team_id)}
+                  to={hrefDoTime(r.team_id)}
                   className="w-full text-left px-4 py-1.5 grid grid-cols-[22px_1fr_22px_30px_30px] gap-2 items-center hover:bg-canvas-2 transition"
                   style={{ borderTop: '1px solid #f1e9d6' }}
                 >
@@ -134,7 +136,7 @@ export function GruposFase({
                     {sg}
                   </span>
                   <span className="text-center text-[12.5px] font-bold tabular-nums text-ink">{r.points}</span>
-                </button>
+                </Link>
               );
             })}
           </div>

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -232,9 +232,12 @@ export function JogoResumoPanel({
         {/* O título leva à tela do jogo (#341). Era o único caminho para lá que
             não existia: o painel só tinha o botão do rodapé, que fica abaixo da
             dobra em painel comprido. */}
+        {/* `py-1.5 -my-1.5` dá 24px de altura de alvo sem empurrar o cabeçalho:
+            o texto tem 13,5px e sozinho ficava em ~18px, abaixo do mínimo de
+            alvo de clique. A margem negativa devolve o espaço ao layout. */}
         <Link
           to={`/futebol/jogo/${fixture.fixture_id}`}
-          className="text-[13.5px] font-semibold tracking-tight text-ink truncate hover:underline"
+          className="text-[13.5px] font-semibold tracking-tight text-ink truncate hover:underline py-1.5 -my-1.5"
           title="Abrir a tela do jogo"
         >
           {fixture.home_team_name} × {fixture.away_team_name}

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -229,9 +229,16 @@ export function JogoResumoPanel({
         style={{ background: 'var(--canvas-2)', borderBottom: '1px solid #ded2b6' }}
       >
         <Crest name={fixture.home_team_name} id={fixture.home_team_id} size={20} />
-        <span className="text-[13.5px] font-semibold tracking-tight text-ink truncate">
+        {/* O título leva à tela do jogo (#341). Era o único caminho para lá que
+            não existia: o painel só tinha o botão do rodapé, que fica abaixo da
+            dobra em painel comprido. */}
+        <Link
+          to={`/futebol/jogo/${fixture.fixture_id}`}
+          className="text-[13.5px] font-semibold tracking-tight text-ink truncate hover:underline"
+          title="Abrir a tela do jogo"
+        >
           {fixture.home_team_name} × {fixture.away_team_name}
-        </span>
+        </Link>
         <Crest name={fixture.away_team_name} id={fixture.away_team_id} size={20} />
         <span className="text-[11px] truncate" style={{ color: '#8d8672' }}>
           {fim || live

--- a/src/components/futebol/StandingsTable.tsx
+++ b/src/components/futebol/StandingsTable.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { useMemo, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -60,12 +61,13 @@ function blocos(rows: FutebolStandingRow[]): Bloco[] {
 
 function Linha({
   r,
-  onTeam,
+  hrefDoTime,
   cor,
   compacto,
 }: {
   r: FutebolStandingRow;
-  onTeam: (id: number) => void;
+  /** O endereço da página do time. Destino de link, não ação (#341). */
+  hrefDoTime: (id: number) => string;
   cor: string | null;
   compacto: boolean;
 }) {
@@ -74,8 +76,8 @@ function Linha({
   const num = 'text-center text-[11.5px] tabular-nums';
 
   return (
-    <button
-      onClick={() => onTeam(r.team_id)}
+    <Link
+      to={hrefDoTime(r.team_id)}
       className={`w-full text-left px-3 sm:px-4 py-2 hover:bg-canvas-2 transition ${compacto ? GRID_M : GRID}`}
       style={{ borderTop: '1px solid #f1e9d6' }}
     >
@@ -98,21 +100,22 @@ function Linha({
       {!compacto && <span className={num} style={{ color: '#6b6350' }}>{r.loses}</span>}
       <span className={num} style={{ color: sgCor }}>{sgTexto}</span>
       <span className="text-center text-[13.5px] font-bold tabular-nums text-ink">{r.points}</span>
-    </button>
+    </Link>
   );
 }
 
 export function StandingsTable({
   rows,
   loading,
-  onTeam,
+  hrefDoTime,
   compacto = false,
   legenda,
   vazio,
 }: {
   rows?: FutebolStandingRow[];
   loading: boolean;
-  onTeam: (id: number) => void;
+  /** O endereço da página do time. Destino de link, não ação (#341). */
+  hrefDoTime: (id: number) => string;
   /** Mobile: esconde V, E e D, que não cabem em 390px. */
   compacto?: boolean;
   /** Texto do canto direito do cabeçalho, ex.: "após 22 rodadas". */
@@ -216,7 +219,7 @@ export function StandingsTable({
 
             {!escondido &&
               g.linhas.map((r) => (
-                <Linha key={r.team_id} r={r} onTeam={onTeam} cor={g.zona?.cor ?? null} compacto={compacto} />
+                <Linha key={r.team_id} r={r} hrefDoTime={hrefDoTime} cor={g.zona?.cor ?? null} compacto={compacto} />
               ))}
           </div>
         );

--- a/src/components/onboarding/demo/futebol.ts
+++ b/src/components/onboarding/demo/futebol.ts
@@ -50,7 +50,6 @@ const base = (versao: FutebolScoreVersion, over: Partial<FutebolValueBoardRow>):
   pts_corroboracao: 0,
   penalidades: 0,
   score: 50,
-  faixa: 'Média',
   evidencias: [],
   ...over,
   score_versao: versao,

--- a/src/pages/FutebolCampeonato.tsx
+++ b/src/pages/FutebolCampeonato.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { CalendarDays, ChevronDown } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -89,7 +89,6 @@ function Estatistica({ rotulo, valor, unidade }: { rotulo: string; valor: string
 }
 
 export default function FutebolCampeonato() {
-  const navigate = useNavigate();
   const { slug } = useParams<{ slug: string }>();
   const [params, setParams] = useSearchParams();
 
@@ -266,7 +265,8 @@ export default function FutebolCampeonato() {
     [rounds.length, porPontos, duasColunas],
   );
 
-  const goTeam = (id: number) => navigate(`/futebol/time/${id}?c=${competition}&s=${season}`);
+  /** O endereço da página do time, com a liga e a temporada em que ele foi visto. */
+  const hrefDoTime = (id: number) => `/futebol/time/${id}?c=${competition}&s=${season}`;
   const setSeason = (s: number) => setParams({ s: String(s) }, { replace: true });
 
   const listaJogos = (
@@ -314,11 +314,9 @@ export default function FutebolCampeonato() {
                   fixture={f}
                   best={bestByFixture.get(f.fixture_id) ?? null}
                   leituraCarregando={leituraCarregando}
+                  // Sem `onClick`: aqui não há painel, então o clique simples vai
+                  // para o mesmo lugar que o do meio e o `<Link>` basta.
                   to={`/futebol/jogo/${f.fixture_id}`}
-                  // Aqui não há painel: o clique simples vai para o mesmo lugar
-                  // que o `to`. O `<Link>` resolve sozinho, e o intercepto só
-                  // devolve a navegação ao roteador.
-                  onClick={() => navigate(`/futebol/jogo/${f.fixture_id}`)}
                 />
               ))}
             </div>
@@ -351,15 +349,15 @@ export default function FutebolCampeonato() {
         rounds={rounds}
         idxSelecionado={roundIdx}
         competition={competition}
-        onJogo={(id) => navigate(`/futebol/jogo/${id}`)}
+        hrefDoJogo={(id) => `/futebol/jogo/${id}`}
       />
     ) : null;
-  const grupos = <GruposFase rows={standings} loading={loadingStandings} onTeam={goTeam} />;
+  const grupos = <GruposFase rows={standings} loading={loadingStandings} hrefDoTime={hrefDoTime} />;
   const tabela = (
     <StandingsTable
       rows={standings}
       loading={loadingStandings}
-      onTeam={goTeam}
+      hrefDoTime={hrefDoTime}
       legenda={legendaTabela}
       vazio={vazioTabela}
     />
@@ -419,12 +417,15 @@ export default function FutebolCampeonato() {
                   </div>
                   <div className="max-h-[320px] overflow-y-auto minimal-scrollbar">
                     {ligas.map((c, i) => (
-                      <button
+                      <Link
                         key={c}
-                        onClick={() => {
-                          setMenuLiga(false);
-                          navigate(`/futebol/campeonato/${c}`);
-                        }}
+                        to={`/futebol/campeonato/${c}`}
+                        // Fechar o menu é efeito colateral da escolha, não a
+                        // navegação em si — por isso não interceptamos: o
+                        // `<Link>` navega e o menu fecha junto. No clique do meio
+                        // o menu também fecha, o que é o certo: a aba nova levou
+                        // a escolha e esta aqui volta ao estado neutro (#341).
+                        onClick={() => setMenuLiga(false)}
                         className="w-full px-3.5 py-2.5 flex items-center gap-2.5 text-left"
                         style={{
                           background: c === competition ? '#f4eddc' : '#fff',
@@ -437,7 +438,7 @@ export default function FutebolCampeonato() {
                         >
                           {competitionLabel(c)}
                         </span>
-                      </button>
+                      </Link>
                     ))}
                   </div>
                 </PopoverContent>
@@ -595,7 +596,7 @@ export default function FutebolCampeonato() {
                   <StandingsTable
                     rows={standings}
                     loading={loadingStandings}
-                    onTeam={goTeam}
+                    hrefDoTime={hrefDoTime}
                     compacto
                     legenda={legendaTabela}
                     vazio={vazioTabela}

--- a/src/pages/FutebolCampeonato.tsx
+++ b/src/pages/FutebolCampeonato.tsx
@@ -314,6 +314,10 @@ export default function FutebolCampeonato() {
                   fixture={f}
                   best={bestByFixture.get(f.fixture_id) ?? null}
                   leituraCarregando={leituraCarregando}
+                  to={`/futebol/jogo/${f.fixture_id}`}
+                  // Aqui não há painel: o clique simples vai para o mesmo lugar
+                  // que o `to`. O `<Link>` resolve sozinho, e o intercepto só
+                  // devolve a navegação ao roteador.
                   onClick={() => navigate(`/futebol/jogo/${f.fixture_id}`)}
                 />
               ))}

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Zap, ArrowRight, Check, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Seo } from '@/components/Seo';
@@ -90,7 +90,7 @@ function HeroStat({ label, value, dark, locked, ajuda }: { label: string; value:
 
 // ── Hero: melhor valor do dia — 3 colunas (pick · por quê · confiab). ────────
 // Alta = gradiente forest (texto branco); Média = card claro com acento âmbar.
-function TopValueHero({ o, onClick, favor, contra, textoScore, locked, carregandoMotivos = false }: { o: FutebolValueBoardRow; onClick: () => void; favor: Motivo[]; contra: Motivo[]; textoScore: string; locked?: boolean; carregandoMotivos?: boolean }) {
+function TopValueHero({ o, to, favor, contra, textoScore, locked, carregandoMotivos = false }: { o: FutebolValueBoardRow; to: string; favor: Motivo[]; contra: Motivo[]; textoScore: string; locked?: boolean; carregandoMotivos?: boolean }) {
   const pick = pickLabel(o, o.home_team_name, o.away_team_name);
   const ev = topEvidencia(o.evidencias);
   const d = true; // hero sempre no fundo forest (mockup); a faixa vai no selo, não na cor do card
@@ -125,10 +125,10 @@ function TopValueHero({ o, onClick, favor, contra, textoScore, locked, carregand
             </span>
             <span className="opacity-70"><span className="hidden sm:inline">· </span>{fmtDayTime(o.kickoff_utc)}</span>
           </div>
-          <button onClick={onClick} className={`h-11 px-5 mt-5 w-fit rounded-md text-[13px] font-semibold inline-flex items-center gap-2 ${d ? '' : 'bg-ink text-canvas hover:bg-ink-2'} transition`}
+          <Link to={to} className={`h-11 px-5 mt-5 w-fit rounded-md text-[13px] font-semibold inline-flex items-center gap-2 ${d ? '' : 'bg-ink text-canvas hover:bg-ink-2'} transition`}
             style={d ? { background: '#fbbf24', color: '#1a1d1a' } : undefined}>
             Abrir análise do jogo <ArrowRight className="w-4 h-4" />
-          </button>
+          </Link>
         </div>
 
         {/* Meio — o que sustenta e o que pesa contra.
@@ -223,11 +223,11 @@ function TopValueHero({ o, onClick, favor, contra, textoScore, locked, carregand
 }
 
 // ── Card de oportunidade ───────────────────────────────────
-function OppCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClick: () => void; locked?: boolean }) {
+function OppCard({ o, to, locked }: { o: FutebolValueBoardRow; to: string; locked?: boolean }) {
   const pick = pickLabel(o, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
   return (
-    <button onClick={onClick} className={`${CARD} p-4 text-left hover:shadow-sm hover:border-line-2 transition w-full`}>
+    <Link to={to} className={`${CARD} block p-4 text-left hover:shadow-sm hover:border-line-2 transition w-full`}>
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-1.5">
           <span className="px-1.5 h-5 inline-flex items-center rounded text-[10px] font-semibold uppercase tracking-[0.1em] bg-canvas-2 text-ink-2">{marketLabel(o.market)}</span>
@@ -259,15 +259,15 @@ function OppCard({ o, onClick, locked }: { o: FutebolValueBoardRow; onClick: () 
           <div className="text-[15px] font-bold tabular-nums text-forest mt-0.5"><Blur active={!!locked}>{fmtEdgeScore(o.edge)}</Blur></div>
         </div>
       </div>
-    </button>
+    </Link>
   );
 }
 
 // ── Linha de jogo (rail) ───────────────────────────────────
-function GameRailRow({ f, best, onClick }: { f: FutebolFixture & { competition?: string }; best: FutebolValueBoardRow | null; onClick: () => void }) {
+function GameRailRow({ f, best, to }: { f: FutebolFixture & { competition?: string }; best: FutebolValueBoardRow | null; to: string }) {
   const finished = isFinished(f.status_short);
   return (
-    <button onClick={onClick} style={finished ? { background: 'var(--canvas-2)' } : undefined} className="w-full flex items-center gap-2.5 px-4 py-3 border-t border-line first:border-t-0 hover:bg-canvas-2 transition text-left">
+    <Link to={to} style={finished ? { background: 'var(--canvas-2)' } : undefined} className="w-full flex items-center gap-2.5 px-4 py-3 border-t border-line first:border-t-0 hover:bg-canvas-2 transition text-left">
       <span className={`w-10 text-[11px] font-semibold tabular-nums shrink-0 ${finished ? 'text-ink-3 uppercase tracking-wide' : 'text-ink-2'}`}>{finished ? 'fim' : fmtTime(f.kickoff_utc)}</span>
       <div className="flex items-center gap-1.5 min-w-0 flex-1">
         <Crest teamId={f.home_team_id} name={f.home_team_name} size={20} />
@@ -283,12 +283,11 @@ function GameRailRow({ f, best, onClick }: { f: FutebolFixture & { competition?:
       {best ? (
         <span className={`text-[10px] font-bold rounded px-1.5 py-0.5 shrink-0 tabular-nums ${faixaBadgeCls(best.faixa)}`} title="Score de Confiabilidade">{best.score}</span>
       ) : null}
-    </button>
+    </Link>
   );
 }
 
 export default function FutebolHoje() {
-  const navigate = useNavigate();
   // UM instante para a tela inteira, e ele anda: o seletor de dias, o corte de
   // "já começou" e a janela do calendário têm que concordar sobre que horas são.
   const agora = useNow();
@@ -573,7 +572,7 @@ export default function FutebolHoje() {
         {loading ? (
           <Skeleton className="h-64 w-full bg-canvas-2 rounded-2xl" />
         ) : heroOpp ? (
-          <TopValueHero o={heroOpp} favor={heroFavor} contra={heroContra} carregandoMotivos={carregandoMotivos} textoScore={textoScore} onClick={() => navigate(`/futebol/jogo/${heroOpp.fixture_id}`)} locked={locked} />
+          <TopValueHero o={heroOpp} favor={heroFavor} contra={heroContra} carregandoMotivos={carregandoMotivos} textoScore={textoScore} to={`/futebol/jogo/${heroOpp.fixture_id}`} locked={locked} />
         ) : (
           <div className={`${CARD} p-6 flex items-start gap-3`}>
             <Zap className="w-5 h-5 text-ink-3 mt-0.5 shrink-0" />
@@ -595,15 +594,15 @@ export default function FutebolHoje() {
                 <div className={LABEL}>Mais oportunidades</div>
                 <div className="text-lg font-bold tracking-tight text-ink mt-0.5">Por confiabilidade</div>
               </div>
-              <button onClick={() => navigate('/futebol/oportunidades')} className="text-[12px] font-semibold inline-flex items-center gap-1 text-forest hover:text-forest-2">
+              <Link to="/futebol/oportunidades" className="text-[12px] font-semibold inline-flex items-center gap-1 text-forest hover:text-forest-2">
                 Ver todas <ArrowRight className="w-3.5 h-3.5" />
-              </button>
+              </Link>
             </div>
             {loading ? (
               <div className="grid sm:grid-cols-2 gap-4">{Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-40 w-full bg-canvas-2 rounded-rebrand-md" />)}</div>
             ) : moreOpps.length > 0 ? (
               <div className="grid sm:grid-cols-2 gap-4">
-                {moreOpps.map((o) => <OppCard key={`${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`} o={o} onClick={() => navigate(`/futebol/jogo/${o.fixture_id}`)} locked={locked} />)}
+                {moreOpps.map((o) => <OppCard key={`${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`} o={o} to={`/futebol/jogo/${o.fixture_id}`} locked={locked} />)}
               </div>
             ) : (
               <div className={`${CARD} p-6 text-center text-sm text-ink-3`}>Sem outras oportunidades relevantes agora.</div>
@@ -616,16 +615,16 @@ export default function FutebolHoje() {
                 <div className={LABEL}>{isToday ? 'Jogos de hoje' : 'Jogos do dia'}</div>
                 <div className="text-lg font-bold tracking-tight text-ink mt-0.5">{gameList.length} partida{gameList.length === 1 ? '' : 's'}</div>
               </div>
-              <button onClick={() => navigate('/futebol/jogos')} className="text-[12px] font-semibold inline-flex items-center gap-1 text-forest hover:text-forest-2">
+              <Link to="/futebol/jogos" className="text-[12px] font-semibold inline-flex items-center gap-1 text-forest hover:text-forest-2">
                 Ver todos <ArrowRight className="w-3.5 h-3.5" />
-              </button>
+              </Link>
             </div>
             {loading ? (
               <Skeleton className="h-64 w-full bg-canvas-2 rounded-rebrand-md" />
             ) : gameList.length > 0 ? (
               <div className={`${CARD} overflow-hidden`}>
                 {gameList.map((f) => (
-                  <GameRailRow key={f.fixture_id} f={f} best={bestByFixture.get(f.fixture_id) ?? null} onClick={() => navigate(`/futebol/jogo/${f.fixture_id}`)} />
+                  <GameRailRow key={f.fixture_id} f={f} best={bestByFixture.get(f.fixture_id) ?? null} to={`/futebol/jogo/${f.fixture_id}`} />
                 ))}
               </div>
             ) : (

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { ArrowRight, ArrowUpRight, CalendarOff, ChevronDown } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -73,7 +73,6 @@ function monthRange(dayKey: string): { from: string; to: string } {
 const DIA_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 export default function FutebolJogos() {
-  const navigate = useNavigate();
   const hasPanel = useHasPanel();
   const [params, setParams] = useSearchParams();
 
@@ -175,11 +174,15 @@ export default function FutebolJogos() {
     setParams({ dia: d }, { replace: true });
   };
 
-  const openJogo = (f: FutebolFixtureByDay) => {
-    if (!hasPanel) {
-      navigate(`/futebol/jogo/${f.fixture_id}`);
-      return;
-    }
+  /**
+   * O que o clique SIMPLES faz na linha: abrir o painel.
+   *
+   * Só existe quando há painel. Em tela estreita não há, e aí não interceptamos
+   * nada — o `<Link>` da linha navega sozinho para a tela do jogo, que é o mesmo
+   * destino do clique do meio. A versão anterior cancelava o link para chamar
+   * `navigate` na mesma URL do `href`, o que funcionava e não servia para nada.
+   */
+  const abrirPainel = (f: FutebolFixtureByDay) => {
     // push: o voltar do navegador fecha o painel, que é o que o usuário espera.
     setParams({ dia, jogo: String(f.fixture_id) });
   };
@@ -334,7 +337,7 @@ export default function FutebolJogos() {
                               leituraCarregando={leituraCarregando}
                               selected={f.fixture_id === jogoParam}
                               to={`/futebol/jogo/${f.fixture_id}`}
-                              onClick={() => openJogo(f)}
+                              onClick={hasPanel ? () => abrirPainel(f) : undefined}
                             />
                           ))}
                       </div>

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -333,6 +333,7 @@ export default function FutebolJogos() {
                               best={bestByFixture.get(f.fixture_id) ?? null}
                               leituraCarregando={leituraCarregando}
                               selected={f.fixture_id === jogoParam}
+                              to={`/futebol/jogo/${f.fixture_id}`}
                               onClick={() => openJogo(f)}
                             />
                           ))}

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -500,7 +500,7 @@ export default function FutebolOportunidades() {
   // saídas cotadas no mesmo mercado. Navegando só com o id do jogo, clicar no card
   // da segunda abria a tela na primeira, e o pick que o usuário leu aqui virava
   // outro lá. O link carrega qual card foi clicado.
-  /** A URL da saída clicada. Vira  de link, não argumento de navigate (#341). */
+  /** A URL da saída clicada: destino de link, não argumento de navigate (#341). */
   const hrefDoJogo = (o: OppLike) => {
     const q = new URLSearchParams({ mercado: o.market, saida: o.outcome });
     if (o.line_value != null) q.set('linha', String(o.line_value));

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useEffect } from 'react';
 import { usePostHog } from '@posthog/react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { ChevronRight, AlertTriangle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -65,8 +65,8 @@ const LABEL = 'text-[10px] uppercase tracking-[0.14em] font-bold text-ink-3';
 const GRID = 'grid grid-cols-[56px_64px_1fr_140px_64px_80px_72px_28px] gap-3 items-center';
 
 // Linha da tabela (desktop)
-function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
-  o: OppLike; onClick: () => void; muted?: boolean; locked?: boolean;
+function OppRow({ o, to, muted, locked, result, homeGoals, awayGoals }: {
+  o: OppLike; to: string; muted?: boolean; locked?: boolean;
   result?: BetResult | null; homeGoals?: number | null; awayGoals?: number | null;
 }) {
   const pick = pickLabel(o, o.home_team_name, o.away_team_name);
@@ -77,7 +77,7 @@ function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
   // chutar faixa (faixaWord de vazio diria "Baixa", que seria falso).
   const badgeCls = o.faixa != null ? faixaBadgeCls(o.faixa) : 'bg-canvas-2 text-ink-3 border border-line';
   return (
-    <button onClick={onClick} className={`${GRID} w-full text-left px-5 py-3 border-t border-line hover:bg-canvas-2 transition ${muted ? 'opacity-60' : ''}`}>
+    <Link to={to} className={`${GRID} w-full text-left px-5 py-3 border-t border-line hover:bg-canvas-2 transition ${muted ? 'opacity-60' : ''}`}>
       <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[16px] w-10 h-9 ${badgeCls}`}>{o.score ?? '—'}</span>
       <span className={`px-1.5 h-5 w-fit inline-flex items-center rounded text-[10px] font-bold uppercase tracking-[0.1em] ${badgeCls}`}>{o.faixa != null ? faixaWord(o.faixa) : '—'}</span>
       <div className="flex items-center gap-2.5 min-w-0">
@@ -105,13 +105,13 @@ function OppRow({ o, onClick, muted, locked, result, homeGoals, awayGoals }: {
       <div className="text-right tabular-nums text-[13px] font-semibold text-ink"><Blur active={showLock}>{o.best_odd.toFixed(2)}</Blur></div>
       <div className={`text-right tabular-nums text-[14px] font-bold ${edgeToneCls(o.edge)}`}><Blur active={showLock}>{o.edge != null ? fmtEdgeScore(o.edge) : '—'}</Blur></div>
       <ChevronRight className="w-4 h-4 text-ink-3 justify-self-end" />
-    </button>
+    </Link>
   );
 }
 
 // Card (mobile)
-function OppMobileCard({ o, onClick, locked, result, homeGoals, awayGoals, canRegister = false }: {
-  o: OppLike; onClick: () => void; locked?: boolean;
+function OppMobileCard({ o, to, locked, result, homeGoals, awayGoals, canRegister = false }: {
+  o: OppLike; to: string; locked?: boolean;
   result?: BetResult | null; homeGoals?: number | null; awayGoals?: number | null; canRegister?: boolean;
 }) {
   const pick = pickLabel(o, o.home_team_name, o.away_team_name);
@@ -120,7 +120,7 @@ function OppMobileCard({ o, onClick, locked, result, homeGoals, awayGoals, canRe
   const hasScore = homeGoals != null && awayGoals != null;
   return (
     <div className="w-full rounded-rebrand-md bg-white border border-line overflow-hidden">
-      <button onClick={onClick} className="w-full text-left p-3.5">
+      <Link to={to} className="block w-full text-left p-3.5">
         <div className="flex items-start gap-3">
           <div className="flex items-center -space-x-1 shrink-0 pt-0.5">
             <Crest teamId={o.home_team_id} name={o.home_team_name} size={24} />
@@ -161,7 +161,7 @@ function OppMobileCard({ o, onClick, locked, result, homeGoals, awayGoals, canRe
             </div>
           ))}
         </div>
-      </button>
+      </Link>
       {canRegister && (
         <div className="px-3.5 pb-3.5 -mt-0.5">
           <RegistrarApostaCTA variant="text" draft={draftFromBoardRow(o)} />
@@ -500,10 +500,11 @@ export default function FutebolOportunidades() {
   // saídas cotadas no mesmo mercado. Navegando só com o id do jogo, clicar no card
   // da segunda abria a tela na primeira, e o pick que o usuário leu aqui virava
   // outro lá. O link carrega qual card foi clicado.
-  const go = (o: OppLike) => {
+  /** A URL da saída clicada. Vira  de link, não argumento de navigate (#341). */
+  const hrefDoJogo = (o: OppLike) => {
     const q = new URLSearchParams({ mercado: o.market, saida: o.outcome });
     if (o.line_value != null) q.set('linha', String(o.line_value));
-    navigate(`/futebol/jogo/${o.fixture_id}?${q}`);
+    return `/futebol/jogo/${o.fixture_id}?${q}`;
   };
   const key = (o: OppLike) => `${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`;
 
@@ -657,7 +658,7 @@ export default function FutebolOportunidades() {
                 const g = goalsMap.get(o.fixture_id);
                 return (
                   <div key={key(o)}>
-                    <OppRow o={o} onClick={() => go(o)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
+                    <OppRow o={o} to={hrefDoJogo(o)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
                     {!isPastDay && !locked && !res && (
                       <div className="px-5 pb-2 -mt-0.5">
                         <RegistrarApostaCTA variant="text" draft={draftFromBoardRow(o)} />
@@ -677,7 +678,7 @@ export default function FutebolOportunidades() {
                   <OppMobileCard
                     key={key(o)}
                     o={o}
-                    onClick={() => go(o)}
+                    to={hrefDoJogo(o)}
                     locked={locked}
                     result={res}
                     homeGoals={g?.gh}

--- a/src/utils/futebol-score.ts
+++ b/src/utils/futebol-score.ts
@@ -9,6 +9,11 @@ import { linhaDaSaida, type Saida } from '@/utils/futebol-saida';
 // ============================================================
 import type { FutebolFixtureValueRow, FutebolValueBoardRow } from '@/services/futebol-data.service';
 import type { FutebolScoreVersion } from '@/services/futebol-score-contract';
+// Reexportado porque quem lida com escala já importa `fronteirasDoScore` e
+// `versaoDaJanela` daqui, e obrigar um segundo import do contrato só para o tipo
+// espalha o conhecimento de onde ele mora. Faltava, e ninguém viu: o typecheck
+// da raiz compila zero arquivo (`files: []`) e o CI não roda tsc.
+export type { FutebolScoreVersion };
 
 export type Faixa = 'alta' | 'media' | 'baixa';
 

--- a/src/utils/navegacao-por-link.test.ts
+++ b/src/utils/navegacao-por-link.test.ts
@@ -54,19 +54,23 @@ describe('interceptarCliqueSimples', () => {
   it('no clique simples, segura o link e roda a ação', () => {
     const acao = vi.fn();
     const preventDefault = vi.fn();
-    interceptarCliqueSimples(acao)({ ...clique(), preventDefault } as never);
+    interceptarCliqueSimples(acao)({ ...clique(), preventDefault });
 
     expect(preventDefault).toHaveBeenCalledOnce();
     expect(acao).toHaveBeenCalledOnce();
   });
 
   it('no clique do meio, não faz nada — o navegador abre o href', () => {
-    // O ponto inteiro do recurso. Se `preventDefault` fosse chamado aqui, a aba
-    // nova não abriria, e se a ação rodasse, o painel abriria na aba de trás
-    // sem ninguém ter pedido.
+    // ⚠️ Esta guarda é cinto E suspensório, não o mecanismo do recurso. Quem
+    // abre a aba nova é o `href`, e o navegador nem chega a chamar este `onClick`
+    // no botão do meio: ele dispara `auxclick`, e o React só escuta `click`.
+    //
+    // Fica porque a função é genérica e barata de proteger, e porque o dia em
+    // que alguém a ligar a um `onAuxClick` — ou em que um navegador voltar a
+    // disparar `click` no botão do meio — o comportamento certo já está fixado.
     const acao = vi.fn();
     const preventDefault = vi.fn();
-    interceptarCliqueSimples(acao)({ ...clique({ button: 1 }), preventDefault } as never);
+    interceptarCliqueSimples(acao)({ ...clique({ button: 1 }), preventDefault });
 
     expect(preventDefault).not.toHaveBeenCalled();
     expect(acao).not.toHaveBeenCalled();
@@ -75,7 +79,7 @@ describe('interceptarCliqueSimples', () => {
   it('no Ctrl + clique, também deixa passar', () => {
     const acao = vi.fn();
     const preventDefault = vi.fn();
-    interceptarCliqueSimples(acao)({ ...clique({ ctrlKey: true }), preventDefault } as never);
+    interceptarCliqueSimples(acao)({ ...clique({ ctrlKey: true }), preventDefault });
 
     expect(preventDefault).not.toHaveBeenCalled();
     expect(acao).not.toHaveBeenCalled();

--- a/src/utils/navegacao-por-link.test.ts
+++ b/src/utils/navegacao-por-link.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ehCliqueSimples, interceptarCliqueSimples } from './navegacao-por-link';
+
+// ============================================================================
+// Clique do meio abre em nova aba (issue #341)
+// ============================================================================
+// O módulo navegava com `<button onClick={() => navigate(...)}>`. Botão não é
+// link: o navegador não tem destino nenhum para abrir, então clique do meio,
+// Ctrl+clique e "abrir em nova aba" do botão direito não faziam nada.
+//
+// A troca por `<Link>` resolve isso de graça, porque o comportamento é do
+// navegador e não nosso. Sobra um caso: a linha da lista de Jogos, onde o
+// clique simples deve abrir o PAINEL (mesma página) e o clique do meio deve
+// abrir a TELA DO JOGO em outra aba. Para isso o `href` aponta para o jogo e
+// interceptamos apenas o clique simples.
+//
+// Decisão de produto (02/09/2026): clique simples NUNCA abre aba nova.
+// ============================================================================
+
+const clique = (over: Partial<Parameters<typeof ehCliqueSimples>[0]> = {}) => ({
+  button: 0,
+  metaKey: false,
+  ctrlKey: false,
+  shiftKey: false,
+  altKey: false,
+  ...over,
+});
+
+describe('ehCliqueSimples', () => {
+  it('o clique esquerdo puro é nosso', () => {
+    expect(ehCliqueSimples(clique())).toBe(true);
+  });
+
+  // Cada modificador é uma intenção EXPLÍCITA do usuário sobre onde abrir.
+  // Interceptar qualquer um deles é desobedecer um pedido claro.
+  it.each([
+    ['Ctrl', { ctrlKey: true }],
+    ['Cmd', { metaKey: true }],
+    ['Shift', { shiftKey: true }],
+    ['Alt', { altKey: true }],
+  ])('%s + clique é do navegador, não nosso', (_nome, mod) => {
+    expect(ehCliqueSimples(clique(mod))).toBe(false);
+  });
+
+  it.each([
+    ['do meio', 1],
+    ['direito', 2],
+  ])('o botão %s é do navegador', (_nome, button) => {
+    expect(ehCliqueSimples(clique({ button }))).toBe(false);
+  });
+});
+
+describe('interceptarCliqueSimples', () => {
+  it('no clique simples, segura o link e roda a ação', () => {
+    const acao = vi.fn();
+    const preventDefault = vi.fn();
+    interceptarCliqueSimples(acao)({ ...clique(), preventDefault } as never);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(acao).toHaveBeenCalledOnce();
+  });
+
+  it('no clique do meio, não faz nada — o navegador abre o href', () => {
+    // O ponto inteiro do recurso. Se `preventDefault` fosse chamado aqui, a aba
+    // nova não abriria, e se a ação rodasse, o painel abriria na aba de trás
+    // sem ninguém ter pedido.
+    const acao = vi.fn();
+    const preventDefault = vi.fn();
+    interceptarCliqueSimples(acao)({ ...clique({ button: 1 }), preventDefault } as never);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(acao).not.toHaveBeenCalled();
+  });
+
+  it('no Ctrl + clique, também deixa passar', () => {
+    const acao = vi.fn();
+    const preventDefault = vi.fn();
+    interceptarCliqueSimples(acao)({ ...clique({ ctrlKey: true }), preventDefault } as never);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(acao).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/navegacao-por-link.ts
+++ b/src/utils/navegacao-por-link.ts
@@ -1,0 +1,56 @@
+import type { MouseEvent } from 'react';
+
+/**
+ * Navegação por link, e não por `navigate()` (issue #341).
+ *
+ * O módulo de futebol navegava com `<button onClick={() => navigate(...)}>`.
+ * Botão não é link: o navegador não enxerga destino nenhum, porque o destino só
+ * existe dentro do JavaScript no instante do clique. Por isso clique do meio,
+ * Ctrl+clique, "abrir em nova aba" do botão direito, o destino no rodapé ao
+ * passar o mouse e o anúncio como link no leitor de tela não funcionavam.
+ *
+ * Nada disso se implementa: tudo vem de graça de uma tag `<a href>` de verdade,
+ * que é o que o `<Link>` do react-router gera. O trabalho é a troca.
+ *
+ * Sobra um caso onde as duas ações DIVERGEM de propósito: a linha da lista de
+ * Jogos, em que o clique simples abre o painel lateral (mesma página) e o clique
+ * do meio deve abrir a tela do jogo em outra aba. Ali o `href` aponta para a
+ * tela do jogo — que é o destino "de verdade" — e interceptamos apenas o clique
+ * simples. É este módulo que decide o que é "apenas".
+ */
+
+/** O mínimo que precisamos saber de um clique para decidir de quem ele é. */
+export type CliqueDeMouse = Pick<
+  MouseEvent,
+  'button' | 'metaKey' | 'ctrlKey' | 'shiftKey' | 'altKey'
+>;
+
+/**
+ * O clique é nosso para interceptar?
+ *
+ * Só o esquerdo puro. Cada modificador é uma intenção EXPLÍCITA do usuário sobre
+ * onde a página deve abrir — Ctrl e Cmd para aba nova, Shift para janela nova,
+ * Alt para baixar —, e o botão do meio é a mesma coisa sem tecla. Interceptar
+ * qualquer um deles é desobedecer um pedido claro, e foi por isso que a decisão
+ * de produto ficou sendo "clique simples nunca abre aba nova, e clique com
+ * modificador nunca deixa de abrir".
+ */
+export function ehCliqueSimples(e: CliqueDeMouse): boolean {
+  return e.button === 0 && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey;
+}
+
+/**
+ * Um `onClick` para `<Link>` que roda `acao` no clique simples e sai do caminho
+ * em todo o resto.
+ *
+ * O `preventDefault` mora aqui de propósito: ele é o que impede o `<Link>` de
+ * navegar, e chamá-lo no clique errado mataria justamente a aba nova que o
+ * recurso existe para dar.
+ */
+export function interceptarCliqueSimples(acao: () => void) {
+  return (e: MouseEvent): void => {
+    if (!ehCliqueSimples(e)) return;
+    e.preventDefault();
+    acao();
+  };
+}

--- a/src/utils/navegacao-por-link.ts
+++ b/src/utils/navegacao-por-link.ts
@@ -48,7 +48,11 @@ export function ehCliqueSimples(e: CliqueDeMouse): boolean {
  * recurso existe para dar.
  */
 export function interceptarCliqueSimples(acao: () => void) {
-  return (e: MouseEvent): void => {
+  // Pede o mínimo que usa — a decisão mais o `preventDefault` — e não o
+  // `MouseEvent` inteiro. Exigir o evento completo obrigava o teste a inventar
+  // um DOM ou a mentir com `as never`, e um `as never` no teste é o teste
+  // deixando de provar o formato que a função realmente precisa.
+  return (e: CliqueDeMouse & Pick<MouseEvent, 'preventDefault'>): void => {
     if (!ehCliqueSimples(e)) return;
     e.preventDefault();
     acao();


### PR DESCRIPTION
Fecha #341.

## O problema

O módulo navegava com `<button onClick={() => navigate(...)}>`. Botão não é link: o navegador não enxerga destino nenhum, porque o destino só existe dentro do JavaScript no instante do clique. Por isso clique do meio, Ctrl+clique, "abrir em nova aba" do botão direito, o endereço no rodapé ao passar o mouse e o anúncio como link no leitor de tela não funcionavam.

**Nada disso se implementa** — vem de graça de uma tag `<a href>`. O trabalho é a troca. O painel já provava: o botão "ver jogo completo" dele sempre foi um `<Link>`, e o clique do meio já funcionava ali.

## Dois padrões, não caso a caso

**Clique e clique do meio no mesmo destino** — a maioria. Só `<Link>`, sem handler. Hero da home, cards de oportunidade, régua de jogos, linhas do campeonato, card do chaveamento, linhas da classificação e do grupo, seletor de liga, e os atalhos "ver todas/todos".

**Destinos que divergem de propósito** — só a linha da agenda de Jogos: clique simples abre o painel lateral, clique do meio abre a tela do jogo. O `href` aponta para o jogo e `interceptarCliqueSimples` segura apenas o clique esquerdo puro.

**Regra de produto:** clique simples nunca abre aba nova; clique com modificador nunca deixa de abrir. Cada modificador — Ctrl, Cmd, Shift, Alt — e o botão do meio são intenção explícita do usuário, e interceptar qualquer um é desobedecer um pedido claro.

Nos componentes que recebiam callback, a propriedade deixou de ser ação e passou a ser destino: `onTeam(id)` virou `hrefDoTime(id)`, `onJogo(id)` virou `hrefDoJogo(id)`.

O título do jogo no cabeçalho do painel virou link — o pedido original. Era o único caminho para a tela do jogo que faltava: o painel só tinha o botão do rodapé, que fica abaixo da dobra em painel comprido.

## O que a revisão mudou

**Eu tinha declarado o módulo convertido e ele não estava.** Quatro pontos continuavam como botão: o card do chaveamento, a linha da classificação, a do grupo e o seletor de liga. Todos convertidos no segundo commit.

**Havia um meio-de-campo.** Onde não existe painel, eu passava um `onClick` apontando para o próprio `to` — cancelava o link para refazer à mão o que ele já faria. `onClick` virou opcional; sem ele o `<Link>` navega sozinho. Some do Campeonato, e na agenda o ramo de tela estreita sumiu junto com o `useNavigate` de duas telas.

**O teste do clique do meio dizia ser "o ponto inteiro do recurso". Não é.** Quem abre a aba nova é o `href`; esse `onClick` nem é chamado, porque o navegador dispara `auxclick` no botão do meio e o React escuta `click`. A guarda fica como cinto e suspensório, com o comentário dizendo a verdade.

Também: `interceptarCliqueSimples` passou a pedir o mínimo que usa em vez do `MouseEvent` inteiro (saíram três `as never` do teste), e o título do painel ganhou 24px de altura de alvo — com 13,5px de texto ele ficava em ~18px.

## Custo assumido

Na linha da agenda, o rodapé do navegador mostra o endereço da tela do jogo mas o clique simples abre o painel. É deliberado, e é o preço de ter as duas coisas.

`<a>` responde a Enter e não a Espaço, ao contrário de `<button>`. É a semântica certa: estes elementos navegam e são anunciados como link. O que havia antes é que estava errado.

## Achado colateral, e é sério

**O `tsc --noEmit` deste repositório compila zero arquivos.** O tsconfig da raiz tem `files: []` e só referências. E o CI não roda typecheck — só lint, build e testes, e o build é esbuild, que apaga tipos sem verificá-los.

Rodando com `-p tsconfig.app.json` aparecem dois erros vindos da #333, **já em produção**: a chave `faixa` duplicada no literal da demonstração (sem efeito em execução — a última vence, e é a derivada) e `FutebolScoreVersion` não reexportado. Os dois corrigidos aqui.

Durante este trabalho o typecheck de verdade me pegou quatro vezes — trocas de assinatura que falharam por CRLF e que eu teria descoberto só no navegador.

**Ligar o typecheck no CI é conversa à parte:** o repositório tem cerca de vinte erros pré-existentes fora do futebol, e ligar hoje deixaria o CI vermelho. Vale abrir issue.

## Como validar

Na tela de Jogos, clique do meio na linha de um jogo deve abrir a tela do jogo em aba nova, **sem** passar pelo painel. Clique normal continua abrindo o painel. O título no cabeçalho do painel deve levar à tela do jogo.

## Estado

`tsc -p tsconfig.app.json` limpo na área de futebol, `eslint` sem erros, 461 testes e `build` verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
