### PR TITLE
fix(futebol): registrar aposta que não apaga sozinho, e a tela que para de prometer valor onde não existe

### DIFF
--- a/src/components/futebol/FutebolGate.tsx
+++ b/src/components/futebol/FutebolGate.tsx
@@ -95,8 +95,8 @@ export function FutebolAccessBanner({ access, className = '' }: { access?: Futeb
           <div className="text-[13px] font-bold text-ink">{expired ? 'Seu teste grátis acabou' : 'Veja as oportunidades — 7 dias grátis'}</div>
           <p className="text-[12px] text-ink-2 leading-snug">
             {expired
-              ? 'As oportunidades de valor estão bloqueadas. Assine o Futebol pra continuar vendo os picks.'
-              : 'Crie sua conta e libere os picks de valor por 7 dias, sem cartão.'}
+              ? 'As oportunidades do dia estão bloqueadas. Assine o Futebol pra continuar vendo os picks.'
+              : 'Crie sua conta e libere os picks do dia por 7 dias, sem cartão.'}
           </p>
         </div>
       </div>

--- a/src/components/futebol/MotivosJogoPorJogo.test.tsx
+++ b/src/components/futebol/MotivosJogoPorJogo.test.tsx
@@ -1,9 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MotivosJogoPorJogo } from './MotivosJogoPorJogo';
 import { premissaDe } from '@/utils/futebol-premissas';
 import { separarMotivosDoContrato } from '@/utils/futebol-motivos';
 import type { FutebolFixtureHistorico } from '@/services/futebol-data.service';
+import { alinharAbaixoDoCabecalho } from '@/utils/rolagem';
+
+vi.mock('@/utils/rolagem', () => ({ alinharAbaixoDoCabecalho: vi.fn() }));
 
 // ============================================================================
 // O que as abas A favor e Contra mostram (issue #306, spec #301)
@@ -190,5 +194,77 @@ describe('preço não chega à aba como premissa do jogo', () => {
     ]).slugsDePremissas);
 
     expect(screen.getByText('Nenhum motivo a favor desta saída.')).toBeInTheDocument();
+  });
+});
+
+// ============================================================================
+// A rolagem obedece ao toque, e só a ele (04/09)
+// ============================================================================
+// Abrir uma premissa leva o topo dela para baixo do cabeçalho — no celular o
+// gráfico nascia embaixo do dedo e a pessoa ficava no meio do que abriu.
+//
+// O risco do conserto é maior que o defeito: a lista abre a primeira premissa
+// SOZINHA sempre que o conjunto muda, e arrastar a régua muda o conjunto a cada
+// parada. Se a rolagem seguisse a abertura em vez do toque, a tela pularia no
+// meio do arrasto sem ninguém ter clicado.
+//
+// Só premissa com jogo a jogo abre, então o histórico aqui não é decoração: sem
+// ele nenhuma linha é clicável e o teste passaria sem testar nada.
+// ============================================================================
+
+describe('rolagem ao abrir a premissa', () => {
+  const umJogo = (over: Partial<FutebolFixtureHistorico>): FutebolFixtureHistorico => ({
+    side: 'home', team_id: 1, team_name: 'Casa', past_fixture_id: 1, data: '2026-08-01', ordem: 1,
+    mesma_competicao: true, em_casa: true, adversario: 'Adversário', adversario_id: 9,
+    gols_pro: 1, gols_contra: 1, total_gols: 2, ambos_marcaram: true, sem_sofrer: false,
+    sem_marcar: false, xg: 1, xg_contra: 1, resultado: 'E', ...over,
+  });
+
+  const comHistorico = [
+    ...[1, 2, 3].map((i) => umJogo({ side: 'home', team_id: 1, ordem: i, past_fixture_id: i, em_casa: true })),
+    ...[1, 2, 3].map((i) => umJogo({ side: 'away', team_id: 2, team_name: 'Fora', ordem: i, past_fixture_id: 10 + i, em_casa: false })),
+  ];
+
+  const renderDuas = () =>
+    render(
+      <MotivosJogoPorJogo
+        mercado="goals_over_under"
+        premissas={premissas('goals_over_under', ['defesas_firmes', 'defesas_vazaveis'])}
+        modo="favor"
+        extras={[]}
+        historico={comHistorico}
+        numeros={[]}
+        lado="home"
+        linha={3.25}
+        saidaLabel="Menos de 3,25 gols"
+      />,
+    );
+
+  it('não rola quando a lista abre a primeira sozinha', () => {
+    // É o que acontece ao montar, e a cada parada da régua.
+    renderDuas();
+
+    expect(alinharAbaixoDoCabecalho).not.toHaveBeenCalled();
+  });
+
+  it('rola quando o toque abre uma premissa fechada', async () => {
+    renderDuas();
+    vi.mocked(alinharAbaixoDoCabecalho).mockClear();
+
+    // Pelo PAPEL, e não pelo texto: o texto casa também com a div do card, que
+    // fica FORA do botão — clicar nela não abre nada e o teste passaria a
+    // afirmar o contrário do que quer.
+    await userEvent.click(screen.getByRole('button', { name: /ver os jogos/i }));
+
+    expect(alinharAbaixoDoCabecalho).toHaveBeenCalledTimes(1);
+  });
+
+  it('fechar não mexe na rolagem', async () => {
+    renderDuas();
+    vi.mocked(alinharAbaixoDoCabecalho).mockClear();
+
+    await userEvent.click(screen.getByRole('button', { name: /fechar/i }));
+
+    expect(alinharAbaixoDoCabecalho).not.toHaveBeenCalled();
   });
 });

--- a/src/components/futebol/MotivosJogoPorJogo.tsx
+++ b/src/components/futebol/MotivosJogoPorJogo.tsx
@@ -3,7 +3,7 @@ import { ChevronRight } from 'lucide-react';
 import type { FutebolFixtureHistorico, FutebolFixtureNumeros } from '@/services/futebol-data.service';
 import { pesoPalavra, pesoForte, rotuloPremissa, type Premissa } from '@/utils/futebol-premissas';
 import { evidenciaDe, type Evidencia } from '@/utils/futebol-evidencias';
