### PR TITLE
fix(futebol): alerta de publicação diz o dia do jogo, não só a hora

### DIFF
--- a/supabase/functions/notify-published-opportunities/message.ts
+++ b/supabase/functions/notify-published-opportunities/message.ts
@@ -20,12 +20,54 @@ function kickoffDate(value: string): Date {
   return new Date(value.includes("T") ? value : value.replace(" ", "T") + "Z");
 }
 
+const SAO_PAULO = "America/Sao_Paulo";
+
 function brtHourMin(value: string): string {
   return new Intl.DateTimeFormat("pt-BR", {
-    timeZone: "America/Sao_Paulo",
+    timeZone: SAO_PAULO,
     hour: "2-digit",
     minute: "2-digit",
   }).format(kickoffDate(value));
+}
+
+/** YYYY-MM-DD no fuso de Brasília, só para comparar dias. */
+function brtDia(d: Date): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: SAO_PAULO }).format(d);
+}
+
+/** "Sáb 06/09", o mesmo formato da régua de datas do painel. */
+function brtDiaDaSemana(d: Date): string {
+  const semana = new Intl.DateTimeFormat("pt-BR", {
+    timeZone: SAO_PAULO,
+    weekday: "short",
+  }).format(d).replace(".", "");
+  const dia = new Intl.DateTimeFormat("pt-BR", {
+    timeZone: SAO_PAULO,
+    day: "2-digit",
+    month: "2-digit",
+  }).format(d);
+  return `${semana.charAt(0).toUpperCase()}${semana.slice(1)} ${dia}`;
+}
+
+/**
+ * Quando o jogo começa, do jeito que se fala.
+ *
+ * Só a hora não respondia a pergunta que a pessoa faz ao receber o alerta:
+ * "isso é daqui a pouco ou é outro dia?". O lote é publicado sem hora fixa e
+ * mistura jogos de hoje com jogos de dois dias à frente, então "15:30" sozinho
+ * era ambíguo por construção.
+ *
+ * "Amanhã" sai de somar 24h ao relógio: o Brasil não tem mais horário de
+ * verão, então o dia civil de São Paulo anda junto com o UTC e a soma é exata.
+ */
+export function brtQuando(kickoffUtc: string, agora: Date): string {
+  const hora = brtHourMin(kickoffUtc);
+  const dia = brtDia(kickoffDate(kickoffUtc));
+  if (dia === brtDia(agora)) return `Hoje ${hora}`;
+  if (dia === brtDia(new Date(agora.getTime() + 86_400_000))) {
+    return `Amanhã ${hora}`;
+  }
+  return `${brtDiaDaSemana(kickoffDate(kickoffUtc))} ${hora}`;
 }
 
 function fmtHandicapLine(line: number): string {
@@ -86,6 +128,7 @@ export function publishedPickLabel(
 export function publishedMessageText(
   opportunities: PublishedMessageOpportunity[],
   opportunityUrls: ReadonlyMap<string, string>,
+  agora: Date = new Date(),
 ): string {
   const detailed = [...opportunities].sort((a, b) => b.score - a.score).slice(
     0,
@@ -105,7 +148,7 @@ export function publishedMessageText(
     lines.push(
       `<a href="${gameUrl}"><b>${esc(opportunity.home_team_name)} × ${
         esc(opportunity.away_team_name)
-      }</b></a> · ${brtHourMin(opportunity.kickoff_utc)}`,
+      }</b></a> · ${brtQuando(opportunity.kickoff_utc, agora)}`,
       `${
         esc(publishedPickLabel(opportunity))
       } · odd ${opportunity.best_odd} · Score <b>${opportunity.score} · ${

--- a/supabase/functions/tests/published-opportunities-message.test.ts
+++ b/supabase/functions/tests/published-opportunities-message.test.ts
@@ -1,5 +1,6 @@
 import { assert } from "./_assert.ts";
 import {
+  brtQuando,
   type PublishedMessageOpportunity,
   publishedMessageText,
 } from "../notify-published-opportunities/message.ts";
@@ -23,10 +24,15 @@ const opportunity = (
   evidencias: ["O jogo cria chances dos dois lados"],
 });
 
+// O relógio entra por parâmetro porque "Hoje" e "Amanhã" só existem em
+// relação a ele. Sem fixar, o teste passaria hoje e quebraria amanhã.
+const NO_DIA = new Date("2026-08-27T12:00:00.000Z");
+
 Deno.test("mensagem de publicação: oportunidade única aponta a nova leitura", () => {
   const text = publishedMessageText(
     [opportunity(1, 46)],
     new Map([["alert-1", "https://example.test/jogo-1"]]),
+    NO_DIA,
   );
 
   assert(text.includes("Nova oportunidade mapeada"), "título individual");
@@ -60,4 +66,57 @@ Deno.test("mensagem de publicação: lote grande detalha as três maiores e apon
   assert(text.includes("Casa 3 × Fora 3"), "terceira maior entra");
   assert(!text.includes("Casa 1 × Fora 1"), "quarta não ocupa detalhe");
   assert(text.includes("+ 1 oportunidade no painel."), "restante explícito");
+});
+
+// ============================================================
+// Quando o jogo começa
+// ============================================================
+// A hora sozinha não dizia se era daqui a pouco ou outro dia, e o lote mistura
+// os dois. A conversão é em Brasília, não no fuso de quem roda o teste.
+// ============================================================
+
+Deno.test("quando: jogo do mesmo dia é 'Hoje'", () => {
+  // 19:30 UTC é 16:30 em Brasília, mesmo dia civil.
+  assert(
+    brtQuando("2026-08-27T19:30:00.000Z", new Date("2026-08-27T12:00:00.000Z")) ===
+      "Hoje 16:30",
+    "mesmo dia",
+  );
+});
+
+Deno.test("quando: jogo do dia seguinte é 'Amanhã'", () => {
+  assert(
+    brtQuando("2026-08-28T19:30:00.000Z", new Date("2026-08-27T12:00:00.000Z")) ===
+      "Amanhã 16:30",
+    "dia seguinte",
+  );
+});
+
+Deno.test("quando: mais longe que amanhã traz dia da semana e data", () => {
+  // 2026-08-29 é um sábado.
+  assert(
+    brtQuando("2026-08-29T19:30:00.000Z", new Date("2026-08-27T12:00:00.000Z")) ===
+      "Sáb 29/08 16:30",
+    "dia da semana e data",
+  );
+});
+
+Deno.test("quando: a virada do dia segue Brasília, não o UTC", () => {
+  // 01:00 UTC do dia 28 ainda é 22:00 do dia 27 em Brasília: quem recebe às
+  // 20h precisa ler "Hoje", e não "Amanhã".
+  assert(
+    brtQuando("2026-08-28T01:00:00.000Z", new Date("2026-08-27T23:00:00.000Z")) ===
+      "Hoje 22:00",
+    "dia civil de Brasília",
+  );
+});
+
+Deno.test("mensagem de publicação: a data acompanha a hora do jogo", () => {
+  const text = publishedMessageText(
+    [opportunity(1, 46)],
+    new Map([["alert-1", "u1"]]),
+    new Date("2026-08-26T12:00:00.000Z"),
+  );
+
+  assert(text.includes("· Amanhã 16:30"), "data junto da hora");
 });


### PR DESCRIPTION
A mensagem do alerta trazia `VfB Stuttgart × 1. FC Köln · 15:30`. O lote é publicado sem hora fixa e mistura jogo de hoje com jogo de dois dias à frente, então a hora sozinha não respondia a única pergunta que importa ao receber: **é daqui a pouco ou é outro dia?**

Agora sai `· Hoje 15:30`, `· Amanhã 15:30` ou `· Sáb 06/09 15:30` — o mesmo formato da régua de datas do painel (`fmtDayChip`), para não inventar um segundo vocabulário de data no produto.

Dois cuidados que valem registro:

- **O relógio entra por parâmetro.** "Hoje" só existe em relação a um agora. Com `new Date()` escondido dentro da função, o teste passaria hoje e quebraria amanhã.
- **A virada do dia é a de Brasília.** Um jogo às 22:00 de terça é 01:00 UTC de quarta; comparar em UTC diria "Amanhã" para quem está lendo às 20h da terça. O teste cobre exatamente esse caso.

## De brinde, a auditoria que originou o PR

Junto veio a pergunta de se algum alerta sai depois do apito. **Nenhum**, e não por sorte: são duas barreiras independentes.

O `planner` corta `kickoff > now` antes de montar o lote, e o `claim_futebol_publication_alert_deliveries` corta de novo, no banco, tanto na elegibilidade do lote quanto nas linhas que entram na mensagem — então uma retentativa horas depois só levaria o que ainda não começou.

Nos 459 alertas do staging: 0 detectados com o jogo já em andamento, 0 enviados depois do apito em 119 linhas, e o intervalo entre a checagem no banco e o envio ao Telegram é de no máximo 0,7s.

O que **não** existe é antecedência mínima. O corte é `>`, sem margem, então um jogo que falta 1 minuto seria alertado. Na prática o menor caso observado foi 9,9 minutos (efeito da grade de 10 em 10 do cron), e só 1 dos 459 ficou abaixo de 30 minutos. Fica anotado como decisão de produto, fora deste PR.

## Testes

De 131 para 136 no `deno test supabase/functions/tests/`. Os novos cobrem hoje, amanhã, dia da semana, a virada do dia em Brasília e a data dentro da mensagem montada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
