### PR TITLE
O typecheck passa a checar, e vira catraca no CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,18 @@ jobs:
 
       - run: npm run lint
 
+      # O typecheck entrou em 09/09/2026, e até então NENHUM dos passos deste
+      # arquivo olhava tipo: lint não olha, teste não olha, e o build é
+      # Vite/esbuild, que apaga os tipos sem verificá-los. Um erro de tipo
+      # compilava e subia (#343).
+      #
+      # Não é `tsc --noEmit`: na raiz esse comando compila zero arquivo e passa.
+      # `npm run typecheck` aponta para os projetos de verdade e é uma CATRACA —
+      # a dívida de hoje está declarada em scripts/typecheck-divida.json e o que
+      # ele impede é ela crescer. Ligar o gate inteiro hoje deixaria o CI vermelho
+      # no primeiro PR, e gate vermelho por dívida velha é gate desligado.
+      - run: npm run typecheck
+
       - run: npm run build
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL_STAGING }}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:staging": "vite build --mode staging",
     "postbuild:staging": "node scripts/gen-route-heads.mjs",
     "lint": "eslint .",
+    "typecheck": "node scripts/typecheck.mjs",
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",

--- a/scripts/typecheck-divida.json
+++ b/scripts/typecheck-divida.json
@@ -1,0 +1,18 @@
+{
+  "_leia-me": "Divida de tipo declarada, arquivo por arquivo, medida em 09/09/2026. Nao e lista de tarefas: e a catraca de scripts/typecheck.mjs. Numero so pode DESCER. Arquivo fora desta lista nao pode ter erro nenhum. Chaves com _ no comeco sao ignoradas.",
+  "src/services/bolao.service.ts": 23,
+  "src/services/bigquery.service.ts": 14,
+  "src/hooks/use-bets.ts": 7,
+  "src/services/player-stats.service.ts": 7,
+  "src/services/prop-betting.service.ts": 4,
+  "src/hooks/use-bolao.ts": 2,
+  "src/components/bolao/AchievementProvider.tsx": 1,
+  "src/components/bolao/PredictionsList.tsx": 1,
+  "src/components/bolao/special-deadlines.test.ts": 1,
+  "src/components/bolao/SpecialPredictionsModal.tsx": 1,
+  "src/components/bolao/SpecialPredictionsSection.tsx": 1,
+  "src/hooks/use-injury-insights.ts": 1,
+  "src/pages/BolaoDetail.tsx": 1,
+  "src/pages/Dashboard.tsx": 1,
+  "src/pages/Onboarding.tsx": 1
+}

