### PR TITLE
Depois do apito, a agenda para de afirmar coisa sobre odds

### DIFF
--- a/src/components/futebol/FixtureRow.test.tsx
+++ b/src/components/futebol/FixtureRow.test.tsx
@@ -76,6 +76,42 @@ describe('FixtureRow · estado da leitura', () => {
     expect(screen.queryByTestId('linha-leitura-carregando')).not.toBeInTheDocument();
     expect(screen.getAllByText(/sem leitura/i).length).toBeGreaterThan(0);
   });
+
+  // ==========================================================================
+  // Depois do apito a frase não pode afirmar nada sobre odds
+  // ==========================================================================
+  // O board é point-in-time: o expurgo tira a linha no apito, e a partir daí a
+  // agenda lê um lugar onde o jogo já não está. Ela não sabe se houve leitura,
+  // só que não há mais.
+  //
+  // As duas frases antigas afirmavam mais do que isso, e as duas foram
+  // reportadas no smoke test da virada (#309): "odds entram perto do jogo"
+  // aparecia com a bola rolando, e "não teve odds coletadas" aparecia em jogo
+  // cujo histórico listava quatro oportunidades com odd.
+  // ==========================================================================
+
+  it('jogo ao vivo não promete odds que ainda vão entrar', () => {
+    renderLinha({ fixture: { ...jogo, status_short: '2H' } as typeof jogo, best: null });
+
+    expect(screen.getByText('Ao vivo')).toBeInTheDocument();
+    expect(screen.queryByText(/odds entram perto do jogo/i)).not.toBeInTheDocument();
+  });
+
+  it('jogo encerrado não afirma que não teve odds coletadas', () => {
+    renderLinha({
+      fixture: { ...jogo, status_short: 'FT', goals_home: 1, goals_away: 0 } as typeof jogo,
+      best: null,
+    });
+
+    expect(screen.queryByText(/não teve odds coletadas/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/odds entram perto do jogo/i)).not.toBeInTheDocument();
+  });
+
+  it('antes do apito a promessa das odds continua, porque ali ela é verdade', () => {
+    renderLinha({ fixture: { ...jogo, status_short: 'NS' } as typeof jogo, best: null });
+
+    expect(screen.getByText(/odds entram perto do jogo/i)).toBeInTheDocument();
+  });
 });
 
 // ============================================================================

