### PR TITLE
fix(futebol): o link carrega a saída clicada, vindo de qualquer tela

### DIFF
--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -150,7 +150,7 @@ export function JogoResumoPanel({
   // Sem isso a tela do jogo abria no desempate padrão — normalmente gols — e o
   // pick que a pessoa acabou de ler não estava mais na tela. Sem preço não há
   // saída para filtrar, e aí abre a tela inteira, que é o honesto.
-  const paraOJogo = hrefDaSaida(best, fixture.fixture_id);
+  const paraOJogo = hrefDaSaida(fixture.fixture_id, best);
   const lado = cand ? ladoDaSaida(mercadoLeitura!, cand.outcome) : null;
   const nValem = cand && mercadoLeitura ? contaQueValem(mercadoLeitura, cand.acesas) : 0;
 

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -13,6 +13,7 @@ import {
   useVitrine,
 } from '@/hooks/use-futebol-data';
 import { fmtDayChip, fmtTime, isFinished, isLive } from '@/utils/futebol-datas';
+import { hrefDaSaida } from '@/utils/futebol-links';
 import { chancePct, pickLabel } from '@/utils/futebol-score';
 import { marketShort, rotuloDaFaixa } from '@/utils/futebol-score';
 import { contaQueValem, rotuloPremissa, pesoForte } from '@/utils/futebol-premissas';
@@ -145,6 +146,11 @@ export function JogoResumoPanel({
   // No tour os dados são de mentira e chegam prontos: não há espera a mostrar.
   const carregandoLeitura = demo ? false : leituraCarregando || premissasCarregando;
   const temLeitura = !!best || (topo != null && topo.nValem > 0);
+  // Os dois links do painel levam à MESMA leitura que ele está exibindo (#344).
+  // Sem isso a tela do jogo abria no desempate padrão — normalmente gols — e o
+  // pick que a pessoa acabou de ler não estava mais na tela. Sem preço não há
+  // saída para filtrar, e aí abre a tela inteira, que é o honesto.
+  const paraOJogo = hrefDaSaida(best, fixture.fixture_id);
   const lado = cand ? ladoDaSaida(mercadoLeitura!, cand.outcome) : null;
   const nValem = cand && mercadoLeitura ? contaQueValem(mercadoLeitura, cand.acesas) : 0;
 
@@ -236,7 +242,7 @@ export function JogoResumoPanel({
             o texto tem 13,5px e sozinho ficava em ~18px, abaixo do mínimo de
             alvo de clique. A margem negativa devolve o espaço ao layout. */}
         <Link
-          to={`/futebol/jogo/${fixture.fixture_id}`}
+          to={paraOJogo}
           className="text-[13.5px] font-semibold tracking-tight text-ink truncate hover:underline py-1.5 -my-1.5"
           title="Abrir a tela do jogo"
         >
@@ -448,7 +454,7 @@ export function JogoResumoPanel({
 
         <div className="mt-4 flex gap-2">
           <Link
-            to={`/futebol/jogo/${fixture.fixture_id}`}
+            to={paraOJogo}
             className="flex-1 h-10 rounded-[10px] bg-forest text-canvas text-[13px] font-semibold inline-flex items-center justify-center gap-1.5 hover:bg-forest-2 transition"
           >
             {temLeitura ? 'Ver a análise dos 5 mercados' : 'Ver a análise completa'} <ArrowRight className="w-4 h-4" />

--- a/src/pages/FutebolCampeonato.tsx
+++ b/src/pages/FutebolCampeonato.tsx
@@ -20,7 +20,7 @@ import type { Competition, FutebolFixture, FutebolValueBoardRow } from '@/servic
 import { brtDayOf, fmtDayHeader, isFinished } from '@/utils/futebol-datas';
 import { groupBoardByFixture } from '@/utils/futebol-score';
 import { sufixoDeLeitura } from '@/utils/futebol-leitura';
-import { hrefDaSaida } from '@/utils/futebol-links';
+import { hrefDaSaida, hrefDoJogo } from '@/utils/futebol-links';
 import { settleFutebol, isHit } from '@/utils/futebol-settlement';
 import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
 import { ChaveamentoBracket } from '@/components/futebol/ChaveamentoBracket';
@@ -317,7 +317,7 @@ export default function FutebolCampeonato() {
                   leituraCarregando={leituraCarregando}
                   // Sem `onClick`: aqui não há painel, então o clique simples vai
                   // para o mesmo lugar que o do meio e o `<Link>` basta.
-                  to={hrefDaSaida(bestByFixture.get(f.fixture_id), f.fixture_id)}
+                  to={hrefDaSaida(f.fixture_id, bestByFixture.get(f.fixture_id))}
                 />
               ))}
             </div>
@@ -350,7 +350,9 @@ export default function FutebolCampeonato() {
         rounds={rounds}
         idxSelecionado={roundIdx}
         competition={competition}
-        hrefDoJogo={(id) => `/futebol/jogo/${id}`}
+        // O chaveamento mostra confronto, não pick: sem filtro, mas pelo
+        // módulo — URL de jogo montada à mão foi como a #344 começou.
+        hrefDoJogo={hrefDoJogo}
       />
     ) : null;
   const grupos = <GruposFase rows={standings} loading={loadingStandings} hrefDoTime={hrefDoTime} />;

--- a/src/pages/FutebolCampeonato.tsx
+++ b/src/pages/FutebolCampeonato.tsx
@@ -20,6 +20,7 @@ import type { Competition, FutebolFixture, FutebolValueBoardRow } from '@/servic
 import { brtDayOf, fmtDayHeader, isFinished } from '@/utils/futebol-datas';
 import { groupBoardByFixture } from '@/utils/futebol-score';
 import { sufixoDeLeitura } from '@/utils/futebol-leitura';
+import { hrefDaSaida } from '@/utils/futebol-links';
 import { settleFutebol, isHit } from '@/utils/futebol-settlement';
 import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
 import { ChaveamentoBracket } from '@/components/futebol/ChaveamentoBracket';
@@ -316,7 +317,7 @@ export default function FutebolCampeonato() {
                   leituraCarregando={leituraCarregando}
                   // Sem `onClick`: aqui não há painel, então o clique simples vai
                   // para o mesmo lugar que o do meio e o `<Link>` basta.
-                  to={`/futebol/jogo/${f.fixture_id}`}
+                  to={hrefDaSaida(bestByFixture.get(f.fixture_id), f.fixture_id)}
                 />
               ))}
             </div>

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -573,7 +573,7 @@ export default function FutebolHoje() {
         {loading ? (
           <Skeleton className="h-64 w-full bg-canvas-2 rounded-2xl" />
         ) : heroOpp ? (
-          <TopValueHero o={heroOpp} favor={heroFavor} contra={heroContra} carregandoMotivos={carregandoMotivos} textoScore={textoScore} to={hrefDaSaida(heroOpp)} locked={locked} />
+          <TopValueHero o={heroOpp} favor={heroFavor} contra={heroContra} carregandoMotivos={carregandoMotivos} textoScore={textoScore} to={hrefDaSaida(heroOpp.fixture_id, heroOpp)} locked={locked} />
         ) : (
           <div className={`${CARD} p-6 flex items-start gap-3`}>
             <Zap className="w-5 h-5 text-ink-3 mt-0.5 shrink-0" />
@@ -603,7 +603,7 @@ export default function FutebolHoje() {
               <div className="grid sm:grid-cols-2 gap-4">{Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-40 w-full bg-canvas-2 rounded-rebrand-md" />)}</div>
             ) : moreOpps.length > 0 ? (
               <div className="grid sm:grid-cols-2 gap-4">
-                {moreOpps.map((o) => <OppCard key={`${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`} o={o} to={hrefDaSaida(o)} locked={locked} />)}
+                {moreOpps.map((o) => <OppCard key={`${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`} o={o} to={hrefDaSaida(o.fixture_id, o)} locked={locked} />)}
               </div>
             ) : (
               <div className={`${CARD} p-6 text-center text-sm text-ink-3`}>Sem outras oportunidades relevantes agora.</div>
@@ -625,7 +625,7 @@ export default function FutebolHoje() {
             ) : gameList.length > 0 ? (
               <div className={`${CARD} overflow-hidden`}>
                 {gameList.map((f) => (
-                  <GameRailRow key={f.fixture_id} f={f} best={bestByFixture.get(f.fixture_id) ?? null} to={hrefDaSaida(bestByFixture.get(f.fixture_id), f.fixture_id)} />
+                  <GameRailRow key={f.fixture_id} f={f} best={bestByFixture.get(f.fixture_id) ?? null} to={hrefDaSaida(f.fixture_id, bestByFixture.get(f.fixture_id))} />
                 ))}
               </div>
             ) : (

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -28,6 +28,7 @@ import { useDemoFutebolBoard } from '@/components/onboarding/demo/use-demo-futeb
 import { SAO_PAULO_TZ, parseUtc, brtDateStr, brtDayOf, fmtTime, isFinished, addDays } from '@/utils/futebol-datas';
 import { mergeBoardAndHistory } from '@/utils/futebol-history';
 import { mercadoEstaOculto } from '@/utils/futebol-mercados-ocultos';
+import { hrefDaSaida } from '@/utils/futebol-links';
 import { oportunidadesDoDia, type OppLike } from '@/utils/futebol-registradas';
 import { estadoDosMotivos, explicacaoDaLeitura, type MotivoExibivel as Motivo } from '@/utils/futebol-motivos';
 import { ladoDaSaida } from '@/utils/futebol-evidencias';
@@ -572,7 +573,7 @@ export default function FutebolHoje() {
         {loading ? (
           <Skeleton className="h-64 w-full bg-canvas-2 rounded-2xl" />
         ) : heroOpp ? (
-          <TopValueHero o={heroOpp} favor={heroFavor} contra={heroContra} carregandoMotivos={carregandoMotivos} textoScore={textoScore} to={`/futebol/jogo/${heroOpp.fixture_id}`} locked={locked} />
+          <TopValueHero o={heroOpp} favor={heroFavor} contra={heroContra} carregandoMotivos={carregandoMotivos} textoScore={textoScore} to={hrefDaSaida(heroOpp)} locked={locked} />
         ) : (
           <div className={`${CARD} p-6 flex items-start gap-3`}>
             <Zap className="w-5 h-5 text-ink-3 mt-0.5 shrink-0" />
@@ -602,7 +603,7 @@ export default function FutebolHoje() {
               <div className="grid sm:grid-cols-2 gap-4">{Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-40 w-full bg-canvas-2 rounded-rebrand-md" />)}</div>
             ) : moreOpps.length > 0 ? (
               <div className="grid sm:grid-cols-2 gap-4">
-                {moreOpps.map((o) => <OppCard key={`${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`} o={o} to={`/futebol/jogo/${o.fixture_id}`} locked={locked} />)}
+                {moreOpps.map((o) => <OppCard key={`${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`} o={o} to={hrefDaSaida(o)} locked={locked} />)}
               </div>
             ) : (
               <div className={`${CARD} p-6 text-center text-sm text-ink-3`}>Sem outras oportunidades relevantes agora.</div>
@@ -624,7 +625,7 @@ export default function FutebolHoje() {
             ) : gameList.length > 0 ? (
               <div className={`${CARD} overflow-hidden`}>
                 {gameList.map((f) => (
-                  <GameRailRow key={f.fixture_id} f={f} best={bestByFixture.get(f.fixture_id) ?? null} to={`/futebol/jogo/${f.fixture_id}`} />
+                  <GameRailRow key={f.fixture_id} f={f} best={bestByFixture.get(f.fixture_id) ?? null} to={hrefDaSaida(bestByFixture.get(f.fixture_id), f.fixture_id)} />
                 ))}
               </div>
             ) : (

--- a/src/pages/FutebolJogo.tsx
+++ b/src/pages/FutebolJogo.tsx
@@ -21,6 +21,7 @@ import {
 import { settleFutebol, resultBadge, isHit, type BetResult } from '@/utils/futebol-settlement';
 import { escalacaoExibida, rotuloEscalacao } from '@/utils/futebol-escalacao';
 import { isFinished, isLive } from '@/utils/futebol-datas';
+import { PARAMS_DA_SAIDA } from '@/utils/futebol-links';
 import type {
   FutebolEvent, FutebolFormResult, FutebolInjury, FutebolLineupPlayer, FutebolPlayerStat, FutebolTeamStats, FutebolFixtureValueRow, FutebolTeamProfile, Competition,
 } from '@/services/futebol-data.service';
@@ -277,10 +278,10 @@ export default function FutebolJogo() {
   // A saída que o usuário clicou em Oportunidades. Sem ela, a tela escolhia sozinha
   // a de maior Score do mercado, que nem sempre é a do card clicado.
   const preferida = useMemo((): SaidaPreferida | null => {
-    const market = params.get('mercado');
-    const outcome = params.get('saida');
+    const market = params.get(PARAMS_DA_SAIDA.mercado);
+    const outcome = params.get(PARAMS_DA_SAIDA.saida);
     if (!market || !outcome) return null;
-    const linha = params.get('linha');
+    const linha = params.get(PARAMS_DA_SAIDA.linha);
     const n = linha != null ? Number(linha) : NaN;
     return { market, outcome, line_value: Number.isFinite(n) ? n : null };
   }, [params]);

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -339,7 +339,7 @@ export default function FutebolJogos() {
                               selected={f.fixture_id === jogoParam}
                               // A linha mostra o pick; o link leva a ELE, e não
                               // ao desempate padrão da tela do jogo (#344).
-                              to={hrefDaSaida(bestByFixture.get(f.fixture_id), f.fixture_id)}
+                              to={hrefDaSaida(f.fixture_id, bestByFixture.get(f.fixture_id))}
                               onClick={hasPanel ? () => abrirPainel(f) : undefined}
                             />
                           ))}

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -11,6 +11,7 @@ import type { FutebolFixtureByDay, FutebolValueBoardRow } from '@/services/futeb
 import { addDays, brtToday, fmtDayHeader } from '@/utils/futebol-datas';
 import { groupBoardByFixture } from '@/utils/futebol-score';
 import { sufixoDeLeitura } from '@/utils/futebol-leitura';
+import { hrefDaSaida } from '@/utils/futebol-links';
 import { competitionLabel, sortCompetitions } from '@/utils/futebol-competitions';
 import OnboardingTour from '@/components/onboarding/OnboardingTour';
 import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
@@ -336,7 +337,9 @@ export default function FutebolJogos() {
                               best={bestByFixture.get(f.fixture_id) ?? null}
                               leituraCarregando={leituraCarregando}
                               selected={f.fixture_id === jogoParam}
-                              to={`/futebol/jogo/${f.fixture_id}`}
+                              // A linha mostra o pick; o link leva a ELE, e não
+                              // ao desempate padrão da tela do jogo (#344).
+                              to={hrefDaSaida(bestByFixture.get(f.fixture_id), f.fixture_id)}
                               onClick={hasPanel ? () => abrirPainel(f) : undefined}
                             />
                           ))}

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -656,7 +656,7 @@ export default function FutebolOportunidades() {
                 const g = goalsMap.get(o.fixture_id);
                 return (
                   <div key={key(o)}>
-                    <OppRow o={o} to={hrefDaSaida(o)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
+                    <OppRow o={o} to={hrefDaSaida(o.fixture_id, o)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
                     {!isPastDay && !locked && !res && (
                       <div className="px-5 pb-2 -mt-0.5">
                         <RegistrarApostaCTA variant="text" draft={draftFromBoardRow(o)} />
@@ -676,7 +676,7 @@ export default function FutebolOportunidades() {
                   <OppMobileCard
                     key={key(o)}
                     o={o}
-                    to={hrefDaSaida(o)}
+                    to={hrefDaSaida(o.fixture_id, o)}
                     locked={locked}
                     result={res}
                     homeGoals={g?.gh}

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/utils/futebol-score';
 import { settleFutebol, resultBadge, resumoDoDia, type BetResult } from '@/utils/futebol-settlement';
 import { mercadoEstaOculto } from '@/utils/futebol-mercados-ocultos';
+import { hrefDaSaida } from '@/utils/futebol-links';
 import { mergeBoardAndHistory, historyWindow, HISTORY_WINDOW_DAYS } from '@/utils/futebol-history';
 import { oppKey, oportunidadesDoDia, type OppLike } from '@/utils/futebol-registradas';
 import { parseUtc, brtDayOf, brtDateStr, fmtTime, hasKickoffPassed, addDays } from '@/utils/futebol-datas';
@@ -500,12 +501,9 @@ export default function FutebolOportunidades() {
   // saídas cotadas no mesmo mercado. Navegando só com o id do jogo, clicar no card
   // da segunda abria a tela na primeira, e o pick que o usuário leu aqui virava
   // outro lá. O link carrega qual card foi clicado.
-  /** A URL da saída clicada: destino de link, não argumento de navigate (#341). */
-  const hrefDoJogo = (o: OppLike) => {
-    const q = new URLSearchParams({ mercado: o.market, saida: o.outcome });
-    if (o.line_value != null) q.set('linha', String(o.line_value));
-    return `/futebol/jogo/${o.fixture_id}?${q}`;
-  };
+  // A montagem da URL saiu daqui para `futebol-links.ts` (#344): esta tela era a
+  // única que carregava a saída clicada, e a home e o painel abriam a tela do
+  // jogo no desempate padrão. Com um lugar só, a próxima origem não esquece.
   const key = (o: OppLike) => `${o.fixture_id}-${o.market}-${o.outcome}-${o.line_value}`;
 
   const oppSteps = useMemo(
@@ -658,7 +656,7 @@ export default function FutebolOportunidades() {
                 const g = goalsMap.get(o.fixture_id);
                 return (
                   <div key={key(o)}>
-                    <OppRow o={o} to={hrefDoJogo(o)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
+                    <OppRow o={o} to={hrefDaSaida(o)} locked={locked} result={res} homeGoals={g?.gh} awayGoals={g?.ga} />
                     {!isPastDay && !locked && !res && (
                       <div className="px-5 pb-2 -mt-0.5">
                         <RegistrarApostaCTA variant="text" draft={draftFromBoardRow(o)} />
@@ -678,7 +676,7 @@ export default function FutebolOportunidades() {
                   <OppMobileCard
                     key={key(o)}
                     o={o}
-                    to={hrefDoJogo(o)}
+                    to={hrefDaSaida(o)}
                     locked={locked}
                     result={res}
                     homeGoals={g?.gh}

--- a/src/utils/futebol-links.test.ts
+++ b/src/utils/futebol-links.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { hrefDoJogo, hrefDaSaida } from './futebol-links';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { hrefDoJogo, hrefDaSaida, PARAMS_DA_SAIDA } from './futebol-links';
 
 // ============================================================================
 // O link carrega a saída clicada (issue #344)
@@ -9,58 +11,89 @@ import { hrefDoJogo, hrefDaSaida } from './futebol-links';
 // gols, normalmente — e o pick que ela tinha acabado de ler não estava mais na
 // tela. A tela do jogo sempre soube ler `?mercado=&saida=&linha=`; só a
 // Oportunidades sabia escrever.
-//
-// A URL passa a ser montada num lugar só, para não existir de novo uma origem
-// que esquece o filtro.
 // ============================================================================
 
-const over25 = { fixture_id: 42, market: 'goals_over_under', outcome: 'Over', line_value: 2.5 };
+const over25 = { market: 'goals_over_under', outcome: 'Over', line_value: 2.5 };
 
 describe('hrefDoJogo', () => {
-  it('sem saída, é só a tela do jogo', () => {
+  it('é só a tela do jogo', () => {
     expect(hrefDoJogo(42)).toBe('/futebol/jogo/42');
   });
 });
 
 describe('hrefDaSaida', () => {
   it('carrega mercado, saída e linha', () => {
-    expect(hrefDaSaida(over25)).toBe('/futebol/jogo/42?mercado=goals_over_under&saida=Over&linha=2.5');
+    expect(hrefDaSaida(42, over25)).toBe('/futebol/jogo/42?mercado=goals_over_under&saida=Over&linha=2.5');
   });
 
   it('omite a linha quando o mercado não tem linha', () => {
     // 1x2 não tem linha. Mandar `linha=null` faria a tela procurar uma saída
     // com linha nula literal e não achar nada.
-    expect(hrefDaSaida({ fixture_id: 7, market: 'match_winner', outcome: 'Home', line_value: null }))
+    expect(hrefDaSaida(7, { market: 'match_winner', outcome: 'Home', line_value: null }))
       .toBe('/futebol/jogo/7?mercado=match_winner&saida=Home');
   });
 
   it('a linha zero é linha, e não ausência de linha', () => {
     // Handicap 0 existe e é diferente de "sem linha". Um `if (line_value)` o
     // apagaria — é o tipo de engano que só aparece num mercado específico.
-    expect(hrefDaSaida({ fixture_id: 9, market: 'asian_handicap', outcome: 'Home', line_value: 0 }))
+    expect(hrefDaSaida(9, { market: 'asian_handicap', outcome: 'Home', line_value: 0 }))
       .toBe('/futebol/jogo/9?mercado=asian_handicap&saida=Home&linha=0');
   });
 
   it('a linha negativa sobrevive ao encode', () => {
-    expect(hrefDaSaida({ fixture_id: 9, market: 'asian_handicap', outcome: 'Away', line_value: -1.25 }))
+    expect(hrefDaSaida(9, { market: 'asian_handicap', outcome: 'Away', line_value: -1.25 }))
       .toContain('linha=-1.25');
   });
 
-  it('sem saída identificável, devolve a tela do jogo sem filtro', () => {
+  it('sem saída, devolve a tela do jogo sem filtro', () => {
     // O trilho da agenda mostra jogo, não oportunidade: pode não haver leitura
     // com preço. Melhor abrir a tela inteira que inventar um filtro.
-    expect(hrefDaSaida({ fixture_id: 42, market: null, outcome: null, line_value: null }))
-      .toBe('/futebol/jogo/42');
-    expect(hrefDaSaida(null, 42)).toBe('/futebol/jogo/42');
+    expect(hrefDaSaida(42)).toBe('/futebol/jogo/42');
+    expect(hrefDaSaida(42, undefined)).toBe('/futebol/jogo/42');
   });
 
-  it('o que a tela do jogo lê é o que este módulo escreve', () => {
-    // Guarda de contrato entre as duas pontas. Se alguém renomear um parâmetro
-    // de um lado só, o link continua válido e o filtro para de funcionar em
-    // silêncio — que é exatamente o defeito que a #344 conserta.
-    const url = new URL(hrefDaSaida(over25), 'https://x');
-    expect(url.searchParams.get('mercado')).toBe('goals_over_under');
-    expect(url.searchParams.get('saida')).toBe('Over');
-    expect(url.searchParams.get('linha')).toBe('2.5');
+  it('saída sem mercado também não vira filtro pela metade', () => {
+    // Alcançável de verdade: `oppFromAlerted` monta `OppLike` com `market:
+    // a.market!`, e o `!` mente — o campo de origem é nulável ("null nas linhas
+    // antigas sem pick estruturado"). A montagem anterior produzia
+    // `mercado=null&saida=null` nesses casos.
+    expect(hrefDaSaida(42, { market: null, outcome: null, line_value: null }))
+      .toBe('/futebol/jogo/42');
+  });
+});
+
+// ============================================================================
+// A guarda de contrato entre quem escreve e quem lê
+// ============================================================================
+// A primeira versão desta guarda não guardava nada: ela repetia os literais
+// `mercado`, `saida` e `linha` no próprio teste e lia de volta o que o módulo
+// tinha acabado de escrever. Renomear na tela do jogo deixava tudo verde e o
+// filtro morto — que é exatamente o defeito da #344, voltando pela porta dos
+// fundos.
+//
+// O que amarra de verdade é `PARAMS_DA_SAIDA` ser a única fonte dos dois lados.
+// Estes testes protegem esse acordo: um confere que a montagem usa a constante,
+// o outro confere que a tela do jogo não voltou a cravar os nomes na mão.
+// ============================================================================
+
+describe('contrato dos parâmetros', () => {
+  it('a montagem usa os nomes da constante, e não literais próprios', () => {
+    const url = new URL(hrefDaSaida(42, over25), 'https://x');
+    expect(url.searchParams.get(PARAMS_DA_SAIDA.mercado)).toBe('goals_over_under');
+    expect(url.searchParams.get(PARAMS_DA_SAIDA.saida)).toBe('Over');
+    expect(url.searchParams.get(PARAMS_DA_SAIDA.linha)).toBe('2.5');
+  });
+
+  it('a tela do jogo lê pela constante, não por literal', () => {
+    // Guarda de arquivo, no mesmo espírito do shape-file: se alguém trocar
+    // `params.get(PARAMS_DA_SAIDA.mercado)` por `params.get('mercado')`, o
+    // acordo se desfaz em silêncio e a próxima renomeação quebra o filtro sem
+    // quebrar teste nenhum.
+    const tela = readFileSync(resolve(__dirname, '../pages/FutebolJogo.tsx'), 'utf8');
+
+    for (const nome of Object.values(PARAMS_DA_SAIDA)) {
+      expect(tela, `a tela lê "${nome}" por literal`).not.toContain(`params.get('${nome}')`);
+    }
+    expect(tela).toContain('PARAMS_DA_SAIDA');
   });
 });

--- a/src/utils/futebol-links.test.ts
+++ b/src/utils/futebol-links.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { hrefDoJogo, hrefDaSaida } from './futebol-links';
+
+// ============================================================================
+// O link carrega a saída clicada (issue #344)
+// ============================================================================
+// Vindo de Oportunidades, a tela do jogo abria já na saída que a pessoa clicou.
+// Vindo da home ou do painel da agenda, abria no primeiro mercado da lista —
+// gols, normalmente — e o pick que ela tinha acabado de ler não estava mais na
+// tela. A tela do jogo sempre soube ler `?mercado=&saida=&linha=`; só a
+// Oportunidades sabia escrever.
+//
+// A URL passa a ser montada num lugar só, para não existir de novo uma origem
+// que esquece o filtro.
+// ============================================================================
+
+const over25 = { fixture_id: 42, market: 'goals_over_under', outcome: 'Over', line_value: 2.5 };
+
+describe('hrefDoJogo', () => {
+  it('sem saída, é só a tela do jogo', () => {
+    expect(hrefDoJogo(42)).toBe('/futebol/jogo/42');
+  });
+});
+
+describe('hrefDaSaida', () => {
+  it('carrega mercado, saída e linha', () => {
+    expect(hrefDaSaida(over25)).toBe('/futebol/jogo/42?mercado=goals_over_under&saida=Over&linha=2.5');
+  });
+
+  it('omite a linha quando o mercado não tem linha', () => {
+    // 1x2 não tem linha. Mandar `linha=null` faria a tela procurar uma saída
+    // com linha nula literal e não achar nada.
+    expect(hrefDaSaida({ fixture_id: 7, market: 'match_winner', outcome: 'Home', line_value: null }))
+      .toBe('/futebol/jogo/7?mercado=match_winner&saida=Home');
+  });
+
+  it('a linha zero é linha, e não ausência de linha', () => {
+    // Handicap 0 existe e é diferente de "sem linha". Um `if (line_value)` o
+    // apagaria — é o tipo de engano que só aparece num mercado específico.
+    expect(hrefDaSaida({ fixture_id: 9, market: 'asian_handicap', outcome: 'Home', line_value: 0 }))
+      .toBe('/futebol/jogo/9?mercado=asian_handicap&saida=Home&linha=0');
+  });
+
+  it('a linha negativa sobrevive ao encode', () => {
+    expect(hrefDaSaida({ fixture_id: 9, market: 'asian_handicap', outcome: 'Away', line_value: -1.25 }))
+      .toContain('linha=-1.25');
+  });
+
+  it('sem saída identificável, devolve a tela do jogo sem filtro', () => {
+    // O trilho da agenda mostra jogo, não oportunidade: pode não haver leitura
+    // com preço. Melhor abrir a tela inteira que inventar um filtro.
+    expect(hrefDaSaida({ fixture_id: 42, market: null, outcome: null, line_value: null }))
+      .toBe('/futebol/jogo/42');
+    expect(hrefDaSaida(null, 42)).toBe('/futebol/jogo/42');
+  });
+
+  it('o que a tela do jogo lê é o que este módulo escreve', () => {
+    // Guarda de contrato entre as duas pontas. Se alguém renomear um parâmetro
+    // de um lado só, o link continua válido e o filtro para de funcionar em
+    // silêncio — que é exatamente o defeito que a #344 conserta.
+    const url = new URL(hrefDaSaida(over25), 'https://x');
+    expect(url.searchParams.get('mercado')).toBe('goals_over_under');
+    expect(url.searchParams.get('saida')).toBe('Over');
+    expect(url.searchParams.get('linha')).toBe('2.5');
+  });
+});

--- a/src/utils/futebol-links.ts
+++ b/src/utils/futebol-links.ts
@@ -1,0 +1,49 @@
+/**
+ * Os endereços do módulo de futebol, montados num lugar só (issue #344).
+ *
+ * A tela do jogo sempre soube ler `?mercado=&saida=&linha=` e abrir já na saída
+ * clicada. Só a tela de Oportunidades sabia escrever isso — a home e o painel da
+ * agenda mandavam a URL pelada, e a tela caía no desempate padrão: normalmente
+ * gols, na primeira linha. A pessoa clicava num pick e chegava noutro.
+ *
+ * Montar a URL aqui é o que impede a próxima origem de esquecer o filtro de
+ * novo, e mantém as duas pontas do contrato — quem escreve e quem lê — a uma
+ * busca de distância uma da outra.
+ */
+
+/** O mínimo para identificar uma saída num jogo. */
+export type SaidaClicavel = {
+  fixture_id: number;
+  market: string | null | undefined;
+  outcome: string | null | undefined;
+  line_value: number | null | undefined;
+};
+
+/** A tela do jogo, sem filtro nenhum. */
+export function hrefDoJogo(fixtureId: number): string {
+  return `/futebol/jogo/${fixtureId}`;
+}
+
+/**
+ * A tela do jogo já na saída clicada.
+ *
+ * Sem mercado ou sem saída, devolve a tela sem filtro em vez de um filtro pela
+ * metade: o trilho da agenda mostra jogo, não oportunidade, e nem todo jogo tem
+ * leitura com preço. Abrir a tela inteira é honesto; inventar filtro não.
+ *
+ * Filtro que não casa também não quebra nada do outro lado — `saidaComPreco`
+ * cai no desempate normal quando não encontra a saída pedida.
+ */
+export function hrefDaSaida(saida: SaidaClicavel | null | undefined, fixtureIdDeReserva?: number): string {
+  const fixtureId = saida?.fixture_id ?? fixtureIdDeReserva;
+  if (fixtureId == null) throw new Error('hrefDaSaida precisa de um fixture_id');
+  if (!saida?.market || !saida?.outcome) return hrefDoJogo(fixtureId);
+
+  const q = new URLSearchParams({ mercado: saida.market, saida: saida.outcome });
+  // `!= null`, e não um teste de verdade: handicap 0 é uma linha de verdade, e
+  // um `if (line_value)` a apagaria. Mercado sem linha (1x2, ambos marcam) manda
+  // o parâmetro ausente, porque `linha=null` faria a tela procurar uma saída com
+  // linha nula literal e não achar nenhuma.
+  if (saida.line_value != null) q.set('linha', String(saida.line_value));
+  return `${hrefDoJogo(fixtureId)}?${q}`;
+}

--- a/src/utils/futebol-links.ts
+++ b/src/utils/futebol-links.ts
@@ -11,9 +11,24 @@
  * busca de distância uma da outra.
  */
 
+/**
+ * Os nomes dos parâmetros, compartilhados entre quem escreve (aqui) e quem lê
+ * (a tela do jogo).
+ *
+ * Existem como constante, e não como literais dos dois lados, porque renomear
+ * um deles numa ponta só deixa o link **válido** e o filtro **morto**, sem erro
+ * nenhum: a tela procura um parâmetro que ninguém manda, não acha, e cai no
+ * desempate padrão. É o defeito que esta issue conserta, e ele voltaria pela
+ * porta dos fundos. Mesmo espírito da guarda de paridade da copy das premissas.
+ */
+export const PARAMS_DA_SAIDA = {
+  mercado: 'mercado',
+  saida: 'saida',
+  linha: 'linha',
+} as const;
+
 /** O mínimo para identificar uma saída num jogo. */
 export type SaidaClicavel = {
-  fixture_id: number;
   market: string | null | undefined;
   outcome: string | null | undefined;
   line_value: number | null | undefined;
@@ -27,23 +42,38 @@ export function hrefDoJogo(fixtureId: number): string {
 /**
  * A tela do jogo já na saída clicada.
  *
+ * O id do jogo vem primeiro e é obrigatório: ele é o que sempre existe, e a
+ * saída é o que pode faltar. Na ordem inversa a função precisava de um segundo
+ * parâmetro de reserva e de um `throw` quando nenhum dos dois vinha — derrubar
+ * a árvore de render dentro de uma lista por falta de dado é desproporcional,
+ * ainda mais numa função que já degrada com elegância quando falta a saída.
+ *
  * Sem mercado ou sem saída, devolve a tela sem filtro em vez de um filtro pela
  * metade: o trilho da agenda mostra jogo, não oportunidade, e nem todo jogo tem
- * leitura com preço. Abrir a tela inteira é honesto; inventar filtro não.
+ * leitura com preço.
  *
- * Filtro que não casa também não quebra nada do outro lado — `saidaComPreco`
- * cai no desempate normal quando não encontra a saída pedida.
+ * ⚠️ `market` e `outcome` aceitam nulo apesar de `FutebolValueBoardRow` declarar
+ * os dois como `string`. Não é frouxidão: `oppFromAlerted` monta `OppLike` com
+ * `market: a.market!`, e o `!` mente — `FutebolAlertedPick.market` é
+ * `string | null` ("null nas linhas antigas sem pick estruturado"). Um registro
+ * antigo chega aqui com nulo e o tipo declarado não avisa. A versão anterior
+ * desta montagem, dentro de Oportunidades, produzia `mercado=null` na URL
+ * nesses casos.
+ *
+ * Filtro que não casa também não quebra do outro lado: `saidaComPreco` cai no
+ * desempate normal quando não encontra a saída pedida.
  */
-export function hrefDaSaida(saida: SaidaClicavel | null | undefined, fixtureIdDeReserva?: number): string {
-  const fixtureId = saida?.fixture_id ?? fixtureIdDeReserva;
-  if (fixtureId == null) throw new Error('hrefDaSaida precisa de um fixture_id');
+export function hrefDaSaida(fixtureId: number, saida?: SaidaClicavel | null): string {
   if (!saida?.market || !saida?.outcome) return hrefDoJogo(fixtureId);
 
-  const q = new URLSearchParams({ mercado: saida.market, saida: saida.outcome });
+  const q = new URLSearchParams({
+    [PARAMS_DA_SAIDA.mercado]: saida.market,
+    [PARAMS_DA_SAIDA.saida]: saida.outcome,
+  });
   // `!= null`, e não um teste de verdade: handicap 0 é uma linha de verdade, e
   // um `if (line_value)` a apagaria. Mercado sem linha (1x2, ambos marcam) manda
   // o parâmetro ausente, porque `linha=null` faria a tela procurar uma saída com
   // linha nula literal e não achar nenhuma.
-  if (saida.line_value != null) q.set('linha', String(saida.line_value));
+  if (saida.line_value != null) q.set(PARAMS_DA_SAIDA.linha, String(saida.line_value));
   return `${hrefDoJogo(fixtureId)}?${q}`;
 }


### PR DESCRIPTION
Fecha #344.

## O problema

Clicar numa oportunidade na **home**, ou no painel de resumo dentro de **Jogos**, abria a tela do jogo **sem o filtro do que foi clicado**. Ela caía no desempate padrão — normalmente gols, na primeira linha — e o pick que a pessoa acabou de ler não estava mais na tela. Vindo de **Oportunidades** funcionava.

A tela do jogo sempre soube **ler** `?mercado=&saida=&linha=`. Só a Oportunidades sabia **escrever**: o construtor da URL vivia como função local dentro dela, e as outras origens montavam `/futebol/jogo/${id}` na mão, sem ter como saber que existia um contrato de query a respeitar.

O defeito era silencioso por desenho: quando a saída pedida não existe, `saidaComPreco` cai no desempate normal. Nada falha — só abre no lugar errado.

## A solução

`futebol-links.ts` monta o endereço num lugar só, e toda origem que mostra um pick usa ele: o hero e os cards da home, o trilho de jogos, a agenda, o campeonato, e os dois links do painel.

Onde não há leitura com preço, o link leva à tela inteira. Inventar filtro seria pior que não ter — é o caso do trilho e da agenda, que mostram jogo e nem sempre têm oportunidade.

Duas decisões que os testes fixam:

- **Linha zero é linha.** Handicap 0 existe e é diferente de "sem linha", então o teste é ausência (`!= null`) e não falsidade. Um `if (line_value)` apagaria o parâmetro justamente no mercado onde ele mais importa.
- **Mercado sem linha omite o parâmetro** em vez de mandar `linha=null`, que faria a tela procurar uma saída com linha nula literal e não achar nenhuma.

## O que a revisão mudou

**A guarda de contrato não guardava nada.** O teste dizia em comentário que protegia contra renomear um parâmetro de um lado só — e repetia os literais dentro dele, lendo de volta o que o módulo tinha acabado de escrever. A tela do jogo tinha a cópia dela. Renomear lá deixava tudo verde e o filtro morto: o defeito desta issue voltando pela porta dos fundos.

`PARAMS_DA_SAIDA` passou a ser a única fonte dos dois lados, mais uma guarda de arquivo que reprova se a tela voltar a ler por literal. **Verificada por mutação** — trocando de volta, ela fica vermelha.

**`hrefDaSaida` derrubava a árvore de render.** Recebia a saída primeiro e o id como reserva opcional, com `throw` quando nenhum vinha — dentro do render de um `<Link>`, numa lista. Política incoerente na mesma função, que já degradava com elegância quando faltava o mercado. O id passou a vir primeiro e obrigatório, e o estado ilegal deixou de ser representável.

**O tipo frouxo ficou, agora justificado.** O revisor apontou que `market` e `outcome` aceitam nulo apesar de `FutebolValueBoardRow` declarar `string`, e que a guarda seria inalcançável. Conferi: **é alcançável**. `oppFromAlerted` monta `OppLike` com `market: a.market!` e o `!` mente — `FutebolAlertedPick.market` é `string | null`, "null nas linhas antigas sem pick estruturado".

Isso resolve também a pergunta sobre a Oportunidades ter mudado de comportamento: mudou, e para melhor. A montagem antiga produzia `mercado=null&saida=null` para esses registros; agora sai URL limpa. A tela renderizada é a mesma nos dois casos, porque a tela já ignorava o filtro inválido.

O chaveamento também passou a usar o módulo — mostra confronto e não pick, então segue sem filtro, mas URL de jogo montada à mão foi como esta issue começou.

## Como validar

Na home, clique numa oportunidade: a tela do jogo deve abrir naquele mercado e naquela saída, não em gols. O mesmo no painel de resumo dentro de Jogos, e na linha da agenda que mostra um pick. Um jogo sem leitura com preço deve abrir a tela inteira.

## Estado

`tsc -p tsconfig.app.json` limpo no módulo de futebol, `eslint` sem erros, 470 testes e `build` verdes.

## Nota

Mesma raiz da #341: conhecimento de navegação espalhado pelas telas. Lá o destino existia só dentro de um `onClick`; aqui a query existia só dentro de uma tela. Nos dois casos uma origem nova nasce sem saber a regra e ninguém percebe, porque nada quebra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
