### PR TITLE
docs(contexto): o vocabulário do que sustenta uma premissa

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,8 +25,12 @@ O momento em que uma oportunidade passa a estar disponível no painel para o usu
 _Avoid_: Alerta, envio, publicação no Telegram
 
 **Motivo**:
-Uma premissa que o backend agrupou como **A favor** ou **Contra** de uma saída publicada. O agrupamento é decisão do backend; a tela só traduz o slug para texto. Não existe motivo que a tela conclua sozinha.
+Uma premissa que o backend agrupou de um lado de uma saída publicada. O agrupamento é decisão do backend; a tela só traduz o slug para texto. Não existe motivo que a tela conclua sozinha.
 _Avoid_: Razão, justificativa
+
+**Contra**:
+Uma **premissa do próprio lado da saída que não atingiu o corte**. Não é evidência apontando para o lado oposto: o modelo só sabe dizer "acendeu" e "não acendeu", e o segundo grupo é a ausência, não a oposição. Numa saída de Menos de 3,25 gols, uma premissa "contra" continua sendo uma premissa de Under.
+_Avoid_: Evidência contrária, sinal para o outro lado, argumento contra a aposta
 
 **Porquê**:
 O mesmo que **motivo a favor** — é o nome que a tela usa quando mostra só o lado positivo.
@@ -37,8 +41,32 @@ As premissas acesas de uma **linha analisada** sem preço. Não é motivo, porqu
 _Avoid_: Motivo, porquê
 
 **Evidência**:
-O número que embasa uma premissa: a média, o histórico, o placar que sustenta a frase. Ela acompanha a premissa e não a substitui — sem evidência a premissa continua verdadeira, só fica sem lastro na tela.
-_Avoid_: Motivo, prova, justificativa
+O **insumo** de uma premissa, mostrado na tela. Ela acompanha a premissa e não a substitui — sem evidência a premissa continua verdadeira, só fica sem lastro na tela. Um número verdadeiro e relacionado que **não** seja o insumo não é evidência daquela premissa: ele ilustra sem explicar, e faz a tela discordar de si mesma.
+_Avoid_: Motivo, prova, justificativa, qualquer número "que combina" com a frase
+
+**Critério**:
+A comparação que decide se uma premissa acende: um **insumo**, um **corte** e um sentido. É definição do modelo, não da tela.
+_Avoid_: Regra, fórmula, condição
+
+**Insumo**:
+O número que o **critério** compara. Média de gols sofridos somados, percentual de jogos sem sofrer gol de cada time, contagem de jogos abaixo da linha — cada premissa tem o seu, e ele é medido na **janela da premissa**.
+_Avoid_: Evidência (é o insumo já na tela), estatística, dado
+
+**Corte**:
+O limiar contra o qual o **insumo** é comparado. Pode ser um número fixo, ou derivado da linha com uma margem — e nesse caso o corte **não** é a linha.
+_Avoid_: Linha, limite, threshold
+
+**Janela da premissa**:
+O conjunto de partidas sobre o qual o **insumo** é medido: os últimos jogos do time em qualquer competição, contados antes do apito da partida analisada. Não é a temporada, não é uma competição só, e não separa casa de fora.
+_Avoid_: Temporada, forma recente, últimos jogos no campeonato
+
+**Premissa acesa**:
+Uma premissa cujo **insumo** cruzou o **corte**. É o que a tela conta em "3 premissas a favor".
+_Avoid_: Premissa verdadeira, premissa ativa
+
+**Não atingiu o corte**:
+Uma premissa avaliada, com **insumo** disponível, cujo número ficou aquém do **corte**. É diferente de não ter dado para avaliar, e diferente de não se aplicar àquele lado.
+_Avoid_: Não aconteceu, premissa falsa, premissa contra
 
 **Board**:
 O conjunto do que o backend publica — tudo que passou nas portas de qualidade de dado, gravado no funil e no histórico. É o universo, não o que está na tela.


### PR DESCRIPTION
Saída da entrevista de 02/09/2026 sobre o desalinhamento entre premissa, evidência e gráfico. Base da spec #349 e dos nove tickets (#350 a #358), que usam estes termos.

## Duas correções

**"Contra" não significa oposição.** O contrato devolve `favor[]` e `contra[]`, e o dado de produção mostra que as duas listas somadas são exatamente as premissas do **próprio lado** da saída: num Under 3,5 vieram quatro em favor e uma em contra, e o Under tem cinco premissas. Ou seja, `contra` é a premissa do mesmo lado que não atingiu o corte — o modelo só sabe dizer "acendeu" e "não acendeu".

A tela e a DM do Telegram chamam isso de "Contra", afirmando um sinal para o lado oposto onde há apenas ausência. Se existe oposição de verdade em algum mercado é pergunta aberta com o Mateus (#348).

**"Evidência" era frouxa demais.** Dizia "o número que embasa uma premissa: a média, o histórico, o placar" — o que autoriza qualquer número relacionado. É exatamente essa frouxidão que deixou a tela ilustrar "clean sheets altos" com média de gols sofridos. Agora ela é o **insumo** mostrado na tela, e um número verdadeiro que não seja o insumo deixa de ser evidência daquela premissa.

## Seis termos novos

**Critério**, **insumo** e **corte** separam o que a tela vinha tratando como uma coisa só. **Janela da premissa** fixa que a medida é sobre os últimos jogos em qualquer competição, e não sobre a temporada com recorte de mando. **Premissa acesa** e **não atingiu o corte** dão nome a estados que a tela hoje exibe como o mesmo silêncio.

O corte ganhou verbete próprio porque ele nem sempre é a linha: em várias premissas de gols ele é a linha com uma margem, e a tela afirma "fica abaixo da linha" numa faixa inteira em que isso é falso.

Só glossário — nenhuma decisão de implementação, nenhum caminho de arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEhivL7BXLRMx3HUoCDUr2