### PR TITLE
A função do CRM entra no deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -62,5 +62,6 @@ jobs:
           supabase functions deploy ingest-fixtures --no-verify-jwt
           supabase functions deploy notify-weekly-summary --no-verify-jwt
           supabase functions deploy ops-healthcheck --no-verify-jwt
+          supabase functions deploy crm-comportamento
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -62,5 +62,6 @@ jobs:
           supabase functions deploy ingest-fixtures --no-verify-jwt
           supabase functions deploy notify-weekly-summary --no-verify-jwt
           supabase functions deploy ops-healthcheck --no-verify-jwt
+          supabase functions deploy crm-comportamento
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
`crm-comportamento` nasceu com o CRM e ficou fora das duas listas de deploy. Em staging ela subiu à mão; em produção não subiria nunca, e o bloco de comportamento da ficha chamaria uma função que não existe.

Entra sem `--no-verify-jwt` de propósito: ela usa o token de quem chamou para perguntar ao banco se a pessoa é sócia, e sem JWT não há quem responda essa pergunta.

⚠️ Ela depende do segredo `POSTHOG_QUERY_KEY` no projeto. Em produção ele ainda não existe, então mesmo com o deploy o bloco vai responder erro até alguém criar o segredo lá.