### PR TITLE
fix(planos): os botões pagos deixam de ser enfeite e levam para onde se paga

### DIFF
--- a/src/pages/Planos.test.tsx
+++ b/src/pages/Planos.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Planos from './Planos';
+
+/**
+ * O que este arquivo protege: cada plano leva à paywall do produto que ele
+ * vende. Errar o destino aqui não quebra a tela — o usuário compra outro
+ * produto, e a gente só descobre pelo suporte.
+ *
+ * Também guarda os dois botões que devem ficar DESABILITADOS: o Completo (o
+ * preço não existe no Stripe) e qualquer plano no modo anual (idem). Botão
+ * que leva a uma tela cobrando valor diferente do anunciado é pior que botão
+ * desabilitado.
+ */
+
+const mocks = vi.hoisted(() => ({ navigate: vi.fn() }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mocks.navigate };
+});
+
+vi.mock('@/hooks/use-auth', () => ({ useAuth: () => ({ user: { id: 'user-1' }, isLoading: false }) }));
+vi.mock('@/components/AnalyticsNav', () => ({ default: () => null }));
+vi.mock('@/components/Seo', () => ({ Seo: () => null, SITE_URL: 'https://www.smartbetting.app' }));
+
+const montar = () => render(<Planos />, { wrapper: MemoryRouter });
+
+/** O botão de assinatura de um plano, achado pelo rótulo visível. */
+const botao = (nome: string | RegExp) => screen.getByRole('button', { name: nome });
+
+beforeEach(() => mocks.navigate.mockClear());
+
+describe('CTAs dos planos (mensal)', () => {
+  it('Entrada leva à paywall do Betinho', async () => {
+    montar();
+    await userEvent.click(botao('Assinar Entrada'));
+    expect(mocks.navigate).toHaveBeenCalledWith('/paywall');
+  });
+
+  it('Essencial leva à tela de assinatura do Futebol', async () => {
+    montar();
+    await userEvent.click(botao('Assinar Essencial'));
+    expect(mocks.navigate).toHaveBeenCalledWith('/futebol/assinar');
+  });
+
+  it('Completo continua desabilitado — o preço não existe no Stripe', async () => {
+    montar();
+    const b = botao('Pagamento em breve');
+    expect(b).toBeDisabled();
+    await userEvent.click(b);
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it('logado já vê o rótulo de assinar, não mais "Pagamento em breve"', () => {
+    montar();
+    expect(screen.queryByRole('button', { name: 'Assinar Entrada' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Assinar Essencial' })).toBeTruthy();
+  });
+});
+
+describe('CTAs no modo anual', () => {
+  const irParaAnual = async () => {
+    montar();
+    await userEvent.click(screen.getByRole('button', { name: /Anual/i }));
+  };
+
+  it('nenhum plano é comprável no anual — os preços anuais não existem', async () => {
+    await irParaAnual();
+    const emBreve = screen.getAllByRole('button', { name: 'Anual em breve' });
+    expect(emBreve).toHaveLength(3);
+    for (const b of emBreve) expect(b).toBeDisabled();
+  });
+
+  it('clicar no anual não navega para uma tela que cobra mensal', async () => {
+    await irParaAnual();
+    mocks.navigate.mockClear();
+    await userEvent.click(screen.getAllByRole('button', { name: 'Anual em breve' })[0]);
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/Planos.tsx
+++ b/src/pages/Planos.tsx
@@ -144,21 +144,41 @@ export default function Planos() {
     ? { label: 'Acessar', onClick: () => navigate('/inicio') }
     : { label: 'Criar conta grátis', onClick: () => navigate('/auth') };
 
-  // O checkout unificado ainda não está plugado. Quando estiver, trocar por
-  // stripeService.createCheckoutSession(priceId[plan][billing], plan): logado
-  // vai direto pro gateway; deslogado passa pelo /auth e volta pro checkout.
+  // Cada plano pago leva à paywall do produto que ele vende, em vez de esperar
+  // um checkout unificado que nunca chegou. Não é o desenho final — é parar de
+  // exibir botão morto no momento de maior intenção de compra da página.
   //
-  // Enquanto isso, o botão diz a verdade em vez de navegar em silêncio. Para
-  // quem está deslogado "Assinar" ainda tem ação real: criar a conta e começar
-  // o teste. Para quem já está logado não há para onde ir, e mandar para
-  // /inicio sem aviso é um beco sem saída invisível — a paywall do futebol, que
-  // esta página absorveu (issue #297), ao menos mostrava o botão desabilitado.
-  const semGateway = !!user;
-  const startCheckout = (_plan: PaidTier) => {
-    if (semGateway) return;
-    navigate('/auth');
+  // As duas telas de destino já cobram de verdade e já tratam quem chega
+  // deslogado (mandam para /auth), então não há caso especial aqui.
+  //
+  // O Completo segue sem destino de propósito: o preço dele não existe no
+  // Stripe, e a NBA — o único diferencial dele sobre o Essencial — não está
+  // recebendo cliente novo. Botão desabilitado é honesto; botão que cobra o
+  // plano errado, não.
+  const DESTINO: Record<PaidTier, string | null> = {
+    entrada: '/paywall',           // Betinho — R$ 14,90/mês
+    essencial: '/futebol/assinar', // Futebol + Betinho ilimitado — R$ 39,90/mês
+    completo: null,
   };
-  const rotuloAssinar = (nome: string) => (semGateway ? 'Pagamento em breve' : `Assinar ${nome}`);
+
+  // Os preços anuais não existem no Stripe. Mandar quem escolheu "Anual" para
+  // uma tela que cobra mensal seria cobrar diferente do que a página prometeu.
+  const anualIndisponivel = billing === 'annual';
+
+  const ctaPago = (plan: PaidTier) => {
+    if (anualIndisponivel) {
+      return { label: 'Anual em breve', disabled: true, onClick: () => {} };
+    }
+    const destino = DESTINO[plan];
+    if (!destino) {
+      return { label: 'Pagamento em breve', disabled: true, onClick: () => {} };
+    }
+    return {
+      label: `Assinar ${PLAN_NAMES[plan]}`,
+      disabled: false,
+      onClick: () => navigate(destino),
+    };
+  };
 
   return (
     <div className="theme-bolao min-h-screen bg-canvas flex flex-col">
@@ -252,8 +272,8 @@ export default function Planos() {
               <div className="text-[13px] font-bold tracking-[0.02em]">Entrada</div>
               <div className="text-[13.5px] text-ink-3 mt-1 min-h-[41px]">Só o Betinho, sua banca no automático.</div>
               <PriceBlock tier="entrada" billing={billing} />
-              <button onClick={() => startCheckout('entrada')} disabled={semGateway} className="mt-5 w-full h-11 rounded-rebrand-sm text-sm font-bold bg-white border border-line-2 text-ink hover:border-forest hover:text-forest transition disabled:opacity-60 disabled:hover:border-line-2 disabled:hover:text-ink disabled:cursor-default">
-                {rotuloAssinar('Entrada')}
+              <button onClick={ctaPago('entrada').onClick} disabled={ctaPago('entrada').disabled} className="mt-5 w-full h-11 rounded-rebrand-sm text-sm font-bold bg-white border border-line-2 text-ink hover:border-forest hover:text-forest transition disabled:opacity-60 disabled:hover:border-line-2 disabled:hover:text-ink disabled:cursor-default">
+                {ctaPago('entrada').label}
               </button>
               <ul className="mt-5 pt-5 border-t border-line flex flex-col gap-2.5 text-sm">
                 <Feat><b className="text-ink font-semibold">Betinho ilimitado</b>, registra e liquida tudo no Telegram</Feat>
@@ -268,8 +288,8 @@ export default function Planos() {
               <div className="text-[13px] font-bold tracking-[0.02em]">Essencial</div>
               <div className="text-[13.5px] text-ink-3 mt-1 min-h-[41px]">Futebol completo + a banca no automático.</div>
               <PriceBlock tier="essencial" billing={billing} />
-              <button onClick={() => startCheckout('essencial')} disabled={semGateway} className="mt-5 w-full h-11 rounded-rebrand-sm text-sm font-bold bg-forest text-white hover:bg-forest-2 transition disabled:opacity-60 disabled:hover:bg-forest disabled:cursor-default">
-                {rotuloAssinar('Essencial')}
+              <button onClick={ctaPago('essencial').onClick} disabled={ctaPago('essencial').disabled} className="mt-5 w-full h-11 rounded-rebrand-sm text-sm font-bold bg-forest text-white hover:bg-forest-2 transition disabled:opacity-60 disabled:hover:bg-forest disabled:cursor-default">
+                {ctaPago('essencial').label}
               </button>
               <ul className="mt-5 pt-5 border-t border-line flex flex-col gap-2.5 text-sm">
                 <Feat><b className="text-ink font-semibold">Futebol completo</b> — oportunidades e Score sem limite</Feat>
@@ -307,8 +327,8 @@ export default function Planos() {
               <div className="text-[12.5px] mt-1.5 min-h-[19px]" style={{ color: '#9fbcae' }}>
                 {PRICES.completo[billing].billed || ' '}
               </div>
-              <button onClick={() => startCheckout('completo')} disabled={semGateway} className="mt-5 w-full h-11 rounded-rebrand-sm text-sm font-bold transition hover:brightness-95 disabled:opacity-60 disabled:hover:brightness-100 disabled:cursor-default" style={{ background: '#d4a017', color: '#2a1f00' }}>
-                {rotuloAssinar('Completo')}
+              <button onClick={ctaPago('completo').onClick} disabled={ctaPago('completo').disabled} className="mt-5 w-full h-11 rounded-rebrand-sm text-sm font-bold transition hover:brightness-95 disabled:opacity-60 disabled:hover:brightness-100 disabled:cursor-default" style={{ background: '#d4a017', color: '#2a1f00' }}>
+                {ctaPago('completo').label}
               </button>
               <ul className="mt-5 pt-5 flex flex-col gap-2.5 text-sm" style={{ borderTop: '1px solid rgba(255,255,255,0.14)' }}>
                 {[


### PR DESCRIPTION
A `/planos` exibia **"Pagamento em breve"** nos três planos pagos, com o handler fazendo `return` — o botão não fazia nada, no ponto de maior intenção de compra da página.

Não era bug: o comentário original explicava a escolha (sem checkout unificado, dizer a verdade era melhor que navegar em silêncio). Só que agora **duas telas que cobram de verdade já existem**, então não precisamos mais esperar o gateway unificado.

## O que muda

| Plano | Antes | Agora |
|---|---|---|
| **Entrada** R$ 14,90 | botão morto | → `/paywall` (Betinho) |
| **Essencial** R$ 39,90 | botão morto | → `/futebol/assinar` (futebol + Betinho ilimitado) |
| **Completo** R$ 89,90 | botão morto | continua desabilitado, e é o certo |
| **Modo anual** | botão morto | "Anual em breve", desabilitado |

As duas telas de destino já tratam quem chega deslogado (mandam para `/auth`), então não há caso especial na `/planos`.

## Por que Completo e anual continuam desabilitados

**Completo:** o preço não existe no Stripe, e a NBA — seu único diferencial sobre o Essencial — não está recebendo cliente novo agora.

**Anual:** os preços anuais também não existem. Mandar quem escolheu "Anual" para uma tela que cobra mensal seria cobrar diferente do que a página acabou de prometer: R$ 31,90/mês no card, R$ 39,90/mês na fatura. O rótulo vira "Anual em breve" para o usuário entender que a opção existe mas ainda não vende.

Botão desabilitado é honesto; botão que leva a uma tela cobrando outro plano, não.

## Verificação

**No navegador, rodando local:**
- `Assinar Entrada` → navegou para `/paywall` ✅
- `Assinar Essencial` → navegou para `/futebol/assinar` ✅
- `Completo` → desabilitado ✅
- Alternando para Anual → os três viram "Anual em breve", desabilitados ✅

**Automatizado:**
- 6 testes novos em `Planos.test.tsx`, cobrindo os destinos e — principalmente — o que **não** deve navegar
- `npx vitest run`: 918 passando, 74 arquivos
- `npm run typecheck`: 66 erros de dívida declarada, **zero novos**
- `npm run build` ok · `eslint` limpo

## Não entra aqui

A `/planos` promete **Pix** em dois lugares (`Planos.tsx:188` e a FAQ), e o checkout só aceita cartão — confirmado na tela real do Stripe. Pix não funciona com assinatura recorrente no Stripe, só à vista, então resolver isso é decisão de modelo de cobrança, não ajuste de botão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)