### PR TITLE
O dia escolhido atravessa a navegação

### DIFF
--- a/src/hooks/use-dia-na-url.test.ts
+++ b/src/hooks/use-dia-na-url.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { comDia, PARAM_DO_DIA } from './use-dia-na-url';
+
+// ============================================================================
+// O dia atravessa a navegação
+// ============================================================================
+// O defeito que isto impede: estando em "amanhã" na home e clicando em "Ver
+// todas", a lista abria em HOJE. O destino nascia com estado zerado e caía no
+// padrão, e a pessoa achava que tinha clicado errado.
+//
+// O guarda de fonte no fim é o que segura a regressão de verdade: um `to=`
+// escrito à mão numa das telas volta a perder o dia, e nenhum teste de unidade
+// perceberia.
+// ============================================================================
+
+const fonte = (caminho: string) =>
+  readFileSync(resolve(__dirname, '..', caminho), 'utf8').replace(/\r\n/g, '\n');
+
+const HOME = fonte('pages/FutebolHoje.tsx');
+
+describe('comDia', () => {
+  it('carrega o dia escolhido para a rota de destino', () => {
+    expect(comDia('/futebol/oportunidades', '2026-09-11')).toBe(
+      `/futebol/oportunidades?${PARAM_DO_DIA}=2026-09-11`,
+    );
+  });
+
+  it('sem dia, o destino fica limpo em vez de ganhar parâmetro vazio', () => {
+    expect(comDia('/futebol/jogos', null)).toBe('/futebol/jogos');
+    expect(comDia('/futebol/jogos', undefined)).toBe('/futebol/jogos');
+  });
+
+  it('dia malformado não vira parâmetro', () => {
+    // Vem da URL, então vem de fora: qualquer coisa pode chegar aqui.
+    expect(comDia('/futebol/jogos', 'amanhã')).toBe('/futebol/jogos');
+    expect(comDia('/futebol/jogos', '2026-9-1')).toBe('/futebol/jogos');
+    expect(comDia('/futebol/jogos', '')).toBe('/futebol/jogos');
+  });
+});
+
+describe('os atalhos da home levam o dia junto', () => {
+  it('nenhum link para as duas telas de dia é escrito à mão', () => {
+    // `to="/futebol/oportunidades"` cru é exatamente o bug voltando.
+    const crus = HOME.split('\n').filter((l) =>
+      /to="\/futebol\/(oportunidades|jogos)"/.test(l),
+    );
+    expect(crus).toEqual([]);
+  });
+
+  it('e os dois passam pelo comDia', () => {
+    expect(HOME).toContain("comDia('/futebol/oportunidades'");
+    expect(HOME).toContain("comDia('/futebol/jogos'");
+  });
+});

--- a/src/hooks/use-dia-na-url.test.ts
+++ b/src/hooks/use-dia-na-url.test.ts
@@ -38,6 +38,40 @@ describe('comDia', () => {
     expect(comDia('/futebol/jogos', '2026-9-1')).toBe('/futebol/jogos');
     expect(comDia('/futebol/jogos', '')).toBe('/futebol/jogos');
   });
