### PR TITLE
fix: menu da conta — WhatsApp em "Falar com o time", "Como usar" oculto, e uma lista só nas duas telas

### DIFF
--- a/docs/design-system/handoff-header-footer.md
+++ b/docs/design-system/handoff-header-footer.md
@@ -100,8 +100,18 @@ oportunidades de valor…"). Repetia o que o H1 da página já diz, e o
 **6. Rodapé lista produtos, não sub-páginas.**
 O desenho listava 6 links em Análises e 5 em Produtos — uma cópia do menu.
 Virou: **Análises** (Futebol · NBA), **Ferramentas** (Betinho) e **Suporte**
-(Planos e preços · Como usar · Configurações · Indique um amigo · Falar com o
-time). As sub-seções já vivem na faixa 2 do header.
+(Planos e preços · Configurações · Indique um amigo · Falar com o time). As
+sub-seções já vivem na faixa 2 do header.
+
+> Atualizado em 08/09/2026. **"Como usar" saiu** da coluna Suporte: a página é
+> o guia do Betinho no Telegram e ficou para trás do produto. Sai atrás da
+> chave `SHOW_COMO_USAR_ENTRY_POINTS` (`src/config/como-usar.ts`), no mesmo formato do
+> Bolão — a rota continua de pé, e reativar é trocar um `false` por `true`.
+>
+> **"Falar com o time" deixou de ser `mailto:` e virou WhatsApp**, com a
+> primeira mensagem já escrita. É o mesmo destino do ícone de WhatsApp aqui do
+> rodapé, que também passou a levar a mensagem: duas portas do mesmo número
+> lado a lado, uma delas abrindo conversa vazia, era o que existia antes.
 
 **7. Termos e privacidade num link só.**
 `/termos` e `/privacidade` renderizam a mesma página (`App.tsx`), que traz as
@@ -130,7 +140,7 @@ Regra: **um conceito, um glifo** — em toda a navegação, nos dois esportes.
 | Análise 360 | `Radar` | só NBA |
 | Relatório | `FileText` | só NBA |
 | Apostas | `Target` | Betinho |
-| Banca / Dashboard | `Wallet` | era `BarChart3`; o gráfico já é "Análises". Mesmo glifo do item de banca na `/perfil` |
+| Banca / Dashboard | `Wallet` | era `BarChart3`; o gráfico já é "Análises" |
 
 Os dois SVGs próprios ficam em `src/components/icons/sports.tsx`. Nasceram no
 hub `/inicio` e foram extraídos quando o header passou a precisar dos mesmos —

--- a/src/components/AnalyticsNav.tsx
+++ b/src/components/AnalyticsNav.tsx
@@ -68,7 +68,7 @@ const FUTEBOL_ITEMS: SubItem[] = [
 const BETINHO_ITEMS: SubItem[] = [
   { name: 'Apostas', href: '/bets', icon: Target },
   // `Wallet` e não `BarChart3`: é a banca, e o gráfico já é "Análises" na
-  // faixa 1. Mesmo glifo do item "Minha banca e apostas" da tela /perfil.
+  // faixa 1. Mesmo glifo da banca no rodapé (ver docs/design-system/handoff-header-footer.md).
   { name: 'Dashboard', href: '/betting-dashboard', icon: Wallet },
 ];
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Instagram, MessageCircle, Mail } from 'lucide-react';
 import { SHOW_BOLAO_ENTRY_POINTS } from '@/config/bolao';
+import { SHOW_COMO_USAR_ENTRY_POINTS } from '@/config/como-usar';
 import { EMAIL_DO_TIME, WHATSAPP_DO_TIME, WHATSAPP_FALAR_COM_O_TIME } from '@/config/contato';
 import { useReferral } from './ReferralProvider';
 
