### PR TITLE
fix(futebol): abrir a premissa leva o topo dela para o topo da tela

### DIFF
--- a/src/components/futebol/MotivosJogoPorJogo.tsx
+++ b/src/components/futebol/MotivosJogoPorJogo.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 import type { FutebolFixtureHistorico, FutebolFixtureNumeros } from '@/services/futebol-data.service';
 import { pesoPalavra, pesoForte, rotuloPremissa, type Premissa } from '@/utils/futebol-premissas';
 import { evidenciaDe, type Evidencia } from '@/utils/futebol-evidencias';
+import { rolarParaOTopo } from '@/utils/rolagem';
 import { EH_BINARIA, evidenciaDoHistorico, storyDaPremissa, type SerieHistorico, type Story } from '@/utils/futebol-historico';
 import {
   corteEmPalavras,
@@ -628,8 +629,26 @@ function LinhaPremissa({
 }) {
   const forte = pesoForte(p);
   const podeAbrir = story != null;
+
+  // Abrir uma premissa leva o topo dela para o topo da tela.
+  //
+  // No celular o gráfico nascia embaixo do dedo e a pessoa ficava no MEIO do que
+  // tinha acabado de abrir, tendo de rolar para cima para ler do começo.
+  //
+  // Só na ABERTURA: rolar ao fechar levaria a tela para um card que a pessoa
+  // acabou de dispensar. Por isso a comparação com o valor anterior, e não um
+  // efeito que dispara sempre que `aberta` existe — no primeiro render também
+  // não rola, senão a tela pularia sozinha ao carregar.
+  const caixaRef = useRef<HTMLDivElement>(null);
+  const estavaAberta = useRef(aberta);
+  useEffect(() => {
+    if (aberta && !estavaAberta.current) rolarParaOTopo(caixaRef.current);
+    estavaAberta.current = aberta;
+  }, [aberta]);
+
   return (
     <div
+      ref={caixaRef}
       className="rounded-[14px] overflow-hidden bg-white"
       style={{ border: `1px solid ${aberta ? '#0a3d2e' : '#ded2b6'}` }}
     >

--- a/src/utils/rolagem.ts
+++ b/src/utils/rolagem.ts
@@ -1,0 +1,32 @@
+/**
+ * Leva o topo de um elemento para o topo da área visível, respeitando o
+ * cabeçalho fixo.
+ *
+ * Existe por causa da leitura no celular: ao abrir uma premissa, o conteúdo
+ * nascia embaixo do dedo e a pessoa ficava no MEIO do que acabou de abrir —
+ * tinha de rolar para cima para ler do começo. Abrir e já estar no começo é o
+ * comportamento que qualquer sanfona tem.
+ *
+ * A altura do cabeçalho é MEDIDA, não constante: ela muda entre celular e
+ * desktop, e a faixa de ambiente local empurra a barra mais 24px para baixo.
+ * Um número fixo acertaria num caso e esconderia o título nos outros.
+ *
+ * Sem animação para quem pediu menos movimento no sistema — a rolagem continua
+ * acontecendo, só que instantânea.
+ */
+export function rolarParaOTopo(el: HTMLElement | null | undefined): void {
+  if (!el || typeof window === 'undefined') return;
+
+  // Depois da pintura: o conteúdo que acabou de abrir ainda não tem altura no
+  // mesmo quadro do clique, e medir antes disso erra o destino.
+  requestAnimationFrame(() => {
+    const nav = document.querySelector('nav');
+    const caixa = nav?.getBoundingClientRect();
+    // `top` entra na conta porque a barra pode não estar colada no zero (é o
+    // caso com a faixa de DEV por cima dela).
+    const cabecalho = caixa ? caixa.height + Math.max(0, caixa.top) : 0;
+    const alvo = window.scrollY + el.getBoundingClientRect().top - cabecalho - 8;
+    const suave = !window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({ top: Math.max(0, alvo), behavior: suave ? 'smooth' : 'auto' });
+  });
+}


### PR DESCRIPTION
No celular, abrir uma premissa deixava a pessoa no **meio** do que tinha acabado de abrir: o jogo a jogo nascia embaixo do dedo e, para ler do começo, era preciso rolar para cima.

Agora a abertura leva o topo do card para logo abaixo do cabeçalho — o comportamento que qualquer sanfona tem.

## Detalhes que a implementação carrega

**A altura do cabeçalho é medida, não constante.** Ela muda entre celular (95px) e desktop, e a faixa de ambiente local empurra a barra mais 24px para baixo. Um número fixo acertaria num caso e esconderia o título nos outros.

**Só na abertura.** Rolar ao fechar levaria a tela para um card que a pessoa acabou de dispensar, e no primeiro render faria a tela pular sozinha ao carregar. Por isso o efeito compara com o valor anterior em vez de disparar sempre que `aberta` é verdadeiro.

**Depois da pintura.** O conteúdo que abriu ainda não tem altura no mesmo quadro do clique; medir antes disso erra o destino.

**Respeita `prefers-reduced-motion`.** Quem pediu menos movimento no sistema continua indo para o topo, só que sem a animação.

## Verificação

Conferido no navegador a 390px: um card que estava a 378px de altura passa a parar a 103px, com o cabeçalho terminando em 95px. Fechar não mexe na rolagem. 621 testes passando, typecheck nos mesmos 66 erros pré-existentes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)