--- a/scripts/typecheck.mjs
+++ b/scripts/typecheck.mjs
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+// ============================================================================
+// O typecheck que realmente checa
+// ============================================================================
+// Este repositório nunca foi typechecado. Não foi regressão: `tsconfig.json` na
+// raiz tem `"files": []` e só `references`, e sem `-b` ou `-p` o tsc compila a
+// lista vazia e sai com sucesso. `npx tsc --noEmit` sempre passou olhando NADA.
+// O CI também não checava tipo: lint, build e teste não olham tipo, e o build é
+// Vite/esbuild, que apaga os tipos sem verificá-los (#343).
+//
+// O custo já apareceu: um componente usando <Link> sem importar passou batido, e
+// quatro trocas de assinatura falharam em silêncio por CRLF e só apareceriam no
+// navegador.
+//
+// ── Por que não ligar o gate de uma vez ─────────────────────────────────────
+// A dívida existente deixaria o CI vermelho no primeiro PR, e o time desligaria
+// o gate. É assim que gate morre. Então a barreira é uma CATRACA: a dívida de
+// hoje está declarada arquivo por arquivo em typecheck-divida.json, e o que ela
+// impede é a dívida CRESCER — arquivo novo com erro reprova, arquivo conhecido
+// que piora reprova, e o resto do repositório fica barrado por padrão.
+//
+// Arquivo que melhora não reprova, só avisa. É de propósito: reprovar quem
+// consertou é a friction que mata catraca.
+//
+// ── A armadilha da raiz ─────────────────────────────────────────────────────
+// Se alguém apontar este script para o `tsconfig.json` da raiz, o problema volta
+// invisível: o tsc não reclama de uma lista de arquivos EXPLICITAMENTE vazia,
+// ele só não tem o que fazer. Por isso o script conta os arquivos de entrada de
+// cada projeto antes de rodar e morre se algum resolver para zero.
+// ============================================================================
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const RAIZ = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Os projetos de verdade. A raiz NÃO entra: ela não compila nada. */
+const PROJETOS = ['tsconfig.app.json', 'tsconfig.node.json'];
+
+/**
+ * A dívida declarada. Chaves com `_` no começo são texto para quem lê o
+ * arquivo, e não caminho — JSON não aceita comentário.
+ */
+const DIVIDA = Object.fromEntries(
+  Object.entries(
+    JSON.parse(readFileSync(resolve(RAIZ, 'scripts/typecheck-divida.json'), 'utf8')),
+  ).filter(([chave]) => !chave.startsWith('_')),
+);
+
+/** `src/foo/bar.ts(12,5): error TS2345: ...` → o caminho, normalizado. */
+const LINHA_DE_ERRO = /^(.+?)\((\d+),(\d+)\): error TS\d+:/;
+
+function arquivosDoProjeto(projeto) {
+  const caminho = resolve(RAIZ, projeto);
+  const lido = ts.readConfigFile(caminho, ts.sys.readFile);
+  if (lido.error) {
+    throw new Error(`${projeto}: ${ts.flattenDiagnosticMessageText(lido.error.messageText, ' ')}`);
+  }
+  return ts.parseJsonConfigFileContent(lido.config, ts.sys, dirname(caminho)).fileNames;
+}
+
+function rodarTsc(projeto) {
+  const tsc = resolve(RAIZ, 'node_modules/typescript/bin/tsc');
+  const r = spawnSync(process.execPath, [tsc, '--noEmit', '-p', projeto], {
+    cwd: RAIZ,
+    encoding: 'utf8',
+  });
+  return `${r.stdout || ''}${r.stderr || ''}`;
+}
+
+const errosPorArquivo = new Map();
+let saidaBruta = '';
+
+for (const projeto of PROJETOS) {
+  const entradas = arquivosDoProjeto(projeto);
+  if (entradas.length === 0) {
+    console.error(
+      `\n✗ ${projeto} resolveu ZERO arquivos de entrada.\n` +
+        `  É exatamente o defeito da #343: o tsc passaria sem olhar nada.\n` +
+        `  Conserte o projeto ou tire-o da lista PROJETOS deste script.\n`,
+    );
+    process.exit(2);
+  }
+  console.log(`· ${projeto}: ${entradas.length} arquivos`);
+
+  const saida = rodarTsc(projeto);
+  saidaBruta += saida;
+  for (const linha of saida.split('\n')) {
+    const m = LINHA_DE_ERRO.exec(linha.trim());
+    if (!m) continue;
+    const arquivo = m[1].replace(/\\/g, '/');
+    errosPorArquivo.set(arquivo, (errosPorArquivo.get(arquivo) ?? 0) + 1);
+  }
+}
+
+const total = [...errosPorArquivo.values()].reduce((a, b) => a + b, 0);
+
+const novos = []; // arquivo com erro que não está na dívida declarada
+const piores = []; // arquivo da dívida que passou do teto
+const melhores = []; // arquivo da dívida que melhorou (só aviso)
+
+for (const [arquivo, n] of errosPorArquivo) {
+  const teto = DIVIDA[arquivo];
+  if (teto == null) novos.push([arquivo, n]);
+  else if (n > teto) piores.push([arquivo, n, teto]);
+  else if (n < teto) melhores.push([arquivo, n, teto]);
+}
+for (const arquivo of Object.keys(DIVIDA)) {
+  if (!errosPorArquivo.has(arquivo)) melhores.push([arquivo, 0, DIVIDA[arquivo]]);
+}
+
+const tetoTotal = Object.values(DIVIDA).reduce((a, b) => a + b, 0);
+console.log(`\n${total} erro(s) de tipo · dívida declarada: ${tetoTotal}`);
+
+if (melhores.length) {
+  console.log('\n↓ melhorou (não reprova, mas atualize o número):');
+  for (const [arquivo, n, teto] of melhores) console.log(`    ${arquivo}: ${teto} → ${n}`);
+}
+
+if (novos.length || piores.length) {
+  console.error('\n✗ a dívida de tipo CRESCEU\n');
+  for (const [arquivo, n] of novos) {
+    console.error(`  ${arquivo}: ${n} erro(s), e este arquivo não está na dívida declarada.`);
+  }
+  for (const [arquivo, n, teto] of piores) {
+    console.error(`  ${arquivo}: ${n} erro(s), acima dos ${teto} declarados.`);
+  }
+  console.error(
+    '\n  Os erros estão acima, na saída do tsc. Conserte-os — declarar o número\n' +
+      '  novo em scripts/typecheck-divida.json desliga a catraca.\n',
+  );
+  console.error(saidaBruta.trim().split('\n').slice(0, 60).join('\n'));
+  process.exit(1);
+}
+
+console.log('\n✓ nenhum erro de tipo novo');