@@ -41,7 +42,7 @@ const Footer = () => {
   // não são o que a gente oferece, são coisas da conta do usuário.
   const suporte: FooterLink[] = [
     { label: 'Planos e preços', href: '/planos' },
-    { label: 'Como usar', href: '/como-usar' },
+    ...(SHOW_COMO_USAR_ENTRY_POINTS ? [{ label: 'Como usar', href: '/como-usar' }] : []),
     { label: 'Configurações da conta', href: '/settings' },
     { label: 'Indique um amigo', onClick: openReferral },
     // WhatsApp, e não e-mail: é onde o time de fato responde, e é o mesmo

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { Instagram, MessageCircle, Mail } from 'lucide-react';
 import { SHOW_BOLAO_ENTRY_POINTS } from '@/config/bolao';
 import { SHOW_COMO_USAR_ENTRY_POINTS } from '@/config/como-usar';
-import { EMAIL_DO_TIME, WHATSAPP_DO_TIME, WHATSAPP_FALAR_COM_O_TIME } from '@/config/contato';
+import { EMAIL_DO_TIME, WHATSAPP_FALAR_COM_O_TIME } from '@/config/contato';
+import { ehExterno } from '@/lib/abrir-destino';
 import { useReferral } from './ReferralProvider';
 
 /**
@@ -61,12 +62,11 @@ const Footer = () => {
         </button>
       );
     }
-    const external = l.href?.startsWith('mailto:') || l.href?.startsWith('http');
-    if (external) {
-      // Só o link http sai em aba nova. No mailto o navegador entrega ao
+    const novaAba = l.href != null && ehExterno(l.href);
+    if (novaAba || l.href?.startsWith('mailto:')) {
+      // Só o link externo sai em aba nova. No mailto o navegador entrega ao
       // cliente de e-mail sem navegar, então o target ali deixaria uma aba em
       // branco aberta para trás.
-      const novaAba = l.href?.startsWith('http');
       return (
         <a
           key={l.label}
@@ -117,7 +117,7 @@ const Footer = () => {
               <Instagram className="w-4 h-4" />
             </a>
             <a
-              href={WHATSAPP_DO_TIME}
+              href={WHATSAPP_FALAR_COM_O_TIME}
               target="_blank"
               rel="noopener noreferrer"
               aria-label="WhatsApp"

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Instagram, MessageCircle, Mail } from 'lucide-react';
 import { SHOW_BOLAO_ENTRY_POINTS } from '@/config/bolao';
-import { EMAIL_DO_TIME, WHATSAPP_DO_TIME } from '@/config/contato';
+import { EMAIL_DO_TIME, WHATSAPP_DO_TIME, WHATSAPP_FALAR_COM_O_TIME } from '@/config/contato';
 import { useReferral } from './ReferralProvider';
 
 /**
@@ -47,7 +47,7 @@ const Footer = () => {
     // WhatsApp, e não e-mail: é onde o time de fato responde, e é o mesmo
     // canal do ícone aqui embaixo. Duas portas com o mesmo nome levando a
     // lugares diferentes era o que existia antes.
-    { label: 'Falar com o time', href: WHATSAPP_DO_TIME },
+    { label: 'Falar com o time', href: WHATSAPP_FALAR_COM_O_TIME },
   ];
 
   const linkCls = 'text-[13px] text-white/70 hover:text-white transition-colors text-left';

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 import { Instagram, MessageCircle, Mail } from 'lucide-react';
 import { SHOW_BOLAO_ENTRY_POINTS } from '@/config/bolao';
+import { EMAIL_DO_TIME, WHATSAPP_DO_TIME } from '@/config/contato';
 import { useReferral } from './ReferralProvider';
 
 /**
@@ -43,7 +44,10 @@ const Footer = () => {
     { label: 'Como usar', href: '/como-usar' },
     { label: 'Configurações da conta', href: '/settings' },
     { label: 'Indique um amigo', onClick: openReferral },
-    { label: 'Falar com o time', href: 'mailto:tecnologia@smartbetting.app' },
+    // WhatsApp, e não e-mail: é onde o time de fato responde, e é o mesmo
+    // canal do ícone aqui embaixo. Duas portas com o mesmo nome levando a
+    // lugares diferentes era o que existia antes.
+    { label: 'Falar com o time', href: WHATSAPP_DO_TIME },
   ];
 
   const linkCls = 'text-[13px] text-white/70 hover:text-white transition-colors text-left';
@@ -58,8 +62,18 @@ const Footer = () => {
     }
     const external = l.href?.startsWith('mailto:') || l.href?.startsWith('http');
     if (external) {
+      // Só o link http sai em aba nova. No mailto o navegador entrega ao
+      // cliente de e-mail sem navegar, então o target ali deixaria uma aba em
+      // branco aberta para trás.
+      const novaAba = l.href?.startsWith('http');
       return (
-        <a key={l.label} href={l.href} className={linkCls}>
+        <a
+          key={l.label}
+          href={l.href}
+          target={novaAba ? '_blank' : undefined}
+          rel={novaAba ? 'noopener noreferrer' : undefined}
+          className={linkCls}
+        >
           {l.label}
         </a>
       );
@@ -102,7 +116,7 @@ const Footer = () => {
               <Instagram className="w-4 h-4" />
             </a>
             <a
-              href="https://wa.me/5511952136845"
+              href={WHATSAPP_DO_TIME}
               target="_blank"
               rel="noopener noreferrer"
               aria-label="WhatsApp"
@@ -110,7 +124,7 @@ const Footer = () => {
             >
               <MessageCircle className="w-4 h-4" />
             </a>
-            <a href="mailto:tecnologia@smartbetting.app" aria-label="E-mail" className={socialCls}>
+            <a href={`mailto:${EMAIL_DO_TIME}`} aria-label="E-mail" className={socialCls}>
               <Mail className="w-4 h-4" />
             </a>
           </div>

--- a/src/components/UserNav.tsx
+++ b/src/components/UserNav.tsx
@@ -19,6 +19,7 @@ import {
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useReferral } from './ReferralProvider';
 import { WHATSAPP_FALAR_COM_O_TIME } from '@/config/contato';
+import { SHOW_COMO_USAR_ENTRY_POINTS } from '@/config/como-usar';
 import { useSettingsData } from '@/hooks/use-settings-data';
 import { getInitials } from '@/lib/user-display';
 
@@ -79,7 +80,7 @@ export default function UserNav({ className }: UserNavProps) {
     { label: 'Configurações', icon: Settings, href: '/settings' },
     { label: 'Planos e preços', icon: CreditCard, href: '/planos' },
     { label: 'Indique um amigo', icon: Gift, onClick: openReferral },
-    { label: 'Como usar', icon: BookOpen, href: '/como-usar' },
+    ...(SHOW_COMO_USAR_ENTRY_POINTS ? [{ label: 'Como usar', icon: BookOpen, href: '/como-usar' }] : []),
     // Mesmo destino do rodapé, pela constante e não por uma cópia da string.
     { label: 'Falar com o time', icon: MessageCircle, href: WHATSAPP_FALAR_COM_O_TIME },
   ];

--- a/src/components/UserNav.tsx
+++ b/src/components/UserNav.tsx
@@ -12,13 +12,13 @@ import {
   Gift,
   BookOpen,
   CreditCard,
-  HelpCircle,
+  MessageCircle,
   ChevronRight,
   Zap,
 } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useReferral } from './ReferralProvider';
-import { WHATSAPP_DO_TIME } from '@/config/contato';
+import { WHATSAPP_FALAR_COM_O_TIME } from '@/config/contato';
 import { useSettingsData } from '@/hooks/use-settings-data';
 import { getInitials } from '@/lib/user-display';
 
@@ -81,7 +81,7 @@ export default function UserNav({ className }: UserNavProps) {
     { label: 'Indique um amigo', icon: Gift, onClick: openReferral },
     { label: 'Como usar', icon: BookOpen, href: '/como-usar' },
     // Mesmo destino do rodapé, pela constante e não por uma cópia da string.
-    { label: 'Falar com o time', icon: HelpCircle, href: WHATSAPP_DO_TIME },
+    { label: 'Falar com o time', icon: MessageCircle, href: WHATSAPP_FALAR_COM_O_TIME },
   ];
 
   const go = (item: MenuItem) => {

--- a/src/components/UserNav.tsx
+++ b/src/components/UserNav.tsx
@@ -7,19 +7,14 @@ import {
 } from './ui/dropdown-menu';
 import { Avatar, AvatarFallback } from './ui/avatar';
 import {
-  Settings,
   LogOut,
-  Gift,
-  BookOpen,
-  CreditCard,
-  MessageCircle,
   ChevronRight,
   Zap,
 } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useReferral } from './ReferralProvider';
-import { WHATSAPP_FALAR_COM_O_TIME } from '@/config/contato';
-import { SHOW_COMO_USAR_ENTRY_POINTS } from '@/config/como-usar';
+import { itensDaConta, type ItemDaConta } from '@/config/menu-da-conta';
+import { abrirDestino } from '@/lib/abrir-destino';
 import { useSettingsData } from '@/hooks/use-settings-data';
 import { getInitials } from '@/lib/user-display';
 
@@ -38,13 +33,6 @@ interface UserNavProps {
 }
 
 /** Itens do menu, na ordem do desenho. `Configurações` é sempre o primeiro. */
-type MenuItem = {
-  label: string;
-  icon: typeof Settings;
-  href?: string;
-  onClick?: () => void;
-};
-
 export default function UserNav({ className }: UserNavProps) {
   const { user, signOut } = useAuth();
   const navigate = useNavigate();
@@ -76,29 +64,11 @@ export default function UserNav({ className }: UserNavProps) {
     ? new Date(activeSub.periodEnd).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' })
     : null;
 
-  const items: MenuItem[] = [
-    { label: 'Configurações', icon: Settings, href: '/settings' },
-    { label: 'Planos e preços', icon: CreditCard, href: '/planos' },
-    { label: 'Indique um amigo', icon: Gift, onClick: openReferral },
-    ...(SHOW_COMO_USAR_ENTRY_POINTS ? [{ label: 'Como usar', icon: BookOpen, href: '/como-usar' }] : []),
-    // Mesmo destino do rodapé, pela constante e não por uma cópia da string.
-    { label: 'Falar com o time', icon: MessageCircle, href: WHATSAPP_FALAR_COM_O_TIME },
-  ];
+  const items = itensDaConta(openReferral);
 
-  const go = (item: MenuItem) => {
+  const go = (item: ItemDaConta) => {
     if (item.onClick) return item.onClick();
-    // Link externo abre em aba nova, e precisa vir ANTES do navigate: o
-    // `navigate` do router trataria a URL inteira como rota interna e
-    // levaria a pessoa para o 404 em vez do WhatsApp.
-    if (item.href?.startsWith('http')) {
-      window.open(item.href, '_blank', 'noopener,noreferrer');
-      return;
-    }
-    if (item.href?.startsWith('mailto:')) {
-      window.location.href = item.href;
-      return;
-    }
-    if (item.href) navigate(item.href);
+    if (item.href) abrirDestino(item.href, navigate);
   };
 
   return (

--- a/src/components/UserNav.tsx
+++ b/src/components/UserNav.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useReferral } from './ReferralProvider';
+import { WHATSAPP_DO_TIME } from '@/config/contato';
 import { useSettingsData } from '@/hooks/use-settings-data';
 import { getInitials } from '@/lib/user-display';
 
@@ -79,11 +80,19 @@ export default function UserNav({ className }: UserNavProps) {
     { label: 'Planos e preços', icon: CreditCard, href: '/planos' },
     { label: 'Indique um amigo', icon: Gift, onClick: openReferral },
     { label: 'Como usar', icon: BookOpen, href: '/como-usar' },
-    { label: 'Falar com o time', icon: HelpCircle, href: 'mailto:tecnologia@smartbetting.app' },
+    // Mesmo destino do rodapé, pela constante e não por uma cópia da string.
+    { label: 'Falar com o time', icon: HelpCircle, href: WHATSAPP_DO_TIME },
   ];
 
   const go = (item: MenuItem) => {
     if (item.onClick) return item.onClick();
+    // Link externo abre em aba nova, e precisa vir ANTES do navigate: o
+    // `navigate` do router trataria a URL inteira como rota interna e
+    // levaria a pessoa para o 404 em vez do WhatsApp.
+    if (item.href?.startsWith('http')) {
+      window.open(item.href, '_blank', 'noopener,noreferrer');
+      return;
+    }
     if (item.href?.startsWith('mailto:')) {
       window.location.href = item.href;
       return;

--- a/src/components/bolao/CreateBolaoModal.tsx
+++ b/src/components/bolao/CreateBolaoModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
+import { whatsappDoTime } from '@/config/contato';
 import {
   Trophy,
   Users,
@@ -47,8 +48,10 @@ const PREMIUM_FEATURES = [
   { icon: Sparkles, text: 'Tudo do Free incluído', highlight: true },
 ];
 
-const WHATSAPP_PIX_URL =
-  'https://wa.me/5511952136845?text=Ol%C3%A1!%20Quero%20pagar%20o%20Bol%C3%A3o%20Premium%20via%20PIX';
+// A frase em português, e a codificação por conta do encodeURIComponent. O
+// %C3%A1 estava digitado na mão aqui, e sobrevivia até alguém editar o texto e
+// esquecer de recodificar — aí o WhatsApp abre com lixo no campo.
+const WHATSAPP_PIX_URL = whatsappDoTime('Olá! Quero pagar o Bolão Premium via PIX');
 
 export const CreateBolaoModal: React.FC<CreateBolaoModalProps> = ({
   open,

--- a/src/config/como-usar.ts
+++ b/src/config/como-usar.ts
@@ -1,0 +1,17 @@
+/**
+ * Pontos de entrada do guia "Como usar" na navegação.
+ *
+ * Desligado em 2026-09-08: a página é o guia do Betinho no Telegram, e o
+ * produto andou muito desde que ela foi escrita. Mandar alguém para lá hoje é
+ * pior do que não oferecer nada — instrução desatualizada não é ajuda, é uma
+ * pessoa seguindo um passo a passo que não bate com a tela na frente dela.
+ *
+ * A ROTA continua de pé. Quem tem o link, o favorito ou veio de fora continua
+ * chegando; e o botão "Guia de uso" dentro da própria página do Betinho
+ * continua ali, porque naquele contexto o guia ainda é do assunto certo.
+ * O que sai é a porta de entrada nos menus gerais, onde ela se apresenta como
+ * o jeito de aprender o produto inteiro.
+ *
+ * Para reativar depois de reescrever a página: `true`.
+ */
+export const SHOW_COMO_USAR_ENTRY_POINTS = false;

--- a/src/config/contato.test.ts
+++ b/src/config/contato.test.ts
@@ -4,30 +4,26 @@ import { resolve } from 'node:path';
 import { WHATSAPP_DO_TIME, WHATSAPP_FALAR_COM_O_TIME, whatsappDoTime } from './contato';
 
 // ============================================================================
-// "Falar com o time" leva ao mesmo lugar nos dois menus
+// O WhatsApp do time é um número só, escrito num lugar só
 // ============================================================================
-// O pedido do produto não foi "coloque o WhatsApp no menu da conta" — foi "o
-// mesmo link que tem no rodapé". Isso é uma exigência de IGUALDADE entre dois
-// arquivos, e igualdade é justamente o que uma string copiada não sustenta:
-// basta alguém trocar o número num lugar para metade do app passar a mandar a
-// pessoa para um telefone que não atende.
+// O pedido do produto não foi "coloque o WhatsApp no menu" — foi "o mesmo link
+// que tem no rodapé". Isso é uma exigência de IGUALDADE entre arquivos, e
+// igualdade é justamente o que uma string copiada não sustenta: basta alguém
+// trocar o número num lugar para metade do app passar a mandar a pessoa para um
+// telefone que não atende.
 //
-// Por isso o teste não olha o valor do link. Ele olha se os dois consumidores
-// leem da MESMA constante, que é a única forma de a igualdade sobreviver à
-// próxima edição.
+// A igualdade entre os DOIS MENUS mora em menu-da-conta.test.ts, porque desde
+// que eles passaram a ler o mesmo catálogo o assunto é de lá. Aqui fica o
+// rodapé, que tem lista própria por ser outro componente.
 // ============================================================================
 
-const fonte = (caminho: string) =>
-  readFileSync(resolve(__dirname, '..', caminho), 'utf8').replace(/\r\n/g, '\n');
-
-const FOOTER = fonte('components/Footer.tsx');
-const USER_NAV = fonte('components/UserNav.tsx');
+const FOOTER = readFileSync(resolve(__dirname, '../components/Footer.tsx'), 'utf8').replace(
+  /\r\n/g,
+  '\n',
+);
 
 /** O número, escrito por extenso só aqui — para poder proibi-lo lá. */
 const NUMERO_CRU = '5511952136845';
-
-const linhaDoItem = (arquivo: string) =>
-  arquivo.split('\n').find((l) => l.includes("label: 'Falar com o time'"));
 
 describe('contato do time', () => {
   it('o WhatsApp é um link wa.me', () => {
@@ -47,33 +43,15 @@ describe('contato do time', () => {
     expect(decodeURIComponent(WHATSAPP_FALAR_COM_O_TIME.split('?text=')[1])).toMatch(/\S/);
   });
 
-  it('o rodapé e o menu da conta leem a mesma constante', () => {
-    for (const arquivo of [FOOTER, USER_NAV]) {
-      expect(arquivo).toContain("from '@/config/contato'");
-      expect(linhaDoItem(arquivo)).toContain('WHATSAPP_FALAR_COM_O_TIME');
-    }
-  });
-
-  it('nenhum dos dois repete o número na mão', () => {
+  it('o rodapé lê a constante, e não repete o número na mão', () => {
+    expect(FOOTER).toContain("from '@/config/contato'");
     expect(FOOTER).not.toContain(NUMERO_CRU);
-    expect(USER_NAV).not.toContain(NUMERO_CRU);
   });
 
-  it('"Falar com o time" não é mais e-mail em nenhum dos dois', () => {
-    for (const arquivo of [FOOTER, USER_NAV]) {
-      const linha = linhaDoItem(arquivo);
-      expect(linha).toBeDefined();
-      expect(linha).not.toContain('mailto:');
-    }
-  });
-
-  it('o menu da conta abre link externo em aba nova, e não pelo router', () => {
-    // `navigate` trataria a URL inteira como rota interna e cairia no 404. O
-    // ramo do http tem de vir antes dele.
-    const go = USER_NAV.slice(USER_NAV.indexOf('const go = (item: MenuItem)'));
-    const corpo = go.slice(0, go.indexOf('};'));
-    expect(corpo).toContain("item.href?.startsWith('http')");
-    expect(corpo).toContain('window.open');
-    expect(corpo.indexOf("startsWith('http')")).toBeLessThan(corpo.indexOf('navigate('));
+  it('"Falar com o time" no rodapé não é mais e-mail', () => {
+    const linha = FOOTER.split('\n').find((l) => l.includes("label: 'Falar com o time'"));
+    expect(linha).toBeDefined();
+    expect(linha).toContain('WHATSAPP_FALAR_COM_O_TIME');
+    expect(linha).not.toContain('mailto:');
   });
 });

--- a/src/config/contato.test.ts
+++ b/src/config/contato.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { WHATSAPP_DO_TIME } from './contato';
+import { WHATSAPP_DO_TIME, WHATSAPP_FALAR_COM_O_TIME, whatsappDoTime } from './contato';
 
 // ============================================================================
 // "Falar com o time" leva ao mesmo lugar nos dois menus
@@ -26,15 +26,31 @@ const USER_NAV = fonte('components/UserNav.tsx');
 /** O número, escrito por extenso só aqui — para poder proibi-lo lá. */
 const NUMERO_CRU = '5511952136845';
 
+const linhaDoItem = (arquivo: string) =>
+  arquivo.split('\n').find((l) => l.includes("label: 'Falar com o time'"));
+
 describe('contato do time', () => {
   it('o WhatsApp é um link wa.me', () => {
     expect(WHATSAPP_DO_TIME).toMatch(/^https:\/\/wa\.me\/\d+$/);
   });
 
+  it('a mensagem pronta é codificada, e não escrita à mão', () => {
+    // Acento e espaço quebram a URL. Um link do bolão foi escrito com o %C3%A1
+    // digitado na mão, e é isso que este teste impede de virar hábito.
+    expect(whatsappDoTime('Olá, tudo bem?')).toBe(
+      `${WHATSAPP_DO_TIME}?text=Ol%C3%A1%2C%20tudo%20bem%3F`,
+    );
+  });
+
+  it('o link de falar com o time leva mensagem pronta', () => {
+    expect(WHATSAPP_FALAR_COM_O_TIME).toContain(`${WHATSAPP_DO_TIME}?text=`);
+    expect(decodeURIComponent(WHATSAPP_FALAR_COM_O_TIME.split('?text=')[1])).toMatch(/\S/);
+  });
+
   it('o rodapé e o menu da conta leem a mesma constante', () => {
     for (const arquivo of [FOOTER, USER_NAV]) {
       expect(arquivo).toContain("from '@/config/contato'");
-      expect(arquivo).toContain('WHATSAPP_DO_TIME');
+      expect(linhaDoItem(arquivo)).toContain('WHATSAPP_FALAR_COM_O_TIME');
     }
   });
 
@@ -45,11 +61,8 @@ describe('contato do time', () => {
 
   it('"Falar com o time" não é mais e-mail em nenhum dos dois', () => {
     for (const arquivo of [FOOTER, USER_NAV]) {
-      const linha = arquivo
-        .split('\n')
-        .find((l) => l.includes("label: 'Falar com o time'"));
+      const linha = linhaDoItem(arquivo);
       expect(linha).toBeDefined();
-      expect(linha).toContain('WHATSAPP_DO_TIME');
       expect(linha).not.toContain('mailto:');
     }
   });

--- a/src/config/contato.test.ts
+++ b/src/config/contato.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readdirSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
 import { WHATSAPP_DO_TIME, WHATSAPP_FALAR_COM_O_TIME, whatsappDoTime } from './contato';
 
 // ============================================================================
@@ -22,8 +22,13 @@ const FOOTER = readFileSync(resolve(__dirname, '../components/Footer.tsx'), 'utf
   '\n',
 );
 
-/** O número, escrito por extenso só aqui — para poder proibi-lo lá. */
-const NUMERO_CRU = '5511952136845';
+/**
+ * O número, tirado da própria constante.
+ *
+ * Não escrito à mão de propósito: o teste abaixo varre o app inteiro atrás
+ * dele, e um literal aqui faria o arquivo de teste se acusar.
+ */
+const NUMERO_CRU = WHATSAPP_DO_TIME.split('/').pop() as string;
 
 describe('contato do time', () => {
   it('o WhatsApp é um link wa.me', () => {
@@ -53,5 +58,32 @@ describe('contato do time', () => {
     expect(linha).toBeDefined();
     expect(linha).toContain('WHATSAPP_FALAR_COM_O_TIME');
     expect(linha).not.toContain('mailto:');
+  });
+
+  it('o número não aparece em mais nenhum arquivo do app', () => {
+    // Este é o teste que torna o comentário lá em cima verdadeiro. Sem ele, o
+    // módulo AFIRMA ser a fonte única e três telas de paywall e o modal do
+    // bolão seguiam com o número escrito na mão — a promessa valia só para
+    // quem tivesse lido os dois lugares.
+    const raiz = resolve(__dirname, '..');
+    const fora: string[] = [];
+
+    const varrer = (dir: string) => {
+      for (const item of readdirSync(dir, { withFileTypes: true })) {
+        const caminho = resolve(dir, item.name);
+        if (item.isDirectory()) {
+          varrer(caminho);
+          continue;
+        }
+        if (!/\.(ts|tsx)$/.test(item.name)) continue;
+        if (caminho === resolve(__dirname, 'contato.ts')) continue;
+        if (readFileSync(caminho, 'utf8').includes(NUMERO_CRU)) {
+          fora.push(relative(raiz, caminho).replace(/\\/g, '/'));
+        }
+      }
+    };
+    varrer(raiz);
+
+    expect(fora).toEqual([]);
   });
 });

--- a/src/config/contato.test.ts
+++ b/src/config/contato.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { WHATSAPP_DO_TIME } from './contato';
+
+// ============================================================================
+// "Falar com o time" leva ao mesmo lugar nos dois menus
+// ============================================================================
+// O pedido do produto não foi "coloque o WhatsApp no menu da conta" — foi "o
+// mesmo link que tem no rodapé". Isso é uma exigência de IGUALDADE entre dois
+// arquivos, e igualdade é justamente o que uma string copiada não sustenta:
+// basta alguém trocar o número num lugar para metade do app passar a mandar a
+// pessoa para um telefone que não atende.
+//
+// Por isso o teste não olha o valor do link. Ele olha se os dois consumidores
+// leem da MESMA constante, que é a única forma de a igualdade sobreviver à
+// próxima edição.
+// ============================================================================
+
+const fonte = (caminho: string) =>
+  readFileSync(resolve(__dirname, '..', caminho), 'utf8').replace(/\r\n/g, '\n');
+
+const FOOTER = fonte('components/Footer.tsx');
+const USER_NAV = fonte('components/UserNav.tsx');
+
+/** O número, escrito por extenso só aqui — para poder proibi-lo lá. */
+const NUMERO_CRU = '5511952136845';
+
+describe('contato do time', () => {
+  it('o WhatsApp é um link wa.me', () => {
+    expect(WHATSAPP_DO_TIME).toMatch(/^https:\/\/wa\.me\/\d+$/);
+  });
+
+  it('o rodapé e o menu da conta leem a mesma constante', () => {
+    for (const arquivo of [FOOTER, USER_NAV]) {
+      expect(arquivo).toContain("from '@/config/contato'");
+      expect(arquivo).toContain('WHATSAPP_DO_TIME');
+    }
+  });
+
+  it('nenhum dos dois repete o número na mão', () => {
+    expect(FOOTER).not.toContain(NUMERO_CRU);
+    expect(USER_NAV).not.toContain(NUMERO_CRU);
+  });
+
+  it('"Falar com o time" não é mais e-mail em nenhum dos dois', () => {
+    for (const arquivo of [FOOTER, USER_NAV]) {
+      const linha = arquivo
+        .split('\n')
+        .find((l) => l.includes("label: 'Falar com o time'"));
+      expect(linha).toBeDefined();
+      expect(linha).toContain('WHATSAPP_DO_TIME');
+      expect(linha).not.toContain('mailto:');
+    }
+  });
+
+  it('o menu da conta abre link externo em aba nova, e não pelo router', () => {
+    // `navigate` trataria a URL inteira como rota interna e cairia no 404. O
+    // ramo do http tem de vir antes dele.
+    const go = USER_NAV.slice(USER_NAV.indexOf('const go = (item: MenuItem)'));
+    const corpo = go.slice(0, go.indexOf('};'));
+    expect(corpo).toContain("item.href?.startsWith('http')");
+    expect(corpo).toContain('window.open');
+    expect(corpo.indexOf("startsWith('http')")).toBeLessThan(corpo.indexOf('navigate('));
+  });
+});

--- a/src/config/contato.ts
+++ b/src/config/contato.ts
@@ -2,10 +2,10 @@
  * Os canais de contato do time.
  *
  * Uma constante, e não a string repetida em cada tela: o WhatsApp aparece no
- * rodapé, no menu da conta e nas telas de paywall, e a exigência do produto é
- * que TODOS levem ao mesmo lugar. Copiada, a string sobrevive à primeira
- * mudança de número em um lugar só — e aí metade do app manda a pessoa para um
- * telefone que não atende mais.
+ * rodapé, no menu da conta, nas telas de paywall e no modal do bolão, e a
+ * exigência do produto é que TODOS levem ao mesmo lugar. Copiada, a string
+ * sobrevive à primeira mudança de número em um lugar só — e aí metade do app
+ * manda a pessoa para um telefone que não atende mais.
  */
 export const WHATSAPP_DO_TIME = 'https://wa.me/5511952136845';
 
@@ -16,8 +16,8 @@ export const EMAIL_DO_TIME = 'tecnologia@smartbetting.app';
  * O link do WhatsApp já com a primeira mensagem escrita.
  *
  * A codificação é do `encodeURIComponent`, e não da mão: acento e espaço
- * quebram a URL, e um link do bolão foi escrito com `%C3%A1` digitado
- * manualmente — funciona até alguém editar a frase e esquecer de recodificar.
+ * quebram a URL, e o link do PIX do bolão estava com o `%C3%A1` digitado
+ * manualmente — funcionava até alguém editar a frase e esquecer de recodificar.
  */
 export function whatsappDoTime(mensagem: string): string {
   return `${WHATSAPP_DO_TIME}?text=${encodeURIComponent(mensagem)}`;

--- a/src/config/contato.ts
+++ b/src/config/contato.ts
@@ -1,0 +1,17 @@
+/**
+ * Os canais de contato do time.
+ *
+ * Uma constante, e não a string repetida em cada tela: o WhatsApp aparece no
+ * rodapé, no menu da conta e nas telas de paywall, e a exigência do produto é
+ * que TODOS levem ao mesmo lugar. Copiada, a string sobrevive à primeira
+ * mudança de número em um lugar só — e aí metade do app manda a pessoa para um
+ * telefone que não atende mais.
+ *
+ * O link é o cru, sem mensagem pré-preenchida, porque é o mesmo que o ícone do
+ * rodapé já usava e é o que o usuário reconhece. Quem precisa de texto pronto
+ * (as telas de paywall) monta em cima deste, e não ao lado dele.
+ */
+export const WHATSAPP_DO_TIME = 'https://wa.me/5511952136845';
+
+/** O e-mail do time. Continua sendo o canal do rodapé e do ícone de envelope. */
+export const EMAIL_DO_TIME = 'tecnologia@smartbetting.app';

--- a/src/config/contato.ts
+++ b/src/config/contato.ts
@@ -6,12 +6,31 @@
  * que TODOS levem ao mesmo lugar. Copiada, a string sobrevive à primeira
  * mudança de número em um lugar só — e aí metade do app manda a pessoa para um
  * telefone que não atende mais.
- *
- * O link é o cru, sem mensagem pré-preenchida, porque é o mesmo que o ícone do
- * rodapé já usava e é o que o usuário reconhece. Quem precisa de texto pronto
- * (as telas de paywall) monta em cima deste, e não ao lado dele.
  */
 export const WHATSAPP_DO_TIME = 'https://wa.me/5511952136845';
 
 /** O e-mail do time. Continua sendo o canal do rodapé e do ícone de envelope. */
 export const EMAIL_DO_TIME = 'tecnologia@smartbetting.app';
+
+/**
+ * O link do WhatsApp já com a primeira mensagem escrita.
+ *
+ * A codificação é do `encodeURIComponent`, e não da mão: acento e espaço
+ * quebram a URL, e um link do bolão foi escrito com `%C3%A1` digitado
+ * manualmente — funciona até alguém editar a frase e esquecer de recodificar.
+ */
+export function whatsappDoTime(mensagem: string): string {
+  return `${WHATSAPP_DO_TIME}?text=${encodeURIComponent(mensagem)}`;
+}
+
+/**
+ * "Falar com o time" — o link do rodapé e do menu da conta.
+ *
+ * A mensagem pronta existe para os dois lados. Para quem escreve, tira o custo
+ * da primeira frase, que é onde a maioria desiste. Para quem atende, diz de
+ * onde a pessoa veio: sem isso a conversa começa com um "oi" solto e o time
+ * gasta uma rodada só para descobrir o assunto.
+ */
+export const WHATSAPP_FALAR_COM_O_TIME = whatsappDoTime(
+  'Oi! Preciso de ajuda com a Smart Betting.',
+);

--- a/src/config/menu-da-conta.test.ts
+++ b/src/config/menu-da-conta.test.ts
@@ -53,10 +53,12 @@ describe('itens do menu da conta', () => {
     expect(indicar).toHaveBeenCalledOnce();
   });
 
-  it('"Como usar" respeita a chave, e hoje está desligado', () => {
+  // O teste segue a chave em vez de fixar o valor dela: prender `false` aqui
+  // faria o CI quebrar em quem religar o item, que é exatamente a instrução
+  // escrita em como-usar.ts.
+  it('"Como usar" respeita a chave', () => {
     const temComoUsar = itensDaConta(() => {}).some((i) => i.label === 'Como usar');
     expect(temComoUsar).toBe(SHOW_COMO_USAR_ENTRY_POINTS);
-    expect(SHOW_COMO_USAR_ENTRY_POINTS).toBe(false);
   });
 
   it('as duas telas leem do catálogo, e nenhuma monta lista própria', () => {

--- a/src/config/menu-da-conta.test.ts
+++ b/src/config/menu-da-conta.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { itensDaConta } from './menu-da-conta';
+import { SHOW_COMO_USAR_ENTRY_POINTS } from './como-usar';
+import { WHATSAPP_FALAR_COM_O_TIME } from './contato';
+
+// ============================================================================
+// O menu da conta é o mesmo no computador e no celular
+// ============================================================================
+// A regra já estava escrita no topo da tela de Perfil: "mesmo conteúdo nas duas
+// plataformas, formato diferente". Só que o conteúdo morava em duas listas, uma
+// em cada arquivo, e cumprir a regra dependia de alguém lembrar de editar as
+// duas. Não lembrou — as listas divergiram em três pontos ao mesmo tempo:
+//
+//   · o celular tinha "Minha banca e apostas", que o computador não tinha
+//   · a mesma página era "Plano e pagamento" lá e "Planos e preços" cá
+//   · o celular oferecia um guia que o computador já tinha tirado do ar
+//
+// Uma lista só resolve por construção. Estes testes existem para que ela
+// continue sendo uma: o guarda de fonte no fim é o que impede alguém de
+// reescrever um array literal dentro de uma das telas outra vez.
+// ============================================================================
+
+const fonte = (caminho: string) =>
+  readFileSync(resolve(__dirname, '..', caminho), 'utf8').replace(/\r\n/g, '\n');
+
+const USER_NAV = fonte('components/UserNav.tsx');
+const PERFIL = fonte('pages/Perfil.tsx');
+
+describe('itens do menu da conta', () => {
+  it('traz a lista na ordem do desenho', () => {
+    const labels = itensDaConta(() => {}).map((i) => i.label);
+    expect(labels).toEqual([
+      'Configurações',
+      'Planos e preços',
+      'Indique um amigo',
+      ...(SHOW_COMO_USAR_ENTRY_POINTS ? ['Como usar'] : []),
+      'Falar com o time',
+    ]);
+  });
+
+  it('"Falar com o time" aponta para o WhatsApp com mensagem pronta', () => {
+    const item = itensDaConta(() => {}).find((i) => i.label === 'Falar com o time');
+    expect(item?.href).toBe(WHATSAPP_FALAR_COM_O_TIME);
+  });
+
+  it('"Indique um amigo" chama a ação recebida, e não navega', () => {
+    const indicar = vi.fn();
+    const item = itensDaConta(indicar).find((i) => i.label === 'Indique um amigo');
+    expect(item?.href).toBeUndefined();
+    item?.onClick?.();
+    expect(indicar).toHaveBeenCalledOnce();
+  });
+
+  it('"Como usar" respeita a chave, e hoje está desligado', () => {
+    const temComoUsar = itensDaConta(() => {}).some((i) => i.label === 'Como usar');
+    expect(temComoUsar).toBe(SHOW_COMO_USAR_ENTRY_POINTS);
+    expect(SHOW_COMO_USAR_ENTRY_POINTS).toBe(false);
+  });
+
+  it('as duas telas leem do catálogo, e nenhuma monta lista própria', () => {
+    for (const arquivo of [USER_NAV, PERFIL]) {
+      expect(arquivo).toContain('itensDaConta(openReferral)');
+      // Nenhum item de menu escrito à mão dentro da tela. Um item de menu é uma
+      // linha com rótulo E ícone — os blocos de número da tela de Perfil também
+      // têm `label`, e não são menu. O "Sair da conta" é a exceção declarada:
+      // ele muda de forma entre as duas telas e por isso não entra no catálogo.
+      const itensNaMao = arquivo
+        .split('\n')
+        .filter((l) => /label: '/.test(l) && /icon:/.test(l) && !l.includes('Sair da conta'));
+      expect(itensNaMao).toEqual([]);
+    }
+  });
+});

--- a/src/config/menu-da-conta.ts
+++ b/src/config/menu-da-conta.ts
@@ -1,0 +1,37 @@
+import { Settings, CreditCard, Gift, BookOpen, MessageCircle } from 'lucide-react';
+import { SHOW_COMO_USAR_ENTRY_POINTS } from './como-usar';
+import { WHATSAPP_FALAR_COM_O_TIME } from './contato';
+
+/**
+ * Os itens do menu da conta — a mesma lista no computador e no celular.
+ *
+ * A regra de desenho já estava escrita na tela de Perfil: "mesmo conteúdo nas
+ * duas plataformas, formato diferente". Só que o conteúdo morava em DUAS
+ * listas, uma em cada arquivo, e a regra dependia de alguém lembrar de editar
+ * as duas. Não lembrou: as listas divergiram em três pontos — o celular tinha
+ * um item a mais, chamava a mesma página de "Plano e pagamento" enquanto o
+ * computador chamava de "Planos e preços", e mandava para um guia que o
+ * computador já não oferecia.
+ *
+ * Agora existe uma lista só. O que muda entre as plataformas é o formato —
+ * dropdown lá, tela cheia aqui — e o "Sair da conta", que cada uma desenha do
+ * seu jeito e por isso não entra aqui.
+ */
+export type ItemDaConta = {
+  label: string;
+  icon: typeof Settings;
+  href?: string;
+  onClick?: () => void;
+};
+
+export function itensDaConta(indicarUmAmigo: () => void): ItemDaConta[] {
+  return [
+    { label: 'Configurações', icon: Settings, href: '/settings' },
+    { label: 'Planos e preços', icon: CreditCard, href: '/planos' },
+    { label: 'Indique um amigo', icon: Gift, onClick: indicarUmAmigo },
+    ...(SHOW_COMO_USAR_ENTRY_POINTS
+      ? [{ label: 'Como usar', icon: BookOpen, href: '/como-usar' }]
+      : []),
+    { label: 'Falar com o time', icon: MessageCircle, href: WHATSAPP_FALAR_COM_O_TIME },
+  ];
+}

--- a/src/lib/abrir-destino.test.ts
+++ b/src/lib/abrir-destino.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { abrirDestino } from './abrir-destino';
+
+// O erro que este módulo existe para impedir: `navigate('https://wa.me/...')`
+// não abre o WhatsApp — ele monta uma rota interna com a URL inteira dentro e
+// entrega um 404. É silencioso no código e óbvio na cara do usuário.
+
+const semNavegar = () => {
+  throw new Error('navigate não deveria ter sido chamado para link externo');
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('abrirDestino', () => {
+  it('rota interna vai pelo router', () => {
+    const navigate = vi.fn();
+    abrirDestino('/settings', navigate);
+    expect(navigate).toHaveBeenCalledWith('/settings');
+  });
+
+  it('link externo abre em aba nova, e não pelo router', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    abrirDestino('https://wa.me/5511952136845?text=Oi', semNavegar as never);
+    expect(open).toHaveBeenCalledWith(
+      'https://wa.me/5511952136845?text=Oi',
+      '_blank',
+      'noopener,noreferrer',
+    );
+  });
+
+  it('http também é externo', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    abrirDestino('http://exemplo.com', semNavegar as never);
+    expect(open).toHaveBeenCalled();
+  });
+
+  it('mailto não abre aba, entrega ao cliente de e-mail', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const navigate = vi.fn();
+    abrirDestino('mailto:time@exemplo.com', navigate);
+    expect(open).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('uma rota que só COMEÇA parecida com externa continua interna', () => {
+    // "/httpsomething" não é link externo. A checagem é pelo esquema completo,
+    // e não por um `startsWith('http')` solto.
+    const navigate = vi.fn();
+    abrirDestino('/https-guia', navigate);
+    expect(navigate).toHaveBeenCalledWith('/https-guia');
+  });
+});

--- a/src/lib/abrir-destino.test.ts
+++ b/src/lib/abrir-destino.test.ts
@@ -22,9 +22,9 @@ describe('abrirDestino', () => {
 
   it('link externo abre em aba nova, e não pelo router', () => {
     const open = vi.spyOn(window, 'open').mockImplementation(() => null);
-    abrirDestino('https://wa.me/5511952136845?text=Oi', semNavegar as never);
+    abrirDestino('https://exemplo.com/oi', semNavegar as never);
     expect(open).toHaveBeenCalledWith(
-      'https://wa.me/5511952136845?text=Oi',
+      'https://exemplo.com/oi',
       '_blank',
       'noopener,noreferrer',
     );

--- a/src/lib/abrir-destino.ts
+++ b/src/lib/abrir-destino.ts
@@ -1,6 +1,20 @@
 import type { NavigateFunction } from 'react-router-dom';
 
 /**
+ * O destino é externo ao app?
+ *
+ * A checagem é pelo esquema completo, e não por um `startsWith('http')`: uma
+ * rota interna chamada "/https-guia" casaria com o segundo e sairia do app.
+ *
+ * Exportada porque o rodapé precisa da MESMA resposta para outra pergunta —
+ * ele não navega, ele escolhe entre desenhar uma âncora e desenhar um botão.
+ * Duas leituras do que é "externo" é como as duas divergem.
+ */
+export function ehExterno(href: string): boolean {
+  return /^https?:\/\//.test(href);
+}
+
+/**
  * Abre o destino de um item de menu, seja ele rota interna ou link externo.
  *
  * Existe porque a escolha errada aqui é silenciosa e leva a pessoa ao 404: o
@@ -10,16 +24,16 @@ import type { NavigateFunction } from 'react-router-dom';
  * ganhar um link externo para o defeito aparecer só naquele.
  *
  * Link externo abre em aba nova de propósito: o menu é atalho, e mandar a
- * pessoa para fora perderia a tela em que ela estava. `mailto` e `tel` não
- * ganham aba: o navegador entrega ao aplicativo sem navegar, e a aba ficaria
- * em branco atrás.
+ * pessoa para fora perderia a tela em que ela estava. `mailto` não ganha aba: o
+ * navegador entrega ao cliente de e-mail sem navegar, e a aba ficaria em branco
+ * atrás.
  */
 export function abrirDestino(href: string, navigate: NavigateFunction): void {
-  if (/^https?:\/\//.test(href)) {
+  if (ehExterno(href)) {
     window.open(href, '_blank', 'noopener,noreferrer');
     return;
   }
-  if (/^(mailto|tel):/.test(href)) {
+  if (href.startsWith('mailto:')) {
     window.location.href = href;
     return;
   }

--- a/src/lib/abrir-destino.ts
+++ b/src/lib/abrir-destino.ts
@@ -1,0 +1,27 @@
+import type { NavigateFunction } from 'react-router-dom';
+
+/**
+ * Abre o destino de um item de menu, seja ele rota interna ou link externo.
+ *
+ * Existe porque a escolha errada aqui é silenciosa e leva a pessoa ao 404: o
+ * `navigate` do router trata QUALQUER string como caminho interno, então um
+ * link do WhatsApp vira a rota "/https://wa.me/...". O menu da conta e a tela
+ * de perfil faziam essa distinção cada um por conta própria, e bastava um deles
+ * ganhar um link externo para o defeito aparecer só naquele.
+ *
+ * Link externo abre em aba nova de propósito: o menu é atalho, e mandar a
+ * pessoa para fora perderia a tela em que ela estava. `mailto` e `tel` não
+ * ganham aba: o navegador entrega ao aplicativo sem navegar, e a aba ficaria
+ * em branco atrás.
+ */
+export function abrirDestino(href: string, navigate: NavigateFunction): void {
+  if (/^https?:\/\//.test(href)) {
+    window.open(href, '_blank', 'noopener,noreferrer');
+    return;
+  }
+  if (/^(mailto|tel):/.test(href)) {
+    window.location.href = href;
+    return;
+  }
+  navigate(href);
+}

--- a/src/pages/Paywall.tsx
+++ b/src/pages/Paywall.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Lock, Zap, BarChart3, ArrowRight, ArrowLeft, MessageCircle, CheckCircle, XCircle, Loader2 } from "lucide-react";
 import { useNavigate, useSearchParams, Navigate } from "react-router-dom";
 import { useAuth } from "@/hooks/use-auth";
+import { whatsappDoTime } from "@/config/contato";
 import { createClient } from "@/integrations/supabase/client";
 import { stripeService } from "@/services/stripe.service";
 import { toast } from "@/hooks/use-toast";
@@ -150,7 +151,7 @@ export default function Paywall() {
   const handleUpgrade = () => {
     // Open WhatsApp with pre-filled message for upgrade (Betinho)
     const message = "Oi, gostaria de fazer upgrade do meu plano Betinho (registro de apostas)";
-    const whatsappUrl = `https://wa.me/5511952136845?text=${encodeURIComponent(message)}`;
+    const whatsappUrl = whatsappDoTime(message);
     
     // Open WhatsApp with pre-filled message
     window.open(whatsappUrl, '_blank');

--- a/src/pages/PaywallDashboard.tsx
+++ b/src/pages/PaywallDashboard.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Lock, ArrowRight, ArrowLeft, MessageCircle, Loader2, Check, BarChart2, Database, FileText, BarChart3 } from "lucide-react";
 import { useNavigate, useSearchParams, Navigate } from "react-router-dom";
 import { useAuth } from "@/hooks/use-auth";
+import { whatsappDoTime } from "@/config/contato";
 import { createClient } from "@/integrations/supabase/client";
 import { stripeService } from "@/services/stripe.service";
 import { toast } from "@/hooks/use-toast";
@@ -137,7 +138,7 @@ export default function PaywallDashboard() {
 
   const handleWhatsApp = () => {
     const message = "Oi, gostaria de fazer upgrade do meu plano Smartbetting para acessar o Dashboard Premium";
-    const whatsappUrl = `https://wa.me/5511952136845?text=${encodeURIComponent(message)}`;
+    const whatsappUrl = whatsappDoTime(message);
     window.open(whatsappUrl, '_blank');
   };
 

--- a/src/pages/PaywallPlatform.tsx
+++ b/src/pages/PaywallPlatform.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Lock, Zap, BarChart3, ArrowRight, MessageCircle, CheckCircle, XCircle, Loader2 } from "lucide-react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAuth } from "@/hooks/use-auth";
+import { whatsappDoTime } from "@/config/contato";
 import { createClient } from "@/integrations/supabase/client";
 import { stripeService } from "@/services/stripe.service";
 import { toast } from "@/hooks/use-toast";
@@ -141,7 +142,7 @@ export default function PaywallPlatform() {
   const handleUpgrade = () => {
     // Open WhatsApp with pre-filled message for upgrade (Plataforma de Análise)
     const message = "Oi, gostaria de fazer upgrade do meu plano na Plataforma de Análise";
-    const whatsappUrl = `https://wa.me/5511952136845?text=${encodeURIComponent(message)}`;
+    const whatsappUrl = whatsappDoTime(message);
     
     // Open WhatsApp with pre-filled message
     window.open(whatsappUrl, '_blank');

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -11,7 +11,7 @@ import { useBets } from '@/hooks/use-bets';
 import { useSettingsData } from '@/hooks/use-settings-data';
 import { useReferral } from '@/components/ReferralProvider';
 import { getInitials } from '@/lib/user-display';
-import { itensDaConta } from '@/config/menu-da-conta';
+import { itensDaConta, type ItemDaConta } from '@/config/menu-da-conta';
 import { abrirDestino } from '@/lib/abrir-destino';
 
 /**
@@ -22,13 +22,8 @@ import { abrirDestino } from '@/lib/abrir-destino';
  * "Configurações" deixou de ser navegação global e virou o primeiro item daqui.
  */
 
-type Row = {
-  label: string;
-  icon: typeof Settings;
-  href?: string;
-  onClick?: () => void;
-  danger?: boolean;
-};
+/** Um item do menu, mais o "Sair da conta", que é o único em vermelho. */
+type Row = ItemDaConta & { danger?: boolean };
 
 export default function Perfil() {
   const navigate = useNavigate();

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -1,10 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import {
   Settings,
-  Wallet,
-  CreditCard,
-  Gift,
-  HelpCircle,
   LogOut,
   ChevronRight,
   Zap,
@@ -15,6 +11,8 @@ import { useBets } from '@/hooks/use-bets';
 import { useSettingsData } from '@/hooks/use-settings-data';
 import { useReferral } from '@/components/ReferralProvider';
 import { getInitials } from '@/lib/user-display';
+import { itensDaConta } from '@/config/menu-da-conta';
+import { abrirDestino } from '@/lib/abrir-destino';
 
 /**
  * Tela de Perfil — o equivalente mobile do dropdown do pill no desktop.
@@ -49,18 +47,17 @@ export default function Perfil() {
     navigate('/auth');
   };
 
+  // Os itens vêm do catálogo compartilhado com o menu do computador. Só o
+  // "Sair da conta" nasce aqui: ele é o único que muda de forma entre as duas
+  // telas — lá é um bloco separado embaixo, aqui é a última linha da lista.
   const rows: Row[] = [
-    { label: 'Configurações', icon: Settings, href: '/settings' },
-    { label: 'Minha banca e apostas', icon: Wallet, href: '/bets' },
-    { label: 'Plano e pagamento', icon: CreditCard, href: '/planos' },
-    { label: 'Indique um amigo', icon: Gift, onClick: openReferral },
-    { label: 'Ajuda e suporte', icon: HelpCircle, href: '/como-usar' },
+    ...itensDaConta(openReferral),
     { label: 'Sair da conta', icon: LogOut, onClick: handleSignOut, danger: true },
   ];
 
   const go = (row: Row) => {
     if (row.onClick) return row.onClick();
-    if (row.href) navigate(row.href);
+    if (row.href) abrirDestino(row.href, navigate);
   };
 
   // Só mostra o bloco de números quando já carregou. Zerado tem significado


### PR DESCRIPTION
## O que muda

**"Falar com o time" abre o WhatsApp.** Nos dois menus, o do computador e o do rodapé. Antes abria o cliente de e-mail, enquanto o WhatsApp já estava ali ao lado no ícone do rodapé — a mesma tela oferecia dois canais e mandava o nome mais convidativo para o que o time menos usa. O ícone virou o balão de conversa, e o link já leva a primeira mensagem escrita.

**"Como usar" sai dos menus.** A página é o guia do Betinho no Telegram e ficou para trás do produto; instrução desatualizada não é ajuda. Sai atrás de uma chave, no mesmo formato que o Bolão já usa: a rota continua de pé, e reativar depois de reescrever a página é trocar um `false` por `true`. O botão "Guia de uso" dentro da própria página do Betinho fica, porque ali o contexto é o Telegram.

**O menu da conta vira uma lista só.** O topo da tela de Perfil já dizia "mesmo conteúdo nas duas plataformas, formato diferente", mas o conteúdo morava em duas listas, uma em cada arquivo. Cumprir a regra dependia de alguém lembrar de editar as duas, e não lembrou: o celular tinha um item a mais, chamava a mesma página de "Plano e pagamento" enquanto o computador chamava de "Planos e preços", e oferecia um guia que o computador já não oferecia. Agora a regra é verdade por construção.

Resultado nas duas telas: Configurações · Planos e preços · Indique um amigo · Falar com o time · Sair da conta.

## Decisões que valem revisão

**"Minha banca e apostas" saiu do menu do celular**, por consequência da igualdade. A tela continua alcançável: a barra de navegação tem "Apostas" nas duas larguras, e o registro de aposta do futebol linka direto para lá. Se a preferência for o contrário — manter o item e adicioná-lo também no computador — é uma linha no catálogo.

**O ícone de WhatsApp do rodapé passou a levar a mesma mensagem** do item ao lado. Eram duas portas do mesmo número lado a lado, e a de cima abria conversa vazia.

**Os paywalls e o modal do bolão passaram a ler a constante.** Não era o pedido, mas o comentário do módulo afirmava ser fonte única enquanto quatro arquivos escreviam o número na mão. O link do PIX foi conferido caractere a caractere: é o mesmo de antes, agora codificado por código em vez de ter o `%C3%A1` digitado manualmente.

## Como está travado

Um módulo novo, `abrirDestino`, decide entre rota interna e link externo. Errar isso é silencioso no código e óbvio na tela: `navigate` com uma URL inteira monta a rota `/https://wa.me/...` e entrega um 404. A checagem é pelo esquema completo, e não por um `startsWith('http')` que também casaria com uma rota chamada `/https-guia`.

Os testes novos foram verificados por mutação — quebrei cada garantia de propósito, vi o teste falhar, e restaurei:

- se alguém escrever um item de menu na mão dentro de uma das telas, o teste quebra
- se alguém devolver o número cru a qualquer arquivo de `src`, o teste quebra
- se "Falar com o time" voltar a ser `mailto:`, o teste quebra

## Documentação

O handoff do rodapé listava "Como usar" na coluna Suporte e justificava o glifo da banca por um item da tela de Perfil que deixou de existir. Os dois foram corrigidos, com nota datada.

## Estado

880 testes passando, 69 arquivos. Type-check limpo nos arquivos tocados, lint sem erro novo, build de produção OK.
