### PR TITLE
Script que mede taxa de acerto e ROI das oportunidades

### DIFF
--- a/scripts/futebol-roi.mjs
+++ b/scripts/futebol-roi.mjs
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // ============================================================================
 // Taxa de acerto e ROI das oportunidades de futebol, medidos em produção
 // ============================================================================
@@ -38,9 +37,16 @@
 //    para medir o board bruto, que é outra pergunta.
 //
 // ── O que este script NÃO consegue responder ────────────────────────────────
-// ROI por PREMISSA. Quais premissas acenderam em cada linha não existe no
-// Postgres — não há coluna de evidência nem array de premissas em
-// `fact_value_opportunities_hist`. Isso vive só no mart, no BigQuery.
+// ROI por PREMISSA, no sentido de "quando a premissa X acendeu". Quais
+// premissas acenderam em cada linha não existe no Postgres: não há coluna de
+// evidência nem array de premissas em `fact_value_opportunities_hist`. Isso
+// vive só no mart, no BigQuery.
+//
+// O que a tabela TEM, e serve de aproximação grosseira: `pts_premissas` (a
+// soma dos pesos que acenderam, sem dizer quais), `premissas_sem_dado`,
+// `modelo_api_concorda`, `linha_sharp_confirma` e os quatro `pen_*`. Dá para
+// cortar por eles, e não é a mesma pergunta — por isso não estão nas tabelas
+// padrão.
 // ============================================================================
 
 import { readFileSync } from 'node:fs';