--- a/src/hooks/use-scroll-depth-pixel.test.ts
+++ b/src/hooks/use-scroll-depth-pixel.test.ts
@@ -1,3 +1,4 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useScrollDepthPixel } from "./use-scroll-depth-pixel";
 

--- a/src/utils/typecheck-catraca.test.ts
+++ b/src/utils/typecheck-catraca.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import ts from 'typescript';
+
+// ============================================================================
+// A catraca do typecheck não pode voltar a checar nada
+// ============================================================================
+// Este repositório passou a existência inteira sem nunca ter sido typechecado, e
+// ninguém percebeu porque o comando que todo mundo roda PASSA: o tsconfig da
+// raiz tem `"files": []` e só `references`, e sem `-b` ou `-p` o tsc compila a
+// lista vazia e sai com sucesso (#343).
+//
+// É o modo de falha mais difícil de notar — a ferramenta certa, rodando, dizendo
+// que está tudo bem. Não há mensagem, aviso nem lista vazia.
+//
+// Por isso a guarda: se alguém apontar o script para a raiz, ou tirar o passo do
+// CI, o buraco volta invisível e nenhum outro teste percebe.
+// ============================================================================
+
+const RAIZ = resolve(__dirname, '../..');
+
+const ler = (caminho: string) => readFileSync(resolve(RAIZ, caminho), 'utf8');
+
+/** Quantos arquivos um projeto do TypeScript de fato compila. */
+function arquivosDoProjeto(projeto: string): string[] {
+  const caminho = resolve(RAIZ, projeto);
+  const lido = ts.readConfigFile(caminho, ts.sys.readFile);
+  expect(lido.error).toBeUndefined();
+  return ts.parseJsonConfigFileContent(lido.config, ts.sys, dirname(caminho)).fileNames;
+}
+
+const SCRIPT = ler('scripts/typecheck.mjs');
+const CI = ler('.github/workflows/ci.yml');
+const PACKAGE = JSON.parse(ler('package.json')) as { scripts: Record<string, string> };
+const DIVIDA = JSON.parse(ler('scripts/typecheck-divida.json')) as Record<string, unknown>;
+
+describe('catraca do typecheck', () => {
+  it('o tsconfig da raiz compila zero arquivos — a armadilha existe mesmo', () => {
+    // Este teste não protege nada: ele DOCUMENTA. Se um dia a raiz passar a
+    // compilar de verdade, ele fica vermelho e quem passar por aqui descobre
+    // que o aviso escrito no tsconfig e no script virou mentira.
+    expect(arquivosDoProjeto('tsconfig.json')).toEqual([]);
+  });
+
+  it('os projetos que o script checa compilam arquivos de verdade', () => {
+    const projetos = [...SCRIPT.matchAll(/'(tsconfig\.[a-z]+\.json)'/g)].map((m) => m[1]);
+    expect(projetos.length).toBeGreaterThan(0);
+
+    for (const projeto of projetos) {
+      expect(arquivosDoProjeto(projeto).length).toBeGreaterThan(0);
+    }
+  });
+
+  it('o script não aponta para o tsconfig da raiz', () => {
+    // `-p tsconfig.json` seria o mesmo verde vazio de sempre.
+    expect(SCRIPT).not.toMatch(/'tsconfig\.json'/);
+  });
+
+  it('existe um comando de typecheck, e ele é o script', () => {
+    expect(PACKAGE.scripts.typecheck).toBe('node scripts/typecheck.mjs');
+  });
+
+  it('o CI roda o typecheck', () => {
+    // Sem isto, o comando existe e ninguém o executa — que era metade do
+    // defeito: lint, teste e build passavam sem olhar tipo nenhum.
+    expect(CI).toContain('npm run typecheck');
+  });
+
+  it('todo arquivo da dívida declarada ainda existe', () => {
+    // Caminho que sumiu (renomeado, apagado) deixa um número protegendo nada, e
+    // faz a dívida parecer maior do que é.
+    const sumidos = Object.keys(DIVIDA)
+      .filter((chave) => !chave.startsWith('_'))
+      .filter((caminho) => !existsSync(resolve(RAIZ, caminho)));
+
+    expect(sumidos).toEqual([]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,11 @@
+// ⚠️ ESTE ARQUIVO NÃO CHECA NADA SOZINHO.
+//
+// `"files": []` mais `references` é a forma de projeto composto: sem `-b` ou
+// `-p <projeto>`, o tsc compila a lista vazia e sai com SUCESSO. Foi assim que
+// o repositório passou a existência inteira sem nunca ter sido typechecado —
+// `npx tsc --noEmit` aqui sempre passou olhando zero arquivo (#343).
+//
+// O comando que checa de verdade é `npm run typecheck`.
 {
   "files": [],
   "references": [


### PR DESCRIPTION
Fecha a #343.

## O defeito

Este repositório **nunca foi typechecado**. Não é regressão — é o estado desde sempre, e ninguém percebeu porque o comando que todo mundo roda passa.

O `tsconfig.json` da raiz tem `"files": []` e apenas `references`. Sem `-b` ou `-p <projeto>`, o tsc não segue as referências: compila a lista vazia e sai com sucesso. `npx tsc --noEmit` sempre passou olhando **zero arquivo**, e sempre vai passar.

O CI também não olhava tipo. `lint`, `build` e `test:run` não verificam tipo, e o build é Vite/esbuild, que apaga os tipos sem checá-los — um erro de tipo compila e sobe.

É o modo de falha mais difícil de notar: a ferramenta certa, rodando, dizendo que está tudo bem.

## O que entra

- **`npm run typecheck`**, apontando para `tsconfig.app.json` e `tsconfig.node.json`. O script conta os arquivos de entrada de cada projeto antes de rodar e **morre se algum resolver para zero** — que é o defeito voltando invisível.
- **Aviso no próprio `tsconfig.json` da raiz.** Quem digitar o comando conhecido continua vendo verde, então o arquivo diz que não checa nada e aponta o comando que checa.
- **O passo no `ci.yml`**, ao lado do lint.

## Catraca, não gate

A dívida de hoje está declarada arquivo por arquivo em `scripts/typecheck-divida.json`. O que a barreira impede é a dívida **crescer**:

- arquivo novo com erro **reprova**
- arquivo declarado que piora **reprova**, citando o teto
- todo o resto do repositório fica barrado por padrão
- arquivo que **melhora não reprova**, só avisa o número novo

Ligar o gate inteiro hoje deixaria o CI vermelho no primeiro PR, e gate vermelho por dívida velha é gate desligado — foi por isso que a issue pediu entrada por área. A catraca é a mesma ideia sem precisar manter lista de áreas: o padrão é barrado, e a exceção é nominal e só encolhe.

## Um conserto entrou junto, e ele é a prova

A issue mediu **66 erros em 02/09**. Hoje eram **87**.

Os 21 novos estavam todos em `use-scroll-depth-pixel.test.ts`, que entrou em 07/09 usando os globais do vitest sem importar. É o **único** teste do repositório que faz isso — todos os outros importam. Com o import, a dívida volta exatamente aos 66 medidos.

Ou seja: em uma semana sem catraca, a dívida cresceu um terço, por um arquivo que fugiu da convenção e ninguém tinha como ver.

## Fora de escopo

Quitar os 66. Deles, **44 estão em dois arquivos** (`bolao.service.ts` 23 e `bigquery.service.ts` 14). O módulo de futebol está limpo e passa a ser barrado a partir de agora.

Também fora: ligar `strictNullChecks`, `noImplicitAny` ou `noUnusedLocals`, como a issue já registrava.

## Testes

Seis guardas novas em `src/utils/typecheck-catraca.test.ts`: o tsconfig da raiz resolve zero arquivos (documenta a armadilha), os projetos do script resolvem arquivos de verdade, o script não aponta para a raiz, o comando existe, o CI o executa, e todo caminho da dívida ainda existe no disco.

Os dois sentidos da catraca foram quebrados de propósito antes de entrar: erro novo em arquivo limpo reprova com saída 1, e arquivo declarado que piora reprova citando o teto.

Suíte: 892 passando, 1 pulado, 71 arquivos. Lint sem erro, build de produção OK.
