### PR TITLE
Instrumenta o funil do Futebol no PostHog

### DIFF
--- a/src/components/futebol/FutebolGate.tsx
+++ b/src/components/futebol/FutebolGate.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { usePostHog } from '@posthog/react';
 import { Lock, Sparkles } from 'lucide-react';
 import { useFutebolAccess } from '@/hooks/use-futebol-data';
 import type { FutebolAccess } from '@/services/futebol-data.service';
@@ -82,6 +83,7 @@ export function FutebolTrialChip() {
  */
 export function FutebolAccessBanner({ access, className = '' }: { access?: FutebolAccess; className?: string }) {
   const navigate = useNavigate();
+  const posthog = usePostHog();
   // Durante o trial (estado saudável) NÃO mostramos faixa — o chip do cabeçalho
   // cuida disso. A faixa forte fica só pra expirado/deslogado (hora de agir).
   if (!access || access.state === 'subscribed' || access.state === 'trial') return null;
@@ -101,7 +103,16 @@ export function FutebolAccessBanner({ access, className = '' }: { access?: Futeb
         </div>
       </div>
       <button
-        onClick={() => navigate(expired ? '/futebol/assinar' : '/auth')}
+        onClick={() => {
+          // Quem esbarrou na parede e reagiu. Mede intenção de quem NÃO tem
+          // acesso, que é o oposto do funil de uso e a outra metade da conta.
+          posthog?.capture('futebol_gate_hit', {
+            product: 'futebol',
+            acesso: access.state,
+            acao: expired ? 'assinar' : 'criar_conta',
+          });
+          navigate(expired ? '/futebol/assinar' : '/auth');
+        }}
         className="shrink-0 inline-flex items-center justify-center gap-1.5 rounded-rebrand-sm bg-forest text-canvas text-[12px] font-bold px-4 h-9 hover:bg-forest-2 transition"
       >
         {expired ? 'Assinar Futebol' : 'Criar conta grátis'}

--- a/src/components/futebol/RegistrarAposta.tsx
+++ b/src/components/futebol/RegistrarAposta.tsx
@@ -10,6 +10,7 @@
 // ============================================================
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { usePostHog } from '@posthog/react';
 import { Receipt, Check, Loader2, ArrowRight } from 'lucide-react';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import * as VisuallyHidden from '@radix-ui/react-visually-hidden';
@@ -87,6 +88,7 @@ export function RegistrarApostaModal({
   const valid = !isNaN(stakeN) && stakeN > 0 && !isNaN(oddN) && oddN > 1;
   const retorno = valid ? stakeN * oddN : null;
   const atalhos = atalhosDaUnidade(unidade.unit_value);
+  const posthog = usePostHog();
 
   const handleSave = async () => {
     if (!draft || !user?.id || !valid) return;
@@ -111,6 +113,19 @@ export function RegistrarApostaModal({
         channel: 'futebol',
       });
       if (err) throw err;
+      // Mesmo evento do Betinho (Bets.tsx) de propósito: a liquidação já emite
+      // `bet_settled` com este esquema dos dois lados, então o futebol entra nas
+      // métricas que já rodam em vez de exigir uma análise paralela. O que separa
+      // os dois produtos é `product`/`channel`, não o nome do evento.
+      posthog?.capture('bet_created', {
+        product: 'futebol',
+        channel: 'futebol',
+        bet_type: 'single',
+        sport: 'Futebol',
+        betting_market: mkt,
+        odds: oddN,
+        is_credit_bet: false,
+      });
       setDone(true);
     } catch {
       setError('Não foi possível registrar a aposta. Tente de novo.');

--- a/src/pages/FutebolAssinar.tsx
+++ b/src/pages/FutebolAssinar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
+import { usePostHog } from '@posthog/react';
 import { Check, Loader2, Lock } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
 import { Button } from '@/components/ui/button';
@@ -39,6 +40,7 @@ export default function FutebolAssinar() {
 
   const [isLoading, setIsLoading] = useState(false);
   const [assinouAgora, setAssinouAgora] = useState(false);
+  const posthog = usePostHog();
 
   const success = searchParams.get('success');
   const canceled = searchParams.get('canceled');
@@ -59,6 +61,14 @@ export default function FutebolAssinar() {
         const r = await stripeService.verifySession(sessionId);
         if (r.verified) {
           setAssinouAgora(true);
+          // ATENÇÃO: esta é a contagem do NAVEGADOR, e ela subconta por um motivo
+          // conhecido: quem fecha a aba depois de pagar nunca chega aqui. A
+          // contagem confiável é a do webhook do Stripe, que ainda não emite
+          // evento. Até lá, tratar este número como piso, nunca como receita.
+          posthog?.capture('futebol_subscribed', {
+            product: 'futebol',
+            fonte: 'retorno_checkout',
+          });
           await refetchAccess();
           toast({ title: 'Assinatura ativa!', description: 'Bom proveito. Te levando pras oportunidades...' });
           setTimeout(() => navigate('/futebol/oportunidades'), 1200);
@@ -72,7 +82,7 @@ export default function FutebolAssinar() {
 
     verificar(0);
     return () => { cancelado = true; };
-  }, [success, sessionId, user?.id, navigate, refetchAccess]);
+  }, [success, sessionId, user?.id, navigate, refetchAccess, posthog]);
 
   useEffect(() => {
     if (canceled) {
@@ -104,6 +114,11 @@ export default function FutebolAssinar() {
     }
 
     setIsLoading(true);
+    posthog?.capture('futebol_checkout_started', {
+      product: 'futebol',
+      estado_anterior: access?.state ?? null,
+      dias_restantes: access?.days_left ?? null,
+    });
     try {
       const { url } = await stripeService.createCheckoutSession(STRIPE_PRICE_ID, 'futebol');
       await stripeService.redirectToCheckout(url);

--- a/src/pages/FutebolLP.tsx
+++ b/src/pages/FutebolLP.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
+import { usePostHog } from "@posthog/react";
 import { Seo } from "@/components/Seo";
 import { faqPageSchema, type FaqItem } from "@/lib/structured-data";
 import { useAuth } from "@/hooks/use-auth";
@@ -126,8 +127,45 @@ const FutebolLP = () => {
   const comValor = OPPS.filter((o) => o.faixa !== "Baixa");
   const semValor = OPPS.filter((o) => o.faixa === "Baixa");
 
-  const goAuth = () => navigate("/auth");
-  const goProduct = () => navigate("/futebol");
+  // Esta LP recebe o tráfego pago de futebol e, até aqui, o único rastro dela no
+  // PostHog era o `$pageview` automático: quem clicava num CTA e desistia na tela
+  // de cadastro ficava indistinguível de quem nunca teve interesse. `secao` diz
+  // QUAL das cinco chamadas converteu, que é a pergunta que a mídia paga faz.
+  const posthog = usePostHog();
+  const cta = (secao: string, destino: "auth" | "produto") => {
+    posthog?.capture("futebol_lp_cta_click", {
+      product: "futebol",
+      secao,
+      destino,
+      logado: Boolean(user),
+    });
+  };
+
+  // A LP inteira convida a mexer na demonstração ("clica numa oportunidade aí
+  // embaixo"), e esse clique é o único sinal de interesse que existe antes do
+  // cadastro. Dispara uma vez por visita: o que interessa é se a pessoa mexeu,
+  // não quantas vezes.
+  const [demoTocada, setDemoTocada] = useState(false);
+  const abrirDemo = (o: MockOpp) => {
+    setSelectedId(o.id);
+    if (demoTocada) return;
+    setDemoTocada(true);
+    posthog?.capture("futebol_lp_demo_opened", {
+      product: "futebol",
+      mercado: o.market,
+      faixa: o.faixa,
+      score: o.score,
+    });
+  };
+
+  const goAuth = (secao: string) => {
+    cta(secao, "auth");
+    navigate("/auth");
+  };
+  const goProduct = (secao: string) => {
+    cta(secao, "produto");
+    navigate("/futebol");
+  };
 
   const FAQ: FaqItem[] = [
     {
@@ -167,14 +205,14 @@ const FutebolLP = () => {
           <div className="flex items-center gap-2 sm:gap-3">
             <button
               type="button"
-              onClick={() => navigate(user ? "/futebol" : "/auth")}
+              onClick={() => (user ? goProduct("nav") : goAuth("nav"))}
               className="inline-flex items-center h-10 px-3 sm:px-4 rounded-rebrand-md border border-line-2 bg-white text-ink hover:border-forest/40 font-semibold text-sm transition-colors"
             >
               {user ? "Acessar" : "Entrar"}
             </button>
             <button
               type="button"
-              onClick={goAuth}
+              onClick={() => goAuth("nav")}
               className="inline-flex items-center h-10 px-3 sm:px-4 rounded-rebrand-md bg-amber text-white hover:bg-amber-2 font-bold text-sm shadow-sm transition-colors whitespace-nowrap"
             >
               Começar Grátis
@@ -204,7 +242,7 @@ const FutebolLP = () => {
           <div className="flex flex-col sm:flex-row gap-3 sm:items-center">
             <button
               type="button"
-              onClick={goAuth}
+              onClick={() => goAuth("hero")}
               className="inline-flex items-center justify-center gap-2 h-12 px-6 rounded-rebrand-md bg-amber text-white hover:bg-amber-2 font-bold text-[15px] shadow-md transition-colors"
             >
               <PlayCircle className="h-5 w-5 shrink-0" />
@@ -212,7 +250,7 @@ const FutebolLP = () => {
             </button>
             <button
               type="button"
-              onClick={goProduct}
+              onClick={() => goProduct("hero")}
               className="inline-flex items-center justify-center gap-2 h-12 px-6 rounded-rebrand-md bg-white text-forest hover:bg-white/90 font-bold text-[15px] shadow-md transition-colors"
             >
               Espiar sem login
@@ -256,7 +294,7 @@ const FutebolLP = () => {
                     <button
                       key={o.id}
                       type="button"
-                      onClick={() => setSelectedId(o.id)}
+                      onClick={() => abrirDemo(o)}
                       className={`w-full text-left flex items-center gap-2.5 px-4 py-3 border-b border-line transition-colors ${active ? "bg-forest/[0.06]" : "hover:bg-canvas-2"}`}
                     >
                       <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[15px] w-9 h-8 shrink-0 ${faixaBadge(o.faixa)}`}>{o.score}</span>
@@ -285,7 +323,7 @@ const FutebolLP = () => {
                     <button
                       key={o.id}
                       type="button"
-                      onClick={() => setSelectedId(o.id)}
+                      onClick={() => abrirDemo(o)}
                       className={`w-full text-left flex items-center gap-2.5 px-4 py-3 border-b border-line last:border-b-0 opacity-60 transition-colors ${active ? "bg-forest/[0.06]" : "hover:bg-canvas-2"}`}
                     >
                       <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[15px] w-9 h-8 shrink-0 ${faixaBadge(o.faixa)}`}>{o.score}</span>
@@ -378,7 +416,7 @@ const FutebolLP = () => {
         <div className="text-center mt-8 sm:mt-10">
           <button
             type="button"
-            onClick={goProduct}
+            onClick={() => goProduct("produto")}
             className="inline-flex items-center gap-2 h-12 px-8 rounded-rebrand-md bg-amber text-white hover:bg-amber-2 font-bold text-[15px] shadow-md transition-colors"
           >
             <PlayCircle className="h-5 w-5" />
@@ -539,7 +577,7 @@ const FutebolLP = () => {
           <div className="flex flex-col sm:flex-row md:flex-col gap-3 md:min-w-[240px]">
             <button
               type="button"
-              onClick={goAuth}
+              onClick={() => goAuth("final")}
               className="inline-flex items-center justify-center gap-2 h-12 px-8 rounded-rebrand-md bg-amber text-white hover:bg-amber-2 font-bold text-[15px] shadow-md transition-colors"
             >
               <PlayCircle className="h-5 w-5" />
@@ -547,7 +585,7 @@ const FutebolLP = () => {
             </button>
             <button
               type="button"
-              onClick={goProduct}
+              onClick={() => goProduct("final")}
               className="inline-flex items-center justify-center gap-2 h-12 px-8 rounded-rebrand-md border border-line-2 bg-white text-ink hover:border-forest/40 font-bold text-[15px] transition-colors"
             >
               Espiar sem login

--- a/src/pages/FutebolOportunidades.tsx
+++ b/src/pages/FutebolOportunidades.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from 'react';
+import { useMemo, useState, useEffect, useRef } from 'react';
 import { usePostHog } from '@posthog/react';
 import { Link, useNavigate } from 'react-router-dom';
 import { ChevronRight, AlertTriangle } from 'lucide-react';
@@ -67,11 +67,30 @@ function Crest({ teamId, name, size = 20 }: { teamId: number; name: string; size
 const LABEL = 'text-[10px] uppercase tracking-[0.14em] font-bold text-ink-3';
 const GRID = 'grid grid-cols-[56px_64px_1fr_140px_64px_80px_72px_28px] gap-3 items-center';
 
+// Abrir a análise a partir daqui é o passo que separa "chegou no board" de
+// "usou o produto". O evento sai no CLIQUE, e não na tela do jogo, porque só
+// aqui se sabe de onde a pessoa veio; a tela do jogo é alcançável por link
+// direto, alerta do Telegram e home.
+function useAbrirOportunidade(origem: 'board' | 'board_mobile') {
+  const posthog = usePostHog();
+  return (o: OppLike) => {
+    posthog?.capture('futebol_opportunity_opened', {
+      product: 'futebol',
+      origem,
+      fixture_id: o.fixture_id,
+      mercado: o.market,
+      faixa: o.faixa ?? null,
+      score: o.score ?? null,
+    });
+  };
+}
+
 // Linha da tabela (desktop)
 function OppRow({ o, to, muted, locked, result, homeGoals, awayGoals }: {
   o: OppLike; to: string; muted?: boolean; locked?: boolean;
   result?: BetResult | null; homeGoals?: number | null; awayGoals?: number | null;
 }) {
+  const abrir = useAbrirOportunidade('board');
   const pick = pickLabel(o, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
   const showLock = !!locked && !result; // histórico (com resultado) é sempre visível
@@ -80,7 +99,7 @@ function OppRow({ o, to, muted, locked, result, homeGoals, awayGoals }: {
   // chutar faixa (faixaWord de vazio diria "Baixa", que seria falso).
   const badgeCls = o.faixa != null ? faixaBadgeCls(o.faixa) : 'bg-canvas-2 text-ink-3 border border-line';
   return (
-    <Link to={to} className={`${GRID} w-full text-left px-5 py-3 border-t border-line hover:bg-canvas-2 transition ${muted ? 'opacity-60' : ''}`}>
+    <Link to={to} onClick={() => abrir(o)} className={`${GRID} w-full text-left px-5 py-3 border-t border-line hover:bg-canvas-2 transition ${muted ? 'opacity-60' : ''}`}>
       <span className={`inline-flex items-center justify-center rounded-md font-bold tabular-nums text-[16px] w-10 h-9 ${badgeCls}`}>{o.score ?? '—'}</span>
       <span className={`px-1.5 h-5 w-fit inline-flex items-center rounded text-[10px] font-bold uppercase tracking-[0.1em] ${badgeCls}`}>{o.faixa != null ? faixaWord(o.faixa) : '—'}</span>
       <div className="flex items-center gap-2.5 min-w-0">
@@ -117,13 +136,14 @@ function OppMobileCard({ o, to, locked, result, homeGoals, awayGoals, canRegiste
   o: OppLike; to: string; locked?: boolean;
   result?: BetResult | null; homeGoals?: number | null; awayGoals?: number | null; canRegister?: boolean;
 }) {
+  const abrir = useAbrirOportunidade('board_mobile');
   const pick = pickLabel(o, o.home_team_name, o.away_team_name);
   const chance = chancePct(o.prob_justa_fechamento);
   const showLock = !!locked && !result;
   const hasScore = homeGoals != null && awayGoals != null;
   return (
     <div className="w-full rounded-rebrand-md bg-white border border-line overflow-hidden">
-      <Link to={to} className="block w-full text-left p-3.5">
+      <Link to={to} onClick={() => abrir(o)} className="block w-full text-left p-3.5">
         <div className="flex items-start gap-3">
           <div className="flex items-center -space-x-1 shrink-0 pt-0.5">
             <Crest teamId={o.home_team_id} name={o.home_team_name} size={24} />
@@ -488,6 +508,23 @@ export default function FutebolOportunidades() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [isPastDay, comValor, goalsMap, fixtureMap],
   );
+
+  // "Chegou a ver o produto": é o passo que faltava entre o cadastro e o uso, e
+  // sem ele um lead que nunca abriu o board é indistinguível de um bom. Dispara
+  // UMA vez por visita: esta tela remonta a cada troca de dia, faixa, mercado e
+  // competição, e sem a trava viraria uma dúzia de eventos por sessão (foi o que
+  // aconteceu com o `bolao_ranking_viewed` sem guarda em BolaoDetail).
+  const boardViewFired = useRef(false);
+  useEffect(() => {
+    if (boardViewFired.current || isLoading || isDemo) return;
+    boardViewFired.current = true;
+    posthog?.capture('futebol_board_viewed', {
+      product: 'futebol',
+      dia: selectedDay,
+      oportunidades: bestRows.length,
+      acesso: access?.state ?? null,
+    });
+  }, [isLoading, isDemo, selectedDay, bestRows.length, access?.state, posthog]);
 
   // Pick publicado num jogo que o calendário não trouxe é anomalia de catálogo,
   // e some do histórico sem barulho — foi assim que a #323 passou despercebida


### PR DESCRIPTION
## Por quê

A campanha paga de futebol no Meta começou em 08/09 e a LP `/futebol/comecar` não emitia **nenhum** evento PostHog. O rastro de um visitante pago era o `$pageview` e, se ele se cadastrasse, o `signed_up` no `/auth`. Entre um e outro, nada.

Na prática isso deixava três perguntas sem resposta: qual chamada da LP converte, se o cadastro chegou a ver o produto, e quantos registraram palpite. A última era a mais grave: o `insert` em `bets` do módulo de futebol já gravava `channel: 'futebol'` mas **não emitia evento nenhum**, enquanto o mesmo ato pelo Betinho emite `bet_created`. A ação-núcleo do produto era invisível.

## O que entra

Oito pontos de captura, todos com `product: 'futebol'`:

| Evento | Onde | Para quê |
|---|---|---|
| `futebol_lp_cta_click` | `FutebolLP` | `secao` diz qual das cinco chamadas converteu |
| `futebol_lp_demo_opened` | `FutebolLP` | único sinal de interesse antes do cadastro |
| `futebol_board_viewed` | `FutebolOportunidades` | "chegou a ver o produto" |
| `futebol_opportunity_opened` | `FutebolOportunidades` | abriu a análise, com a origem |
| `bet_created` | `RegistrarAposta` | palpite registrado |
| `futebol_checkout_started` | `FutebolAssinar` | abriu o pagamento |
| `futebol_subscribed` | `FutebolAssinar` | assinou |
| `futebol_gate_hit` | `FutebolGate` | esbarrou na parede e reagiu |

## Duas decisões que valem revisão

**Palpite reusa `bet_created` em vez de criar `futebol_bet_registered`.** O plano de julho (`docs/plano-metricas-retencao.md`) reservou o nome próprio, mas `bet_settled` já roda com o esquema de `bet_created` dos dois lados, cliente e servidor. Reusando o nome canônico, o futebol entra nas métricas de liquidação que já existem sem duplicar análise. O que separa os produtos é `product`/`channel`. Se o time preferir o nome do plano, que seja só um dos dois, nunca os dois.

**`futebol_board_viewed` tem trava por `ref`.** A tela remonta a cada troca de dia, faixa, mercado e competição. Sem a trava seriam dez eventos por sessão, que é exatamente o que acontece hoje com o `bolao_ranking_viewed` sem guarda em `BolaoDetail.tsx:118`.

## Ressalvas

- `futebol_subscribed` é contagem de **navegador** e subconta por um motivo conhecido: quem fecha a aba depois de pagar nunca volta para a verificação. A contagem confiável é a do webhook do Stripe, que ainda não emite evento. Até lá, tratar como piso, nunca como receita.
- Nenhum evento carrega origem ou criativo. O `posthog-js` já grava os UTMs da primeira visita como propriedade da pessoa no `identify`, e repetir por evento abriria espaço para divergência.
- Um detalhe fora deste PR: o nome do criativo viaja do Meta num parâmetro `ad`, que não é UTM padrão e por isso o PostHog ignora. Renomear para `utm_term` nos anúncios resolve sem tocar no app.
- `docs/lp-testes-plano.md` afirma que o gateway de pagamento do futebol não está plugado. Está desatualizado: `FutebolAssinar` chama `createCheckoutSession` e confirma com `verifySession`.

## Validação

- `npm run typecheck`: sem erros novos (66 de dívida declarada).
- `npx eslint` nos cinco arquivos: limpo.
- `npm run test:run`: 904 passando. A única falha é `src/seo/gen-route-heads.test.ts`, que lê `dist/index.html` e portanto exige build prévio; não tem relação com estas mudanças.
- Falta validar no staging que uma visita completa gera **um** `futebol_board_viewed`, e não vários.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YMWyZGxwosT5GVZBbdNbf