### PR TITLE
fix(futebol): o mercado escondido para de voltar no dia seguinte

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -2801,6 +2801,32 @@ $function$;
 
 grant execute on function public.get_futebol_mercados_ocultos() to anon, authenticated, service_role;
 
+-- A MESMA vitrine, com a data em que cada mercado saiu (migration 119). A data
+-- é o que separa a linha que foi publicada e vista da que nunca esteve na
+-- tela: sem ela o painel só sabia esconder o presente, e o histórico devolvia
+-- o mercado escondido no dia seguinte.
+--
+-- Convive com a leitura acima em vez de substituí-la: as duas funções de
+-- notificação só olham o board — presente e futuro, sempre depois do corte —
+-- e para elas a lista de nomes basta.
+create or replace function public.get_futebol_vitrine()
+returns table (market text, oculto_desde timestamptz)
+ language sql
+ stable
+ security definer
+ set search_path to ''
+as $function$
+  select o.market, o.oculto_desde
+    from public.futebol_mercados_ocultos o
+   where o.oculto
+   order by o.market;
+$function$;
+
+comment on function public.get_futebol_vitrine() is
+  'Mercados fora da vitrine COM a data de corte. A data é o que separa a linha que foi publicada e vista da que nunca esteve na tela.';
+
+grant execute on function public.get_futebol_vitrine() to anon, authenticated, service_role;
+
 insert into public.futebol_mercados_ocultos (market, oculto, oculto_desde, motivo)
 values (
   'asian_handicap',

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useAuth } from '@/hooks/use-auth';
 import { brtToday } from '@/utils/futebol-datas';
 import { historyWindow } from '@/utils/futebol-history';