--- a/src/components/futebol/FixtureRow.tsx
+++ b/src/components/futebol/FixtureRow.tsx
@@ -80,6 +80,14 @@ export function FixtureRow({
 }) {
   const fim = isFinished(fixture.status_short);
   const live = isLive(fixture.status_short);
+  /**
+   * O apito já foi, esteja a bola rolando ou o jogo encerrado.
+   *
+   * A leitura da agenda separava só encerrado de não-encerrado, e o jogo ao
+   * vivo caía no lado errado da conta: prometia odds futuras para uma partida
+   * em andamento, três centímetros ao lado do próprio selo "Ao vivo".
+   */
+  const apitou = fim || live;
   const temPlacar = fim || live;
   const gh = fixture.goals_home;
   const ga = fixture.goals_away;
@@ -160,7 +168,7 @@ export function FixtureRow({
         ) : (
         <>
         <span className="hidden sm:block text-[9px] uppercase tracking-[0.14em] font-semibold" style={{ color: '#8d8672' }}>
-          {best ? marketShort(best.market) : fim ? 'sem leitura' : 'sem leitura ainda'}
+          {best ? marketShort(best.market) : apitou ? 'sem leitura' : 'sem leitura ainda'}
         </span>
         {best ? (
           <>
@@ -179,8 +187,17 @@ export function FixtureRow({
         ) : (
           <span className="block sm:mt-0.5 text-[10.5px] sm:text-[11px] truncate" style={{ color: '#8d8672' }}>
             <span className="sm:hidden">sem leitura</span>
-            {/* Em jogo encerrado não faz sentido prometer que as odds entram. */}
-            <span className="hidden sm:inline">{fim ? 'não teve odds coletadas' : 'odds entram perto do jogo'}</span>
+            {/* Depois do apito a agenda não sabe se houve leitura, só que não há
+                mais: o board é point-in-time e o expurgo tira a linha no apito,
+                então a agenda passa a ler um lugar onde o jogo já não está.
+
+                As duas frases anteriores afirmavam mais do que isso. Em jogo AO
+                VIVO dizia "odds entram perto do jogo", promessa de futuro com a
+                bola rolando. Em jogo ENCERRADO dizia "não teve odds coletadas",
+                e teve — o mesmo jogo aparecia no histórico com quatro
+                oportunidades e odd em cada uma. Ambas reportadas no smoke test
+                da virada (#309). */}
+            <span className="hidden sm:inline">{apitou ? 'a leitura sai antes do apito' : 'odds entram perto do jogo'}</span>
           </span>
         )}
         </>

--- a/src/utils/futebol-premissas.ts
+++ b/src/utils/futebol-premissas.ts
@@ -175,7 +175,7 @@ const P_OU: Premissa[] = [
   P('historico_under', 'Histórico de jogo com poucos gols', 'O histórico de poucos gols não entrou como sinal a favor', 'preco', 3, { lado: 'under', motivo: 'sinal fraco' }),
   P('ambos_vazam', 'Os dois sofrem gol quase todo jogo', 'Os gols sofridos não entraram como sinal a favor', 'preco', 0, {
     lado: 'over',
-    motivo: 'o preço cobra mais do que ela vale',
+    motivo: 'o preço já cobra',
   }),
   P('ritmo_alto', 'Jogo de ritmo alto', 'O ritmo do jogo não entrou como sinal a favor', 'preco', 0, { lado: 'over', motivo: 'atrapalha nos dois testes' }),
   P('historico_over', 'Histórico de jogo com muitos gols', 'O histórico de muitos gols não entrou como sinal a favor', 'preco', 0, { lado: 'over', motivo: 'atrapalha nos dois testes' }),


### PR DESCRIPTION
Fecha os dois achados de texto que sobraram do smoke test da virada (#309). O terceiro, o do título "oportunidades com valor", já tinha sido resolvido em 04/09.

## A agenda depois do apito

A linha da agenda separava só jogo encerrado de jogo não encerrado, e o jogo **ao vivo** caía no lado errado da conta: prometia "odds entram perto do jogo" com a bola rolando, três centímetros ao lado do próprio selo "Ao vivo". No encerrado a frase era outra e também falsa — "não teve odds coletadas" num jogo cujo histórico listava quatro oportunidades, cada uma com odd.

A causa é a mesma nos dois: o board é point-in-time e o expurgo tira a linha no apito, então a partir dali a agenda lê um lugar onde o jogo já não está. Ela não sabe se houve leitura, só que não há mais.

Passa a haver um estado só depois do apito, e ele diz o que a agenda de fato sabe: a leitura sai antes. Antes do apito a promessa das odds continua, porque ali ela é verdade.

## O motivo da premissa zerada

"Os dois sofrem gol quase todo jogo" dava como motivo "o preço cobra mais do que ela vale". O que a recalibragem mediu — e o que o docstring do `pesoPalavra` registra — é "o preço já cobra": o sinal não acrescenta porque o mercado já o embutiu.

A diferença não é de estilo. "Cobra mais do que ela vale" é afirmação de valor, e valor é exatamente o que saiu do Score na virada de 03/09. A frase explicava o peso zero com um argumento que o produto deixou de fazer.

## Testes

Três novos no `FixtureRow.test.tsx`: ao vivo não promete odds, encerrado não afirma que não houve coleta, e antes do apito a promessa continua. Os três foram quebrados de propósito antes de entrar — revertendo a condição, dois ficam vermelhos.

Suíte inteira: 886 passando, 1 pulado, 70 arquivos. Tipos e lint limpos, build de produção OK.
