### PR TITLE
fix(futebol): sem oportunidade, a tela abre na leitura que ela mesma anuncia

### DIFF
--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -31,7 +31,7 @@ import { evidenciaDe, ladoDaSaida } from '@/utils/futebol-evidencias';
 import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 import { MotivosJogoPorJogo } from './MotivosJogoPorJogo';
 import { avisoSemDado } from '@/utils/futebol-sem-dado';
-import { valueDoCandidato, resumoDosMercados, mesmaLinha, type SaidaPreferida } from '@/utils/futebol-leitura';
+import { valueDoCandidato, resumoDosMercados, mesmaLinha, candidatoQueAbreAFolha, type SaidaPreferida } from '@/utils/futebol-leitura';
 import { ehDestaque, ehFaixaAlta, rotuloDaFaixa, fronteirasDoScore } from '@/utils/futebol-score';
 import { leituraDaCotacao } from '@/utils/futebol-cotacao';
 import { filtrarCatalogoDeMercados } from '@/utils/futebol-mercados-ocultos';
@@ -305,22 +305,10 @@ export function BancadaMercados({
   // Sem fallback de propósito: resumoDosMercados só deixa um mercado de fora quando
   // melhorCandidato dele já é nulo, então um "?? melhorCandidato(...)" aqui nunca
   // teria o que devolver, e ainda reabriria a porta das duas verdades.
-  const candidatoInicialDoMercado = useMemo(() => {
-    const resumo = resumos.find((r) => r.mercado.slug === mercado.slug) ?? null;
-    // Primeiro, a oportunidade de maior score (ou a que veio pelo link). Sem ela,
-    // uma candidata que já tem cotação é mais útil que uma linha só analisada.
-    if (resumo?.value) return resumo.candidato;
-
-    const candidataCotada = [...doMercado]
-      .filter((c) => leituraDaCotacao(mercado.slug, c.outcome, c.line_value, valueRows, oddsRows).estado === 'cotada')
-      .sort(
-        (a, b) =>
-          contaQueValem(mercado.slug, b.acesas) - contaQueValem(mercado.slug, a.acesas) ||
-          (a.line_value ?? 0) - (b.line_value ?? 0) ||
-          a.outcome.localeCompare(b.outcome),
-      )[0];
-    return candidataCotada ?? resumo?.candidato ?? null;
-  }, [resumos, mercado.slug, doMercado, valueRows, oddsRows]);
+  const candidatoInicialDoMercado = useMemo(
+    () => candidatoQueAbreAFolha(resumos.find((r) => r.mercado.slug === mercado.slug)),
+    [resumos, mercado.slug],
+  );
 
   // TODAS as linhas cotadas do mercado, em ordem. Com pills a tela mostrava as 5
   // mais centrais e as outras 16 não existiam; na régua arrastável cabem todas.

--- a/src/components/futebol/BancadaMercados.tsx
+++ b/src/components/futebol/BancadaMercados.tsx
@@ -31,7 +31,7 @@ import { evidenciaDe, ladoDaSaida } from '@/utils/futebol-evidencias';
 import { evidenciaDoHistorico } from '@/utils/futebol-historico';
 import { MotivosJogoPorJogo } from './MotivosJogoPorJogo';
 import { avisoSemDado } from '@/utils/futebol-sem-dado';
-import { valueDoCandidato, resumoDosMercados, mesmaLinha, candidatoQueAbreAFolha, type SaidaPreferida } from '@/utils/futebol-leitura';
+import { valueDoCandidato, resumoDosMercados, mesmaLinha, saidaQueAbreAFolha, type SaidaPreferida } from '@/utils/futebol-leitura';
 import { ehDestaque, ehFaixaAlta, rotuloDaFaixa, fronteirasDoScore } from '@/utils/futebol-score';
 import { leituraDaCotacao } from '@/utils/futebol-cotacao';
 import { filtrarCatalogoDeMercados } from '@/utils/futebol-mercados-ocultos';
@@ -306,12 +306,17 @@ export function BancadaMercados({
   // melhorCandidato dele já é nulo, então um "?? melhorCandidato(...)" aqui nunca
   // teria o que devolver, e ainda reabriria a porta das duas verdades.
   const candidatoInicialDoMercado = useMemo(
-    () => candidatoQueAbreAFolha(resumos.find((r) => r.mercado.slug === mercado.slug)),
+    () => saidaQueAbreAFolha(resumos.find((r) => r.mercado.slug === mercado.slug)),
     [resumos, mercado.slug],
   );
 
-  // TODAS as linhas cotadas do mercado, em ordem. Com pills a tela mostrava as 5
-  // mais centrais e as outras 16 não existiam; na régua arrastável cabem todas.
+  // TODAS as linhas ANALISADAS do mercado, em ordem — não só as cotadas, que é o
+  // que este comentário dizia e o código nunca fez: a fonte é `doMercado`, que
+  // são as premissas. A distinção passou a importar na #346, onde a régua abre
+  // numa linha sem cotação de propósito.
+  //
+  // Com pills a tela mostrava as 5 mais centrais e as outras 16 não existiam; na
+  // régua arrastável cabem todas.
   const paradas = useMemo(() => {
     if (!ehLinha) return [] as number[];
     return [...new Set(doMercado.map((r) => r.line_value).filter((v): v is number => v != null))].sort((a, b) => a - b);
@@ -323,7 +328,14 @@ export function BancadaMercados({
   // separadas, e quando o preço chegava depois a régua ficava parada na linha que as
   // premissas tinham escolhido sozinhas.
   useEffect(() => {
-    setLinha(candidatoInicialDoMercado?.line_value != null && paradas.includes(candidatoInicialDoMercado.line_value) ? candidatoInicialDoMercado.line_value : paradas[Math.floor(paradas.length / 2)] ?? null);
+    const anunciada = candidatoInicialDoMercado?.line_value;
+    // `mesmaLinha`, e não `includes`: a linha é float e a comparação estrita
+    // falha por ruído de representação. Hoje a linha anunciada vem do mesmo
+    // array das paradas, então o `includes` acertava por sorte — no dia em que
+    // ela vier de outra fonte (a URL, por exemplo), a régua centralizaria em
+    // silêncio, que é o desvio que a #346 existe para tirar da frente.
+    const naRegua = anunciada != null && paradas.some((p) => mesmaLinha(p, anunciada));
+    setLinha(naRegua ? anunciada : paradas[Math.floor(paradas.length / 2)] ?? null);
     setSaida(candidatoInicialDoMercado?.outcome ?? null);
   }, [candidatoInicialDoMercado, paradas]);
 

--- a/src/components/futebol/JogoResumoPanel.tsx
+++ b/src/components/futebol/JogoResumoPanel.tsx
@@ -147,10 +147,13 @@ export function JogoResumoPanel({
   const carregandoLeitura = demo ? false : leituraCarregando || premissasCarregando;
   const temLeitura = !!best || (topo != null && topo.nValem > 0);
   // Os dois links do painel levam à MESMA leitura que ele está exibindo (#344).
-  // Sem isso a tela do jogo abria no desempate padrão — normalmente gols — e o
-  // pick que a pessoa acabou de ler não estava mais na tela. Sem preço não há
-  // saída para filtrar, e aí abre a tela inteira, que é o honesto.
-  const paraOJogo = hrefDaSaida(fixture.fixture_id, best);
+  //
+  // `best ?? cand`, e não só `best`: a #344 mandava apenas a leitura COM preço,
+  // com o argumento de que sem preço não havia saída para filtrar. Falso — há
+  // saída anunciada, ela só não tem preço, e o painel a exibe em letra grande.
+  // Sem isto, num jogo sem oportunidade o link ia pelado e a tela do jogo abria
+  // noutra linha (#346).
+  const paraOJogo = hrefDaSaida(fixture.fixture_id, best ?? cand);
   const lado = cand ? ladoDaSaida(mercadoLeitura!, cand.outcome) : null;
   const nValem = cand && mercadoLeitura ? contaQueValem(mercadoLeitura, cand.acesas) : 0;
 

--- a/src/utils/futebol-leitura-anunciada.test.ts
+++ b/src/utils/futebol-leitura-anunciada.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { resumoDosMercados, candidatoQueAbreAFolha } from './futebol-leitura';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { resumoDosMercados, saidaQueAbreAFolha, melhorLeitura } from './futebol-leitura';
 import { melhorCandidato } from './futebol-premissas';
 import type { FutebolFixturePremissas } from '@/services/futebol-data.service';
 
@@ -50,16 +52,15 @@ describe('a leitura anunciada, sem preço nenhum', () => {
     expect(gols.value).toBeNull();
   });
 
-  it('a folha de detalhe abre NA MESMA saída do card', () => {
-    // A invariante que o defeito quebrou. Antes a folha preferia uma candidata
-    // cotada e abria em Over 0,5 enquanto o card ao lado dizia Under 3,25.
+  it('a folha de detalhe abre na saída anunciada, e não numa cotada qualquer', () => {
+    // O caso concreto do defeito: existe um Over 0,5 na lista, e antes era ELE
+    // que abria a folha por ter cotação, enquanto o card ao lado dizia
+    // Under 3,25. O teste afirma o valor esperado, e não `=== resumo.candidato`
+    // — comparar a função com a propriedade que ela devolve não falha nunca.
     const [gols] = resumoDosMercados(ROWS, SEM_PRECO, null, SEM_OCULTOS);
-    const abre = candidatoQueAbreAFolha(gols);
+    const abre = saidaQueAbreAFolha(gols);
 
-    expect(abre).not.toBeNull();
-    expect(`${abre!.outcome} ${abre!.line_value}`).toBe(
-      `${gols.candidato.outcome} ${gols.candidato.line_value}`,
-    );
+    expect(`${abre?.outcome} ${abre?.line_value}`).toBe('Under 3.25');
   });
 
   it('a saída do link vence, mesmo sem preço', () => {
@@ -75,7 +76,7 @@ describe('a leitura anunciada, sem preço nenhum', () => {
 
     expect(gols.candidato.outcome).toBe('Over');
     expect(gols.candidato.line_value).toBe(2.5);
-    expect(candidatoQueAbreAFolha(gols)?.line_value).toBe(2.5);
+    expect(saidaQueAbreAFolha(gols)?.line_value).toBe(2.5);
   });
 
   it('link apontando para saída que não existe cai na leitura anunciada', () => {
@@ -110,5 +111,69 @@ describe('melhorCandidato com preferência', () => {
       line_value: null,
     });
     expect(c?.line_value).toBe(3.25);
+  });
+});
+
+// A invariante de verdade mora entre dois arquivos: o card do mercado nomeia
+// `resumo.candidato`, e a folha precisa abrir na mesma saída. Um teste de
+// unidade não alcança isso — a folha é estado de componente.
+//
+// Esta guarda é modesta de propósito, e é bom dizer o que ela NÃO faz: ela não
+// impede que alguém volte a calcular a saída por outro caminho. Uma tentativa de
+// proibir o padrão antigo por regex reprovou código legítimo — `candidataCotada`
+// existe no arquivo como variável local de outra coisa, e `estado === 'cotada'`
+// aparece em quatro lugares corretos. Guarda que acusa código certo é pior que
+// guarda nenhuma: ensina a contornar.
+//
+// O que ela garante é o mínimo verdadeiro: a Bancada continua consultando a
+// decisão compartilhada em vez de ter a sua.
+describe('a Bancada usa a decisão compartilhada', () => {
+  it('chama saidaQueAbreAFolha', () => {
+    const bancada = readFileSync(
+      resolve(__dirname, '../components/futebol/BancadaMercados.tsx'),
+      'utf8',
+    );
+    expect(bancada).toContain('saidaQueAbreAFolha(');
+  });
+});
+
+describe('o desempate não é mais a menor linha', () => {
+  // O defeito nascia do desempate: entre candidatas equivalentes, a menor linha
+  // vencia, e em gols a menor é sempre a mais inútil. Aqui as três empatam em
+  // premissas de propósito — sem empate, o teste não exercita o desempate.
+  const EMPATADAS = [
+    prem('Over', 0.5, ['ataque_combinado']),
+    prem('Over', 2.5, ['ataque_combinado']),
+    prem('Over', 5.5, ['ataque_combinado']),
+  ];
+
+  it('empatadas, ganha a linha que o mercado de fato negocia', () => {
+    // Desempate por distância da linha central do mercado de gols, não por
+    // ordem crescente. "Mais de 0,5" só venceria de novo se o critério voltasse
+    // a ser a menor.
+    expect(melhorCandidato(EMPATADAS, 'goals_over_under')?.line_value).toBe(2.5);
+  });
+
+  it('e a folha abre nela também', () => {
+    const [gols] = resumoDosMercados(EMPATADAS, SEM_PRECO, null, SEM_OCULTOS);
+    expect(saidaQueAbreAFolha(gols)?.line_value).toBe(2.5);
+  });
+});
+
+describe('os três lugares nomeiam a mesma saída', () => {
+  // A coerência que o defeito quebrou, percorrida pelos caminhos reais de cada
+  // tela: o painel de resumo usa `melhorLeitura`, o card usa `resumoDosMercados`
+  // e a folha usa `saidaQueAbreAFolha`. Antes os dois primeiros diziam
+  // "Menos de 3,25" e o terceiro dizia "Mais de 0,5".
+  it('painel de resumo, card do mercado e folha de detalhe', () => {
+    const resumos = resumoDosMercados(ROWS, SEM_PRECO, null, SEM_OCULTOS);
+    const doPainel = melhorLeitura(resumos);
+    const doCard = resumos.find((r) => r.mercado.slug === 'goals_over_under');
+    const daFolha = saidaQueAbreAFolha(doCard);
+
+    const nome = (o: string | undefined, l: number | null | undefined) => `${o} ${l}`;
+    expect(nome(doPainel?.candidato.outcome, doPainel?.candidato.line_value)).toBe('Under 3.25');
+    expect(nome(doCard?.candidato.outcome, doCard?.candidato.line_value)).toBe('Under 3.25');
+    expect(nome(daFolha?.outcome, daFolha?.line_value)).toBe('Under 3.25');
   });
 });

--- a/src/utils/futebol-leitura-anunciada.test.ts
+++ b/src/utils/futebol-leitura-anunciada.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest';
+import { resumoDosMercados, candidatoQueAbreAFolha } from './futebol-leitura';
+import { melhorCandidato } from './futebol-premissas';
+import type { FutebolFixturePremissas } from '@/services/futebol-data.service';
+
+// ============================================================================
+// Sem oportunidade, a tela abre no que ela anuncia (issue #346)
+// ============================================================================
+// Flamengo × Mirassol, 02/09/2026, fixture 1492145. O jogo não tinha preço
+// coletado. O painel de resumo anunciava "Menos de 3,25 gols"; o card do mercado
+// dentro da tela do jogo repetia "Menos de 3,25 gols · sem cotação"; e a folha de
+// detalhe, ao lado do card, abria em "Mais de 0,5 gols", odd 1.03.
+//
+// Três lugares, duas respostas — duas delas na mesma tela, lado a lado.
+//
+// A causa era um degrau que preferia QUALQUER candidata cotada à leitura
+// anunciada, desempatando pela MENOR linha. Em gols a menor linha é sempre
+// "Mais de 0,5", a mais verdadeira e mais inútil do mercado. Não era borda:
+// acontecia em todo jogo sem oportunidade, que é a maioria dos jogos.
+// ============================================================================
+
+const prem = (outcome: string, line: number | null, acesas: string[]): FutebolFixturePremissas => ({
+  market: 'goals_over_under',
+  outcome,
+  line_value: line,
+  pts_premissas: 0,
+  penalidades_pts: 0,
+  acesas,
+  apagadas: [],
+  penalidades: [],
+});
+
+// O caso real: a leitura forte é o Under 3,25, e existe um Over 0,5 cotado que
+// não diz nada. As três premissas do Under são as que o painel mostrava.
+const DEFESAS = ['defesas_firmes', 'xg_baixo_combinado', 'historico_under'];
+const ROWS = [
+  prem('Under', 3.25, DEFESAS),
+  prem('Over', 0.5, ['ataques_fracos']),
+  prem('Over', 2.5, []),
+];
+
+const SEM_PRECO = null;
+const SEM_OCULTOS: string[] = [];
+
+describe('a leitura anunciada, sem preço nenhum', () => {
+  it('o card do mercado nomeia a saída com mais premissas', () => {
+    const [gols] = resumoDosMercados(ROWS, SEM_PRECO, null, SEM_OCULTOS);
+    expect(gols.candidato.outcome).toBe('Under');
+    expect(gols.candidato.line_value).toBe(3.25);
+    expect(gols.value).toBeNull();
+  });
+
+  it('a folha de detalhe abre NA MESMA saída do card', () => {
+    // A invariante que o defeito quebrou. Antes a folha preferia uma candidata
+    // cotada e abria em Over 0,5 enquanto o card ao lado dizia Under 3,25.
+    const [gols] = resumoDosMercados(ROWS, SEM_PRECO, null, SEM_OCULTOS);
+    const abre = candidatoQueAbreAFolha(gols);
+
+    expect(abre).not.toBeNull();
+    expect(`${abre!.outcome} ${abre!.line_value}`).toBe(
+      `${gols.candidato.outcome} ${gols.candidato.line_value}`,
+    );
+  });
+
+  it('a saída do link vence, mesmo sem preço', () => {
+    // Vindo do painel de resumo de um jogo sem oportunidade, o link carrega a
+    // leitura que a pessoa estava lendo. Antes a preferência só era consultada
+    // entre linhas COM preço, então ela sumia justamente neste caso.
+    const [gols] = resumoDosMercados(
+      ROWS,
+      SEM_PRECO,
+      { market: 'goals_over_under', outcome: 'Over', line_value: 2.5 },
+      SEM_OCULTOS,
+    );
+
+    expect(gols.candidato.outcome).toBe('Over');
+    expect(gols.candidato.line_value).toBe(2.5);
+    expect(candidatoQueAbreAFolha(gols)?.line_value).toBe(2.5);
+  });
+
+  it('link apontando para saída que não existe cai na leitura anunciada', () => {
+    const [gols] = resumoDosMercados(
+      ROWS,
+      SEM_PRECO,
+      { market: 'goals_over_under', outcome: 'Over', line_value: 9.5 },
+      SEM_OCULTOS,
+    );
+    expect(gols.candidato.line_value).toBe(3.25);
+  });
+});
+
+describe('melhorCandidato com preferência', () => {
+  it('sem preferência, manda a contagem de premissas', () => {
+    expect(melhorCandidato(ROWS, 'goals_over_under')?.line_value).toBe(3.25);
+  });
+
+  it('com preferência que casa, ela vence a contagem', () => {
+    const c = melhorCandidato(ROWS, 'goals_over_under', {
+      market: 'goals_over_under',
+      outcome: 'Over',
+      line_value: 0.5,
+    });
+    expect(`${c?.outcome} ${c?.line_value}`).toBe('Over 0.5');
+  });
+
+  it('preferência de outro mercado é ignorada', () => {
+    const c = melhorCandidato(ROWS, 'goals_over_under', {
+      market: 'match_winner',
+      outcome: 'Home',
+      line_value: null,
+    });
+    expect(c?.line_value).toBe(3.25);
+  });
+});

--- a/src/utils/futebol-leitura.ts
+++ b/src/utils/futebol-leitura.ts
@@ -200,7 +200,7 @@ export function sufixoDeLeitura(carregando: boolean, comLeitura: number): string
  * aviso "sem cotação" já explica por que ainda não dá para apostar, e isso é
  * mais honesto que desviar a pessoa para uma linha que ela não quer.
  */
-export function candidatoQueAbreAFolha(
+export function saidaQueAbreAFolha(
   resumo: MercadoResumo | null | undefined,
 ): FutebolFixturePremissas | null {
   return resumo?.candidato ?? null;

--- a/src/utils/futebol-leitura.ts
+++ b/src/utils/futebol-leitura.ts
@@ -1,7 +1,7 @@
 import type { FutebolFixturePremissas, FutebolFixtureValueRow } from '@/services/futebol-data.service';
 import { filtrarCatalogoDeMercados } from '@/utils/futebol-mercados-ocultos';
 import { ehDestaque } from '@/utils/futebol-score';
-import type { Saida } from '@/utils/futebol-saida';
+import { mesmaLinha, type Saida } from '@/utils/futebol-saida';
 import {
   MERCADOS,
   PORTA_PREMISSAS,
@@ -20,12 +20,10 @@ import {
 // (get_futebol_fixture_value). Sem odds, a leitura vive das premissas — o próprio
 // protótipo tem esse padrão no "sem preço" do BTTS.
 
-/** Mesma parada da régua? Compara com folga porque a linha vem em float. */
-export function mesmaLinha(a: number | null, b: number | null): boolean {
-  if (a == null && b == null) return true;
-  if (a == null || b == null) return false;
-  return Math.abs(a - b) < 0.011;
-}
+// `mesmaLinha` mudou para futebol-saida.ts (módulo folha), porque as premissas
+// também precisam dela e a leitura já importa delas — importar de volta fecharia
+// um ciclo. Reexportada aqui para os consumidores que a conhecem por este nome.
+export { mesmaLinha };
 
 /** Casa uma linha de valor (odds reais) com um candidato de premissas. */
 export function valueDoCandidato(
@@ -145,7 +143,10 @@ export function resumoDosMercados(
     // Oportunidades mostrava o segundo. Pior: o botão de registrar gravava a aposta
     // do preço, não a do rótulo que o usuário leu.
     const comPreco = saidaComPreco(rows, valueRows, m.slug, preferida);
-    const c = comPreco?.candidato ?? melhorCandidato(rows, m.slug);
+    // A preferência do link agora vale também sem preço (#346): antes ela era
+    // consultada só entre as linhas cotadas, e sumia justamente no jogo sem
+    // oportunidade — que é a maioria dos jogos.
+    const c = comPreco?.candidato ?? melhorCandidato(rows, m.slug, preferida);
     if (!c) return [];
     const nValem = contaQueValem(m.slug, c.acesas);
     // Denominador só do lado da saída: para um Over, "defesas firmes" e as outras do
@@ -179,4 +180,28 @@ export function melhorLeitura(resumos: MercadoResumo[]): MercadoResumo | null {
  */
 export function sufixoDeLeitura(carregando: boolean, comLeitura: number): string {
   return carregando ? '' : ` · ${comLeitura} com leitura`;
+}
+
+/**
+ * A saída que abre a folha de detalhe de um mercado.
+ *
+ * É a MESMA que o card do mercado nomeia — e é só isso que ela faz. Existe como
+ * função, e não como uma linha solta no componente, porque durante um tempo ela
+ * NÃO era a mesma, e ninguém tinha onde escrever um teste que provasse a
+ * igualdade.
+ *
+ * O que havia antes: sem oportunidade, a folha preferia qualquer candidata que
+ * já tivesse cotação, desempatando pela MENOR linha. Em gols a menor linha é
+ * sempre "Mais de 0,5" — a mais verdadeira e mais inútil do mercado, odd 1.03.
+ * Então o card dizia "Menos de 3,25 gols · sem cotação" e a folha ao lado abria
+ * em "Mais de 0,5 gols" (#346, Flamengo × Mirassol de 02/09/2026).
+ *
+ * A preferência por linha cotada não voltou em outro lugar: ela era a causa. O
+ * aviso "sem cotação" já explica por que ainda não dá para apostar, e isso é
+ * mais honesto que desviar a pessoa para uma linha que ela não quer.
+ */
+export function candidatoQueAbreAFolha(
+  resumo: MercadoResumo | null | undefined,
+): FutebolFixturePremissas | null {
+  return resumo?.candidato ?? null;
 }

--- a/src/utils/futebol-premissas.ts
+++ b/src/utils/futebol-premissas.ts
@@ -1,5 +1,5 @@
 import type { FutebolFixturePremissas } from '@/services/futebol-data.service';
-import { linhaDaSaida, type Saida } from '@/utils/futebol-saida';
+import { linhaDaSaida, mesmaLinha, type Saida } from '@/utils/futebol-saida';
 
 // Catálogo das premissas do Score: rótulo, peso e agrupamento.
 //
@@ -380,11 +380,26 @@ export function linhaNegociavel(market: string, line: number | null): boolean {
 export function melhorCandidato(
   rows: FutebolFixturePremissas[],
   market: string,
+  /**
+   * A saída que veio pelo link, quando houver.
+   *
+   * Ela já era respeitada entre as linhas COM preço, mas este caminho — o sem
+   * preço — a ignorava. Resultado: vindo do painel de um jogo sem oportunidade,
+   * o link carregava a leitura e a tela abria noutra (#346).
+   */
+  preferida?: Saida | null,
 ): FutebolFixturePremissas | null {
   const doMercado = rows
     .filter((r) => r.market === market)
     .filter((r) => linhaNegociavel(market, r.line_value));
   if (!doMercado.length) return null;
+
+  if (preferida?.market === market) {
+    const clicada = doMercado.find(
+      (r) => r.outcome === preferida.outcome && mesmaLinha(r.line_value, preferida.line_value),
+    );
+    if (clicada) return clicada;
+  }
   const nota = (r: FutebolFixturePremissas) => contaQueValem(market, r.acesas);
   const nPen = (r: FutebolFixturePremissas) => (r.penalidades ?? []).length;
   // Distância da linha padrão do mercado de gols. Desempata linhas empatadas em

--- a/src/utils/futebol-saida.ts
+++ b/src/utils/futebol-saida.ts
@@ -27,3 +27,25 @@ export function linhaDaSaida({ market, outcome, line_value }: Saida): number | n
   if (market === 'asian_handicap' && outcome === 'Away' && line_value != null) return -line_value;
   return line_value;
 }
+
+/**
+ * Mesma parada da régua?
+ *
+ * Compara com folga porque a linha vem em float e 3.25 do banco não é
+ * necessariamente 3.25 do JavaScript.
+ *
+ * Mora aqui, no módulo da saída, e não em `futebol-leitura.ts`, porque
+ * `futebol-premissas.ts` precisa dela e a leitura já importa das premissas —
+ * importar de volta fecharia um ciclo.
+ *
+ * ⚠️ Existe uma segunda cópia privada em `futebol-cotacao.ts`, com tolerância
+ * DIFERENTE (0.001 contra 0.011 daqui). Não foi unificada aqui de propósito:
+ * mudar a tolerância de lá é mudança de comportamento num módulo que não é o
+ * desta issue. Fica como dívida conhecida — duas comparações de float com
+ * réguas diferentes é como se erra comparação de float.
+ */
+export function mesmaLinha(a: number | null | undefined, b: number | null | undefined): boolean {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  return Math.abs(a - b) < 0.011;
+}


### PR DESCRIPTION
Fecha #346.

## O problema

Flamengo × Mirassol, 02/09/2026. O jogo não tinha preço coletado, e a tela dizia três coisas em dois lugares:

- o painel de resumo anunciava **"Menos de 3,25 gols"**
- o card do mercado repetia **"Menos de 3,25 gols · sem cotação"**
- a folha de detalhe, ao lado do card, abria em **"Mais de 0,5 gols"**, odd 1.03

## A causa

Um degrau na escolha da saída que abre a folha: sem oportunidade, ele preferia **qualquer candidata já cotada** à leitura anunciada, desempatando pela **menor linha**. Em gols a menor linha é sempre "Mais de 0,5" — a mais verdadeira e mais inútil do mercado.

Não era borda: acontecia em todo jogo sem oportunidade, que é a maioria dos jogos.

## A solução

O degrau saiu. Sem oportunidade, a folha abre na saída que o card nomeia, tenha ela cotação ou não. O aviso "sem cotação" já explica por que não dá para apostar ainda, e isso é mais honesto que desviar a pessoa para uma linha que ela não quer.

A decisão virou `saidaQueAbreAFolha`, função em vez de linha solta no componente — durante um tempo ela não era a mesma do card, e não havia onde escrever o teste que prova a igualdade.

**A preferência do link passou a valer sem preço.** `melhorCandidato` ganhou o parâmetro: antes a saída clicada era consultada só entre linhas com preço, e sumia justamente no caso sem oportunidade. Com isso o link do painel voltou a funcionar nesse ramo — ele manda `best ?? cand`, e não só `best`.

Isso corrige um julgamento meu na #344: eu tinha deixado esse ramo de fora argumentando que "sem preço não há saída para filtrar". Falso — há saída anunciada, ela só não tem preço, e o painel a exibe em letra grande. A revisão daquele PR levantou exatamente isso e eu descartei; o PM encontrou navegando.

## O que a revisão mudou

**O nome contradizia o glossário, terceira vez neste projeto.** O CONTEXT.md define candidata como "uma linha **cotada** que foi avaliada pelo funil", e a função nomeia justamente o caso sem cotação — que ali é **linha analisada**. Renomeada.

**Um teste meu era tautológico.** Comparava `f(resumo)` com `resumo.candidato` onde `f` É `resumo.candidato`: só falharia se alguém editasse o corpo da própria função. Agora afirma o valor esperado.

**Duas guardas que escrevi reprovavam código legítimo** — `candidataCotada` existe no arquivo como variável local de outra coisa, e `estado === 'cotada'` aparece em quatro lugares corretos. Saíram. Guarda que acusa código certo ensina a contornar.

**A régua comparava float com igualdade estrita.** Acertava por sorte, porque a linha anunciada vem do mesmo array das paradas; no dia em que ela vier da URL, centralizaria em silêncio. Passou a usar `mesmaLinha` — que já estava importada no arquivo e não era usada ali.

Entraram dois testes que faltavam: o desempate entre candidatas empatadas (o fixture antigo nunca empatava, então o critério novo estava sem prova) e a coerência dos três lugares percorrida pelos caminhos reais, incluindo `melhorLeitura`, que nenhum teste tocava.

## Dois desvios do texto da issue, registrados nela

**A preferência por cotada foi removida, não relocada** como a issue dizia. Quem desempata agora trabalha sobre premissas e não enxerga cotação; levar as odds até lá seria o encanamento que criou "duas verdades" antes. E o desempate que sobrou já resolve: ganha a linha mais próxima do centro do mercado, não a menor.

**"Jogo com oportunidade não muda" é impreciso** — a unidade certa é o mercado. Num jogo com oportunidade em um mercado e só odds nos outros, esses outros passam a abrir na leitura anunciada. Onde existe oportunidade de fato, nada muda.

Os dois estão comentados na issue, com o raciocínio.

## Efeito colateral

`mesmaLinha` mudou para `futebol-saida.ts`, o módulo folha: as premissas precisam dela e a leitura já importa das premissas, então importar de volta fecharia um ciclo. Reexportada da leitura para os consumidores existentes.

Fica registrada uma dívida: existe uma segunda cópia privada em `futebol-cotacao.ts`, com tolerância **diferente** — 0.001 contra 0.011. Não unifiquei porque mudar a tolerância de lá é mudança de comportamento num módulo que não é desta issue. Uma linha a 3.2505 casa numa e não casa na outra.

## Como validar

Abra um jogo sem oportunidade — a maioria. O painel de resumo, o card do mercado e a folha de detalhe têm que nomear a mesma saída. Clicando no título do painel, a tela do jogo abre naquela mesma leitura.

## Estado

`tsc -p tsconfig.app.json` limpo no módulo de futebol, `eslint` sem erros, 481 testes e `build` verdes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