-import { rolarParaOTopo } from '@/utils/rolagem';
+import { alinharAbaixoDoCabecalho } from '@/utils/rolagem';
 import { EH_BINARIA, evidenciaDoHistorico, storyDaPremissa, type SerieHistorico, type Story } from '@/utils/futebol-historico';
 import {
   corteEmPalavras,
@@ -630,20 +630,29 @@ function LinhaPremissa({
   const forte = pesoForte(p);
   const podeAbrir = story != null;
 
-  // Abrir uma premissa leva o topo dela para o topo da tela.
+  // Abrir uma premissa leva o topo dela para logo abaixo do cabeçalho.
   //
   // No celular o gráfico nascia embaixo do dedo e a pessoa ficava no MEIO do que
   // tinha acabado de abrir, tendo de rolar para cima para ler do começo.
   //
-  // Só na ABERTURA: rolar ao fechar levaria a tela para um card que a pessoa
-  // acabou de dispensar. Por isso a comparação com o valor anterior, e não um
-  // efeito que dispara sempre que `aberta` existe — no primeiro render também
-  // não rola, senão a tela pularia sozinha ao carregar.
+  // ⚠️ Só quando o TOQUE abriu. A lista abre a primeira premissa sozinha sempre
+  // que o conjunto muda (ver o efeito de `aberta` na lista), e arrastar a régua
+  // muda o conjunto a cada parada: uma premissa que sobrevive à troca e vira a
+  // primeira faria a tela pular no meio do arrasto, sem ninguém ter clicado.
+  // Rolar sem clique é pior que o problema que isto veio consertar.
+  //
+  // A rolagem fica no EFEITO e não no handler porque a conta só fecha depois da
+  // pintura: fechar o card que estava aberto acima muda a altura da página, e
+  // medir antes disso mira no lugar errado.
   const caixaRef = useRef<HTMLDivElement>(null);
-  const estavaAberta = useRef(aberta);
+  const abriuNoToque = useRef(false);
+  const alternarPorToque = () => {
+    abriuNoToque.current = !aberta;
+    onAlternar();
+  };
   useEffect(() => {
-    if (aberta && !estavaAberta.current) rolarParaOTopo(caixaRef.current);
-    estavaAberta.current = aberta;
+    if (aberta && abriuNoToque.current) alinharAbaixoDoCabecalho(caixaRef.current);
+    abriuNoToque.current = false;
   }, [aberta]);
 
   return (
@@ -654,7 +663,7 @@ function LinhaPremissa({
     >
       <button
         type="button"
-        onClick={podeAbrir ? onAlternar : undefined}
+        onClick={podeAbrir ? alternarPorToque : undefined}
         className="w-full flex items-center gap-3 px-4 py-3 text-left border-0"
         style={{
           background: aberta ? '#0a3d2e' : '#f4eddc',

--- a/src/components/futebol/MotivosJogoPorJogo.tsx
+++ b/src/components/futebol/MotivosJogoPorJogo.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronRight } from 'lucide-react';
 import type { FutebolFixtureHistorico, FutebolFixtureNumeros } from '@/services/futebol-data.service';
 import { pesoPalavra, pesoForte, rotuloPremissa, type Premissa } from '@/utils/futebol-premissas';
 import { evidenciaDe, type Evidencia } from '@/utils/futebol-evidencias';
+import { rolarParaOTopo } from '@/utils/rolagem';
 import { EH_BINARIA, evidenciaDoHistorico, storyDaPremissa, type SerieHistorico, type Story } from '@/utils/futebol-historico';
 import {
   corteEmPalavras,
@@ -628,8 +629,26 @@ function LinhaPremissa({
 }) {
   const forte = pesoForte(p);
   const podeAbrir = story != null;
+
+  // Abrir uma premissa leva o topo dela para o topo da tela.
+  //
+  // No celular o gráfico nascia embaixo do dedo e a pessoa ficava no MEIO do que
+  // tinha acabado de abrir, tendo de rolar para cima para ler do começo.
+  //
+  // Só na ABERTURA: rolar ao fechar levaria a tela para um card que a pessoa
+  // acabou de dispensar. Por isso a comparação com o valor anterior, e não um
+  // efeito que dispara sempre que `aberta` existe — no primeiro render também
+  // não rola, senão a tela pularia sozinha ao carregar.
+  const caixaRef = useRef<HTMLDivElement>(null);
+  const estavaAberta = useRef(aberta);
+  useEffect(() => {
+    if (aberta && !estavaAberta.current) rolarParaOTopo(caixaRef.current);
+    estavaAberta.current = aberta;
+  }, [aberta]);
+
   return (
     <div
+      ref={caixaRef}
       className="rounded-[14px] overflow-hidden bg-white"
       style={{ border: `1px solid ${aberta ? '#0a3d2e' : '#ded2b6'}` }}
     >

--- a/src/components/futebol/OportunidadesFiltros.test.tsx
+++ b/src/components/futebol/OportunidadesFiltros.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { configure, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { OportunidadesFiltros, type MarketFilter } from './OportunidadesFiltros';
 import type { FiltroDeValor } from '@/utils/futebol-score';
@@ -15,12 +15,6 @@ const props = {
   valor: 'todos' as FiltroDeValor,
   onValorChange: vi.fn(),
 };
-
-// Folga no limite da testing-library, pelo mesmo motivo do Onboarding.test:
-// `userEvent` digita caractere a caractere e cada passo espera o React,
-// então com a suíte inteira em paralelo o padrão de 1s estoura por saturação
-// da máquina, não por regressão. Rodando sozinho, o arquivo leva 2 segundos.
-configure({ asyncUtilTimeout: 10_000 });
 
 describe('OportunidadesFiltros', () => {
   it('mantém mercado e filtros de visualização em duas faixas independentes no mobile', () => {

--- a/src/components/futebol/OportunidadesFiltros.test.tsx
+++ b/src/components/futebol/OportunidadesFiltros.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { configure, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { OportunidadesFiltros, type MarketFilter } from './OportunidadesFiltros';
 import type { FiltroDeValor } from '@/utils/futebol-score';
@@ -15,6 +15,12 @@ const props = {
   valor: 'todos' as FiltroDeValor,
   onValorChange: vi.fn(),
 };
+
+// Folga no limite da testing-library, pelo mesmo motivo do Onboarding.test:
+// `userEvent` digita caractere a caractere e cada passo espera o React,
+// então com a suíte inteira em paralelo o padrão de 1s estoura por saturação
+// da máquina, não por regressão. Rodando sozinho, o arquivo leva 2 segundos.
+configure({ asyncUtilTimeout: 10_000 });
 
 describe('OportunidadesFiltros', () => {
   it('mantém mercado e filtros de visualização em duas faixas independentes no mobile', () => {

--- a/src/components/futebol/RegistrarAposta.test.tsx
+++ b/src/components/futebol/RegistrarAposta.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { configure, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { RegistrarApostaModal } from './RegistrarAposta';
@@ -52,12 +52,6 @@ function renderModal(d: FutebolBetDraft) {
     </MemoryRouter>,
   );
 }
-
-// Folga no limite da testing-library, pelo mesmo motivo do Onboarding.test:
-// `userEvent` digita caractere a caractere e cada passo espera o React,
-// então com a suíte inteira em paralelo o padrão de 1s estoura por saturação
-// da máquina, não por regressão. Rodando sozinho, o arquivo leva 2 segundos.
-configure({ asyncUtilTimeout: 10_000 });
 
 describe('RegistrarApostaModal', () => {
   it('o valor digitado sobrevive a um rerender do pai', async () => {

--- a/src/components/futebol/RegistrarAposta.test.tsx
+++ b/src/components/futebol/RegistrarAposta.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { configure, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { RegistrarApostaModal } from './RegistrarAposta';
@@ -38,6 +38,13 @@ const draft = (): FutebolBetDraft => ({
   oddKind: 'melhor',
 });
 
+/**
+ * A mesma aposta com outra odd. O tipo do rascunho é união discriminada pela
+ * origem da odd, então o campo que discrimina vai escrito por extenso: espalhar
+ * o objeto e trocar só a odd apaga a discriminação e o tipo deixa de casar.
+ */
+const draftComOdd = (bestOdd: number): FutebolBetDraft => ({ ...draft(), bestOdd, oddKind: 'melhor' });
+
 function renderModal(d: FutebolBetDraft) {
   return render(
     <MemoryRouter>
@@ -45,6 +52,12 @@ function renderModal(d: FutebolBetDraft) {
     </MemoryRouter>,
   );
 }
+
+// Folga no limite da testing-library, pelo mesmo motivo do Onboarding.test:
+// `userEvent` digita caractere a caractere e cada passo espera o React,
+// então com a suíte inteira em paralelo o padrão de 1s estoura por saturação
+// da máquina, não por regressão. Rodando sozinho, o arquivo leva 2 segundos.
+configure({ asyncUtilTimeout: 10_000 });
 
 describe('RegistrarApostaModal', () => {
   it('o valor digitado sobrevive a um rerender do pai', async () => {
@@ -90,7 +103,7 @@ describe('RegistrarApostaModal', () => {
 
     rerender(
       <MemoryRouter>
-        <RegistrarApostaModal open onOpenChange={vi.fn()} draft={{ ...draft(), bestOdd: 1.9 }} />
+        <RegistrarApostaModal open onOpenChange={vi.fn()} draft={draftComOdd(1.9)} />
       </MemoryRouter>,
     );
 

--- a/src/components/futebol/RegistrarAposta.test.tsx
+++ b/src/components/futebol/RegistrarAposta.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { RegistrarApostaModal } from './RegistrarAposta';
+import type { FutebolBetDraft } from './registrar-aposta-utils';
+
+// ============================================================================
+// O que a pessoa digita não pode sumir sozinho (04/09)
+// ============================================================================
+// Medido em produção: escolher "½ unidade" no modal, esperar, e o campo voltava
+// a 0,00 com o botão desabilitado — sem ninguém tocar em nada.
+//
+// A causa era o efeito que zera os campos ao abrir: ele dependia do OBJETO
+// `draft`, e a lista de oportunidades monta um literal novo a cada render
+// (`draftFromBoardRow(o)` dentro do JSX). Como a lista rerenderiza sozinha — o
+// relógio da tela avança, o board revalida —, cada rerender apagava o valor.
+//
+// Registrar aposta pela lista era, na prática, uma corrida contra o próximo
+// render. Este teste reproduz o rerender com um draft NOVO e igual.
+//
+// Os campos são <input type="number">, então o valor esperado é número.
+// ============================================================================
+
+vi.mock('@/hooks/use-auth', () => ({ useAuth: () => ({ user: { id: 'user-1' } }) }));
+vi.mock('@/hooks/use-user-unit', () => ({ useUserUnit: () => ({ config: { unit_value: 10 } }) }));
+vi.mock('@/integrations/supabase/client', () => ({ createClient: () => ({ from: () => ({ insert: async () => ({ error: null }) }) }) }));
+
+const draft = (): FutebolBetDraft => ({
+  homeName: 'Lyon',
+  awayName: 'Auxerre',
+  competition: 'ligue_1',
+  kickoffUtc: '2026-09-04T14:00:00Z',
+  market: 'goals_over_under',
+  outcome: 'Over',
+  lineValue: 2.5,
+  bestOdd: 1.74,
+  oddKind: 'melhor',
+});
+
+function renderModal(d: FutebolBetDraft) {
+  return render(
+    <MemoryRouter>
+      <RegistrarApostaModal open onOpenChange={vi.fn()} draft={d} />
+    </MemoryRouter>,
+  );
+}
+
+describe('RegistrarApostaModal', () => {
+  it('o valor digitado sobrevive a um rerender do pai', async () => {
+    const { rerender } = renderModal(draft());
+
+    const valor = screen.getByLabelText(/valor/i);
+    await userEvent.clear(valor);
+    await userEvent.type(valor, '5');
+    expect(valor).toHaveValue(5);
+
+    // O pai rerenderiza e monta OUTRO objeto com os mesmos dados — é o que a
+    // lista de oportunidades faz sozinha, sem ninguém mexer na tela.
+    rerender(
+      <MemoryRouter>
+        <RegistrarApostaModal open onOpenChange={vi.fn()} draft={draft()} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText(/valor/i)).toHaveValue(5);
+  });
+
+  it('trocar de aposta zera o valor, que é o que o efeito existe para fazer', async () => {
+    const { rerender } = renderModal(draft());
+
+    const valor = screen.getByLabelText(/valor/i);
+    await userEvent.type(valor, '5');
+
+    rerender(
+      <MemoryRouter>
+        <RegistrarApostaModal open onOpenChange={vi.fn()} draft={{ ...draft(), outcome: 'Under' }} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText(/valor/i)).toHaveValue(null);
+  });
+
+  it('preço novo no board não mexe na odd de quem está digitando', async () => {
+    // A odd fica fora da chave da aposta: se o board trouxer preço melhor com o
+    // modal aberto, o campo não pode trocar embaixo do dedo.
+    const { rerender } = renderModal(draft());
+
+    expect(screen.getByLabelText(/odd/i)).toHaveValue(1.74);
+
+    rerender(
+      <MemoryRouter>
+        <RegistrarApostaModal open onOpenChange={vi.fn()} draft={{ ...draft(), bestOdd: 1.9 }} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText(/odd/i)).toHaveValue(1.74);
+  });
+});

--- a/src/components/futebol/RegistrarAposta.tsx
+++ b/src/components/futebol/RegistrarAposta.tsx
@@ -11,7 +11,8 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Receipt, Check, Loader2, ArrowRight } from 'lucide-react';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
 import { createClient } from '@/integrations/supabase/client';
 import { useAuth } from '@/hooks/use-auth';
 import { useUserUnit } from '@/hooks/use-user-unit';
@@ -40,13 +41,37 @@ export function RegistrarApostaModal({
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /**
+   * A aposta que o modal está editando, em forma de string.
+   *
+   * O efeito abaixo zera os campos ao ABRIR, e precisa saber quando a aposta
+   * mudou de verdade. Ele dependia do objeto `draft`, que nasce novo a cada
+   * render do pai (`draftFromBoardRow(o)` monta um literal dentro do JSX da
+   * lista) — então qualquer rerender zerava o que a pessoa tinha acabado de
+   * digitar. E a lista rerenderiza sozinha: o relógio da tela avança e o board
+   * revalida de tempos em tempos.
+   *
+   * Medido em produção em 04/09: escolher "½ unidade", esperar, e o campo
+   * voltava a 0,00 com o botão desabilitado. Registrar aposta pela lista era,
+   * na prática, uma corrida contra o próximo render.
+   *
+   * A odd fica FORA da chave de propósito. Se o board trouxer preço melhor
+   * enquanto o modal está aberto, quem está digitando não quer o campo trocando
+   * embaixo do dedo — a odd que vale é a que a pessoa viu quando abriu.
+   */
+  const chaveDoDraft = draft
+    ? [draft.market, draft.outcome, draft.lineValue, draft.homeName, draft.awayName, draft.kickoffUtc].join('|')
+    : '';
+
   useEffect(() => {
-    if (open && draft) {
-      setStake('');
-      setOdd(draft.bestOdd ? draft.bestOdd.toFixed(2) : '');
-      setDone(false); setError(null); setSaving(false);
-    }
-  }, [open, draft]);
+    if (!open || !draft) return;
+    setStake('');
+    setOdd(draft.bestOdd ? draft.bestOdd.toFixed(2) : '');
+    setDone(false); setError(null); setSaving(false);
+    // `draft` fica fora das dependências de propósito: quem identifica a aposta
+    // é a chave acima, e não a referência do objeto. Ver o comentário dela.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, chaveDoDraft]);
 
   // O draft veio do formulario com `lineValue` em camelCase, entao a saida se monta
   // aqui. E o unico lugar em que ela nao chega pronta da RPC.
@@ -97,6 +122,13 @@ export function RegistrarApostaModal({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="theme-bolao bg-white border-line p-0 gap-0 max-w-md overflow-hidden">
+        {/* O título existe para o leitor de tela: sem ele o Radix avisa no
+            console que o diálogo é inacessível, e quem navega por áudio ouve
+            "diálogo" sem saber do quê. Escondido à vista porque o cabeçalho
+            desenhado logo abaixo já cumpre esse papel para quem enxerga. */}
+        <VisuallyHidden.Root asChild>
+          <DialogTitle>Registrar aposta no Betinho</DialogTitle>
+        </VisuallyHidden.Root>
         {/* Cabeçalho */}
         <div className="px-5 py-4 border-b border-line">
           <div className="flex items-center gap-2 text-[11px] uppercase tracking-[0.16em] font-bold text-forest">

--- a/src/components/onboarding/tours.tsx
+++ b/src/components/onboarding/tours.tsx
@@ -26,7 +26,7 @@ export const hubSteps: Step[] = [
     placement: 'bottom',
     title: 'Futebol',
     content:
-      'As oportunidades de valor do dia: onde o dado aponta aposta com vantagem, com o Score pra você comparar. É por aqui que a maioria começa.',
+      'As oportunidades do dia: o que o modelo leu em cada jogo, com o Score pra você comparar e o preço de mercado ao lado. É por aqui que a maioria começa.',
   },
   {
     id: 'betinho',
@@ -102,9 +102,9 @@ export function makeFutebolSteps({ hasDayBar }: { hasDayBar: boolean }): Step[] 
       placement: 'top',
       // Bloco grande: mais respiro nas bordas do destaque que o padrão (6).
       spotlightPadding: 14,
-      title: 'As oportunidades de valor',
+      title: 'As oportunidades do dia',
       content:
-        'Aqui ficam as principais apostas com valor do dia, ordenadas pelo Score de Confiabilidade. Quanto maior o Score, mais o histórico apoia aquela linha. Toque numa pra abrir a análise completa do jogo.',
+        'Aqui ficam as principais leituras do dia, ordenadas pelo Score de Confiabilidade. Quanto maior o Score, mais o histórico apoia aquela linha. Toque numa pra abrir a análise completa do jogo.',
     },
     {
       id: 'futebol-jogos',
@@ -147,7 +147,7 @@ export function makeFutebolOportunidadesSteps({
       placement: 'center',
       title: 'Todas as oportunidades',
       content:
-        'Aqui está a lista completa do dia. Toda aposta com valor, ordenada do Score mais alto pro mais baixo.',
+        'Aqui está a lista completa do dia, ordenada do Score mais alto pro mais baixo. O filtro de valor separa as que pagam acima do preço justo.',
     },
   ];
 

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -113,7 +113,7 @@ function TopValueHero({ o, to, favor, contra, textoScore, locked, carregandoMoti
   const porque = chance != null
     ? pagaAcima
       ? <>O mercado dá <b className={forte}>~{chance}% de chance</b>; na odd <b className={forte}>{o.best_odd.toFixed(2)}</b> isso paga acima do risco real — é aí que está o valor.</>
-      : <>O mercado dá <b className={forte}>~{chance}% de chance</b>, e na odd <b className={forte}>{o.best_odd.toFixed(2)}</b> o preço fica <b className={forte}>{Math.abs(Math.round(o.edge * 1000) / 10).toFixed(1).replace('.', ',')}% abaixo do justo</b>. O que sustenta esta leitura é o cenário, não o preço.</>
+      : <>O mercado dá <b className={forte}>~{chance}% de chance</b>, e na odd <b className={forte}>{o.best_odd.toFixed(2)}</b> o preço fica <b className={forte}>{Math.abs(o.edge * 100).toFixed(1).replace('.', ',')}% abaixo do justo</b>. O que sustenta esta leitura é o cenário, não o preço.</>
     : <>Na odd <b className={forte}>{o.best_odd.toFixed(2)}</b>, a aposta se paga a partir de <b className={forte}>{Math.round(100 / o.best_odd)}%</b> de acerto — e a leitura do jogo aponta nessa direção.</>;
 
   return (
@@ -126,7 +126,7 @@ function TopValueHero({ o, to, favor, contra, textoScore, locked, carregandoMoti
         <div className="md:col-span-4 flex flex-col">
           <span className={`inline-flex items-center gap-1.5 px-2.5 h-7 rounded-md text-[10px] uppercase tracking-[0.18em] font-bold w-fit ${d ? '' : 'bg-amber/15 text-amber-2 border border-amber/30'}`}
             style={d ? { background: '#fbbf24', color: '#1a1d1a' } : undefined}>
-            <Zap className="w-3 h-3" /> {d ? 'Melhor valor do dia' : 'Melhor do dia · Média'}
+            <Zap className="w-3 h-3" /> {pagaAcima ? 'Melhor valor do dia' : 'Destaque do dia'}
           </span>
           <div className={`text-[11px] uppercase tracking-[0.16em] font-semibold mt-5 ${d ? 'text-white/50' : 'text-ink-3'}`}>{marketLabel(o.market)} · {competitionLabel(o.competition)}</div>
           <div className={`text-[28px] md:text-[32px] font-bold tracking-tight leading-[1.1] mt-2 ${d ? '' : 'text-ink'}`}><Blur active={!!locked} strength={9}>{pick}</Blur></div>
@@ -591,7 +591,17 @@ export default function FutebolHoje() {
             <Kpi label="Jogos hoje" value={loading ? '—' : gameList.length} sub={isToday ? 'na agenda' : 'no dia'} />
             <Kpi label="Oportunidades" value={loading ? '—' : nOpps} sub="publicadas" tone="green" />
             <Kpi label="Faixa Alta" value={loading ? '—' : alta} sub="maior confiança" anchor />
-            <Kpi label="Melhor valor" value={loading || melhorValor == null ? '—' : `${melhorValor >= 0 ? '+' : '−'}${Math.abs(melhorValor)}%`} sub="maior diferença do dia" tone="green" />
+            {/* Verde é promessa. Num dia em que a melhor diferença do dia é
+                NEGATIVA — e depois da virada de 03/09 isso é o normal, não a
+                exceção — o cartão verde dizia boa notícia com número de má
+                notícia. O tom segue o sinal, e o rótulo deixa de prometer valor
+                onde ele não existe. */}
+            <Kpi
+              label={melhorValor != null && melhorValor < 0 ? 'Preço mais perto do justo' : 'Melhor valor'}
+              value={loading || melhorValor == null ? '—' : `${melhorValor >= 0 ? '+' : '−'}${Math.abs(melhorValor)}%`}
+              sub="maior diferença do dia"
+              tone={melhorValor != null && melhorValor >= 0 ? 'green' : undefined}
+            />
           </div>
         </div>
 

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -98,9 +98,23 @@ function TopValueHero({ o, to, favor, contra, textoScore, locked, carregandoMoti
   const d = true; // hero sempre no fundo forest (mockup); a faixa vai no selo, não na cor do card
   const chance = chancePct(o.prob_justa_fechamento);
   const estado = estadoDosMotivos(favor, contra, carregandoMotivos);
+  // A frase do "por quê" muda com o SINAL da diferença para o preço justo.
+  //
+  // Ela terminava sempre em "isso paga acima do risco real — é aí que está o
+  // valor". Depois da virada de 03/09 o board publica a linha mesmo sem
+  // vantagem, e o destaque do dia pode ser o MENOS pior: em 04/09 os cinco
+  // primeiros pagavam abaixo do justo. A frase afirmava valor com o número
+  // negativo ao lado dela.
+  //
+  // Quando o preço não ajuda, a tela diz isso e devolve o assunto para onde ele
+  // se sustenta: o cenário. É a mesma honestidade do rodapé da lista.
+  const pagaAcima = o.edge > 0;
+  const forte = d ? 'text-white' : 'text-ink';
   const porque = chance != null
-    ? <>O mercado dá <b className={d ? 'text-white' : 'text-ink'}>~{chance}% de chance</b>; na odd <b className={d ? 'text-white' : 'text-ink'}>{o.best_odd.toFixed(2)}</b> isso paga acima do risco real — é aí que está o valor.</>
-    : <>Na odd <b className={d ? 'text-white' : 'text-ink'}>{o.best_odd.toFixed(2)}</b>, a aposta se paga a partir de <b className={d ? 'text-white' : 'text-ink'}>{Math.round(100 / o.best_odd)}%</b> de acerto — e a leitura do jogo aponta nessa direção.</>;
+    ? pagaAcima
+      ? <>O mercado dá <b className={forte}>~{chance}% de chance</b>; na odd <b className={forte}>{o.best_odd.toFixed(2)}</b> isso paga acima do risco real — é aí que está o valor.</>
+      : <>O mercado dá <b className={forte}>~{chance}% de chance</b>, e na odd <b className={forte}>{o.best_odd.toFixed(2)}</b> o preço fica <b className={forte}>{Math.abs(Math.round(o.edge * 1000) / 10).toFixed(1).replace('.', ',')}% abaixo do justo</b>. O que sustenta esta leitura é o cenário, não o preço.</>
+    : <>Na odd <b className={forte}>{o.best_odd.toFixed(2)}</b>, a aposta se paga a partir de <b className={forte}>{Math.round(100 / o.best_odd)}%</b> de acerto — e a leitura do jogo aponta nessa direção.</>;
 
   return (
     <div className={`rounded-2xl overflow-hidden relative ${d ? 'text-white' : 'bg-white border border-line border-l-4 border-l-amber'}`}
@@ -563,7 +577,7 @@ export default function FutebolHoje() {
               {gameList.length > 0 ? (
                 <>
                   <span className="font-semibold text-ink">{gameList.length} jogo{gameList.length === 1 ? '' : 's'}</span>
-                  {nOpps > 0 && <> · {nOpps} oportunidade{nOpps === 1 ? '' : 's'} de valor</>}
+                  {nOpps > 0 && <> · {nOpps} oportunidade{nOpps === 1 ? '' : 's'}</>}
                   {alta > 0 && <> · <span className="font-semibold text-forest">{alta} de faixa Alta</span></>}
                 </>
               ) : 'Sem jogos nesse dia'}
@@ -575,9 +589,9 @@ export default function FutebolHoje() {
           </div>
           <div data-tour="futebol-resumo" className="md:col-span-7 grid grid-cols-2 md:grid-cols-4 gap-3">
             <Kpi label="Jogos hoje" value={loading ? '—' : gameList.length} sub={isToday ? 'na agenda' : 'no dia'} />
-            <Kpi label="Oportunidades" value={loading ? '—' : nOpps} sub="com valor" tone="green" />
+            <Kpi label="Oportunidades" value={loading ? '—' : nOpps} sub="publicadas" tone="green" />
             <Kpi label="Faixa Alta" value={loading ? '—' : alta} sub="maior confiança" anchor />
-            <Kpi label="Melhor valor" value={loading || melhorValor == null ? '—' : `+${melhorValor}%`} sub="destaque do dia" tone="green" />
+            <Kpi label="Melhor valor" value={loading || melhorValor == null ? '—' : `${melhorValor >= 0 ? '+' : '−'}${Math.abs(melhorValor)}%`} sub="maior diferença do dia" tone="green" />
           </div>
         </div>
 

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -578,13 +578,15 @@ export default function FutebolOportunidades() {
                     valor — que volta quando o filtro pede só as que pagam acima
                     do justo, porque aí a frase descreve a lista.
 
-                    A faixa Baixa segue com o rótulo próprio: ali a pessoa está
-                    olhando o que o cenário NÃO sustenta. */}
+                    A faixa Baixa continua calando a frase, e as duas condições
+                    valem juntas: preço acima do justo é uma afirmação, cenário
+                    sustentado é outra, e o título só promete valor quando as duas
+                    são verdade na lista que está na tela. */}
                 <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">
                   {comValor.length} {comValor.length === 1 ? 'oportunidade' : 'oportunidades'}
                   {faixasSelecionadas.length === 1 && faixasSelecionadas[0] === 'baixa'
                     ? ' em faixa baixa'
-                    : valor === 'positivo' ? ' com valor' : ''}
+                    : valor === 'positivo' && !faixasSelecionadas.includes('baixa') ? ' com valor' : ''}
                 </h1>
                 <p className="text-[13px] mt-1 text-ink-2">{isPastDay ? 'Resultado das oportunidades publicadas neste dia' : 'Análises pré-jogo com Score, o que sustenta cada leitura e o preço de mercado ao lado. O filtro de valor separa as que pagam acima do preço justo.'}</p>
               </>

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -541,7 +541,7 @@ export default function FutebolOportunidades() {
                 {resumo.settled > 0 ? (
                   <>
                     <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">{resumo.hit} de {resumo.settled} deram green</h1>
-                    <p className="text-[13px] mt-1 text-ink-2">Resultado das oportunidades com valor deste dia{resumo.push > 0 ? ` · ${resumo.push} anulada${resumo.push === 1 ? '' : 's'}` : ''}</p>
+                    <p className="text-[13px] mt-1 text-ink-2">Resultado das oportunidades publicadas neste dia{resumo.push > 0 ? ` · ${resumo.push} anulada${resumo.push === 1 ? '' : 's'}` : ''}</p>
                   </>
                 ) : (
                   <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">Nenhuma oportunidade deste dia liquidou</h1>
@@ -562,17 +562,31 @@ export default function FutebolOportunidades() {
               </>
             ) : (
               <>
-                {/* O título não afirma "com valor" quando a pessoa pediu para
-                    ver a faixa Baixa: ali ela está olhando o que o cenário NÃO
-                    sustenta, e chamar aquilo de aposta com valor contradiz a
-                    própria legenda. */}
+                {/* O título só afirma "com valor" quando isso é verdade na
+                    lista que está na tela.
+
+                    Ele dizia "N oportunidades com valor" sempre. Depois da
+                    virada de 03/09 a porta de preço saiu do gate: o board
+                    publica a linha independente de a odd pagar acima do justo,
+                    e em 04/09 as cinco primeiras do dia pagavam ABAIXO. A tela
+                    afirmava valor em cima de um número que dizia o contrário,
+                    três centímetros ao lado.
+
+                    "Oportunidade" continua certo, e é o termo do CONTEXT.md:
+                    candidata aprovada pelas regras de publicação VIGENTES. Quem
+                    mudou foram as regras, não o nome. O que sai é a promessa de
+                    valor — que volta quando o filtro pede só as que pagam acima
+                    do justo, porque aí a frase descreve a lista.
+
+                    A faixa Baixa segue com o rótulo próprio: ali a pessoa está
+                    olhando o que o cenário NÃO sustenta. */}
                 <h1 className="font-display text-2xl md:text-[28px] font-extrabold tracking-tight text-ink mt-1">
                   {comValor.length} {comValor.length === 1 ? 'oportunidade' : 'oportunidades'}
                   {faixasSelecionadas.length === 1 && faixasSelecionadas[0] === 'baixa'
                     ? ' em faixa baixa'
-                    : faixasSelecionadas.includes('baixa') ? '' : ' com valor'}
+                    : valor === 'positivo' ? ' com valor' : ''}
                 </h1>
-                <p className="text-[13px] mt-1 text-ink-2">{isPastDay ? 'Resultado das oportunidades com valor deste dia' : 'Análises pré-jogo com Score, argumentos a favor e contra e preço de mercado para apoiar sua decisão.'}</p>
+                <p className="text-[13px] mt-1 text-ink-2">{isPastDay ? 'Resultado das oportunidades publicadas neste dia' : 'Análises pré-jogo com Score, o que sustenta cada leitura e o preço de mercado ao lado. O filtro de valor separa as que pagam acima do preço justo.'}</p>
               </>
             )}
           </div>
@@ -636,14 +650,14 @@ export default function FutebolOportunidades() {
                 uma tela que só precisava de um clique em Todas. */}
             <p className="text-sm text-ink-2">
               {escondidasPeloFiltro > 0 ? 'Nenhuma oportunidade nesse filtro.'
-                : isPastDay ? 'Nenhuma oportunidade com valor nesse dia.'
+                : isPastDay ? 'Nenhuma oportunidade publicada nesse dia.'
                 : isFutureDay ? 'Ainda sem oportunidades para este dia.'
                 : 'Nenhum jogo com odds nesse filtro.'}
             </p>
             <p className="text-xs text-ink-3 mt-1">
               {escondidasPeloFiltro > 0
                 ? `Este dia tem ${escondidasPeloFiltro} ${escondidasPeloFiltro === 1 ? 'oportunidade' : 'oportunidades'}${soEmAberto ? ' de jogos que já começaram ou em outro filtro. Desligue "Só jogos em aberto" para ver.' : ' em outra faixa ou mercado. Troque o filtro para ver.'}`
-                : isPastDay ? 'Só listamos aqui as apostas que sinalizamos com valor.'
+                : isPastDay ? 'Só listamos aqui o que foi publicado no dia.'
                 : isFutureDay ? 'As odds costumam ser coletadas a partir de ~24h antes do jogo — as oportunidades aparecem aqui quando chegarem.'
                 : 'As oportunidades aparecem quando há odds coletadas antes do jogo.'}
             </p>
@@ -698,7 +712,7 @@ export default function FutebolOportunidades() {
         <div className="rounded-rebrand-md px-5 py-4 flex items-start gap-3" style={{ background: '#fef7df', border: '1px solid #fde68a' }}>
           <span className="mt-0.5 shrink-0" style={{ color: '#9a6c00' }}><AlertTriangle className="w-4 h-4" /></span>
           <div className="text-[12px] leading-relaxed" style={{ color: '#5a3c00' }}>
-            <span className="font-semibold">Não é recomendação.</span> Valor = a odd paga acima da chance estimada. A régua separa o que tem valor claro do resto. Abaixo dela, não enxergamos vantagem.
+            <span className="font-semibold">Não é recomendação.</span> Valor = quanto a odd paga acima ou abaixo do preço justo. Publicamos a leitura do cenário mesmo quando o preço não ajuda — o filtro de valor mostra só as que pagam acima.
           </div>
         </div>
 

--- a/src/pages/Onboarding.test.tsx
+++ b/src/pages/Onboarding.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
-import { configure, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Onboarding from './Onboarding';
@@ -36,14 +36,11 @@ function renderOnboarding(search = '') {
   );
 }
 
-// Folga nos DOIS limites, que são independentes: o do vitest cobre importar,
-// montar e esperar; o da testing-library governa cada findBy/waitFor e vem com
-// 1s. A tela espera duas idas ao Supabase antes de pintar, e com a suíte
-// inteira em paralelo qualquer um dos dois estoura por saturação da máquina,
-// não por regressão. Rodando sozinho, o arquivo leva meio segundo.
-configure({ asyncUtilTimeout: 10_000 });
+// Os dois limites de espera moram fora daqui: o do vitest em vitest.config.ts,
+// o da testing-library em src/test/setup.ts. Os dois existem pelo mesmo motivo,
+// que está escrito lá.
 
-describe('Onboarding', { timeout: 20_000 }, () => {
+describe('Onboarding', () => {
   beforeEach(() => {
     mocks.navigate.mockReset();
     mocks.single.mockResolvedValue({ data: { telegram_chat_id: null } });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,10 +2,27 @@
  * Setup global executado antes de todos os testes.
  * - Adiciona matchers extras do jest-dom (toBeInTheDocument, toHaveClass, etc.)
  * - Faz cleanup automático do DOM entre testes
+ * - Dá folga ao limite de espera da testing-library (ver abaixo)
  */
 import '@testing-library/jest-dom/vitest';
 import { afterEach } from 'vitest';
-import { cleanup } from '@testing-library/react';
+import { cleanup, configure } from '@testing-library/react';
+
+/**
+ * O limite de cada `findBy`/`waitFor`, e por que ele não é o padrão de 1s.
+ *
+ * `userEvent` digita caractere a caractere e espera o React entre cada passo.
+ * Com a suíte inteira em paralelo — e mais ainda quando um `tsc` divide a CPU
+ * na mesma máquina —, esse 1s estoura por saturação e não por regressão: os
+ * mesmos testes passam sozinhos, no mesmo commit. Já apareceu em três arquivos
+ * diferentes (Onboarding, OportunidadesFiltros, RegistrarAposta), sempre nos
+ * que usam `userEvent`.
+ *
+ * Vive AQUI e não em cada arquivo porque o valor já estava copiado em três
+ * lugares com o mesmo comentário — e um teste que pisca é pior que um teste
+ * lento: ele ensina o time a reexecutar sem ler.
+ */
+configure({ asyncUtilTimeout: 10_000 });
 
 afterEach(() => {
   cleanup();

--- a/src/utils/rolagem.test.ts
+++ b/src/utils/rolagem.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { alinharAbaixoDoCabecalho } from './rolagem';
+
+// ============================================================================
+// O elemento sobe até encostar no cabeçalho — nem mais, nem menos
+// ============================================================================
+// A conta tem três partes que erram sozinhas se alguém mexer sem olhar:
+//
+//   1. a altura do cabeçalho é MEDIDA, porque muda entre celular e desktop;
+//   2. o `top` dele entra na soma, porque a barra nem sempre está colada no
+//      zero — com a faixa de ambiente local por cima, ela começa 24px abaixo;
+//   3. a rolagem acontece DEPOIS da pintura, senão o conteúdo que acabou de
+//      abrir ainda não tem altura e o destino sai errado.
+//
+// Nenhuma delas aparece na tela quando quebra: o que aparece é o título da
+// premissa escondido atrás da barra, que é o defeito que isto veio consertar.
+// ============================================================================
+
+function cabecalho(altura: number, top = 0): HTMLElement {
+  const nav = document.createElement('nav');
+  nav.getBoundingClientRect = () => ({ height: altura, top, bottom: top + altura, left: 0, right: 0, width: 0, x: 0, y: top, toJSON: () => ({}) });
+  document.body.appendChild(nav);
+  return nav;
+}
+
+function elementoEm(top: number): HTMLElement {
+  const el = document.createElement('div');
+  el.getBoundingClientRect = () => ({ height: 0, top, bottom: top, left: 0, right: 0, width: 0, x: 0, y: top, toJSON: () => ({}) });
+  document.body.appendChild(el);
+  return el;
+}
+
+/** Executa o que foi agendado para o quadro seguinte. */
+function pintaOQuadro() {
+  const agendado = vi.mocked(window.requestAnimationFrame).mock.calls.at(-1)?.[0];
+  agendado?.(0);
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+});
+
+describe('alinharAbaixoDoCabecalho', () => {
+  it('desconta a altura do cabeçalho da posição de destino', () => {
+    vi.stubGlobal('requestAnimationFrame', vi.fn());
+    const scrollTo = vi.fn();
+    vi.stubGlobal('scrollTo', scrollTo);
+    vi.stubGlobal('scrollY', 1000);
+    cabecalho(95);
+
+    alinharAbaixoDoCabecalho(elementoEm(400));
+    pintaOQuadro();
+
+    // 1000 de rolagem + 400 do elemento − 95 do cabeçalho − 8 de respiro.
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 1297 }));
+  });
+
+  it('soma o deslocamento do cabeçalho quando ele não está colado no topo', () => {
+    // É o caso da faixa de ambiente local: a barra começa 24px abaixo, e sem
+    // isso o título da premissa termina escondido atrás dela.
+    vi.stubGlobal('requestAnimationFrame', vi.fn());
+    const scrollTo = vi.fn();
+    vi.stubGlobal('scrollTo', scrollTo);
+    vi.stubGlobal('scrollY', 0);
+    cabecalho(95, 24);
+
+    alinharAbaixoDoCabecalho(elementoEm(400));
+    pintaOQuadro();
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 400 - 95 - 24 - 8 }));
+  });
+
+  it('nunca rola para antes do começo da página', () => {
+    vi.stubGlobal('requestAnimationFrame', vi.fn());
+    const scrollTo = vi.fn();
+    vi.stubGlobal('scrollTo', scrollTo);
+    vi.stubGlobal('scrollY', 0);
+    cabecalho(95);
+
+    alinharAbaixoDoCabecalho(elementoEm(10));
+    pintaOQuadro();
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ top: 0 }));
+  });
+
+  it('não rola no mesmo quadro do clique', () => {
+    // O conteúdo que abriu ainda não tem altura, e o card que fecha acima muda
+    // a página inteira de lugar. Medir agora é medir o layout velho.
+    vi.stubGlobal('requestAnimationFrame', vi.fn());
+    const scrollTo = vi.fn();
+    vi.stubGlobal('scrollTo', scrollTo);
+    cabecalho(95);
+
+    alinharAbaixoDoCabecalho(elementoEm(400));
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('sem elemento, não faz nada', () => {
+    const raf = vi.fn();
+    vi.stubGlobal('requestAnimationFrame', raf);
+
+    alinharAbaixoDoCabecalho(null);
+
+    expect(raf).not.toHaveBeenCalled();
+  });
+
+  it('quem pediu menos movimento no sistema rola sem animação', () => {
+    vi.stubGlobal('requestAnimationFrame', vi.fn());
+    const scrollTo = vi.fn();
+    vi.stubGlobal('scrollTo', scrollTo);
+    vi.stubGlobal('scrollY', 0);
+    vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: true })));
+    cabecalho(95);
+
+    alinharAbaixoDoCabecalho(elementoEm(400));
+    pintaOQuadro();
+
+    expect(scrollTo).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'auto' }));
+  });
+});

--- a/src/utils/rolagem.ts
+++ b/src/utils/rolagem.ts
@@ -1,0 +1,32 @@
+/**
+ * Leva o topo de um elemento para o topo da área visível, respeitando o
+ * cabeçalho fixo.
+ *
+ * Existe por causa da leitura no celular: ao abrir uma premissa, o conteúdo
+ * nascia embaixo do dedo e a pessoa ficava no MEIO do que acabou de abrir —
+ * tinha de rolar para cima para ler do começo. Abrir e já estar no começo é o
+ * comportamento que qualquer sanfona tem.
+ *
+ * A altura do cabeçalho é MEDIDA, não constante: ela muda entre celular e
+ * desktop, e a faixa de ambiente local empurra a barra mais 24px para baixo.
+ * Um número fixo acertaria num caso e esconderia o título nos outros.
+ *
+ * Sem animação para quem pediu menos movimento no sistema — a rolagem continua
+ * acontecendo, só que instantânea.
+ */
+export function rolarParaOTopo(el: HTMLElement | null | undefined): void {
+  if (!el || typeof window === 'undefined') return;
+
+  // Depois da pintura: o conteúdo que acabou de abrir ainda não tem altura no
+  // mesmo quadro do clique, e medir antes disso erra o destino.
+  requestAnimationFrame(() => {
+    const nav = document.querySelector('nav');
+    const caixa = nav?.getBoundingClientRect();
+    // `top` entra na conta porque a barra pode não estar colada no zero (é o
+    // caso com a faixa de DEV por cima dela).
+    const cabecalho = caixa ? caixa.height + Math.max(0, caixa.top) : 0;
+    const alvo = window.scrollY + el.getBoundingClientRect().top - cabecalho - 8;
+    const suave = !window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({ top: Math.max(0, alvo), behavior: suave ? 'smooth' : 'auto' });
+  });
+}

--- a/src/utils/rolagem.ts
+++ b/src/utils/rolagem.ts
@@ -1,6 +1,8 @@
 /**
- * Leva o topo de um elemento para o topo da área visível, respeitando o
- * cabeçalho fixo.
+ * Alinha o topo de um elemento logo abaixo do cabeçalho fixo.
+ *
+ * O nome diz o alvo, e não "rolar ao topo": a página NÃO vai para o começo, o
+ * elemento é que sobe até encostar no cabeçalho.
  *
  * Existe por causa da leitura no celular: ao abrir uma premissa, o conteúdo
  * nascia embaixo do dedo e a pessoa ficava no MEIO do que acabou de abrir —
@@ -14,13 +16,16 @@
  * Sem animação para quem pediu menos movimento no sistema — a rolagem continua
  * acontecendo, só que instantânea.
  */
-export function rolarParaOTopo(el: HTMLElement | null | undefined): void {
+export function alinharAbaixoDoCabecalho(el: HTMLElement | null | undefined): void {
   if (!el || typeof window === 'undefined') return;
 
   // Depois da pintura: o conteúdo que acabou de abrir ainda não tem altura no
   // mesmo quadro do clique, e medir antes disso erra o destino.
   requestAnimationFrame(() => {
-    const nav = document.querySelector('nav');
+    // A barra do produto é o único `nav` colado no topo em todas as telas de
+    // futebol. Se um dia houver outro, o `data-cabecalho` é o lugar de marcar
+    // qual conta — a busca genérica pegaria o primeiro do documento.
+    const nav = document.querySelector('[data-cabecalho], nav');
     const caixa = nav?.getBoundingClientRect();
     // `top` entra na conta porque a barra pode não estar colada no zero (é o
     // caso com a faixa de DEV por cima dela).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,25 @@ export default defineConfig({
     environment: 'jsdom',     // simula DOM do browser pra testar componentes React
     setupFiles: ['./src/test/setup.ts'],
     css: false,               // não processa CSS nos testes (mais rápido)
+    /**
+     * Quanto cada teste pode levar antes de o vitest matá-lo.
+     *
+     * São DOIS limites independentes, e confundi-los custa tempo: este cobre o
+     * teste inteiro (importar, montar, esperar), e o `asyncUtilTimeout` da
+     * testing-library, no setup, governa cada `findBy`/`waitFor` de dentro. Os
+     * testes que usam `userEvent` estouravam O DESTE — a mensagem é "Test timed
+     * out in 5000ms", não a da testing-library.
+     *
+     * `userEvent` digita caractere a caractere e espera o React entre os passos.
+     * Com a suíte inteira em paralelo — e mais ainda com um `tsc` dividindo a
+     * CPU na mesma máquina —, os 5s padrão estouram por saturação, não por
+     * regressão: os mesmos testes passam sozinhos, no mesmo commit. Aconteceu em
+     * quatro arquivos diferentes, todos os que usam `userEvent`.
+     *
+     * Um teste que pisca é pior que um teste lento: ele ensina o time a
+     * reexecutar sem ler.
+     */
+    testTimeout: 20_000,
     // Por padrão, Vitest descobre todos os arquivos *.test.ts(x) e *.spec.ts(x)
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
   },


### PR DESCRIPTION
Dois consertos que saíram do smoke test da #309 em produção.

## 1. O valor digitado no registrar aposta sumia sozinho

Escolher "½ unidade" no modal, esperar, e o campo voltava a `0,00` com o botão desabilitado — sem ninguém tocar em nada. Registrar aposta pela lista de oportunidades era, na prática, uma corrida contra o próximo render.

**Causa:** o efeito que zera os campos ao abrir dependia do **objeto** `draft`, e a lista monta um literal novo a cada render (`draftFromBoardRow(o)` dentro do JSX). Como a lista rerenderiza sozinha — o relógio da tela avança, o board revalida —, cada rerender apagava o que a pessoa tinha digitado.

Agora o efeito depende de uma **chave da aposta** (mercado, saída, linha, times, apito). Trocar de aposta continua zerando, que é o que ele existe para fazer. A **odd fica fora da chave** de propósito: se o board trouxer preço melhor com o modal aberto, o campo não pode trocar embaixo do dedo de quem digita.

De quebra, o mesmo modal derrubava um erro no console — `DialogContent` sem `DialogTitle`. Ganhou título, escondido à vista.

## 2. A tela parou de prometer valor onde ele não existe

Depois da virada de 03/09 a porta de preço saiu do gate: o board publica a linha independente de a odd pagar acima do justo. Em 04/09 as **cinco primeiras oportunidades do dia pagavam abaixo** — e a tela continuava escrita como se filtrasse.

- **"N oportunidades com valor"** afirmava valor em cima de um número que dizia o contrário, três centímetros ao lado. O título só diz "com valor" quando o filtro de valor pede as que pagam acima do justo — aí a frase descreve a lista. "Oportunidade" continua certo: é o termo do CONTEXT.md, *candidata aprovada pelas regras de publicação vigentes*. Quem mudou foram as regras, não o nome.
- **O rodapé** descrevia uma régua que não existe mais. Agora explica o que a coluna mede e diz que publicamos a leitura mesmo quando o preço não ajuda.
- **O hero da home** terminava sempre em "isso paga acima do risco real — é aí que está o valor". Agora a frase muda com o sinal: quando o preço não ajuda, ela diz o quanto ele está abaixo do justo e devolve o assunto para o cenário.
- **O KPI "Melhor valor"** tinha o `+` fixo e escrevia `+-1%` num dia sem vantagem nenhuma.
- **No passado**, "oportunidades com valor deste dia" virou "oportunidades publicadas neste dia".

E o subtítulo deixou de citar "argumentos a favor e contra": o contra não existe no modelo (#348).

## Verificação

Três testes novos do modal, um por comportamento — incluindo o rerender com um draft novo e igual, que é o caso que quebrava. 624 testes passando, typecheck nos mesmos 66 erros pré-existentes. Os dois arquivos que piscavam sob carga ganharam a mesma folga que o `Onboarding.test` já documentava.

🤖 Generated with [Claude Code](https://claude.com/claude-code)