+
+  it('rota que já tem query não vira URL com dois pontos de interrogação', () => {
+    // Nenhum destino de hoje tem query. Concatenar funcionava por sorte, e a
+    // sorte acaba no dia em que alguém acrescentar um parâmetro na rota.
+    expect(comDia('/futebol/jogos?jogo=9', '2026-09-11')).toBe(
+      '/futebol/jogos?jogo=9&dia=2026-09-11',
+    );
+  });
+});
+
+// ============================================================================
+// As três telas concordam sobre o nome do parâmetro
+// ============================================================================
+// A docstring de PARAM_DO_DIA promete "num lugar só". A agenda tinha a própria
+// cópia da regex e a string 'dia' literal, então a promessa era falsa e nada
+// avisava: trocar o parâmetro para `?data=` quebraria a navegação entre telas
+// sem um teste ficar vermelho.
+//
+// A agenda mantém o SETTER próprio de propósito — ao trocar de dia ela descarta
+// o `?jogo=`, e o `trocar` daqui preserva os outros parâmetros. O que precisava
+// ser compartilhado é o nome e a validação, não a escrita.
+// ============================================================================
+
+describe('o parâmetro do dia é um só', () => {
+  const AGENDA = fonte('pages/FutebolJogos.tsx');
+
+  it('a agenda lê o nome e a validação daqui', () => {
+    expect(AGENDA).toContain("from '@/hooks/use-dia-na-url'");
+    expect(AGENDA).toContain('params.get(PARAM_DO_DIA)');
+  });
+
+  it('e não guarda uma segunda cópia da validação', () => {
+    expect(AGENDA).not.toMatch(/const DIA_RE\s*=/);
+  });
 });
 
 describe('os atalhos da home levam o dia junto', () => {

--- a/src/hooks/use-dia-na-url.ts
+++ b/src/hooks/use-dia-na-url.ts
@@ -15,26 +15,49 @@ import { useSearchParams } from 'react-router-dom';
 // ============================================================================
 
 /** `2026-09-11`. Formato do seletor e da chave do dia BRT no resto do módulo. */
-const DIA_RE = /^\d{4}-\d{2}-\d{2}$/;
+export const DIA_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-/** O nome do parâmetro, num lugar só — as três telas precisam concordar. */
+/**
+ * O nome do parâmetro, num lugar só — as três telas precisam concordar.
+ *
+ * A agenda (`FutebolJogos`) consome esta constante e a regex, mas continua com
+ * o SETTER próprio, e isso é de propósito: ao trocar de dia ela descarta o
+ * `?jogo=`, porque o jogo selecionado pertencia ao dia anterior. O `trocar`
+ * daqui preserva os outros parâmetros, que é o certo para as outras duas telas
+ * e seria errado lá.
+ */
 export const PARAM_DO_DIA = 'dia';
 
-/** Monta o destino preservando o dia. `null` cai na rota limpa. */
+/**
+ * Monta o destino preservando o dia. `null` ou dia inválido caem na rota limpa.
+ *
+ * Usa `URLSearchParams` em vez de concatenar: hoje os dois destinos são rotas
+ * secas, mas uma rota que já tivesse query viraria uma URL com dois pontos de
+ * interrogação, quebrada e difícil de enxergar.
+ */
 export function comDia(rota: string, dia: string | null | undefined): string {
-  return dia && DIA_RE.test(dia) ? `${rota}?${PARAM_DO_DIA}=${dia}` : rota;
+  if (!dia || !DIA_RE.test(dia)) return rota;
+  const [caminho, query] = rota.split('?');
+  const params = new URLSearchParams(query);
+  params.set(PARAM_DO_DIA, dia);
+  return `${caminho}?${params.toString()}`;
 }
 
 /**
  * O dia escolhido, lido da URL, e como trocá-lo.
  *
  * Devolve `null` quando não há dia válido no endereço — quem chama decide o
- * padrão, porque ele não é o mesmo nas três telas (a home cai em hoje, a lista
- * de oportunidades cai no primeiro dia com linha).
+ * padrão, porque ele não é o mesmo nas três telas: a home cai em hoje, a lista
+ * de oportunidades cai no primeiro dia com linha, e a agenda cai em hoje pelo
+ * `brtToday()` dela.
  *
  * A troca usa `replace`: clicar cinco dias seguidos não deve encher o histórico
  * de cinco passos, e o botão voltar tem de sair da tela, não desfazer cliques
  * de seta.
+ *
+ * Devolve tupla, e não objeto como os outros hooks daqui, porque as duas telas
+ * substituíram exatamente um `useState<string | null>(null)` por esta chamada —
+ * a mesma forma manteve o diff numa linha por tela.
  */
 export function useDiaNaUrl(): [string | null, (dia: string) => void] {
   const [params, setParams] = useSearchParams();

--- a/src/hooks/use-dia-na-url.ts
+++ b/src/hooks/use-dia-na-url.ts
@@ -1,0 +1,54 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+// ============================================================================
+// O dia selecionado mora na URL, e não em cada tela
+// ============================================================================
+// As três telas de futebol têm seletor de dia, e cada uma guardava o dia do seu
+// jeito: a agenda já usava `?dia=`, a home e as oportunidades usavam estado
+// local. O efeito aparecia na navegação — quem estava vendo amanhã na home e
+// clicava em "Ver todas" caía na lista de HOJE, porque o destino nascia com o
+// estado zerado e voltava ao padrão.
+//
+// Com o dia na URL o link carrega o contexto, o F5 não perde a escolha, e o
+// endereço vira compartilhável. É também o que a agenda já fazia certo.
+// ============================================================================
+
+/** `2026-09-11`. Formato do seletor e da chave do dia BRT no resto do módulo. */
+const DIA_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** O nome do parâmetro, num lugar só — as três telas precisam concordar. */
+export const PARAM_DO_DIA = 'dia';
+
+/** Monta o destino preservando o dia. `null` cai na rota limpa. */
+export function comDia(rota: string, dia: string | null | undefined): string {
+  return dia && DIA_RE.test(dia) ? `${rota}?${PARAM_DO_DIA}=${dia}` : rota;
+}
+
+/**
+ * O dia escolhido, lido da URL, e como trocá-lo.
+ *
+ * Devolve `null` quando não há dia válido no endereço — quem chama decide o
+ * padrão, porque ele não é o mesmo nas três telas (a home cai em hoje, a lista
+ * de oportunidades cai no primeiro dia com linha).
+ *
+ * A troca usa `replace`: clicar cinco dias seguidos não deve encher o histórico
+ * de cinco passos, e o botão voltar tem de sair da tela, não desfazer cliques
+ * de seta.
+ */
+export function useDiaNaUrl(): [string | null, (dia: string) => void] {
+  const [params, setParams] = useSearchParams();
+  const bruto = params.get(PARAM_DO_DIA);
+  const dia = DIA_RE.test(bruto ?? '') ? bruto : null;
+
+  const trocar = useCallback(
+    (novo: string) => {
+      const proximos = new URLSearchParams(params);
+      proximos.set(PARAM_DO_DIA, novo);
+      setParams(proximos, { replace: true });
+    },
+    [params, setParams],
+  );
+
+  return [dia, trocar];
+}

--- a/src/pages/FutebolHoje.tsx
+++ b/src/pages/FutebolHoje.tsx
@@ -36,6 +36,7 @@ import { estadoDosMotivos, explicacaoDaLeitura, type MotivoExibivel as Motivo } 
 import { ladoDaSaida } from '@/utils/futebol-evidencias';
 import { rotuloPremissa } from '@/utils/futebol-premissas';
 import { useNow } from '@/hooks/use-now';
+import { comDia, useDiaNaUrl } from '@/hooks/use-dia-na-url';
 // Quantos dias futuros (com jogos) o navegador mostra — janela curta, não a temporada toda.
 const DAY_WINDOW = 8;
 
@@ -360,7 +361,9 @@ export default function FutebolHoje() {
   // ele mesmo inventou, que era o defeito.
   const locked = isDemo ? false : !access?.unlocked;
 
-  const [day, setDay] = useState<string | null>(null);
+  // O dia mora na URL: os atalhos daqui levam o contexto junto, e quem estava
+  // vendo amanhã para de cair em hoje ao clicar em "Ver todas".
+  const [day, setDay] = useDiaNaUrl();
 
   // dias (BRT) com jogos ainda não começados — base da navegação por dias.
   // Limita aos próximos dias (não varre a temporada inteira do Brasileirão).
@@ -640,7 +643,7 @@ export default function FutebolHoje() {
                 <div className={LABEL}>Mais oportunidades</div>
                 <div className="text-lg font-bold tracking-tight text-ink mt-0.5">Por confiabilidade</div>
               </div>
-              <Link to="/futebol/oportunidades" className="text-[12px] font-semibold inline-flex items-center gap-1 text-forest hover:text-forest-2">
+              <Link to={comDia('/futebol/oportunidades', selectedDay)} className="text-[12px] font-semibold inline-flex items-center gap-1 text-forest hover:text-forest-2">
                 Ver todas <ArrowRight className="w-3.5 h-3.5" />
               </Link>
             </div>
@@ -661,7 +664,7 @@ export default function FutebolHoje() {
                 <div className={LABEL}>{isToday ? 'Jogos de hoje' : 'Jogos do dia'}</div>
                 <div className="text-lg font-bold tracking-tight text-ink mt-0.5">{gameList.length} partida{gameList.length === 1 ? '' : 's'}</div>
               </div>
-              <Link to="/futebol/jogos" className="text-[12px] font-semibold inline-flex items-center gap-1 text-forest hover:text-forest-2">
+              <Link to={comDia('/futebol/jogos', selectedDay)} className="text-[12px] font-semibold inline-flex items-center gap-1 text-forest hover:text-forest-2">
                 Ver todos <ArrowRight className="w-3.5 h-3.5" />
               </Link>
             </div>

--- a/src/pages/FutebolJogos.tsx
+++ b/src/pages/FutebolJogos.tsx
@@ -26,6 +26,7 @@ import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
 import { FUT_JOGOS_TOUR_ID, makeFutebolJogosSteps } from '@/components/onboarding/tours';
 import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
 import { useDemoFutebolBoard } from '@/components/onboarding/demo/use-demo-futebol';
+import { DIA_RE, PARAM_DO_DIA } from '@/hooks/use-dia-na-url';
 import {
   demoFutebolNumeros,
   demoFutebolPremissas,
@@ -79,13 +80,11 @@ function monthRange(dayKey: string): { from: string; to: string } {
   };
 }
 
-const DIA_RE = /^\d{4}-\d{2}-\d{2}$/;
-
 export default function FutebolJogos() {
   const hasPanel = useHasPanel();
   const [params, setParams] = useSearchParams();
 
-  const diaParam = params.get('dia');
+  const diaParam = params.get(PARAM_DO_DIA);
   const dia = DIA_RE.test(diaParam ?? '') ? (diaParam as string) : brtToday();
   const jogoParam = Number(params.get('jogo')) || null;
 
@@ -200,7 +199,12 @@ export default function FutebolJogos() {
   const selectDay = (d: string) => {
     // replace pra seta de dia não empilhar histórico; o jogo selecionado cai fora
     // porque ele pertencia ao dia anterior.
-    setParams({ dia: d }, { replace: true });
+    //
+    // Por isso esta tela NÃO usa o `trocar` do useDiaNaUrl: aquele preserva os
+    // outros parâmetros, que é o certo nas outras duas telas e seria errado aqui
+    // — o `?jogo=` sobreviveria à troca de dia. O nome do parâmetro e a validação
+    // vêm de lá, que é o que precisava ser um lugar só.
+    setParams({ [PARAM_DO_DIA]: d }, { replace: true });
   };
 
   /**

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -36,6 +36,7 @@ import { useOnboardingTour } from '@/components/onboarding/useOnboardingTour';
 import { FUT_OPP_TOUR_ID, makeFutebolOportunidadesSteps } from '@/components/onboarding/tours';
 import { DemoRibbon, DemoBadge } from '@/components/onboarding/DemoRibbon';
 import { useDemoFutebolBoard } from '@/components/onboarding/demo/use-demo-futebol';
+import { useDiaNaUrl } from '@/hooks/use-dia-na-url';
 
 const FINISHED_STATUS = new Set(['FT', 'AET', 'PEN']);
 
@@ -235,7 +236,8 @@ export default function FutebolOportunidades() {
   const [valor, setValor] = useState<FiltroDeValor>(FILTRO_DE_VALOR_PADRAO);
   // `null` significa todas: acompanha automaticamente as competições daquele dia.
   const [competicoesSelecionadas, setCompeticoesSelecionadas] = useState<string[] | null>(null);
-  const [day, setDay] = useState<string | null>(null);
+  // Mesma URL da home e da agenda, para o dia sobreviver à navegação e ao F5.
+  const [day, setDay] = useDiaNaUrl();
 
   // Dispensar o cartão é só marcar que a explicação foi lida; a preferência de
   // alerta continua onde estava. Um erro aqui não pode quebrar o painel: o


### PR DESCRIPTION
Estando em "amanhã" na home e clicando em **Ver todas** ou **Ver todos**, a tela de destino abria em **hoje**. A pessoa achava que tinha clicado errado.

## A causa

As três telas de futebol têm seletor de dia e cada uma guardava o dia do seu jeito. A agenda já usava `?dia=` na URL; a home e as oportunidades usavam estado local, então o destino nascia zerado e caía no padrão. Os dois atalhos da home também apontavam para a rota crua, sem levar contexto nenhum.

## O conserto

O dia passa a morar na URL nas três, com o nome do parâmetro num lugar só. Além de consertar a navegação, isso traz de graça duas coisas que a agenda já tinha e as outras duas não: o F5 deixa de perder a escolha, e o endereço vira compartilhável.

A troca de dia usa `replace`: clicar cinco dias seguidos não deve encher o histórico de cinco passos, e o botão voltar tem de sair da tela em vez de desfazer cliques de seta.

## O guarda

Os testes de unidade cobrem o formato do parâmetro — dia malformado não vira query string, porque ele vem da URL e portanto vem de fora.

Mas o que segura a regressão de verdade é o **guarda de fonte**: um `to="/futebol/jogos"` escrito à mão numa das telas volta a perder o dia, e nenhum teste de unidade perceberia. Quebrado de propósito antes de entrar — devolvendo o link cru, dois testes ficam vermelhos.

## Verificação

- typecheck limpo, lint sem erro
- 909 testes passando, 1 pulado
- build de produção OK