+import type { MercadoOculto } from '@/utils/futebol-mercados-ocultos';
 import type { FixtureScope } from '@/utils/futebol-competitions';
 import {
   futebolDataService,
@@ -427,9 +428,9 @@ export function useFutebolMatchupMarkets(
  * pior do que não ter escondido. Ver prop-play-predictor#324.
  */
 export function useFutebolMercadosOcultos() {
-  return useQuery<string[]>({
+  return useQuery<MercadoOculto[]>({
     queryKey: ['futebol', 'mercados-ocultos'],
-    queryFn: () => futebolDataService.getMercadosOcultos(),
+    queryFn: () => futebolDataService.getVitrine(),
     staleTime: 5 * 60 * 1000,
     gcTime: 15 * 60 * 1000,
     refetchOnWindowFocus: false,
@@ -444,10 +445,17 @@ export function useFutebolMercadosOcultos() {
  * quanto a lista: renderizar antes de a vitrine chegar mostra o mercado
  * escondido por um instante, e ele some depois. Ver prop-play-predictor#324.
  */
-export function useVitrine(): { ocultos: string[]; isLoading: boolean } {
+export function useVitrine(): {
+  vitrine: MercadoOculto[];
+  ocultos: string[];
+  isLoading: boolean;
+} {
   const { data, isLoading } = useFutebolMercadosOcultos();
-  // Memoizado: `?? []` cria array novo a cada render e envenenaria as
-  // dependências de todo useMemo que recebe `ocultos`.
-  const ocultos = useMemo(() => data ?? [], [data]);
-  return { ocultos, isLoading };
+  // Memoizados: o fallback e o .map criam array novo a cada render e
+  // envenenariam as dependencias de todo useMemo que os recebe.
+  const vitrine = useMemo(() => data ?? [], [data]);
+  // Só os nomes, para quem decide sobre o presente e não precisa da data.
+  const ocultos = useMemo(() => vitrine.map((m) => m.market), [vitrine]);
+  return { vitrine, ocultos, isLoading };
 }
+

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -344,7 +344,7 @@ export default function FutebolHoje() {
   const { data: boardRows, isLoading: l3 } = useFutebolValueBoard();
   const { data: histRows, isLoading: lHist } = useFutebolValueHistory();
   const { data: alertedRaw, isLoading: lReg } = useFutebolAlertedPicks();
-  const { ocultos, isLoading: lVitrine } = useVitrine();
+  const { vitrine, ocultos, isLoading: lVitrine } = useVitrine();
   // O acesso ENTRA no gate: enquanto ele não chega, `locked` é verdadeiro e o
   // conteúdo renderiza borrado, desborrando quando a resposta volta. Para quem
   // paga, isso é o mesmo defeito do card de motivos, num lugar diferente.
@@ -400,8 +400,8 @@ export default function FutebolHoje() {
   // exclusivo desta tela: ele zerava a home toda noite, num dia que teve
   // oportunidades. Quem quer só o que dá para acompanhar tem o filtro no painel.
   const valueRows = useMemo(
-    () => mergeBoardAndHistory(boardRows ?? [], histRows ?? [], agora, ocultos),
-    [boardRows, histRows, agora, ocultos],
+    () => mergeBoardAndHistory(boardRows ?? [], histRows ?? [], agora, vitrine),
+    [boardRows, histRows, agora, vitrine],
   );
   // As oportunidades REGISTRADAS entram aqui pelo mesmo motivo que entram no
   // painel: elas existiram no dia e o board não as tem mais, porque o mart é

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -98,7 +98,7 @@ export default function FutebolJogos() {
   // "sem leitura ainda" enquanto a resposta não chegou — isso é conclusão.
   const { data: boardCorrente, isLoading: boardCarregando } = useFutebolValueBoard();
   const { data: histRows, isLoading: histCarregando } = useFutebolValueHistory();
-  const { ocultos } = useVitrine();
+  const { vitrine } = useVitrine();
   const { data: access } = useFutebolAccess();
 
   // A agenda lia SÓ o board, e o board some no apito (migration 102). Resultado:
@@ -110,8 +110,8 @@ export default function FutebolJogos() {
   // apitou, foto do apito para o que já passou. A mesma função, para as duas
   // telas contarem a mesma história do mesmo dia.
   const board = useMemo(
-    () => mergeBoardAndHistory(boardCorrente ?? [], histRows ?? [], Date.now(), ocultos),
-    [boardCorrente, histRows, ocultos],
+    () => mergeBoardAndHistory(boardCorrente ?? [], histRows ?? [], Date.now(), vitrine),
+    [boardCorrente, histRows, vitrine],
   );
 
   const jogosTour = useOnboardingTour(FUT_JOGOS_TOUR_ID, { enabled: !isLoading && !isError });

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -206,7 +206,7 @@ export default function FutebolOportunidades() {
   // sem filtro e o mercado escondido aparece por um instante antes de sumir. O
   // board já vem filtrado do service, mas a fusão com o histórico e os picks
   // registrados reabrem o dia corrente.
-  const { ocultos, isLoading: lVitrine } = useVitrine();
+  const { vitrine, ocultos, isLoading: lVitrine } = useVitrine();
   const isLoading = lBoard || lVitrine;
   const { data: catalog } = useFutebolCompetitions();
   const { data: access } = useFutebolAccess();
@@ -281,8 +281,8 @@ export default function FutebolOportunidades() {
   );
   const { data: fixtures } = useFutebolFixturesMulti(fixtureScopes);
   const allRows = useMemo<FutebolValueBoardRow[]>(
-    () => mergeBoardAndHistory(rows ?? [], histRows ?? [], agora, ocultos),
-    [rows, histRows, agora, ocultos]
+    () => mergeBoardAndHistory(rows ?? [], histRows ?? [], agora, vitrine),
+    [rows, histRows, agora, vitrine]
   );
 
   // Placar por fixture (pra liquidar os jogos já encerrados = histórico "bateu/não").

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -4,14 +4,18 @@ import {
   normalizeFutebolValueBoardRows,
   type FutebolScoreVersion,
 } from './futebol-score-contract';
-import { filtrarMercadosOcultos, VITRINE_FALLBACK } from '@/utils/futebol-mercados-ocultos';
+import {
+  filtrarMercadosOcultos,
+  type MercadoOculto,
+  VITRINE_FALLBACK,
+} from '@/utils/futebol-mercados-ocultos';
 
 // A vitrine muda por UPDATE no banco, não por release, então a lista não pode
 // ser lida uma vez e congelada pela vida da aba. Cinco minutos é curto o
 // bastante para devolver um mercado sem pedir refresh, e longo o bastante para
 // não somar uma chamada a cada carga do board.
 const MERCADOS_OCULTOS_TTL_MS = 5 * 60 * 1000;
-let mercadosOcultosCache: { valor: string[]; expiraEm: number } | null = null;
+let mercadosOcultosCache: { valor: MercadoOculto[]; expiraEm: number } | null = null;
 
 // As RPCs de futebol ainda não estão nos tipos gerados do Supabase (existem
 // só no dev, lendo BigQuery via FDW no schema bq_futebol). Cast pra any, mesmo
@@ -936,9 +940,13 @@ export const futebolDataService = {
   /**
    * Os mercados que estão fora da VITRINE — não fora do board.
    *
-   * A lista vem do banco (migration 116) e não de constante, porque devolver um
-   * mercado à tela tem de ser um UPDATE e não um release, e porque o Telegram
-   * roda em outro runtime e precisa ler a MESMA fonte.
+   * A lista vem do banco (migrations 116 e 119) e não de constante, porque
+   * devolver um mercado à tela tem de ser um UPDATE e não um release, e porque
+   * o Telegram roda em outro runtime e precisa ler a MESMA fonte.
+   *
+   * Vem com a DATA em que cada mercado saiu, e é ela que separa a linha que foi
+   * publicada e vista da que nunca esteve na tela. Sem a data o histórico
+   * devolvia o mercado escondido no dia seguinte.
    *
    * ⚠️ Falha em silêncio, de propósito. O `withRetry` trata "função não existe"
    * como erro definitivo, então um front publicado antes da migration mataria o
@@ -946,24 +954,47 @@ export const futebolDataService = {
    * comportamento é o de hoje — nada escondido —, que é degradação e não
    * regressão. Ver prop-play-predictor#324.
    */
-  async getMercadosOcultos(): Promise<string[]> {
+  async getVitrine(): Promise<MercadoOculto[]> {
     const agora = Date.now();
     if (mercadosOcultosCache && agora < mercadosOcultosCache.expiraEm) {
       return mercadosOcultosCache.valor;
     }
     try {
-      const { data, error } = await supabaseClient.rpc('get_futebol_mercados_ocultos');
+      const { data, error } = await supabaseClient.rpc('get_futebol_vitrine');
       if (error) throw error;
-      const valor = (data || []) as string[];
+      const valor = ((data || []) as { market: string; oculto_desde: string }[]).map(
+        (linha) => ({ market: linha.market, ocultoDesde: linha.oculto_desde }),
+      );
       mercadosOcultosCache = { valor, expiraEm: agora + MERCADOS_OCULTOS_TTL_MS };
       return valor;
     } catch {
-      // No escuro vale o último valor bom; sem ele, o fallback. Cair para lista
-      // vazia mostraria na tela o que o produto tirou da prateleira, e a janela
-      // realista de escuro é justamente a de antes da migration — quando
-      // esconder já é o comportamento decidido.
-      return mercadosOcultosCache?.valor ?? [...VITRINE_FALLBACK];
+      // Degrada em DOIS degraus, e a ordem importa.
+      //
+      // 1) A RPC antiga, que existe desde a 116: dá os nomes, sem a data. É o
+      //    caso do front publicado antes da migration 119 — e sem este degrau
+      //    ele mostraria hoje o mercado que o produto retirou, que é pior do
+      //    que a régua velha.
+      // 2) Sem nem isso, o último valor bom; sem ele, o fallback compilado.
+      //
+      // Nos dois degraus a data sai vazia, e a regra do painel lê isso
+      // como "esconde de hoje em diante, não toca no passado" — exatamente o
+      // comportamento anterior a esta mudança. Degradação, não regressão.
+      try {
+        const { data, error } = await supabaseClient.rpc('get_futebol_mercados_ocultos');
+        if (error) throw error;
+        return ((data || []) as string[]).map((market) => ({ market, ocultoDesde: null }));
+      } catch {
+        return (
+          mercadosOcultosCache?.valor ??
+          VITRINE_FALLBACK.map((market) => ({ market, ocultoDesde: null }))
+        );
+      }
     }
+  },
+
+  /** Só os nomes, para quem não precisa saber desde quando. */
+  async getMercadosOcultos(): Promise<string[]> {
+    return (await this.getVitrine()).map((m) => m.market);
   },
 
   async getValueBoard(): Promise<FutebolValueBoardRow[]> {

--- a/src/utils/futebol-history.ts
+++ b/src/utils/futebol-history.ts
@@ -22,7 +22,7 @@
 // ============================================================================
 import type { FutebolValueBoardRow } from '@/services/futebol-data.service';
 import { parseUtc, brtDateStr, brtDayOf, addDays } from '@/utils/futebol-datas';
-import { mercadoEstaOculto } from '@/utils/futebol-mercados-ocultos';
+import { type MercadoOculto, mercadoOcultoNaData } from '@/utils/futebol-mercados-ocultos';
 
 /** Quantos dias o Histórico navega para trás. */
 export const HISTORY_WINDOW_DAYS = 30;
@@ -73,13 +73,17 @@ export function mergeBoardAndHistory(
   board: FutebolValueBoardRow[],
   history: FutebolValueBoardRow[],
   nowMs: number,
-  // Os mercados fora da vitrine (#324). Valem para o DIA CORRENTE e não para o
-  // passado, e a distinção é a decisão de produto inteira: a linha de dia
-  // passado é registro do que foi publicado e visto, e escondê-la reescreveria
-  // o que o assinante viu; a linha de hoje é a lista de hoje, mesmo quando quem
-  // ganha o desempate é o histórico. Sem esta divisão o mercado escondido
-  // voltava pela porta dos fundos assim que o jogo começava.
-  ocultos: readonly string[] = [],
+  // Os mercados fora da vitrine (#324), cada um com a data em que saiu.
+  //
+  // O corte é a DATA, não "hoje". Antes dela a linha fica: foi publicada, vista
+  // e possivelmente apostada, e escondê-la reescreveria o passado do assinante.
+  // A partir dela some em qualquer tela, porque nunca esteve em nenhuma.
+  //
+  // Cortar por "hoje" — o que esta função fazia — deixava o mercado voltar pela
+  // porta dos fundos: sumia da lista de hoje e reaparecia amanhã, no mesmo
+  // jogo, quando a linha passava a vir do histórico. Em produção isso somava 31
+  // linhas de Handicap que ninguém nunca viu, contra 23 de verdade.
+  vitrine: readonly MercadoOculto[] = [],
 ): FutebolValueBoardRow[] {
   const today = brtDateStr(new Date(nowMs));
   const out: FutebolValueBoardRow[] = [];
@@ -89,10 +93,9 @@ export function mergeBoardAndHistory(
   for (const r of history) {
     const d = brtDayOf(r.kickoff_utc);
     if (!d) continue;
+    if (mercadoOcultoNaData(r.market, r.kickoff_utc, vitrine, nowMs)) continue;
     if (d < today) out.push(r);
-    else if (d === today && !mercadoEstaOculto(r.market, ocultos)) {
-      hojeHist.set(opportunityKey(r), r);
-    }
+    else if (d === today) hojeHist.set(opportunityKey(r), r);
     // d > today: a RPC não devolve; se um dia devolver, o board manda.
   }
 

--- a/src/utils/futebol-mercados-ocultos.test.ts
+++ b/src/utils/futebol-mercados-ocultos.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { filtrarMercadosOcultos, mercadoEstaOculto } from './futebol-mercados-ocultos';
+import {
+  filtrarMercadosOcultos,
+  mercadoEstaOculto,
+  mercadoOcultoNaData,
+} from './futebol-mercados-ocultos';
 
 const linha = (market: string, id: number) => ({ market, fixture_id: id });
 
@@ -60,5 +64,58 @@ describe('filtrarMercadosOcultos', () => {
     filtrarMercadosOcultos(linhas, ['asian_handicap']);
 
     expect(linhas).toHaveLength(2);
+  });
+});
+
+// ============================================================================
+// A data de corte
+// ============================================================================
+// O predicado por nome só sabe responder sobre o presente. Este sabe QUANDO,
+// e é a diferença entre a linha que esteve na tela e a que nunca esteve.
+// ============================================================================
+
+describe('mercadoOcultoNaData', () => {
+  const VITRINE = [{ market: 'asian_handicap', ocultoDesde: '2026-09-01T00:00:00Z' }];
+  const AGORA = Date.parse('2026-09-05T15:00:00Z');
+
+  it('esconde o que é a partir do corte', () => {
+    expect(mercadoOcultoNaData('asian_handicap', '2026-09-03T13:00:00', VITRINE, AGORA))
+      .toBe(true);
+  });
+
+  it('mantém o que é anterior ao corte', () => {
+    expect(mercadoOcultoNaData('asian_handicap', '2026-08-31T13:00:00', VITRINE, AGORA))
+      .toBe(false);
+  });
+
+  it('o instante exato do corte já está escondido', () => {
+    // A fronteira é fechada de um lado só. Deixá-la aberta poria o jogo da
+    // meia-noite do dia do corte do lado errado, e é o caso que ninguém testa.
+    expect(mercadoOcultoNaData('asian_handicap', '2026-09-01T00:00:00', VITRINE, AGORA))
+      .toBe(true);
+  });
+
+  it('mercado fora da vitrine nunca esconde', () => {
+    expect(mercadoOcultoNaData('goals_over_under', '2026-09-03T13:00:00', VITRINE, AGORA))
+      .toBe(false);
+  });
+
+  it('kickoff ilegível esconde, porque não dá para situá-lo', () => {
+    expect(mercadoOcultoNaData('asian_handicap', 'nao é data', VITRINE, AGORA)).toBe(true);
+    expect(mercadoOcultoNaData('asian_handicap', null, VITRINE, AGORA)).toBe(true);
+  });
+
+  describe('sem data (o escuro)', () => {
+    const SEM_DATA = [{ market: 'asian_handicap', ocultoDesde: null }];
+
+    it('esconde de hoje em diante', () => {
+      expect(mercadoOcultoNaData('asian_handicap', '2026-09-05T18:00:00', SEM_DATA, AGORA))
+        .toBe(true);
+    });
+
+    it('não toca no passado', () => {
+      expect(mercadoOcultoNaData('asian_handicap', '2026-09-04T13:00:00', SEM_DATA, AGORA))
+        .toBe(false);
+    });
   });
 });

--- a/src/utils/futebol-mercados-ocultos.ts
+++ b/src/utils/futebol-mercados-ocultos.ts
@@ -15,6 +15,8 @@
 // só a regra, pura, para poder ser testada sem rede.
 // ============================================================
 
+import { brtDateStr, brtDayOf, parseUtc } from '@/utils/futebol-datas';
+
 /**
  * O que vale quando a lista do banco não pode ser lida.
  *
@@ -33,6 +35,59 @@
  * cópias (esta e a de `supabase/functions/shared/`) a andarem juntas.
  */
 export const VITRINE_FALLBACK: readonly string[] = ['asian_handicap'];
+
+/**
+ * Um mercado fora da vitrine, com a data em que saiu.
+ *
+ * A data é o que separa duas coisas que parecem iguais: a linha que ESTEVE na
+ * tela e a que nunca esteve. Sem ela só dá para esconder o presente, e o
+ * passado devolve o mercado pela porta dos fundos — foi o defeito de #324.
+ */
+export interface MercadoOculto {
+  market: string;
+  /**
+   * ISO em UTC, ou `null` quando a data não pôde ser lida (o fallback abaixo).
+   *
+   * Sem data não dá para dizer de que lado do corte a linha está, e chutar
+   * erraria para um dos dois lados: esconder demais apagaria o que a pessoa viu
+   * e pode ter apostado; esconder de menos mostra o que o produto tirou. Sem
+   * data, esta regra só vale para o presente — que é o comportamento de antes,
+   * e portanto degradação e não regressão.
+   */
+  ocultoDesde: string | null;
+}
+
+/**
+ * Esta linha está fora da vitrine, considerando QUANDO ela é?
+ *
+ * Vale em qualquer tela, inclusive no histórico. A regra em uma frase: o
+ * mercado some a partir da data em que saiu da prateleira, e permanece antes
+ * dela, porque ali ele foi publicado, visto e possivelmente apostado.
+ *
+ * `agoraMs` só é usado no escuro — quando a vitrine veio sem data. Ali vale a
+ * regra antiga, que é esconder de hoje em diante e não tocar no passado: sem
+ * saber onde fica o corte, é o único recorte que não inventa nem apaga nada.
+ *
+ * Kickoff ilegível esconde. Entre mostrar um mercado que o produto retirou e
+ * omitir uma linha cuja data o front não soube ler, a segunda erra menos.
+ */
+export function mercadoOcultoNaData(
+  market: string,
+  kickoffUtc: string | null,
+  vitrine: readonly MercadoOculto[],
+  agoraMs: number,
+): boolean {
+  const entrada = vitrine.find((m) => m.market === market);
+  if (!entrada) return false;
+  if (!kickoffUtc) return true;
+  if (entrada.ocultoDesde == null) {
+    const dia = brtDayOf(kickoffUtc);
+    return dia == null || dia >= brtDateStr(new Date(agoraMs));
+  }
+  const kickoff = parseUtc(kickoffUtc)?.getTime();
+  if (kickoff == null) return true;
+  return kickoff >= Date.parse(entrada.ocultoDesde);
+}
 
 /** O mercado está fora da vitrine? */
 export function mercadoEstaOculto(

--- a/src/utils/futebol-vitrine-aceite.test.ts
+++ b/src/utils/futebol-vitrine-aceite.test.ts
@@ -75,34 +75,73 @@ describe('a prateleira do detalhe respeita a vitrine', () => {
   });
 });
 
-describe('a lista de hoje não reabre o mercado pelo histórico', () => {
+describe('o histórico não reabre o mercado escondido', () => {
+  // O corte real da #324: o Handicap saiu da vitrine em 01/09.
+  const VITRINE = [{ market: 'asian_handicap', ocultoDesde: '2026-09-01T00:00:00Z' }];
+
   // 2026-09-01 12:00 BRT. O jogo das 10h já começou: nesse caso a linha do
   // HISTÓRICO vence o desempate, e era por aí que o mercado voltava.
   const agora = Date.parse('2026-09-01T15:00:00Z');
   const jogoDeHoje = '2026-09-01T13:00:00';
-  const jogoDeOntem = '2026-08-31T13:00:00';
+  const jogoAntesDoCorte = '2026-08-31T13:00:00';
 
   it('esconde o mercado quando quem vence o desempate é o histórico', () => {
     const hist = [linhaDoBoard('asian_handicap', jogoDeHoje)];
-    const saida = mergeBoardAndHistory([], hist, agora, OCULTOS);
-    expect(saida).toHaveLength(0);
+    expect(mergeBoardAndHistory([], hist, agora, VITRINE)).toHaveLength(0);
   });
 
-  it('mantém o mercado no dia passado, que é registro do que foi visto', () => {
-    const hist = [linhaDoBoard('asian_handicap', jogoDeOntem)];
-    const saida = mergeBoardAndHistory([], hist, agora, OCULTOS);
+  it('mantém o que é anterior ao corte, que é registro do que foi visto', () => {
+    const hist = [linhaDoBoard('asian_handicap', jogoAntesDoCorte)];
+    const saida = mergeBoardAndHistory([], hist, agora, VITRINE);
     expect(saida).toHaveLength(1);
     expect(saida[0].market).toBe('asian_handicap');
   });
 
+  // ── O defeito que esta mudança conserta ───────────────────────────────────
+  // A régua antiga cortava por "hoje", então a linha de um dia JÁ PASSADO
+  // sempre entrava. Efeito na tela: o jogo de hoje não mostrava Handicap e o
+  // MESMO jogo mostrava amanhã, quando a linha passava a vir do histórico. Em
+  // produção eram 31 linhas que nunca estiveram em tela nenhuma.
+  it('esconde o dia passado que já é posterior ao corte', () => {
+    const depois = Date.parse('2026-09-05T15:00:00Z');
+    const hist = [linhaDoBoard('asian_handicap', '2026-09-03T13:00:00')];
+    expect(mergeBoardAndHistory([], hist, depois, VITRINE)).toHaveLength(0);
+  });
+
+  it('a mesma linha de hoje continua escondida amanhã', () => {
+    const hist = [linhaDoBoard('asian_handicap', jogoDeHoje)];
+    const hoje = mergeBoardAndHistory([], hist, agora, VITRINE);
+    const amanha = mergeBoardAndHistory([], hist, agora + 86_400_000, VITRINE);
+    expect(amanha).toEqual(hoje);
+    expect(amanha).toHaveLength(0);
+  });
+
   it('não mexe nos outros mercados de hoje', () => {
     const hist = [linhaDoBoard('goals_over_under', jogoDeHoje)];
-    const saida = mergeBoardAndHistory([], hist, agora, OCULTOS);
+    const saida = mergeBoardAndHistory([], hist, agora, VITRINE);
     expect(saida.map((r) => r.market)).toEqual(['goals_over_under']);
   });
 
   it('sem vitrine configurada, nada muda', () => {
     const hist = [linhaDoBoard('asian_handicap', jogoDeHoje)];
     expect(mergeBoardAndHistory([], hist, agora, [])).toHaveLength(1);
+  });
+
+  // ── O escuro ──────────────────────────────────────────────────────────────
+  // Vitrine sem data é o front publicado antes da migration 119. Ali vale a
+  // régua antiga — esconde de hoje em diante, não toca no passado —, que é
+  // degradação e não regressão.
+  describe('vitrine sem data', () => {
+    const SEM_DATA = [{ market: 'asian_handicap', ocultoDesde: null }];
+
+    it('ainda esconde o de hoje', () => {
+      const hist = [linhaDoBoard('asian_handicap', jogoDeHoje)];
+      expect(mergeBoardAndHistory([], hist, agora, SEM_DATA)).toHaveLength(0);
+    });
+
+    it('não apaga o passado, que ela não sabe classificar', () => {
+      const hist = [linhaDoBoard('asian_handicap', jogoAntesDoCorte)];
+      expect(mergeBoardAndHistory([], hist, agora, SEM_DATA)).toHaveLength(1);
+    });
   });
 });

--- a/supabase/migrations/20260905180000_119_futebol_vitrine_com_data.sql
+++ b/supabase/migrations/20260905180000_119_futebol_vitrine_com_data.sql
@@ -1,0 +1,52 @@
+-- 20260905180000_119_futebol_vitrine_com_data
+--
+-- O mercado escondido voltava à tela no dia seguinte.
+--
+-- A 116 tirou o `asian_handicap` da vitrine e guardou `oculto_desde` justamente
+-- para separar o antes do depois. Só que a leitura (`get_futebol_mercados_ocultos`)
+-- devolve `text[]` — o nome do mercado e mais nada. A data ficava no banco, sem
+-- chegar em quem decide o que aparece.
+--
+-- Sem a data, o painel só sabia esconder no PRESENTE. O histórico é o registro
+-- do que foi publicado e visto, e não filtra de propósito: esconder ali
+-- reescreveria o passado de quem apostou no Handicap enquanto ele estava na
+-- prateleira. Correto — para as linhas anteriores ao corte.
+--
+-- Para as posteriores, não: elas nunca estiveram na tela. Medido em produção em
+-- 05/09/2026, com o corte em 01/09:
+--
+--   antes do corte    23 linhas de Handicap em 19 jogos   (publicadas e vistas)
+--   depois do corte   31 linhas de Handicap em 14 jogos   (nunca exibidas)
+--
+-- As 23 são exatamente as que motivaram esconder o mercado (ver a 116). As 31
+-- são fantasma, e já são MAIS que o registro real. O efeito visível é o pior
+-- possível de explicar: o jogo de hoje não mostra Handicap, e amanhã o mesmo
+-- jogo mostra — porque no dia seguinte a linha passa a vir do histórico.
+--
+-- ⚠️ POR QUE UMA SEGUNDA RPC, E NÃO MUDAR A PRIMEIRA
+-- `get_futebol_mercados_ocultos()` continua como está porque os dois
+-- consumidores de notificação (Telegram) só olham o board — presente e futuro,
+-- sempre depois do corte — e para eles a lista de nomes basta. Trocar o tipo de
+-- retorno obrigaria a mexer em três runtimes por causa de um deles.
+--
+-- Conferência depois de aplicar:
+--   select * from public.get_futebol_vitrine();
+--   -- espera asian_handicap com oculto_desde 2026-09-01 00:00:00+00
+
+create or replace function public.get_futebol_vitrine()
+returns table (market text, oculto_desde timestamptz)
+language sql
+stable
+security definer
+set search_path to ''
+as $function$
+  select o.market, o.oculto_desde
+    from public.futebol_mercados_ocultos o
+   where o.oculto
+   order by o.market;
+$function$;
+
+comment on function public.get_futebol_vitrine() is
+  'Mercados fora da vitrine COM a data de corte. A data é o que separa a linha que foi publicada e vista da que nunca esteve na tela.';
+
+grant execute on function public.get_futebol_vitrine() to anon, authenticated, service_role;


### PR DESCRIPTION
Reportado pelo PM: o painel de oportunidades mostra Handicap **em dias anteriores**, mas nenhum durante o dia — e a gente tirou o Handicap da vitrine de propósito (#324).

## O que está acontecendo

Não é o board. É o **histórico**, que assume o lugar da linha quando o dia vira.

O `mergeBoardAndHistory` cortava por *"hoje"*: escondia o mercado no dia corrente e deixava passar tudo que fosse de dia passado. O efeito é o pior possível de explicar para um assinante — o jogo de hoje não mostra Handicap, e amanhã o mesmo jogo mostra.

O histórico não filtra a vitrine **de propósito**, e isso está documentado: ele é o registro do que foi publicado e visto, e escondê-lo reescreveria o passado de quem apostou no Handicap enquanto ele estava na prateleira. A justificativa é correta — para as linhas anteriores ao corte. Para as posteriores é falsa: elas nunca estiveram em tela nenhuma, porque o board já saía filtrado.

## O tamanho, medido em produção

Corte em 01/09/2026:

| | linhas | |
|---|---|---|
| Antes do corte | 23 | publicadas e vistas |
| Depois do corte | 37 | **nunca exibidas** |

As 23 são exatamente as que motivaram esconder o mercado (o ROI −48,4 citado na migration 116). As 37 são fantasma, e já são mais que o registro real.

Por dia, depois da mudança: nada muda em 08/08 a 31/08 (11 linhas ficam, em 8 dias); somem 1 em 02/09, 8 em 03/09, 21 em 04/09 e 7 em 05/09. O dia 02/09 fica vazio, o que é correto: ele só tinha uma linha de Handicap.

## O conserto

Trocar a régua: **o corte é `oculto_desde`, não "hoje"**.

A data já estava no banco desde a 116, guardada exatamente com esse propósito — a própria migration diz que `desde` é "o que torna o antes/depois comparável". Ela só nunca chegava na tela, porque `get_futebol_mercados_ocultos()` devolve `text[]`: o nome do mercado e mais nada.

A **migration 119** acrescenta `get_futebol_vitrine()`, com nome e data. Ela **convive** com a leitura antiga em vez de substituí-la: as duas funções de notificação só olham o board — presente e futuro, sempre depois do corte — e para elas a lista de nomes basta. Trocar o tipo de retorno obrigaria a mexer em três runtimes por causa de um deles.

## Degradação

Dois degraus, ambos para a régua anterior e nenhum para "não esconder nada":

1. RPC nova indisponível (front publicado antes da 119) → cai na RPC antiga, que existe desde a 116.
2. Nem isso → último valor bom em cache; sem ele, o fallback compilado.

Nos dois a data sai vazia, e a regra lê isso como *"esconde de hoje em diante, não toca no passado"* — exatamente o comportamento anterior a este PR. Degradação, não regressão. Tem teste para os dois casos.

## Testes

De 761 para 771. Os novos travam a fronteira exata (o instante do corte já está escondido), o dia passado posterior ao corte, a invariante que originou tudo — *a mesma linha de hoje continua escondida amanhã* — e os dois casos do escuro.

A guarda do shape file pegou a função nova e obrigou a entrada em `docs/futebol-prod-deploy.sql`; está lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