@@ -133,27 +139,61 @@ export function estatistica(linhas) {
 
 // ── consulta ───────────────────────────────────────────────────────────────
 
+let tokenEmCache = null;
+
 function tokenDeAcesso() {
-  if (process.env.SUPABASE_ACCESS_TOKEN) return process.env.SUPABASE_ACCESS_TOKEN;
-  const env = readFileSync(resolve(RAIZ, '.env.local'), 'utf8');
+  if (tokenEmCache) return tokenEmCache;
+  if (process.env.SUPABASE_ACCESS_TOKEN) {
+    tokenEmCache = process.env.SUPABASE_ACCESS_TOKEN;
+    return tokenEmCache;
+  }
+  let env;
+  try {
+    env = readFileSync(resolve(RAIZ, '.env.local'), 'utf8');
+  } catch {
+    throw new Error(
+      'sem SUPABASE_ACCESS_TOKEN no ambiente e sem .env.local para ler. ' +
+      'Exporte a variável ou crie o arquivo.',
+    );
+  }
   const m = /^SUPABASE_ACCESS_TOKEN=(.*)$/m.exec(env);
   if (!m) throw new Error('SUPABASE_ACCESS_TOKEN não encontrado no ambiente nem em .env.local');
-  return m[1].trim().replace(/^["']|["']$/g, '');
+  tokenEmCache = m[1].trim().replace(/^["']|["']$/g, '');
+  return tokenEmCache;
 }
 
+/**
+ * Uma consulta somente leitura na produção.
+ *
+ * O status HTTP é checado antes do corpo, como faz `apply-sql-dev.mjs`: sem
+ * isso, um 401 ou um HTML de gateway viram `SyntaxError: Unexpected token '<'`
+ * e o motivo real da falha se perde.
+ */
 async function consultar(sql) {
-  const r = await fetch(
-    `https://api.supabase.com/v1/projects/${PROJETO_PRD}/database/query`,
-    {
+  let r;
+  try {
+    r = await fetch(`https://api.supabase.com/v1/projects/${PROJETO_PRD}/database/query`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${tokenDeAcesso()}`,
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ query: sql, read_only: true }),
-    },
-  );
-  const j = await r.json();
+    });
+  } catch (e) {
+    throw new Error(`não consegui falar com a API do Supabase: ${e.message}`);
+  }
+
+  const corpo = await r.text();
+  if (!r.ok) {
+    throw new Error(`consulta recusada (HTTP ${r.status}): ${corpo.slice(0, 300)}`);
+  }
+  let j;
+  try {
+    j = JSON.parse(corpo);
+  } catch {
+    throw new Error(`resposta não era JSON (HTTP ${r.status}): ${corpo.slice(0, 200)}`);
+  }
   if (!Array.isArray(j)) throw new Error(`consulta falhou: ${JSON.stringify(j).slice(0, 300)}`);
   return j;
 }
@@ -215,7 +255,7 @@ function tabela(titulo, linhas, chave, ordem) {
   }
 }
 
-const FAIXA_DE_ODD = (o) => {
+const faixaDeOdd = (o) => {
   const x = Number(o);
   if (x < 1.6) return '1.25–1.59';
   if (x < 2.0) return '1.60–1.99';
@@ -223,17 +263,42 @@ const FAIXA_DE_ODD = (o) => {
   return '2.60–4.00';
 };
 
-const CORTE_DE_SCORE = (s) => {
+/**
+ * A faixa do produto, com a Alta partida em duas.
+ *
+ * Eram duas tabelas — "por faixa" e "por corte de Score" — e a segunda era a
+ * primeira com um corte a mais, o que é a mesma informação escrita duas vezes.
+ * Ficou uma, no vocabulário que o assinante vê, e o corte extra em 80 vive
+ * dentro dela: é onde a amostra desta semana mostrou a diferença maior.
+ */
+const faixaDoScore = (s) => {
   const n = Number(s);
-  if (n < 30) return 'Score <30';
-  if (n < 60) return 'Score 30–59';
-  if (n < 80) return 'Score 60–79';
-  return 'Score 80+';
+  if (n < 30) return 'Baixa (<30)';
+  if (n < 60) return 'Média (30–59)';
+  if (n < 80) return 'Alta (60–79)';
+  return 'Alta (80+)';
 };
 
-const ORDEM_FAIXA = (a, b) =>
-  ['Alta', 'Média', 'Baixa'].indexOf(a[0]) - ['Alta', 'Média', 'Baixa'].indexOf(b[0]);
-const ALFABETICA = (a, b) => a[0].localeCompare(b[0]);
+const alfabetica = (a, b) => a[0].localeCompare(b[0]);
+
+/** As flags que existem. Qualquer outra é erro de digitação, e erro de digitação silencioso faz o relatório mentir sem avisar. */
+const FLAGS = new Set(['desde', 'fonte', 'com-ocultos']);
+
+/**
+ * A linha entra no recorte?
+ *
+ * A comparação é textual porque as duas datas são ISO, mas as duas FONTES têm
+ * precisão diferente: o board carimba `dbt_valid_from` com hora, e os picks
+ * carimbam `sent_date`, que é só o dia. Comparar `'2026-09-04'` com
+ * `'2026-09-04 14:35'` dá falso, e o dia inteiro sumia do relatório em
+ * silêncio. Quando um dos lados não tem hora, a comparação é de dia contra dia.
+ */
+function dentroDoRecorte(carimbo, desde) {
+  if (!desde) return true;
+  const valor = String(carimbo);
+  const soDia = !valor.includes(':') || !desde.includes(':');
+  return soDia ? valor.slice(0, 10) >= desde.slice(0, 10) : valor >= desde;
+}
 
 async function principal() {
   const args = Object.fromEntries(
@@ -242,8 +307,21 @@ async function principal() {
       return [k, v.join('=') || true];
     }),
   );
+  const desconhecidas = Object.keys(args).filter((k) => !FLAGS.has(k));
+  if (desconhecidas.length) {
+    throw new Error(
+      `flag desconhecida: ${desconhecidas.join(', ')}. Existem: ${[...FLAGS].map((f) => '--' + f).join(', ')}`,
+    );
+  }
+
   const fonte = args.fonte === 'picks' ? 'picks' : 'board';
+  if (args.fonte != null && !['picks', 'board'].includes(args.fonte)) {
+    throw new Error(`--fonte aceita "board" ou "picks", não "${args.fonte}"`);
+  }
   const desde = typeof args.desde === 'string' ? args.desde : null;
+  if (desde && !/^\d{4}-\d{2}-\d{2}( \d{2}:\d{2})?$/.test(desde)) {
+    throw new Error(`--desde precisa ser "AAAA-MM-DD" ou "AAAA-MM-DD HH:MM", não "${desde}"`);
+  }
   const comOcultos = args['com-ocultos'] === true;
 
   const ocultos = comOcultos ? [] : await consultar(SQL_OCULTOS);
@@ -251,7 +329,7 @@ async function principal() {
 
   const brutas = await consultar(fonte === 'picks' ? SQL_PICKS : SQL_BOARD);
   const noRecorte = brutas
-    .filter((l) => (desde ? String(l.dbt_valid_from) >= desde : true))
+    .filter((l) => dentroDoRecorte(l.dbt_valid_from, desde))
     .filter((l) => !mercadosOcultos.has(l.market));
 
   const liquidadas = [];
@@ -267,6 +345,13 @@ async function principal() {
 
   const g = estatistica(liquidadas);
   console.log(`# ${fonte === 'picks' ? 'Picks enviados no Telegram' : 'Board publicado'}${desde ? ` — desde ${desde}` : ''}`);
+  console.log(`\n> Fonte: projeto ${PROJETO_PRD} (PRODUÇÃO), somente leitura.`);
+  if (fonte === 'picks') {
+    console.log(
+      '> Os picks não carregam `score_versao`: a tabela de envio nunca guardou a ' +
+      'escala. Sem `--desde` depois do cutover, o corte de Score mistura as duas.',
+    );
+  }
   for (const o of ocultos) {
     console.log(
       `\n> Fora da conta: ${o.market}, oculto da vitrine desde ` +
@@ -282,12 +367,11 @@ async function principal() {
   if (g.n === 0) return;
 
   tabela('Por mercado', liquidadas, (l) => l.market);
-  tabela('Por faixa', liquidadas, (l) => l.faixa, ORDEM_FAIXA);
-  tabela('Por corte de Score', liquidadas, (l) => CORTE_DE_SCORE(l.score), ALFABETICA);
-  tabela('Por faixa de odd', liquidadas, (l) => FAIXA_DE_ODD(l.best_odd), ALFABETICA);
+  tabela('Por faixa de Score', liquidadas, (l) => faixaDoScore(l.score), alfabetica);
+  tabela('Por faixa de odd', liquidadas, (l) => faixaDeOdd(l.best_odd), alfabetica);
   tabela('Por campeonato', liquidadas, (l) => l.competition);
-  tabela('Por dia do JOGO (BRT)', liquidadas, (l) => diaBrt(l.kickoff_utc), ALFABETICA);
-  tabela('Por dia da DETECÇÃO', liquidadas, (l) => String(l.dbt_valid_from).slice(0, 10), ALFABETICA);
+  tabela('Por dia do JOGO (BRT)', liquidadas, (l) => diaBrt(l.kickoff_utc), alfabetica);
+  tabela('Por dia da DETECÇÃO', liquidadas, (l) => String(l.dbt_valid_from).slice(0, 10), alfabetica);
 
   console.log(
     '\n> Erro-padrão maior que a diferença entre dois recortes significa que a ' +

--- a/scripts/futebol-roi.mjs
+++ b/scripts/futebol-roi.mjs
@@ -29,6 +29,14 @@
 //    OUTRA escala e não é comparável. Para medir a régua de hoje, use
 //    `--desde="2026-09-04 14:35"`.
 //
+// 4. MERCADO OCULTO NÃO CONTA. O Handicap sai da vitrine desde 01/09 e o
+//    assinante não o vê, embora o backend siga publicando para continuar
+//    medindo. Somar as linhas dele à taxa é responder por um produto que
+//    ninguém está usando. O script lê `public.futebol_mercados_ocultos` e os
+//    exclui por padrão — quando o mercado voltar à vitrine, a conta volta
+//    sozinha, sem ninguém lembrar de editar nada aqui. Use `--com-ocultos`
+//    para medir o board bruto, que é outra pergunta.
+//
 // ── O que este script NÃO consegue responder ────────────────────────────────
 // ROI por PREMISSA. Quais premissas acenderam em cada linha não existe no
 // Postgres — não há coluna de evidência nem array de premissas em
@@ -173,6 +181,12 @@ from public.daily_opportunity_picks p
 join futebol.fact_fixtures f on f.fixture_id = p.fixture_id
 `;
 
+const SQL_OCULTOS = `
+select market, oculto_desde, motivo
+from public.futebol_mercados_ocultos
+where oculto is true
+`;
+
 // ── apresentação ───────────────────────────────────────────────────────────
 
 const pct = (x) => `${(x * 100).toFixed(1)}%`;
@@ -230,11 +244,15 @@ async function principal() {
   );
   const fonte = args.fonte === 'picks' ? 'picks' : 'board';
   const desde = typeof args.desde === 'string' ? args.desde : null;
+  const comOcultos = args['com-ocultos'] === true;
+
+  const ocultos = comOcultos ? [] : await consultar(SQL_OCULTOS);
+  const mercadosOcultos = new Set(ocultos.map((o) => o.market));
 
   const brutas = await consultar(fonte === 'picks' ? SQL_PICKS : SQL_BOARD);
-  const noRecorte = desde
-    ? brutas.filter((l) => String(l.dbt_valid_from) >= desde)
-    : brutas;
+  const noRecorte = brutas
+    .filter((l) => (desde ? String(l.dbt_valid_from) >= desde : true))
+    .filter((l) => !mercadosOcultos.has(l.market));
 
   const liquidadas = [];
   let pendentes = 0;
@@ -249,6 +267,13 @@ async function principal() {
 
   const g = estatistica(liquidadas);
   console.log(`# ${fonte === 'picks' ? 'Picks enviados no Telegram' : 'Board publicado'}${desde ? ` — desde ${desde}` : ''}`);
+  for (const o of ocultos) {
+    console.log(
+      `\n> Fora da conta: ${o.market}, oculto da vitrine desde ` +
+      `${String(o.oculto_desde).slice(0, 10)}. ${o.motivo}`,
+    );
+  }
+  if (comOcultos) console.log('\n> --com-ocultos: mercado escondido do assinante ESTÁ na conta.');
   console.log(
     `\n${noRecorte.length} no recorte · ${g.n} liquidadas · ${pendentes} pendentes` +
     `\ntaxa ${g.taxa == null ? '—' : pct(g.taxa)} · ROI ${pct(g.roi)} ± ${(g.ep * 100).toFixed(1)}pp`,

--- a/scripts/futebol-roi.mjs
+++ b/scripts/futebol-roi.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+// ============================================================================
+// Taxa de acerto e ROI das oportunidades de futebol, medidos em produção
+// ============================================================================
+// Uso:
+//   node scripts/futebol-roi.mjs                       # tudo que é contexto_v1
+//   node scripts/futebol-roi.mjs --desde="2026-09-04 14:35"
+//   node scripts/futebol-roi.mjs --fonte=picks         # só o que foi ao Telegram
+//
+// Credencial: `SUPABASE_ACCESS_TOKEN` do ambiente, ou de `.env.local`. Só faz
+// SELECT, com `read_only` no endpoint. Nunca imprime segredo.
+//
+// ── Três armadilhas que este script existe para não deixar você cair ────────
+//
+// 1. NÃO EXISTE RESULTADO PERSISTIDO. O banco guarda a oportunidade, não se ela
+//    bateu. A liquidação é calculada aqui, reproduzindo `src/utils/
+//    futebol-settlement.ts` — e `src/utils/futebol-roi-script.test.ts` compara
+//    as duas implementações caso a caso, porque cópia de regra diverge sozinha.
+//
+// 2. DATA DE DETECÇÃO NÃO É DATA DO JOGO. Oportunidade nasce para jogo futuro.
+//    Cortar por detecção mede a RÉGUA que produziu a linha; cortar por apito
+//    mede o RESULTADO da semana. As duas tabelas saem, e são respostas a
+//    perguntas diferentes.
+//
+// 3. O HISTÓRICO COMEÇOU DE UMA VEZ. Em 03/09/2026 o snapshot capturou o board
+//    inteiro, então esse dia concentra centenas de linhas e distorce qualquer
+//    leitura por dia de detecção. E em 04/09 ~14h35 UTC o denominador da nota
+//    trocou do p95 para o teto de pontos: linha anterior a isso tem Score em
+//    OUTRA escala e não é comparável. Para medir a régua de hoje, use
+//    `--desde="2026-09-04 14:35"`.
+//
+// ── O que este script NÃO consegue responder ────────────────────────────────
+// ROI por PREMISSA. Quais premissas acenderam em cada linha não existe no
+// Postgres — não há coluna de evidência nem array de premissas em
+// `fact_value_opportunities_hist`. Isso vive só no mart, no BigQuery.
+// ============================================================================
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const RAIZ = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PROJETO_PRD = 'lavclmlvvfzkblrstojd';
+
+// ── a regra de liquidação, espelho de src/utils/futebol-settlement.ts ───────
+
+/** Regra asiática pelo saldo `d`: o quanto a aposta está à frente da linha. */
+function mapAsian(dRaw) {
+  const d = Math.round(dRaw * 4) / 4;
+  if (d >= 0.5) return 'won';
+  if (d === 0.25) return 'half_won';
+  if (d === 0) return 'push';
+  if (d === -0.25) return 'half_lost';
+  return 'lost';
+}
+
+/** `null` quando o jogo não tem placar ou o mercado é desconhecido. */
+export function liquidar(market, outcome, line, goalsHome, goalsAway) {
+  if (goalsHome == null || goalsAway == null) return null;
+  const diff = goalsHome - goalsAway; // ótica do mandante
+  const total = goalsHome + goalsAway;
+  const res = diff > 0 ? 'Home' : diff < 0 ? 'Away' : 'Draw';
+
+  switch (market) {
+    case 'match_winner':
+      return outcome === res ? 'won' : 'lost';
+    case 'btts':
+      return (outcome === 'Yes') === (goalsHome > 0 && goalsAway > 0) ? 'won' : 'lost';
+    case 'double_chance': {
+      const ok =
+        outcome === '1X' ? res === 'Home' || res === 'Draw'
+        : outcome === 'X2' ? res === 'Draw' || res === 'Away'
+        : res === 'Home' || res === 'Away';
+      return ok ? 'won' : 'lost';
+    }
+    case 'goals_over_under':
+      if (line == null) return null;
+      return mapAsian(outcome === 'Over' ? total - line : line - total);
+    case 'asian_handicap':
+      if (line == null) return null;
+      return mapAsian(outcome === 'Home' ? diff + line : -diff - line);
+    default:
+      return null;
+  }
+}
+
+/** Lucro de uma aposta plana de 1 unidade. */
+export function lucroDaAposta(resultado, odd) {
+  switch (resultado) {
+    case 'won': return odd - 1;
+    case 'half_won': return (odd - 1) / 2;
+    case 'push': return 0;
+    case 'half_lost': return -0.5;
+    default: return -1;
+  }
+}
+
+export const ehAcerto = (r) => r === 'won' || r === 'half_won';
+
+// ── estatística ────────────────────────────────────────────────────────────
+
+/**
+ * Média, e o erro-padrão dela.
+ *
+ * O erro-padrão não é enfeite: com uma semana de amostra, quase toda diferença
+ * entre recortes cabe dentro dele. Sem essa coluna, a tabela convida a decidir
+ * peso de premissa em cima de ruído.
+ */
+export function estatistica(linhas) {
+  const n = linhas.length;
+  if (n === 0) return { n: 0, roi: 0, ep: 0, taxa: null };
+  const lucros = linhas.map((l) => l.lucro);
+  const media = lucros.reduce((a, b) => a + b, 0) / n;
+  const variancia =
+    n > 1 ? lucros.reduce((a, b) => a + (b - media) ** 2, 0) / (n - 1) : 0;
+  const decididas = linhas.filter((l) => l.resultado !== 'push').length;
+  const acertos = linhas.filter((l) => ehAcerto(l.resultado)).length;
+  return {
+    n,
+    roi: media,
+    ep: Math.sqrt(variancia / n),
+    taxa: decididas ? acertos / decididas : null,
+  };
+}
+
+// ── consulta ───────────────────────────────────────────────────────────────
+
+function tokenDeAcesso() {
+  if (process.env.SUPABASE_ACCESS_TOKEN) return process.env.SUPABASE_ACCESS_TOKEN;
+  const env = readFileSync(resolve(RAIZ, '.env.local'), 'utf8');
+  const m = /^SUPABASE_ACCESS_TOKEN=(.*)$/m.exec(env);
+  if (!m) throw new Error('SUPABASE_ACCESS_TOKEN não encontrado no ambiente nem em .env.local');
+  return m[1].trim().replace(/^["']|["']$/g, '');
+}
+
+async function consultar(sql) {
+  const r = await fetch(
+    `https://api.supabase.com/v1/projects/${PROJETO_PRD}/database/query`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${tokenDeAcesso()}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query: sql, read_only: true }),
+    },
+  );
+  const j = await r.json();
+  if (!Array.isArray(j)) throw new Error(`consulta falhou: ${JSON.stringify(j).slice(0, 300)}`);
+  return j;
+}
+
+/** Só o primeiro snapshot de cada oportunidade: a foto de quando ela nasceu. */
+const SQL_BOARD = `
+with primeiro as (
+  select distinct on (h.opportunity_key)
+    h.opportunity_key, h.fixture_id, h.market, h.outcome, h.line_value,
+    h.best_odd, h.score, h.faixa, h.competition, h.dbt_valid_from
+  from futebol.fact_value_opportunities_hist h
+  where h.score_versao = 'contexto_v1'
+  order by h.opportunity_key, h.dbt_valid_from asc
+)
+select p.*, f.status_short, f.goals_home, f.goals_away, f.kickoff_utc
+from primeiro p
+join futebol.fact_fixtures f on f.fixture_id = p.fixture_id
+`;
+
+const SQL_PICKS = `
+select p.fixture_id, p.market, p.outcome, p.line_value,
+       p.odds as best_odd, p.score, p.faixa, p.sent_date as dbt_valid_from,
+       f.competition, f.status_short, f.goals_home, f.goals_away, f.kickoff_utc
+from public.daily_opportunity_picks p
+join futebol.fact_fixtures f on f.fixture_id = p.fixture_id
+`;
+
+// ── apresentação ───────────────────────────────────────────────────────────
+
+const pct = (x) => `${(x * 100).toFixed(1)}%`;
+const diaBrt = (iso) =>
+  new Date(new Date(`${iso}Z`).getTime() - 3 * 3600000).toISOString().slice(0, 10);
+
+function tabela(titulo, linhas, chave, ordem) {
+  const grupos = new Map();
+  for (const l of linhas) {
+    const k = chave(l);
+    if (k == null) continue;
+    if (!grupos.has(k)) grupos.set(k, []);
+    grupos.get(k).push(l);
+  }
+  console.log(`\n### ${titulo}`);
+  console.log('| recorte | n | taxa | ROI | erro-padrão |');
+  console.log('|---|---:|---:|---:|---:|');
+  const ordenado = [...grupos.entries()].sort(
+    ordem ?? ((a, b) => b[1].length - a[1].length),
+  );
+  for (const [k, ls] of ordenado) {
+    const e = estatistica(ls);
+    console.log(
+      `| ${k} | ${e.n} | ${e.taxa == null ? '—' : pct(e.taxa)} | ${pct(e.roi)} | ±${(e.ep * 100).toFixed(1)}pp |`,
+    );
+  }
+}
+
+const FAIXA_DE_ODD = (o) => {
+  const x = Number(o);
+  if (x < 1.6) return '1.25–1.59';
+  if (x < 2.0) return '1.60–1.99';
+  if (x < 2.6) return '2.00–2.59';
+  return '2.60–4.00';
+};
+
+const CORTE_DE_SCORE = (s) => {
+  const n = Number(s);
+  if (n < 30) return 'Score <30';
+  if (n < 60) return 'Score 30–59';
+  if (n < 80) return 'Score 60–79';
+  return 'Score 80+';
+};
+
+const ORDEM_FAIXA = (a, b) =>
+  ['Alta', 'Média', 'Baixa'].indexOf(a[0]) - ['Alta', 'Média', 'Baixa'].indexOf(b[0]);
+const ALFABETICA = (a, b) => a[0].localeCompare(b[0]);
+
+async function principal() {
+  const args = Object.fromEntries(
+    process.argv.slice(2).map((a) => {
+      const [k, ...v] = a.replace(/^--/, '').split('=');
+      return [k, v.join('=') || true];
+    }),
+  );
+  const fonte = args.fonte === 'picks' ? 'picks' : 'board';
+  const desde = typeof args.desde === 'string' ? args.desde : null;
+
+  const brutas = await consultar(fonte === 'picks' ? SQL_PICKS : SQL_BOARD);
+  const noRecorte = desde
+    ? brutas.filter((l) => String(l.dbt_valid_from) >= desde)
+    : brutas;
+
+  const liquidadas = [];
+  let pendentes = 0;
+  for (const l of noRecorte) {
+    const encerrado = ['FT', 'AET', 'PEN'].includes(l.status_short);
+    const resultado = encerrado
+      ? liquidar(l.market, l.outcome, l.line_value, l.goals_home, l.goals_away)
+      : null;
+    if (resultado == null) { pendentes++; continue; }
+    liquidadas.push({ ...l, resultado, lucro: lucroDaAposta(resultado, Number(l.best_odd)) });
+  }
+
+  const g = estatistica(liquidadas);
+  console.log(`# ${fonte === 'picks' ? 'Picks enviados no Telegram' : 'Board publicado'}${desde ? ` — desde ${desde}` : ''}`);
+  console.log(
+    `\n${noRecorte.length} no recorte · ${g.n} liquidadas · ${pendentes} pendentes` +
+    `\ntaxa ${g.taxa == null ? '—' : pct(g.taxa)} · ROI ${pct(g.roi)} ± ${(g.ep * 100).toFixed(1)}pp`,
+  );
+
+  if (g.n === 0) return;
+
+  tabela('Por mercado', liquidadas, (l) => l.market);
+  tabela('Por faixa', liquidadas, (l) => l.faixa, ORDEM_FAIXA);
+  tabela('Por corte de Score', liquidadas, (l) => CORTE_DE_SCORE(l.score), ALFABETICA);
+  tabela('Por faixa de odd', liquidadas, (l) => FAIXA_DE_ODD(l.best_odd), ALFABETICA);
+  tabela('Por campeonato', liquidadas, (l) => l.competition);
+  tabela('Por dia do JOGO (BRT)', liquidadas, (l) => diaBrt(l.kickoff_utc), ALFABETICA);
+  tabela('Por dia da DETECÇÃO', liquidadas, (l) => String(l.dbt_valid_from).slice(0, 10), ALFABETICA);
+
+  console.log(
+    '\n> Erro-padrão maior que a diferença entre dois recortes significa que a ' +
+    'diferença ainda não existe. Recorte com menos de 30 linhas não decide nada.',
+  );
+}
+
+// Só executa quando chamado direto: o teste de paridade importa este arquivo.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  principal().catch((e) => {
+    console.error(String(e.message ?? e));
+    process.exit(1);
+  });
+}

--- a/src/utils/futebol-roi-script.test.ts
+++ b/src/utils/futebol-roi-script.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from 'vitest';
-import { settleFutebol } from './futebol-settlement';
+import { isHit, settleFutebol } from './futebol-settlement';
 import type { Saida } from './futebol-saida';
-// O script de operação, em .mjs. O `allowJs` do projeto o resolve sozinho.
-import { liquidar, lucroDaAposta } from '../../scripts/futebol-roi.mjs';
+/**
+ * O script de operação, em .mjs.
+ *
+ * ⚠️ O import chega SEM TIPO. `allowJs` só existe no tsconfig da raiz, que é o
+ * que não compila nada; o `tsconfig.app.json`, que compila, não o tem. Com
+ * `noImplicitAny: false` isso degrada para `any` em silêncio — o compilador não
+ * confere nada aqui, e é por isso que a paridade tem de ser verificada em
+ * EXECUÇÃO, caso a caso, como está abaixo.
+ *
+ * O script também não pode ter shebang: o `#!` sobrevive à transformação do
+ * vitest e quebra o parse quando o caminho do projeto tem espaço, deixando o
+ * arquivo de teste inteiro sem rodar — passou uma vez assim, verde no CI e
+ * morto na máquina.
+ */
+import { ehAcerto, liquidar, lucroDaAposta } from '../../scripts/futebol-roi.mjs';
 
 // ============================================================================
 // O script de ROI liquida igual ao produto
@@ -55,6 +68,14 @@ describe('paridade entre o script de ROI e a liquidação do produto', () => {
           if (doProduto !== doScript) {
             divergencias.push(
               `${market} ${outcome} linha ${line} placar ${gh}x${ga}: produto=${doProduto} script=${doScript}`,
+            );
+          }
+          // A terceira cópia: `ehAcerto` no script, `isHit` no produto. Ela
+          // decide a TAXA DE ACERTO, e ficava fora do guarda — meio-green
+          // contar como acerto num lado e não no outro passaria batido.
+          if (doProduto != null && isHit(doProduto) !== ehAcerto(doScript)) {
+            divergencias.push(
+              `${market} ${outcome} linha ${line} placar ${gh}x${ga}: acerto diverge (${doProduto})`,
             );
           }
         }

--- a/src/utils/futebol-roi-script.test.ts
+++ b/src/utils/futebol-roi-script.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { settleFutebol } from './futebol-settlement';
+import type { Saida } from './futebol-saida';
+// O script de operação, em .mjs. O `allowJs` do projeto o resolve sozinho.
+import { liquidar, lucroDaAposta } from '../../scripts/futebol-roi.mjs';
+
+// ============================================================================
+// O script de ROI liquida igual ao produto
+// ============================================================================
+// `scripts/futebol-roi.mjs` reimplementa a regra de `futebol-settlement.ts`,
+// porque é um .mjs de operação e não consegue importar o TypeScript do app.
+//
+// Duas cópias da mesma regra divergem sozinhas, e a divergência aqui é do pior
+// tipo: silenciosa e para trás. O script não quebra — ele passa a devolver uma
+// taxa de acerto diferente da que a tela mostra para o mesmo jogo, e a decisão
+// de peso de premissa é tomada em cima do número errado.
+//
+// Este teste é o que impede isso. Ele varre a grade inteira de mercados,
+// saídas, linhas e placares, e exige acordo caso a caso.
+// ============================================================================
+
+const PLACARES: [number, number][] = [
+  [0, 0], [1, 0], [0, 1], [1, 1], [2, 0], [0, 2],
+  [2, 1], [1, 2], [3, 1], [2, 2], [3, 3], [4, 0],
+];
+
+const CASOS: { market: string; outcome: string; linhas: (number | null)[] }[] = [
+  { market: 'match_winner', outcome: 'Home', linhas: [null] },
+  { market: 'match_winner', outcome: 'Away', linhas: [null] },
+  { market: 'match_winner', outcome: 'Draw', linhas: [null] },
+  { market: 'btts', outcome: 'Yes', linhas: [null] },
+  { market: 'btts', outcome: 'No', linhas: [null] },
+  { market: 'double_chance', outcome: '1X', linhas: [null] },
+  { market: 'double_chance', outcome: 'X2', linhas: [null] },
+  { market: 'double_chance', outcome: '12', linhas: [null] },
+  // Linha cheia, meia, quarto e três quartos — é onde mora meio-green e anulada.
+  { market: 'goals_over_under', outcome: 'Over', linhas: [1.5, 2, 2.25, 2.5, 2.75, 3, 3.5] },
+  { market: 'goals_over_under', outcome: 'Under', linhas: [1.5, 2, 2.25, 2.5, 2.75, 3, 3.5] },
+  { market: 'asian_handicap', outcome: 'Home', linhas: [-1.5, -1, -0.75, -0.5, -0.25, 0, 0.5, 1] },
+  { market: 'asian_handicap', outcome: 'Away', linhas: [-1.5, -1, -0.75, -0.5, -0.25, 0, 0.5, 1] },
+];
+
+describe('paridade entre o script de ROI e a liquidação do produto', () => {
+  it('as duas implementações concordam em toda a grade', () => {
+    const divergencias: string[] = [];
+    let comparados = 0;
+
+    for (const { market, outcome, linhas } of CASOS) {
+      for (const line of linhas) {
+        for (const [gh, ga] of PLACARES) {
+          const saida = { market, outcome, line_value: line } as unknown as Saida;
+          const doProduto = settleFutebol(saida, gh, ga);
+          const doScript = liquidar(market, outcome, line, gh, ga);
+          comparados++;
+          if (doProduto !== doScript) {
+            divergencias.push(
+              `${market} ${outcome} linha ${line} placar ${gh}x${ga}: produto=${doProduto} script=${doScript}`,
+            );
+          }
+        }
+      }
+    }
+
+    expect(divergencias).toEqual([]);
+    // Guarda contra a grade encolher sem ninguém notar: um `CASOS` esvaziado
+    // faria o teste passar sem comparar nada.
+    expect(comparados).toBeGreaterThan(300);
+  });
+
+  it('mercado desconhecido não é liquidado por engano', () => {
+    expect(liquidar('total_de_escanteios', 'Over', 9.5, 3, 1)).toBeNull();
+  });
+
+  it('jogo sem placar não é liquidado', () => {
+    expect(liquidar('match_winner', 'Home', null, null, null)).toBeNull();
+  });
+});
+
+describe('lucro de uma aposta plana de 1 unidade', () => {
+  it('paga a odd menos a unidade no green, e metade no meio-green', () => {
+    expect(lucroDaAposta('won', 2.5)).toBeCloseTo(1.5);
+    expect(lucroDaAposta('half_won', 2.5)).toBeCloseTo(0.75);
+  });
+
+  it('anulada devolve a aposta, meio-red perde metade, red perde tudo', () => {
+    expect(lucroDaAposta('push', 2.5)).toBe(0);
+    expect(lucroDaAposta('half_lost', 2.5)).toBe(-0.5);
+    expect(lucroDaAposta('lost', 2.5)).toBe(-1);
+  });
+});


### PR DESCRIPTION
Não existe registro persistido de green ou red: o banco guarda a oportunidade, não se ela bateu. A liquidação roda no navegador e é descartada. Toda vez que alguém quis o número, refez a conta na mão — e refazer na mão é como duas pessoas chegam a taxas diferentes para a mesma semana.

O script consulta produção em modo somente leitura e quebra por mercado, faixa, corte de Score, faixa de odd, campeonato, dia do jogo e dia da detecção. Aceita `--desde`, `--fonte=picks` e `--com-ocultos`.

## Quatro armadilhas, escritas no cabeçalho porque as quatro me pegaram

**Data de detecção não é data do jogo.** Oportunidade nasce para jogo futuro. Cortar por detecção mede a **régua** que produziu a linha; cortar por apito mede o **resultado** da semana. As duas tabelas saem, e são respostas a perguntas diferentes — nesta amostra elas discordam: o dia 5 foi péssimo como jogo e neutro como detecção.

**O histórico começou de uma vez.** Em 03/09 o snapshot capturou o board inteiro, e esse dia sozinho concentra 909 das 1.214 linhas liquidadas. Ler por dia de detecção sem saber disso dá conclusão errada.

**O denominador da nota trocou em 04/09 ~14h35 UTC**, do p95 para o teto de pontos. Linha anterior tem Score em outra escala e não é comparável. O dado confirma sozinho: o Score médio cai de 40,8 para ~30 exatamente nesse ponto, como o analytics tinha previsto.

**Mercado oculto não conta.** O Handicap está fora da vitrine desde 01/09 e o assinante não o vê, embora o backend siga publicando para continuar medindo. Somar as linhas dele é responder por um produto que ninguém usa. O script lê `public.futebol_mercados_ocultos` em vez de trazer o nome escrito no código — quando o mercado voltar, a conta volta sozinha.

Não é detalhe: na janela do `contexto_v1`, o ROI do que o assinante enxerga é **−0,8% ± 3,8pp em 889 linhas**, contra −2,7% com o Handicap dentro. O primeiro é empate técnico com o zero; o segundo parecia perda.

## O erro-padrão é coluna, não enfeite

Com uma semana de amostra, quase toda diferença entre recortes cabe dentro dele. Sem essa coluna a tabela convida a decidir peso de premissa em cima de ruído — e o rodapé do relatório diz isso com todas as letras.

## O que o script NÃO responde

**ROI por premissa.** Quais premissas acenderam em cada linha não existe no Postgres: não há coluna de evidência nem array em `fact_value_opportunities_hist`. Isso vive só no mart, no BigQuery. Está registrado no cabeçalho para a próxima pessoa não perder tempo procurando.

## Sobre a regra de liquidação estar duplicada

O script é `.mjs` de operação e não importa o TypeScript do app. Duas cópias da mesma regra divergem sozinhas, e aqui a divergência seria silenciosa e para trás: o script passaria a devolver uma taxa diferente da que a tela mostra para o mesmo jogo, e a decisão de peso sairia do número errado.

O teste novo varre a grade inteira — cinco mercados, todas as saídas, linhas cheias, meias, de quarto e de três quartos, e doze placares — e exige acordo caso a caso. Quebrado de propósito: tratar quarto de linha como linha cheia derruba o teste listando as divergências.

## Verificação

- typecheck: 66 erros de dívida declarada, nenhum novo
- 909 testes passando, 1 pulado
- lint sem erro, build OK
