### PR TITLE
fix(vercel): tira o redirect de infra que engolia a /futebol/assinar

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,4 @@
 {
-  "redirects": [
-    {
-      "source": "/futebol/assinar",
-      "destination": "/planos",
-      "permanent": true
-    }
-  ],
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Correção de 1 linha em cima do #384. **Sem ela, o #384 não funciona em produção.**

## O problema

O #384 trocou a rota no `App.tsx` e ligou os CTAs do `FutebolGate`, mas o `vercel.json` carregava um redirect da época em que `/futebol/assinar` era mesmo só um atalho para a página de preços:

```json
{ "source": "/futebol/assinar", "destination": "/planos", "permanent": true }
```

A Vercel resolve isso **na borda, antes do React carregar**. Medido em produção agora há pouco, com o deploy do #384 já concluído:

```
$ curl -sI https://www.smartbetting.app/futebol/assinar
308 -> https://www.smartbetting.app/planos
```

Ou seja: a tela de checkout nunca renderiza, e o usuário cai exatamente no beco que o #384 foi corrigir — o botão "Pagamento em breve" da `/planos`.

## O problema silencioso junto

O `success_url` montado pelo `stripe-create-checkout` aponta para `/futebol/assinar?success=true&session_id=...`. Com o redirect no caminho, quem pagasse voltaria do Stripe direto para `/planos`, e o `verifySession` nunca rodaria — pagamento feito, assinatura não confirmada na volta.

## Para quem for testar

`permanent: true` é **308**, que o navegador guarda de forma persistente. Quem abriu essa URL antes desta correção pode continuar sendo redirecionado pelo cache local mesmo depois do deploy. **Teste em aba anônima**, ou limpe os dados do site, antes de concluir que não funcionou.

## Verificação

Alteração restrita ao `vercel.json` — nenhum código de aplicação, nenhuma migration, nenhuma env var. Os demais redirects/rewrites/headers ficam intactos: o rewrite de SPA (`/(.*) -> /index.html`) continua servindo a rota normalmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)