### PR TITLE
docs(futebol): de onde vem uma premissa, e o que a medição de escanteios derruba

### DIFF
--- a/docs/futebol-metodologia-de-premissas.md
+++ b/docs/futebol-metodologia-de-premissas.md
@@ -478,136 +478,326 @@ desligou. Mas a causa do desligamento foi diagnosticada e é preço, não premis
 — o board publicava com vantagem média de −2,74%. A capacidade de ordenar jogo
 nunca foi o problema dele.
 
-### Quando o Teste 2 fica possível
+### A varredura: todo insumo da base contra escanteio
 
-No ritmo atual — 61 jogos encerrados por semana nas 13 competições — a régua de
-400 jogos precificados leva **cerca de sete semanas** depois que as odds de
-escanteio entrarem no mart, se a cobertura de escanteio nas casas for parecida
-com a de gols. Sendo quatro casas, é razoável esperar mais.
+Isto é a fase 3 aplicada aos insumos, antes de aplicá-la às premissas. Dezesseis
+colunas de `fact_fixture_stats`, todas point-in-time sobre os dez jogos
+anteriores, contra 5.980 jogos.
 
-Isso define o calendário: catálogo e Teste 1 podem sair agora; peso, não antes
-de novembro.
+| insumo | persistência | prevê o total | prevê o saldo |
+|---|---:|---:|---:|
+| passes certos | 0,900 | −0,029 | 0,256 |
+| passes | 0,894 | −0,031 | 0,257 |
+| posse de bola | 0,825 | −0,007 | **0,271** |
+| gols esperados | 0,781 | 0,014 | **0,280** |
+| chutes de fora | 0,779 | 0,071 | 0,108 |
+| finalização na área | 0,766 | 0,005 | 0,259 |
+| finalizações | 0,752 | 0,045 | 0,242 |
+| chutes ao gol | 0,724 | 0,030 | 0,247 |
+| faltas | 0,710 | −0,012 | −0,061 |
+| chutes para fora | 0,672 | 0,044 | 0,147 |
+| cartões amarelos | 0,651 | 0,013 | −0,074 |
+| bloqueios | 0,618 | 0,033 | 0,178 |
+| **escanteios** | 0,589 | 0,051 | 0,221 |
+| defesas do goleiro | 0,473 | 0,063 | −0,149 |
+| impedimentos | 0,281 | 0,000 | 0,018 |
+
+Duas colunas contam histórias opostas.
+
+**A do total é toda zero.** O melhor preditor do total de escanteios de um jogo é
+chute de fora da área, com 0,071 — menos de 1% da variação explicada. Não é
+escolha ruim de insumo: é que nenhum insumo que temos sabe quantos escanteios um
+jogo vai ter.
+
+**A do saldo funciona, e o escanteio é o oitavo colocado.** Gols esperados e
+posse preveem a supremacia de escanteio melhor do que o próprio histórico de
+escanteio.
+
+Também medido e descartado: **árbitro**. A persistência do árbitro entre a
+primeira e a segunda metade dos jogos dele é 0,128, e o poder preditivo 0,033.
+Não existe árbitro de muito escanteio.
+
+### O que o próprio mercado sabe
+
+Antes de concluir qualquer coisa sobre o total, vale saber contra quem estamos
+competindo.
+
+| | correlação com o resultado | desvio da previsão | desvio do real |
+|---|---:|---:|---:|
+| nossa previsão de escanteios | 0,097 | 0,90 | 3,43 |
+| **a linha do mercado de escanteios** | **0,163** | 0,57 | 3,56 |
+| régua: a linha de gols prevendo gols | 0,266 | 0,36 | 1,69 |
+
+As casas, com tudo que elas têm, chegam a 0,163 — e mexem a linha de escanteio
+entre jogos com desvio de 0,57 contra um resultado que varia 3,56. O mercado
+também trata o total de escanteio como quase constante.
+
+Ou seja, a distância entre nós e o melhor previsor disponível é pequena porque o
+previsível é pouco, para todo mundo. Isso muda o que "faltam dados" significa: não
+é volume do que já temos.
+
+### O que existe e ainda não foi testado
+
+Uma correção de registro: **a coleta de eventos existe.** O
+`fixture_events_extractor` bate no `/fixtures/events`, guarda um registro por
+evento com minuto, time, jogador e tipo, e vira `fact_fixture_events` no
+BigQuery. Não está sincronizado no Postgres.
+
+Escanteio não é evento na API — os tipos são gol, cartão, substituição e VAR —,
+então isso não dá o minuto do escanteio. Mas dá **placar minuto a minuto**, e daí
+sai uma premissa pré-jogo que ninguém testou: **time que costuma estar atrás no
+fim do jogo empurra e força escanteio**. É estrutural, é calculável do histórico,
+e é a única hipótese viva para o mercado de mais e menos.
+
+O que realmente não existe, conferido no `stg_futebol_fixture_statistics`: o
+modelo pivota dezoito tipos, e são exatamente os dezoito que o endpoint devolve.
+Não há descarte como houve nas odds. Cruzamento, entrada no terço final e ataque
+pelo lado não estão nessa fonte.
 
 ---
 
-## 6. A recomendação, e o catálogo inicial
+## 6. A simulação de ROI
 
-### A ordem
+As odds de escanteio também estão no Postgres, sincronizadas, com histórico de
+16/06 em diante. Isto é a fase 6 antecipada — Teste 3 e Teste 4 com um catálogo
+provisório, feito para descobrir a forma do problema, não para fixar peso.
 
-| Ordem | Mercado | Por quê |
-|---|---|---|
-| 1º | **Handicap de escanteios** (56) | melhor insumo (0,619) e melhor separação (29,2pp) da família |
-| 2º | **Total do jogo** (45) | separação fraca, mas é o mercado que o assinante reconhece |
-| 3º | **Escanteios do mandante** (57) | 0,588, e reaproveita o catálogo do total |
-| — | **Escanteios do visitante** (58) | 0,435 raspa o piso da fase 1; entra só se o 57 medir bem |
-| — | **Primeiro tempo** (77) | sem insumo na base; coletar sim, publicar não |
+### A armadilha da ótica, de novo
 
-### Os limiares medidos
+No mercado 56 as casas cotam **"Home −4,5" e "Away −4,5" como par**, com odds
+complementares. A linha é sempre na ótica do mandante, igual ao handicap de gols.
+Liquidar pela leitura literal do rótulo inverte um dos lados e produz número
+plausível e errado.
 
-Tudo abaixo sai da base, não do olho. Times com 15 jogos ou mais no lado.
+A validação que fecha: casa e fora têm que somar exatamente 100% em cada linha.
 
-| Grandeza | Mandante | Visitante |
+| linha | casa cobre | fora cobre |
+|---:|---:|---:|
+| −3,5 | 36,9% | 63,1% |
+| −2,5 | 44,5% | 55,5% |
+| −1,5 | 52,5% | 47,5% |
+| −0,5 | 55,5% | 44,5% |
+| +0,5 | 54,7% | 45,3% |
+| +1,5 | 65,8% | 34,2% |
+
+### O universo
+
+1.464 linhas, 373 jogos liquidados. Meia linha, melhor odd, mínimo de três casas,
+janela t24h, aposta de uma unidade.
+
+### ROI geral e por lado
+
+| | linhas | ROI | erro-padrão |
+|---|---:|---:|---:|
+| mercado inteiro | 1.464 | −3,77% | 0,45 |
+| lado casa | 732 | **+1,09%** | 4,91 |
+| lado fora | 732 | **−8,64%** | 4,71 |
+
+E o corte que carrega o sinal **é o mando, não o favoritismo**:
+
+| | ROI |
+|---|---:|
+| casa favorito | +1,14% |
+| casa azarão | +0,88% |
+| fora favorito | −5,81% |
+| fora azarão | −9,24% |
+
+Dentro de casa, favorito e azarão dão a mesma coisa. É diferente do handicap de
+gols, onde o eixo é o favoritismo, e muda o desenho do catálogo.
+
+### ROI por premissa, dentro do lado
+
+Medir a premissa sem controlar o lado dá tudo positivo em casa e tudo negativo
+fora — é o viés de lado se disfarçando de efeito de premissa, o mesmo que já
+enganou no handicap de gols. Controlado:
+
+| premissa | casa | fora | veredito |
+|---|---:|---:|---|
+| escanteio | **+10,80** | **+11,08** | fica nos dois lados |
+| posse | +15,26 | −10,74 | só casa |
+| gols esperados | +14,84 | −13,75 | só casa |
+| finalização na área | +7,44 | −13,55 | só casa |
+| adversário cede escanteio | −1,58 | −5,47 | sai |
+| decisão (mata-mata) | −1,59 | +7,01 | só fora |
+
+**Histórico de escanteio é a única que sobrevive nos dois lados.** Posse, gols
+esperados e finalização na área rendem forte quando é o mandante que domina e
+viram contra quando é o visitante.
+
+Isto é a diferença entre Teste 1 e Teste 2 em estado puro: na varredura acima,
+posse e gols esperados preveem o saldo melhor que escanteio. Contra o preço, é o
+contrário.
+
+### ROI por faixa de odd
+
+| faixa | linhas | ROI | erro-padrão |
+|---|---:|---:|---:|
+| até 1,60 | 172 | −9,66% | 5,79 |
+| 1,60 a 1,90 | 442 | −7,43% | 4,12 |
+| **1,90 a 2,10** | 474 | **+3,85%** | 4,43 |
+| 2,10 a 2,50 | 290 | −9,82% | 6,64 |
+| 2,50 ou mais | 86 | +5,19% | 14,10 |
+
+Só a faixa de linha equilibrada sobrevive.
+
+### O Score, na régua de produção
+
+A conta é a mesma dos cinco mercados: soma do peso das premissas acesas, dividida
+pelo teto, normalizada em 0 a 100, com faixas em 30 e 60. O que muda entre as duas
+versões abaixo é **de onde vem o peso**.
+
+**Versão A — peso do Teste 1.** A força preditiva medida em 5.980 jogos, sem
+olhar odd nem resultado financeiro. Mesmas quatro premissas nos dois lados: gols
+esperados 14, posse 14, área 13, escanteio 11. Teto 52.
+
+| faixa | linhas | % do board | ROI | erro-padrão |
+|---|---:|---:|---:|---:|
+| Alta | 250 | 17,1% | +1,09% | 9,00 |
+| Média | 179 | 12,2% | −7,07% | 9,76 |
+| Baixa | 1.035 | 70,7% | −4,38% | 3,64 |
+
+Não ordena. E por lado se vê o motivo: casa Alta **+19,02%**, fora Alta
+**−18,34%**. Peso simétrico num mercado assimétrico.
+
+**Versão B — premissas e pesos por lado.** Casa com posse 15, gols esperados 15,
+escanteio 11, área 7, teto 48. Fora só com escanteio 11 e decisão 7, teto 18.
+
+| faixa | linhas | % do board | ROI | erro-padrão |
+|---|---:|---:|---:|---:|
+| Alta | 314 | 21,4% | +7,69% | 7,64 |
+| Média | 242 | 16,5% | +1,24% | 8,27 |
+| Baixa | 908 | 62,0% | −9,07% | 3,99 |
+
+Ordena, e nos dois lados. **Mas é circular**: os pesos saíram desta amostra e o
+ROI foi medido nela. O +7,69% é teto, não estimativa — a medição do próprio time
+já mostrou o tamanho desse viés, com um filtro que rende +8,3% definido na mesma
+amostra e −6,2% definido só na primeira metade.
+
+O que a versão B estabelece com honestidade não é o número, é a **forma**: o
+catálogo tem que ser diferente por lado. A versão A prova isso pelo avesso, ao
+falhar exatamente por ser simétrica — e esse motivo não depende da circularidade.
+
+### A armadilha do teto, que é o defeito mais grave
+
+Na versão B o teto de casa é 48 e o de fora é 18. Para ser faixa Alta basta 60%
+do teto.
+
+| lado | pontos para ser Alta | o que basta |
+|---|---:|---|
+| casa | 28,8 de 48 | duas premissas |
+| fora | 10,8 de 18 | **a de escanteio sozinha, que vale 11** |
+
+O resultado é que **o lado com metade das premissas produz mais faixa Alta que o
+outro**:
+
+| lado | linhas Alta | % do lado | ROI da Alta |
+|---|---:|---:|---:|
+| casa | 142 | 19,4% | **+17,21%** |
+| fora | 172 | 23,5% | **−0,16%** |
+
+São 160 linhas de fora que viram Alta com uma única premissa acesa, e elas dão
+−2,42%.
+
+Cruzando com favorito e azarão, a faixa Alta de fora ainda mistura duas coisas
+opostas:
+
+| | linhas Alta | ROI |
 |---|---:|---:|
-| escanteios a favor, mediana | 5,33 | 4,15 |
-| escanteios sofridos, p75 | 4,90 | 5,94 |
-| saldo de escanteios, p25 | −0,13 | −2,11 |
-| saldo de escanteios, p75 | +2,06 | −0,41 |
+| casa favorito | 142 | +17,21% |
+| fora favorito | 78 | −10,51% |
+| fora azarão | 94 | +8,43% |
 
-Por jogo, sobre 8.125 partidas: finalizações somadas com mediana 25 e p75 29;
-diferença de posse com mediana 16 pontos e p75 28.
+É o mesmo defeito que o handicap de gols já tem — azarão com teto 13 contra 35 do
+favorito — e que a task [A] corrigiu subindo o teto do azarão para 30. Aqui a
+correção é pré-requisito de qualquer publicação: **o teto não pode premiar o lado
+por ter menos premissa.**
 
-### Catálogo do handicap de escanteios (56)
+E o eixo do catálogo provavelmente não é mando sozinho, é mando cruzado com
+favoritismo, em quatro grupos. Casa favorito é o único que anda bem.
 
-**Lado favorito** — o que dá o handicap.
+### A ressalva que vale para tudo nesta seção
 
-| Premissa | Regra | Grupo | Por que este limiar |
-|---|---|---|---|
-| Domina o jogo pelo lado | saldo médio de escanteios ≥ +2,0 | decide | p75 do mandante (+2,06); é o quartil superior de supremacia |
-| Encurrala o adversário | diferença de posse média ≥ 28 pontos | decide | p75 medido da diferença por jogo; a mediana (16) pegaria metade dos jogos |
-| Chuta muito mais | diferença de finalizações médias ≥ 6 | decide | metade do p75 de finalizações somadas, aplicada à diferença; a medir |
-| Adversário cede escanteio fora | escanteios sofridos do visitante ≥ 5,9 | decide | p75 medido de sofridos fora |
-| Joga melhor pelo lado em casa | saldo em casa especificamente ≥ +2,0 | decide | mesmo corte, mas com o histórico recortado pelo mando — o mando persiste 0,588 em casa |
+Todos os erros-padrão acima estão entre 4 e 25 pontos, sobre números de 1 a 19.
+São 373 jogos, e depois de partir por lado e faixa sobram de 30 a 170 linhas por
+célula. **Nada aqui é significativo isoladamente.**
 
-**Lado azarão** — o que recebe o handicap.
+O que sustenta a leitura é a coerência do padrão — a inversão por lado aparece em
+quatro premissas independentes, no score e na faixa, sempre na mesma direção — e
+não o tamanho de nenhum número.
 
-| Premissa | Regra | Grupo | Por que este limiar |
-|---|---|---|---|
-| Segura o jogo fora | saldo médio fora ≥ −0,4 | decide | p75 medido do saldo fora; é o visitante do quartil superior |
-| Não se encolhe fora | posse média fora ≥ 45% | decide | chute, a medir; é o ponto em que o time deixa de ser o encurralado |
-| O favorito não domina pelo lado | saldo médio do adversário ≤ +1,0 | decide | metade do p75; premissa de negação, espelha `favorito_irregular` do handicap de gols |
-
-O lado azarão nasce com três premissas e a porta de contexto pede duas. Isso é
-proposital, e é a correção do defeito conhecido do handicap de gols, onde o
-azarão tem exatamente duas premissas de peso e por aritmética só publica quando
-as duas acendem.
-
-### Catálogo do total de escanteios (45)
-
-**Lado Mais**
-
-| Premissa | Regra | Grupo | Por que este limiar |
-|---|---|---|---|
-| Os dois forçam escanteio | soma das médias a favor ≥ linha + 0,5 | decide | espelha `ataque_combinado` do Gols; margem 0,5 e não zero por causa do encolhimento da seção 5 |
-| Os dois cedem escanteio | soma das médias sofridas ≥ linha + 0,5 | decide | mesma margem, pelo mesmo motivo |
-| Jogo de muita finalização | soma das médias de finalizações ≥ 29 | decide | p75 medido; finalização persiste 0,756, bem mais que escanteio |
-| Assimetria de posse | diferença de posse média ≥ 28 pontos | decide | p75 medido; time encurralado cede escanteio |
-| Mandante que pressiona | escanteios a favor do mandante em casa ≥ 5,3 | decide | mediana medida do mandante; a vantagem de mando em escanteio é 25%, maior que em gols |
-
-**Lado Menos**
-
-| Premissa | Regra | Grupo | Por que este limiar |
-|---|---|---|---|
-| Os dois forçam pouco escanteio | soma das médias a favor ≤ linha − 0,5 | decide | espelho |
-| Os dois cedem pouco escanteio | soma das médias sofridas ≤ linha − 0,5 | decide | espelho |
-| Jogo de pouca finalização | soma das médias de finalizações ≤ 25 | decide | mediana medida |
-| Equilíbrio de posse | diferença de posse média ≤ 5 pontos | decide | chute, a medir; jogo equilibrado tende a menos pressão prolongada |
-
-### Catálogo dos escanteios de um time (57 e 58)
-
-As mesmas quatro, com o histórico recortado pelo mando do time apostado:
-ataque próprio contra a linha, defesa do adversário contra a linha, finalizações
-do time, e posse do time. O corte usa a mediana do lado — 5,33 em casa, 4,15
-fora — em vez da soma dos dois.
-
-Vale registrar que o 58 entra com expectativa pior que todo o resto: a
-persistência do visitante é 0,435, e 0,4 é o piso.
-
-### O que fica deliberadamente fora
-
-**Histórico recente, por R2.** Nada de "três dos últimos cinco acima da linha".
-O achado transversal diz que não ajuda em nenhum mercado, e não há motivo para
-escanteio ser exceção. Se alguém quiser, que entre como controle — para
-confirmar o achado, não para publicar.
-
-**Escanteios por finalização, medido e cortado na fase 3.** A ideia era capturar
-estilo: time que ataca pelo lado converte mais finalização em escanteio. O dado
-diz que a razão quase não varia — p10 0,339, mediana 0,379, p90 0,431, desvio
-0,036. É praticamente uma constante do futebol, não um traço de time. Custaria
-uma linha de dbt para acender quase igual em todo mundo.
-
-Este é o primeiro uso prático da fase 3: a premissa morreu antes de custar
-código, e o motivo ficou escrito.
+Não dá para escrever peso com isto. Dá para escrever hipótese.
 
 ---
 
-## 7. O que este documento não resolve
+## 7. A recomendação
+
+### Por mercado
+
+| id | mercado | decisão |
+|---:|---|---|
+| 56 | Corners Asian Handicap | **primeiro**, e é o único com sinal estrutural |
+| 45 | Corners Over/Under (mais e menos) | **espera um teste**: a premissa de placar no fim |
+| 57 | Home Corners O/U | depois do 56, reaproveita o catálogo |
+| 58 | Away Corners O/U | só se o 57 medir bem — persistência 0,435 raspa o piso |
+| 77 | Total 1º tempo | fora: sem insumo por tempo na base |
+
+O mais e menos não sai por ser ruim de mercado; sai porque nenhum insumo que
+temos prevê o total, e a única hipótese não testada é a de placar minuto a minuto,
+vinda de `fact_fixture_events`. Se ela falhar, o mercado sai de vez. Se acertar,
+ele volta com catálogo próprio.
+
+### O catálogo do handicap, revisado pelo ROI
+
+Quatro grupos, não dois: mando cruzado com favoritismo. O teto tem que ser
+igualado entre os grupos antes de qualquer publicação.
+
+**Casa** — as quatro de domínio mais escanteio:
+
+| premissa | regra | por que este limiar |
+|---|---|---|
+| Domina a posse | diferença de posse média ≥ 5,8 pontos | p75 da distribuição simétrica |
+| Cria mais chance | diferença de gols esperados ≥ 0,34 | p75 |
+| Força mais escanteio | diferença de média de escanteios ≥ 1,0 | p75 |
+| Ataca mais dentro da área | diferença de finalizações na área ≥ 1,6 | p75 |
+
+**Fora** — só o que sobrevive ao controle de lado:
+
+| premissa | regra | por que este limiar |
+|---|---|---|
+| Força mais escanteio | diferença de média de escanteios ≥ 1,0 | p75, e é a única positiva nos dois lados |
+| Decisão | mata-mata | saldo do mandante em mata-mata é +1,95 contra +1,13 |
+
+**Fora do catálogo, medido:** "adversário cede escanteio" dá −1,58 em casa e
+−5,47 fora. Sai antes de custar uma linha de dbt.
+
+**A medir, ainda sem número:** must win de liga — reta final com posição em jogo.
+Precisa de um seed por campeonato dizendo quais posições importam, porque
+`fact_standings_snapshot` traz rank, pontos e jogos mas não traz a fronteira.
+
+---
+
+## 8. O que este documento não resolve
+
 
 **Não recupera o porquê dos 39 limiares originais.** Os dois documentos de origem
 não existem, e não estão no git. O que dá para fazer é o que a seção 4 faz:
 exigir o campo daqui para frente.
 
-**Não mede escanteio contra preço.** Tudo na seção 5 é Teste 1. A conclusão de
-que escanteio é metade do mercado de gols vale para "prever a linha", e pode se
-inverter em "bater o preço" — mercado com quatro casas é outro bicho. Só a fase 5
-responde.
+**Não fixa peso nenhum.** A seção 6 mede, e mede com erro-padrão maior que o
+efeito. Tudo ali é hipótese nomeada, não calibragem. O peso precisa de amostra
+maior e de controle fora da amostra (R5), e nenhuma das duas coisas existe hoje.
 
-**Não decide se escanteio entra.** A decisão de investir nele contra outra
-frente é de produto. O que este documento acrescenta é a ordem: se entrar, entra
-pelo handicap, e o total vem depois com expectativa calibrada para baixo.
+**Não testa a premissa de placar no fim.** É a única hipótese viva para o mercado
+de mais e menos, depende de `fact_fixture_events`, que está no BigQuery e não no
+Postgres. Não foi medida aqui.
 
-**Não confere os limiares contra o preço.** Os cortes da seção 6 saem da
-distribuição da nossa base — p75, mediana, quartil. Isso decide quantas vezes a
-premissa acende, não se ela vale. O que ela vale é a fase 5.
+**Não resolve o must win de liga.** O mata-mata está medido; a reta final com
+posição em jogo precisa de um seed por campeonato com as fronteiras da tabela, e
+esse seed não existe.
+
+**Não iguala os tetos.** A seção 6 mostra que o teto por lado distorce a faixa, e
+diz que precisa ser corrigido. Não diz em quanto — isso é decisão de produto, como
+foi no handicap de gols.
 
 **Não reabre a task [B].** A limpeza do catálogo dos cinco mercados continua
 bloqueada pelos cinco termos declarados nela. Este documento não altera nenhum.
@@ -625,3 +815,5 @@ bloqueada pelos cinco termos declarados nela. Este documento não altera nenhum.
 - `dbt_futebol/docs/adr/0001`, `0004`, `0008`, `0010` — as decisões de método citadas
 - `supabase/migrations/093_futebol_mapa_premissas.sql` — a virada de 01/08
 - `futebol.fact_fixture_stats` e `futebol.fact_fixtures` — as medições da seção 5
+- `futebol.fact_odds_snapshot` no Postgres — as odds de escanteio da simulação da seção 6
+- `scripts/futebol-escanteios-retrato.mjs` — reproduz as medições da seção 5

--- a/docs/futebol-metodologia-de-premissas.md
+++ b/docs/futebol-metodologia-de-premissas.md
@@ -417,6 +417,67 @@ Se o preço já sabe disso, não há produto. E aqui há um motivo real para esp
 que gol não tem: escanteio é cotado por **quatro casas**, contra dezenas em gols.
 Mercado fino erra mais. Mas isso é hipótese até a fase 5, não argumento.
 
+### Escanteio não é um mercado, são cinco
+
+Isto muda a conclusão, e é o motivo de a seção 6 não ser uma lista só. Os cinco
+tipos de aposta que a coleta vai trazer pedem insumos diferentes, e eles não
+valem a mesma coisa:
+
+| id | Mercado | Insumo que ele pede | Persistência do insumo |
+|---:|---|---|---:|
+| 56 | Handicap de escanteios | **saldo** de escanteios do time | **0,619** |
+| 45 | Total do jogo | escanteios a favor e sofridos | 0,589 / 0,546 |
+| 57 | Escanteios do mandante | escanteios a favor, só em casa | 0,588 |
+| 58 | Escanteios do visitante | escanteios a favor, só fora | **0,435** |
+| 77 | Total do primeiro tempo | escanteio por tempo | **não existe** |
+
+Duas coisas saltam.
+
+**O saldo persiste mais que as pontas que o formam.** 0,619 contra 0,589 e
+0,546. Faz sentido: quem domina jogo força escanteio e concede pouco, e as duas
+metades erram na mesma direção quando o time enfrenta um adversário forte. Na
+prática, a supremacia de escanteio é o traço mais estável que este mercado tem.
+
+**O primeiro tempo não tem insumo nenhum.** A base inteira tem uma única coluna
+de escanteio, `fact_fixture_stats.corner_kicks`, e ela é do jogo completo. Não
+há como escrever premissa para o id 77 — ele pode ser coletado, mas não
+modelado, e não deveria ir para a vitrine.
+
+### A separação, mercado a mercado
+
+Quintis da previsão point-in-time, sempre ao lado da régua equivalente em gols.
+
+**Handicap de escanteio** — mandante cobrindo o −0,5:
+
+| Quintil | Supremacia prevista | Saldo real | Mandante cobre |
+|---|---:|---:|---:|
+| 1 | −1,84 | −0,43 | 41,6% |
+| 2 | −0,75 | +0,40 | 47,5% |
+| 3 | −0,05 | +1,28 | 57,1% |
+| 4 | +0,63 | +1,67 | 61,2% |
+| 5 | +1,77 | +2,84 | 70,8% |
+
+A régua, no handicap de gols que já existe: 28,2% no primeiro quintil e 62,6% no
+quinto.
+
+| Mercado | Separação entre o 1º e o 5º quintil | Régua em gols |
+|---|---:|---:|
+| **Handicap de escanteio** | **29,2pp** | 34,4pp |
+| Total de escanteios | 10,3pp | 19,4pp |
+
+**O handicap de escanteio chega a 84% da separação do handicap de gols. O total
+de escanteios chega a 53% da do total de gols.** Dentro da família de escanteio,
+o handicap separa quase três vezes mais que o total.
+
+Isso inverte a ordem óbvia. A intuição manda começar pelo total, que é o mercado
+mais conhecido e o que tem mais casa cotando. O dado manda começar pelo
+handicap.
+
+Uma ressalva honesta: o handicap de gols é justamente o mercado que a gente
+desligou. Mas a causa do desligamento foi diagnosticada e é preço, não premissa
+— o board publicava com vantagem média de −2,74%. A capacidade de ordenar jogo
+nunca foi o problema dele.
+
 ### Quando o Teste 2 fica possível
 
 No ritmo atual — 61 jogos encerrados por semana nas 13 competições — a régua de
@@ -429,44 +490,103 @@ de novembro.
 
 ---
 
-## 6. O catálogo exaustivo proposto para escanteios
+## 6. A recomendação, e o catálogo inicial
 
-Primeira lista, para a fase 2. Todas point-in-time, todas em cima de
-`fact_fixture_stats`, que tem escanteios, finalizações, posse e gols esperados no
-mesmo grão.
+### A ordem
 
-O limiar aqui é **declaradamente provisório** — é o que a fase 3 e a fase 5
-existem para corrigir. O que não é provisório é a família: são todas estruturais,
-seguindo R2.
-
-**Lado Mais escanteios**
-
-| Premissa | Regra provisória | Por que este limiar |
+| Ordem | Mercado | Por quê |
 |---|---|---|
-| Os dois forçam escanteio | soma das médias de escanteios a favor ≥ linha + 0,5 | espelha `ataque_combinado` do Gols, que é a premissa mais bem medida da família |
-| Os dois cedem escanteio | soma das médias de escanteios sofridos ≥ linha + 0,5 | margem 0,5 e não zero, por causa do encolhimento medido na seção 5 |
-| Jogo de muita finalização | soma das médias de finalizações dos dois ≥ mediana da liga | finalização persiste 0,756, mais que escanteio; é o melhor insumo disponível |
-| Time que ataca pelo lado | percentual de escanteios sobre finalizações acima do p75 da liga | proxy de estilo; chute, a medir |
-| Assimetria de posse | diferença de posse média ≥ 15 pontos | time encurralado cede escanteio; chute, a medir |
+| 1º | **Handicap de escanteios** (56) | melhor insumo (0,619) e melhor separação (29,2pp) da família |
+| 2º | **Total do jogo** (45) | separação fraca, mas é o mercado que o assinante reconhece |
+| 3º | **Escanteios do mandante** (57) | 0,588, e reaproveita o catálogo do total |
+| — | **Escanteios do visitante** (58) | 0,435 raspa o piso da fase 1; entra só se o 57 medir bem |
+| — | **Primeiro tempo** (77) | sem insumo na base; coletar sim, publicar não |
 
-**Lado Menos escanteios**
+### Os limiares medidos
 
-| Premissa | Regra provisória | Por que este limiar |
-|---|---|---|
-| Os dois forçam pouco escanteio | soma das médias a favor ≤ linha − 0,5 | espelho |
-| Os dois cedem pouco escanteio | soma das médias sofridas ≤ linha − 0,5 | espelho |
-| Jogo de pouca finalização | soma das médias de finalizações ≤ mediana da liga | espelho |
-| Equilíbrio de posse | diferença de posse média ≤ 5 pontos | jogo equilibrado tende a menos pressão prolongada; chute |
+Tudo abaixo sai da base, não do olho. Times com 15 jogos ou mais no lado.
 
-**Deliberadamente fora, por R2:** qualquer premissa de "últimos cinco jogos acima
-da linha". O achado transversal diz que ela não ajuda em nenhum mercado, e não há
-motivo para escanteio ser exceção. Se alguém quiser incluir, que inclua como
-controle — para confirmar o achado, não para publicar.
+| Grandeza | Mandante | Visitante |
+|---|---:|---:|
+| escanteios a favor, mediana | 5,33 | 4,15 |
+| escanteios sofridos, p75 | 4,90 | 5,94 |
+| saldo de escanteios, p25 | −0,13 | −2,11 |
+| saldo de escanteios, p75 | +2,06 | −0,41 |
 
-**Uma premissa que só escanteio permite:** vantagem de mando. Em escanteio a
-diferença entre casa e fora é proporcionalmente maior que em gols (5,31 contra
-4,23, uma diferença de 25%). Vale testar uma premissa de mando no lado Mais que
-não tem equivalente útil em Gols.
+Por jogo, sobre 8.125 partidas: finalizações somadas com mediana 25 e p75 29;
+diferença de posse com mediana 16 pontos e p75 28.
+
+### Catálogo do handicap de escanteios (56)
+
+**Lado favorito** — o que dá o handicap.
+
+| Premissa | Regra | Grupo | Por que este limiar |
+|---|---|---|---|
+| Domina o jogo pelo lado | saldo médio de escanteios ≥ +2,0 | decide | p75 do mandante (+2,06); é o quartil superior de supremacia |
+| Encurrala o adversário | diferença de posse média ≥ 28 pontos | decide | p75 medido da diferença por jogo; a mediana (16) pegaria metade dos jogos |
+| Chuta muito mais | diferença de finalizações médias ≥ 6 | decide | metade do p75 de finalizações somadas, aplicada à diferença; a medir |
+| Adversário cede escanteio fora | escanteios sofridos do visitante ≥ 5,9 | decide | p75 medido de sofridos fora |
+| Joga melhor pelo lado em casa | saldo em casa especificamente ≥ +2,0 | decide | mesmo corte, mas com o histórico recortado pelo mando — o mando persiste 0,588 em casa |
+
+**Lado azarão** — o que recebe o handicap.
+
+| Premissa | Regra | Grupo | Por que este limiar |
+|---|---|---|---|
+| Segura o jogo fora | saldo médio fora ≥ −0,4 | decide | p75 medido do saldo fora; é o visitante do quartil superior |
+| Não se encolhe fora | posse média fora ≥ 45% | decide | chute, a medir; é o ponto em que o time deixa de ser o encurralado |
+| O favorito não domina pelo lado | saldo médio do adversário ≤ +1,0 | decide | metade do p75; premissa de negação, espelha `favorito_irregular` do handicap de gols |
+
+O lado azarão nasce com três premissas e a porta de contexto pede duas. Isso é
+proposital, e é a correção do defeito conhecido do handicap de gols, onde o
+azarão tem exatamente duas premissas de peso e por aritmética só publica quando
+as duas acendem.
+
+### Catálogo do total de escanteios (45)
+
+**Lado Mais**
+
+| Premissa | Regra | Grupo | Por que este limiar |
+|---|---|---|---|
+| Os dois forçam escanteio | soma das médias a favor ≥ linha + 0,5 | decide | espelha `ataque_combinado` do Gols; margem 0,5 e não zero por causa do encolhimento da seção 5 |
+| Os dois cedem escanteio | soma das médias sofridas ≥ linha + 0,5 | decide | mesma margem, pelo mesmo motivo |
+| Jogo de muita finalização | soma das médias de finalizações ≥ 29 | decide | p75 medido; finalização persiste 0,756, bem mais que escanteio |
+| Assimetria de posse | diferença de posse média ≥ 28 pontos | decide | p75 medido; time encurralado cede escanteio |
+| Mandante que pressiona | escanteios a favor do mandante em casa ≥ 5,3 | decide | mediana medida do mandante; a vantagem de mando em escanteio é 25%, maior que em gols |
+
+**Lado Menos**
+
+| Premissa | Regra | Grupo | Por que este limiar |
+|---|---|---|---|
+| Os dois forçam pouco escanteio | soma das médias a favor ≤ linha − 0,5 | decide | espelho |
+| Os dois cedem pouco escanteio | soma das médias sofridas ≤ linha − 0,5 | decide | espelho |
+| Jogo de pouca finalização | soma das médias de finalizações ≤ 25 | decide | mediana medida |
+| Equilíbrio de posse | diferença de posse média ≤ 5 pontos | decide | chute, a medir; jogo equilibrado tende a menos pressão prolongada |
+
+### Catálogo dos escanteios de um time (57 e 58)
+
+As mesmas quatro, com o histórico recortado pelo mando do time apostado:
+ataque próprio contra a linha, defesa do adversário contra a linha, finalizações
+do time, e posse do time. O corte usa a mediana do lado — 5,33 em casa, 4,15
+fora — em vez da soma dos dois.
+
+Vale registrar que o 58 entra com expectativa pior que todo o resto: a
+persistência do visitante é 0,435, e 0,4 é o piso.
+
+### O que fica deliberadamente fora
+
+**Histórico recente, por R2.** Nada de "três dos últimos cinco acima da linha".
+O achado transversal diz que não ajuda em nenhum mercado, e não há motivo para
+escanteio ser exceção. Se alguém quiser, que entre como controle — para
+confirmar o achado, não para publicar.
+
+**Escanteios por finalização, medido e cortado na fase 3.** A ideia era capturar
+estilo: time que ataca pelo lado converte mais finalização em escanteio. O dado
+diz que a razão quase não varia — p10 0,339, mediana 0,379, p90 0,431, desvio
+0,036. É praticamente uma constante do futebol, não um traço de time. Custaria
+uma linha de dbt para acender quase igual em todo mundo.
+
+Este é o primeiro uso prático da fase 3: a premissa morreu antes de custar
+código, e o motivo ficou escrito.
 
 ---
 
@@ -481,9 +601,13 @@ que escanteio é metade do mercado de gols vale para "prever a linha", e pode se
 inverter em "bater o preço" — mercado com quatro casas é outro bicho. Só a fase 5
 responde.
 
-**Não decide se escanteio entra.** Ele passa a porta da fase 1 na faixa baixa. A
-decisão de investir nele contra outra frente é de produto, e a única coisa que
-este documento acrescenta é que a expectativa deve ser calibrada para baixo.
+**Não decide se escanteio entra.** A decisão de investir nele contra outra
+frente é de produto. O que este documento acrescenta é a ordem: se entrar, entra
+pelo handicap, e o total vem depois com expectativa calibrada para baixo.
+
+**Não confere os limiares contra o preço.** Os cortes da seção 6 saem da
+distribuição da nossa base — p75, mediana, quartil. Isso decide quantas vezes a
+premissa acende, não se ela vale. O que ela vale é a fase 5.
 
 **Não reabre a task [B].** A limpeza do catálogo dos cinco mercados continua
 bloqueada pelos cinco termos declarados nela. Este documento não altera nenhum.

--- a/docs/futebol-metodologia-de-premissas.md
+++ b/docs/futebol-metodologia-de-premissas.md
@@ -1,0 +1,503 @@
+# Como uma premissa nasce, é medida e morre
+
+Este documento responde a uma pergunta de memória — **como a gente definiu as
+premissas de cada mercado?** — e transforma a resposta num procedimento, para
+que o próximo mercado não dependa de ninguém lembrar.
+
+Ele tem duas metades. A primeira reconstrói o que foi feito de fato, com data e
+fonte. A segunda propõe o método para um mercado novo, e o aplica a escanteios.
+
+> Não confundir com os outros dois. `docs/futebol-metodologia.md` é o desenho de
+> um modelo de projeção que nunca foi construído.
+> `docs/futebol-metodologia-por-mercado.md` descreve o que roda hoje, mercado a
+> mercado. Este aqui é sobre **o processo**: de onde vem uma premissa, o que
+> decide o peso dela, e o que a mata.
+
+---
+
+## 0. Por que este documento existe
+
+Três documentos são citados como a origem de tudo, em comentário de código e em
+cabeçalho de migration. **Nenhum dos três jamais esteve neste repositório**, e
+não estão no histórico do git:
+
+| Documento citado | Citado por | O que ele guardava |
+|---|---|---|
+| `docs/futebol-metodologia-premissas.md` | épico do Motor de Score, 19/06/2026 | o playbook: premissas, pesos, limiares, fontes |
+| `docs/futebol-metodologia-benchmark.md` | mesmo épico | a fundamentação: pesquisa de mercado e benchmark |
+| `docs/premissas-recalibragem.md` | migration 093 e o catálogo do front | a revisão de 01/08/2026 que inverteu a ordem do produto |
+
+O que sobreviveu foi a descrição das tasks no ClickUp, as issues do
+analytics-engineering e as ADRs do dbt. É bastante — dá para reconstruir o
+método inteiro —, mas está espalhado em três sistemas e nenhum deles é o
+repositório onde o código mora.
+
+Este documento é a correção disso.
+
+---
+
+## 1. Onde a memória está hoje
+
+Tudo abaixo foi conferido, não lembrado.
+
+| O quê | Onde | Responde |
+|---|---|---|
+| O catálogo original, 39 premissas | ClickUp `86aj4p7b5` e as cinco filhas, 19/06/2026 | regra, limiar, fonte e peso inicial de cada uma |
+| A fórmula do Score original | ClickUp `86aj4p7b5` | como premissa virava nota |
+| A virada de 01/08 | migration `093_futebol_mapa_premissas.sql`, cabeçalho | por que o contexto virou porta e o preço virou filtro |
+| A auditoria point-in-time | ClickUp `wdx6zev64w` (task [0]) | 27 das 39 liam dado posterior ao jogo |
+| O vocabulário dos quatro Testes | `dbt_futebol/CONTEXT.md`, seção Measurement and calibration | qual medição pode justificar um peso |
+| A remedição na base limpa | ClickUp `wdx6zevfgf` e issues #3 a #10 | o ganho medido de cada premissa, mercado a mercado |
+| O ranking medido das 39 | ClickUp `wdx6zev64y` (task [B]) | quais funcionam, quais perdem, quais eram artefato |
+| Como o histórico entra | issues #49 a #59 (task [F]) | escopo e recorte do passado de cada time |
+| As decisões de método | `dbt_futebol/docs/adr/0001` a `0015` | por que cada regra é o que é |
+
+**A lacuna que sobra é uma só, e é justamente a que você não lembra:** a regra e
+o limiar de cada uma das 39 premissas estão registrados, mas **o motivo de cada
+limiar não está em lugar nenhum**. Por que `supremacia` pede oito posições de
+diferença e não seis. Por que `defesa_fora_solida` corta em 1,1 gol sofrido.
+Isso vivia no playbook e no benchmark, e os dois sumiram.
+
+Na prática isso importa menos do que parece, porque a medição depois passou por
+cima: hoje o que decide o peso é o ganho medido, não o argumento original. Mas
+importa para o mercado novo, e é o que a seção 4 conserta.
+
+---
+
+## 2. O que foi feito de fato
+
+Cinco movimentos, em três meses.
+
+### 2.1 O catálogo exaustivo, escrito à mão (19/06/2026)
+
+Você lembrou certo: a origem foi **exaustiva de propósito**. Cinco tasks, uma
+por mercado, com 39 premissas no total, cada uma com quatro campos — nome, regra
+com limiar, tabela de origem e peso.
+
+O peso inicial **foi decidido no olho**, e a task diz isso com todas as letras:
+
+> Pesos/thresholds são ponto de partida → calibrar depois com RPS/calibração +
+> CLV (quando o t15m acumular).
+
+A distribuição de pesos também seguia uma intuição simples: força estrutural do
+time valia 12, sinal indireto valia 8, histórico recente valia 6, desempate
+valia 4. O Handicap, por exemplo, nasceu com `supremacia` 12, `tende_golear` 10,
+`adversario_fragil_fora` 8, `mando_forte` 6, `sem_rodizio` 4.
+
+Junto vieram três coisas que hoje não existem mais: o preço somava até 30 pontos
+na nota, a corroboração somava 15, e a publicação exigia vantagem positiva.
+
+### 2.2 A virada: o preço sai da porta (01/08/2026)
+
+A revisão comparou quatro regras de publicação em backtest. A regra antiga —
+vantagem maior que zero — foi a única que perdeu dinheiro: R$ 100 viraram R$ 85
+em 393 apostas, contra R$ 110 de "duas premissas, sem olhar preço" em 1.087
+apostas.
+
+O produto inverteu: o contexto virou a porta, o preço virou filtro de sanidade.
+
+### 2.3 A auditoria que matou o número (task [0])
+
+Antes de reescrever qualquer peso, alguém perguntou se as premissas liam só
+informação anterior ao jogo. **27 das 39 não liam.** A correção point-in-time
+levou o ROI de +9,7% para −7,6%.
+
+Esse é o achado mais caro do projeto inteiro, e é a razão de tudo que veio
+depois ser tão cauteloso. O sinal que sustentava a revisão não existia.
+
+### 2.4 Os quatro Testes, e qual deles vale (task [0.1])
+
+Aqui o método virou vocabulário. Cada Teste responde uma pergunta diferente, e
+**só um deles pode justificar um peso**:
+
+| Teste | Pergunta | Precisa de odds? |
+|---|---|---|
+| **Teste 1** | a premissa acerta mais que a média das linhas parecidas? | não |
+| **Teste 2** | a premissa acerta mais do que o preço já dizia? | sim |
+| **Teste 3** | uma regra de contagem seleciona aposta? | sim |
+| **Teste 4** | a nota ordena aposta? | sim |
+
+Teste 1 mede se a premissa **prevê a linha**. Teste 2 mede se ela **bate o
+preço**. A diferença é a diferença entre saber futebol e ganhar dinheiro: uma
+premissa pode acertar 70% e ser inútil, se a odd já pagava como 70%.
+
+Daí saiu a regra de peso, com encolhimento por amostra:
+
+```
+peso = max(ganho_teste2, 0) × n / (n + k)        k = 50
+```
+
+O encolhimento não é preferência estética. É defesa contra o modo de falha
+medido na task [0]: **amostra curta fabrica sinal**. Os +9,7% vinham inteiros de
+competições de mata-mata, onde os times tinham de 0,8 a 2,4 jogos de histórico.
+Peso proporcional ao ganho cru premiaria exatamente essas.
+
+### 2.5 O achado transversal, e o que ele fez com metade do catálogo
+
+Medidas todas as 39 na base limpa, apareceu um padrão que atravessa os cinco
+mercados:
+
+> **Premissa de histórico recente não ajuda em nenhum mercado.** Histórico over,
+> histórico seco, histórico de ambos marcam, confronto direto, invicto recente.
+> O que ajuda é sempre característica estrutural: como o time defende, como ele
+> ataca, quanto ele descansou.
+
+A explicação é econômica, não estatística: histórico recente é o dado mais fácil
+de olhar, então a casa de aposta já olhou antes da gente. Ele está no preço.
+
+Foi isso que criou os dois grupos que o produto usa hoje — **decide** e
+**preço** — e que zerou metade do catálogo.
+
+Vale ver o placar do plano original contra o medido, só no mercado de Gols,
+porque ele é a melhor defesa que existe contra escrever peso na mão:
+
+| Premissa | O plano mandava | O medido disse |
+|---|---|---|
+| ambos_vazam | zerar | −3,7 · acertou |
+| ritmo_alto | zerar | −5,3 · acertou |
+| linha_subindo | zerar | −1,5 · acertou |
+| historico_over | zerar | −0,5 · acertou |
+| linha_descendo | zerar | +3,1 · **errou, ela funciona** |
+| defesas_vazaveis | subir de 10 para 12 | −5,0 · **errou, ela perde** |
+| xg_combinado_alto | subir de 8 para 10 | −2,6 · **errou, ela perde** |
+| ataque_combinado | manter em 12 | −3,6 · **errou, ela perde** |
+| clean_sheets_altos | manter, "melhor sinal" | +17,1 sem piso, −1,7 com piso · **era artefato** |
+
+Quatro acertos e cinco erros, num mercado só.
+
+---
+
+## 3. As sete regras que sobreviveram
+
+Isto é a metodologia. Tudo abaixo foi pago com erro.
+
+**R1 — Só "bate o preço" justifica peso.** Teste 1 é peneira barata e serve para
+descartar cedo. Ele nunca vira peso. (ADR 0001)
+
+**R2 — Estrutural ganha de histórico.** Antes de propor uma premissa, pergunte
+se ela é característica do time ou notícia da semana. Notícia da semana já está
+na odd.
+
+**R3 — Amostra curta fabrica sinal.** Todo ganho vem com o `n` ao lado e com o
+percentual de linhas cujos times tinham menos de cinco jogos de histórico. Peso
+encolhe com `n / (n + 50)`.
+
+**R4 — Point-in-time ou não é medição.** Qualquer agregado do time é reconstruído
+só com partidas que começaram antes do jogo avaliado.
+
+**R5 — Peso escrito na mesma amostra em que foi medido é overfit.** O Mateus
+mediu o tamanho disso: o filtro "exigir ao menos uma premissa forte" rende +8,3%
+com "forte" definido na própria amostra e −6,2% com "forte" definido só na
+primeira metade. **14,5 pontos de viés puro.** Reescrever peso exige controle
+fora da amostra.
+
+**R6 — O número tem que voltar igual.** Média é `SAFE_DIVIDE(SUM, COUNT)`, nunca
+`AVG` — o BigQuery paraleliza e a última casa decimal muda entre execuções. Uma
+premissa que compara média contra limiar muda a própria contagem entre builds do
+mesmo código.
+
+**R7 — O nome da premissa tem que dizer o que a regra faz.** "Raramente perde
+por dois ou mais" enunciava uma condição de aposta que só vale em duas das sete
+linhas do handicap. O cálculo estava certo; a frase mentia. Toda premissa nova
+passa por essa leitura antes de ir para a tela.
+
+---
+
+## 4. O método proposto para um mercado novo
+
+Sete fases, cada uma com uma porta explícita. A porta é o que faltou da primeira
+vez: em 19/06 o catálogo foi direto do papel para o código, e a primeira medição
+honesta só veio seis semanas depois.
+
+### Fase 0 — Viabilidade de dado
+
+Antes de pensar em premissa, três perguntas com resposta numérica:
+
+1. **Temos o resultado?** A estatística que liquida a aposta existe na base, por
+   jogo, e com que cobertura por competição.
+2. **Temos o insumo?** As colunas que alimentariam as premissas existem com a
+   mesma cobertura.
+3. **Temos ou teremos preço?** Sem odds não há Teste 2, e sem Teste 2 não há
+   peso. Se o preço ainda não existe, a fase 5 tem data, não pressa.
+
+**Porta:** cobertura abaixo de 90% nas competições da vitrine mata o mercado ou
+reduz o escopo dele a quem tem dado.
+
+### Fase 1 — O retrato do mercado, antes de qualquer premissa
+
+Quatro medições que decidem se vale a pena, e que custam um dia:
+
+| Medição | O que responde |
+|---|---|
+| Média, desvio e percentis do total por jogo | onde as linhas vão cair |
+| Dispersão entre times | quanto o time explica |
+| **Persistência** (metade 1 contra metade 2 dos jogos do time) | isso é traço do time ou é ruído? |
+| Separação por faixa prevista, point-in-time | o quanto dá para ordenar jogo |
+
+A persistência é a que manda. Se o que o time faz na primeira metade da
+temporada não prevê o que ele faz na segunda, **não existe premissa estrutural
+possível** e o mercado não é para a gente.
+
+**Porta:** persistência abaixo de 0,4 encerra o assunto. Entre 0,4 e 0,6, segue
+com expectativa baixa. A régua está na seção 5.
+
+### Fase 2 — O catálogo exaustivo
+
+Aqui sim, escrever muita premissa de propósito, como foi feito em 19/06. Quatro
+campos obrigatórios por premissa, e agora **um quinto**:
+
+| Campo | Obrigatório desde |
+|---|---|
+| nome que descreve a regra (R7) | sempre |
+| regra com limiar | sempre |
+| tabela e coluna de origem | sempre |
+| grupo esperado: decide ou preço (R2) | **novo** |
+| **por que este limiar** | **novo** |
+
+O quinto campo é a lição da seção 0. Uma linha basta: "a mediana da liga", "o
+p75 da distribuição", "chute, a ser medido". Chute declarado é honesto; chute
+esquecido vira folclore.
+
+**Porta:** nenhuma. Exaustividade é barata nesta fase.
+
+### Fase 3 — Teste 1, a peneira barata
+
+Roda sem odds, sobre o histórico inteiro, point-in-time. Corta o que não prevê
+nem a própria linha.
+
+**Porta:** premissa que não bate a média das linhas comparáveis sai do catálogo
+antes de custar uma linha de dbt.
+
+### Fase 4 — A janela de odds
+
+O mercado entra no mart, o preço começa a acumular. A janela é **fixada antes de
+olhar resultado** (ADR 0004: uma observação por linha; três preços do mesmo
+palpite são liquidados pelo mesmo placar e não multiplicam amostra).
+
+**Porta:** a janela tem que ter tamanho declarado antes de começar. A régua que
+a task [B] usa é 400 jogos encerrados e precificados, 300 deles acima do piso de
+cinco jogos de histórico, e zero Copa do Mundo.
+
+### Fase 5 — Teste 2 e o peso
+
+A tabela premissa a premissa, com as colunas que a [0.1] fixou:
+
+```
+Mercado | Premissa | n | benchmark de preço | A odd dava | Aconteceu | Diferença
+```
+
+O benchmark tem que estar declarado por mercado, porque a Pinnacle não cota
+tudo. Escanteios vão cair em consenso, que é o grau mais fraco — e isso entra na
+tabela como coluna, não como rodapé.
+
+Peso sai de `max(ganho, 0) × n / (n + 50)`, com controle fora da amostra (R5).
+
+**Porta:** premissa com ganho negativo ou com `n` pequeno demais nasce com peso
+zero. Peso zero não é morte: ela continua sendo calculada e continua aparecendo
+como leitura, só não abre porta.
+
+### Fase 6 — Teste 3 e Teste 4, a porta de publicação
+
+Teste 3 diz se contar premissa seleciona aposta. Teste 4 diz se a nota ordena. O
+segundo é a pergunta de produto; o primeiro nunca a fez.
+
+**Porta:** se o ROI não sobe com a nota, o mercado publica por contagem simples
+ou não publica.
+
+### Fase 7 — Publicação
+
+Mercado entra na vitrine. A partir daqui, o ciclo é o mesmo dos outros cinco:
+remedição periódica, e peso que não sobrevive vira zero.
+
+---
+
+## 5. O retrato do mercado de escanteios
+
+Medido em 10/09/2026 sobre `futebol.fact_fixture_stats`, jogos encerrados.
+Reproduz a fase 1 do método acima.
+
+Tudo abaixo sai de `scripts/futebol-escanteios-retrato.mjs`, que está no
+repositório justamente pela lição da seção 0 — a rodada de medição anterior
+ficou num diretório temporário do sistema e só é retomável hoje por sorte.
+
+### Cobertura (fase 0)
+
+8.125 jogos com escanteio registrado desde 07/02/2024, 481 times, 13
+competições. Nos jogos encerrados de 2026:
+
+| Competição | Cobertura | Competição | Cobertura |
+|---|---:|---|---:|
+| brasileirao | 100% | ligue_1 | 100% |
+| la_liga | 100% | bundesliga | 100% |
+| serie_a_ita | 100% | sudamericana | 100% |
+| premier_league | 100% | libertadores | 100% |
+| primeira_liga | 99,5% | copa_mundo | 100% |
+| serie_b | 98,9% | champions_league | **72,7%** |
+| copa_do_brasil | **65,8%** | | |
+
+Onze das treze passam a porta. As duas que não passam são as mesmas que já são
+problema de amostra curta em todo o resto do produto.
+
+### O total por jogo
+
+Média 9,72 · desvio 3,44 · mediana 9 · p10 5 · p90 14. Mandante 5,31, visitante
+4,23 — a vantagem de mando em escanteio é proporcionalmente **maior** que em
+gols.
+
+Isso coloca as linhas de mercado em torno de 8,5 a 10,5, que é exatamente onde
+as casas cotam.
+
+### Dispersão entre times
+
+Com pelo menos 15 jogos no lado, o desvio entre médias de time é 1,00 em casa e
+0,69 fora, contra um desvio de 3,44 dentro do jogo. Ou seja: **a identidade do
+time explica pouco do que acontece num jogo específico.** Isso não é defeito de
+escanteio — gols se comportam igual.
+
+### Persistência — a medição que decide
+
+Metade 1 dos jogos de cada time contra a metade 2, times com 30 jogos ou mais:
+
+| Estatística | A favor | Sofridos |
+|---|---:|---:|
+| posse de bola | 0,822 | 0,822 |
+| gols esperados | 0,781 | 0,722 |
+| finalizações | 0,756 | 0,676 |
+| **gols** | **0,748** | **0,625** |
+| faltas | 0,705 | 0,668 |
+| cartões amarelos | 0,647 | 0,538 |
+| **escanteios** | **0,589** | **0,546** |
+
+**Escanteio é um traço menos estável do time do que gol.** Isso contraria a
+intuição comum — escanteio parece estatística de volume, e estatística de volume
+costuma ser mais estável. Não é o caso aqui: ele fica na parte de baixo da
+tabela, acima só de cartão.
+
+Passa a porta da fase 1 (0,589 está acima de 0,4), mas passa na faixa de
+expectativa baixa.
+
+### Separação, point-in-time
+
+Média dos últimos 10 jogos de cada time, só com partidas anteriores, somando
+ataque de um com defesa do outro. Quintis da previsão, 5.980 jogos:
+
+| Quintil | Previsto | Real | Acima de 9,5 |
+|---|---:|---:|---:|
+| 1 | 8,47 | 9,26 | 45,1% |
+| 2 | 9,20 | 9,50 | 48,2% |
+| 3 | 9,66 | 9,65 | 48,5% |
+| 4 | 10,15 | 9,95 | 53,7% |
+| 5 | 10,98 | 10,24 | 55,4% |
+
+A mesma conta, no mercado de gols, para servir de régua:
+
+| Quintil | Previsto | Real | Acima de 2,5 |
+|---|---:|---:|---:|
+| 1 | 2,02 | 2,31 | 41,4% |
+| 2 | 2,36 | 2,47 | 44,4% |
+| 3 | 2,61 | 2,62 | 50,0% |
+| 4 | 2,87 | 2,76 | 52,6% |
+| 5 | 3,34 | 3,10 | 60,8% |
+
+**Escanteio separa 10,3 pontos entre o primeiro e o último quintil. Gol separa
+19,4.** Pela nossa própria régua, escanteio é cerca de metade do mercado de gols
+em capacidade de ordenar jogo.
+
+Duas leituras importam:
+
+**A previsão encolhe para a média nos dois mercados, e mais em escanteio.** O
+quintil 5 previu 10,98 e saiu 10,24; o quintil 1 previu 8,47 e saiu 9,26. A
+média do time exagera nas pontas. Qualquer premissa que compare soma de médias
+contra a linha crua vai acender demais nos extremos — que é, aliás, o defeito da
+premissa `defesas_vazaveis` do mercado de Gols, a única com margem zero e uma
+das que mediram negativo.
+
+**Nada disso é Teste 2.** Tudo acima é Teste 1: escanteio prevê a própria linha.
+Se o preço já sabe disso, não há produto. E aqui há um motivo real para esperança
+que gol não tem: escanteio é cotado por **quatro casas**, contra dezenas em gols.
+Mercado fino erra mais. Mas isso é hipótese até a fase 5, não argumento.
+
+### Quando o Teste 2 fica possível
+
+No ritmo atual — 61 jogos encerrados por semana nas 13 competições — a régua de
+400 jogos precificados leva **cerca de sete semanas** depois que as odds de
+escanteio entrarem no mart, se a cobertura de escanteio nas casas for parecida
+com a de gols. Sendo quatro casas, é razoável esperar mais.
+
+Isso define o calendário: catálogo e Teste 1 podem sair agora; peso, não antes
+de novembro.
+
+---
+
+## 6. O catálogo exaustivo proposto para escanteios
+
+Primeira lista, para a fase 2. Todas point-in-time, todas em cima de
+`fact_fixture_stats`, que tem escanteios, finalizações, posse e gols esperados no
+mesmo grão.
+
+O limiar aqui é **declaradamente provisório** — é o que a fase 3 e a fase 5
+existem para corrigir. O que não é provisório é a família: são todas estruturais,
+seguindo R2.
+
+**Lado Mais escanteios**
+
+| Premissa | Regra provisória | Por que este limiar |
+|---|---|---|
+| Os dois forçam escanteio | soma das médias de escanteios a favor ≥ linha + 0,5 | espelha `ataque_combinado` do Gols, que é a premissa mais bem medida da família |
+| Os dois cedem escanteio | soma das médias de escanteios sofridos ≥ linha + 0,5 | margem 0,5 e não zero, por causa do encolhimento medido na seção 5 |
+| Jogo de muita finalização | soma das médias de finalizações dos dois ≥ mediana da liga | finalização persiste 0,756, mais que escanteio; é o melhor insumo disponível |
+| Time que ataca pelo lado | percentual de escanteios sobre finalizações acima do p75 da liga | proxy de estilo; chute, a medir |
+| Assimetria de posse | diferença de posse média ≥ 15 pontos | time encurralado cede escanteio; chute, a medir |
+
+**Lado Menos escanteios**
+
+| Premissa | Regra provisória | Por que este limiar |
+|---|---|---|
+| Os dois forçam pouco escanteio | soma das médias a favor ≤ linha − 0,5 | espelho |
+| Os dois cedem pouco escanteio | soma das médias sofridas ≤ linha − 0,5 | espelho |
+| Jogo de pouca finalização | soma das médias de finalizações ≤ mediana da liga | espelho |
+| Equilíbrio de posse | diferença de posse média ≤ 5 pontos | jogo equilibrado tende a menos pressão prolongada; chute |
+
+**Deliberadamente fora, por R2:** qualquer premissa de "últimos cinco jogos acima
+da linha". O achado transversal diz que ela não ajuda em nenhum mercado, e não há
+motivo para escanteio ser exceção. Se alguém quiser incluir, que inclua como
+controle — para confirmar o achado, não para publicar.
+
+**Uma premissa que só escanteio permite:** vantagem de mando. Em escanteio a
+diferença entre casa e fora é proporcionalmente maior que em gols (5,31 contra
+4,23, uma diferença de 25%). Vale testar uma premissa de mando no lado Mais que
+não tem equivalente útil em Gols.
+
+---
+
+## 7. O que este documento não resolve
+
+**Não recupera o porquê dos 39 limiares originais.** Os dois documentos de origem
+não existem, e não estão no git. O que dá para fazer é o que a seção 4 faz:
+exigir o campo daqui para frente.
+
+**Não mede escanteio contra preço.** Tudo na seção 5 é Teste 1. A conclusão de
+que escanteio é metade do mercado de gols vale para "prever a linha", e pode se
+inverter em "bater o preço" — mercado com quatro casas é outro bicho. Só a fase 5
+responde.
+
+**Não decide se escanteio entra.** Ele passa a porta da fase 1 na faixa baixa. A
+decisão de investir nele contra outra frente é de produto, e a única coisa que
+este documento acrescenta é que a expectativa deve ser calibrada para baixo.
+
+**Não reabre a task [B].** A limpeza do catálogo dos cinco mercados continua
+bloqueada pelos cinco termos declarados nela. Este documento não altera nenhum.
+
+---
+
+## Fontes
+
+- ClickUp `86aj4p7b5` e as cinco tasks filhas — o catálogo original, 19/06/2026
+- ClickUp `wdx6zev64w` — a auditoria point-in-time
+- ClickUp `wdx6zevfgf` e issues tech-lamjav/analytics-engineering #3 a #10 — a remedição
+- ClickUp `wdx6zev64y` — o ranking medido das 39 premissas
+- issues #49 a #59 — como o histórico entra nas premissas
+- `dbt_futebol/CONTEXT.md`, seção Measurement and calibration — o vocabulário dos Testes
+- `dbt_futebol/docs/adr/0001`, `0004`, `0008`, `0010` — as decisões de método citadas
+- `supabase/migrations/093_futebol_mapa_premissas.sql` — a virada de 01/08
+- `futebol.fact_fixture_stats` e `futebol.fact_fixtures` — as medições da seção 5

--- a/docs/futebol-metodologia-por-mercado.md
+++ b/docs/futebol-metodologia-por-mercado.md
@@ -1,0 +1,423 @@
+# Metodologia do futebol, mercado por mercado
+
+Este documento descreve **o que roda hoje**: como uma linha de aposta é avaliada,
+o que faz uma premissa acender, quanto cada uma pesa, e o que precisa acontecer
+para virar oportunidade publicada.
+
+Ele foi escrito lendo o código, não de memória. Cada afirmação aponta para onde
+mora.
+
+> ⚠️ Não confundir com `docs/futebol-metodologia.md`. Aquele é o **desenho de uma
+> metodologia futura** (modelo de projeção próprio, lambda por time, matriz de
+> placar, Dixon-Coles). Ele nunca foi construído além de um esboço, e nada do que
+> está lá roda em produção. O que roda é o que está aqui.
+
+---
+
+## 1. O vocabulário mínimo
+
+Os termos abaixo estão definidos em `CONTEXT.md` e são usados com precisão neste
+documento.
+
+| Termo | O que é |
+|---|---|
+| **Linha analisada** | Uma linha para a qual o modelo calcula premissas, mesmo sem nenhuma casa ter cotado |
+| **Linha cotada** | Linha analisada que teve ao menos uma odd coletada |
+| **Candidata** | Linha cotada que passou pelo funil, aprovada ou não |
+| **Oportunidade** | Candidata aprovada pelas regras de publicação |
+| **Premissa** | Uma característica do jogo que o modelo testa |
+| **Critério** | A comparação que decide se a premissa acende: um insumo, um corte e um sentido |
+| **Insumo** | O número que o critério compara |
+| **Corte** | O limiar contra o qual o insumo é comparado |
+| **Premissa acesa** | Premissa cujo insumo cruzou o corte |
+| **Board** | Tudo que o backend publica |
+| **Vitrine** | O recorte do board que o assinante de fato vê |
+
+Uma coisa que confunde e vale repetir: **"contra" não significa evidência do lado
+oposto.** É uma premissa do *mesmo* lado da aposta que não atingiu o corte. Numa
+saída de Menos de 3,25 gols, uma premissa "contra" continua sendo uma premissa de
+Under. O modelo só sabe dizer "acendeu" e "não acendeu"; o segundo grupo é
+ausência, não oposição.
+
+---
+
+## 2. A virada de metodologia que explica o resto
+
+Em 01/08/2026 a metodologia foi revista, e a conclusão inverteu a ordem do
+produto. Está registrada no cabeçalho da migration `093_futebol_mapa_premissas.sql`:
+
+> A porta de publicação passa a ser o **contexto** (2 ou mais premissas acesas) e
+> o preço vira filtro de sanidade. A regra antiga (vantagem maior que zero) é a
+> única das quatro testadas que perde dinheiro: R$ 100 viraram R$ 85 em 393
+> apostas, contra R$ 110 de "2 premissas, sem olhar preço" em 1.087 apostas.
+
+Duas consequências que atravessam tudo:
+
+**O preço saiu da nota.** Desde a migration 112 (29/08/2026), o Score não soma
+mais preço, corroboração nem penalidade de odd. Ele expressa só quanto do
+contexto favorável está presente. A odd, a vantagem e o número de casas continuam
+publicados como informação e continuam servindo de porta de segurança, mas não
+compõem a nota nem destravam a publicação.
+
+**Premissa de histórico recente não ajuda em nenhum mercado.** Foi o achado
+transversal da revisão, e é o motivo de metade das premissas valerem zero ou
+quase: histórico over, histórico seco, histórico de ambos marcam, confronto
+direto e invicto recente são o dado mais fácil de olhar, então a casa de aposta
+já olhou antes da gente. O que ajuda é sempre característica estrutural do time:
+como ele defende, como ele ataca, quanto ele descansou.
+
+Daí os dois grupos em que toda premissa cai:
+
+- **decide** — característica estrutural, peso maior que zero
+- **preço** — o mercado já cobra, peso zero ou quase
+
+---
+
+## 3. Como uma linha vira oportunidade
+
+```
+   linha analisada              todas as linhas de todos os mercados de um jogo
+          │                     (premissas cobrem TODOS os jogos, inclusive futuros)
+          │
+          ▼  chega odd (só a partir de T−24h)
+   linha cotada
+          │
+          ▼  porta de contexto: 2+ premissas acesas do lado da saída,
+          │  contando só as de peso > 0
+   candidata aprovada
+          │
+          ▼  filtros de sanidade de preço (faixa de odd, número de casas)
+   oportunidade  ──── publicada no board
+          │
+          ▼  o mercado está na vitrine?
+   aparece na tela e vai para o Telegram
+```
+
+**A porta de contexto** é `PORTA_PREMISSAS = 2`, em `src/utils/futebol-premissas.ts`.
+Contam apenas as premissas que sobreviveram à recalibragem daquele mercado, ou
+seja, peso maior que zero. O motivo está escrito no código: contar as antigas
+deixaria a porta aberta justamente pelas premissas que foram cortadas por
+atrapalhar.
+
+**Odds só existem a partir de 24 horas antes do jogo.** As premissas, ao
+contrário, cobrem todos os jogos do mart, incluindo os futuros. Por isso o mapa
+de premissas é o único conteúdo analítico que existe para um jogo de amanhã, e
+por isso a tela de um jogo distante mostra leitura sem mostrar aposta.
+
+### O Score e as faixas
+
+O Score é calculado no mart (BigQuery) e chega pronto. O frontend só rotula.
+
+| Faixa | Corte na escala atual (`contexto_v1`) |
+|---|---|
+| Alta | 60 ou mais |
+| Média | 30 ou mais |
+| Baixa | abaixo de 30 |
+
+Os cortes eram 25 e 55 e viraram 30 e 60 em 01/09/2026, por decisão de produto e
+não por leitura de evidência. O estudo que os mediu concluiu que **nenhum par da
+grade discrimina** de verdade. O que o 30/60 comprou: a faixa Alta deixou de ser
+a segunda melhor e passou a ser a melhor, e o board padrão encolheu de 63,5% para
+52,8% do total. O que ele não consertou: a faixa Média continua sendo o fundo do
+poço. Está escrito em `src/utils/futebol-score.ts`, e vale ler literalmente —
+**faixa é rótulo, não porta.**
+
+Existe uma escala anterior, `legacy`, com cortes em 40 e 60, que somava preço.
+Registros históricos gravados antes da virada permanecem nela e não são
+recalculados. Qualquer medição que junte as duas escalas está somando maçã com
+laranja.
+
+---
+
+## 4. Os cinco mercados
+
+Em todas as tabelas: **peso** é o da recalibragem, e **grupo** é `decide` ou
+`preço` conforme a seção 2.
+
+### 4.1 Gols (mais ou menos) — `goals_over_under`
+
+A aposta é no total de gols da partida contra uma linha. É o mercado mais
+desenvolvido: é o único cujos critérios estão transcritos no repositório.
+
+**Lado Over** (teto 34 pontos, 3 premissas contam para a porta)
+
+| Premissa | Peso | Grupo | Critério |
+|---|---:|---|---|
+| Defesas frágeis dos dois lados | 12 | decide | Soma das médias de gols sofridos ≥ linha (margem zero) |
+| Os dois somam muitos gols | 12 | decide | Soma das médias de gols marcados ≥ linha + 0,5 |
+| Os dois criam muita chance de gol | 10 | decide | Soma dos gols esperados ≥ linha + 0,3 |
+| Os dois sofrem gol quase todo jogo | 0 | preço | Cada time com menos de 35% de jogos sem sofrer gol (comparação estrita) |
+| Jogo de ritmo alto | 0 | preço | não transcrito |
+| Histórico de jogo com muitos gols | 0 | preço | Cada time com 3+ dos últimos 5 jogos acima da linha |
+
+**Lado Under** (teto 40 pontos, 5 premissas contam para a porta)
+
+| Premissa | Peso | Grupo | Critério |
+|---|---:|---|---|
+| Defesas firmes dos dois lados | 14 | decide | Soma das médias de gols sofridos ≤ linha − 0,3 |
+| Os dois criam pouca chance de gol | 10 | decide | Soma dos gols esperados ≤ linha − 0,3 |
+| Os dois passam muitos jogos sem sofrer gol | 10 | decide | Cada time com 40% ou mais de jogos sem sofrer gol |
+| Ataque fraco em pelo menos um lado | 3 | preço | **Um dos dois** times com 35% ou mais de jogos sem marcar |
+| Histórico de jogo com poucos gols | 3 | preço | Cada time com 3+ dos últimos 5 jogos abaixo da linha |
+
+**Penalidade:** Linha muito longe do normal, −10 pontos.
+
+Três detalhes que já causaram erro e estão documentados no código:
+
+- **"Defesas frágeis" é a única premissa com margem zero.** O corte é a linha
+  crua. É a única em que "fica acima da linha" é frase verdadeira; nas outras
+  quatro o corte não é a linha.
+- **"Ataque fraco em pelo menos um lado" é o único OU do produto.** Ela se
+  chamava "Ataques fracos dos dois lados" e afirmava o que a regra não exige.
+- **A contagem não sai da média.** Nas duas premissas de histórico, cada um dos
+  últimos 5 jogos é comparado individualmente contra a linha. Uma média pode
+  estar de um lado da linha enquanto a contagem diz o contrário.
+
+### 4.2 Resultado — `match_winner`
+
+A aposta é em quem ganha, ou no empate. Teto de 30 pontos; **4 premissas contam
+para a porta**. As mesmas 7 valem para mandante e visitante.
+
+| Premissa | Peso | Grupo | Observação |
+|---|---:|---|---|
+| Em boa fase, vem ganhando | 10 | decide | |
+| O mando pesa neste jogo | 8 | decide | Rótulo muda por mando: "manda bem em casa" / "vai bem fora" |
+| Bem à frente na tabela | 8 | decide | |
+| Ataque forte contra defesa frágil do adversário | 4 | decide | Entende o jogo, mas o preço já cobra quase tudo |
+| Cria mais chances de gol que o adversário | 0 | preço | Chance de gol prevê gols, não quem ganha |
+| Leva vantagem no histórico do confronto | 0 | preço | Todo mundo olha, então já está na odd |
+| Adversário com desfalque de titular importante | 0 | preço | Ver abaixo |
+
+**Penalidades:** empate como aposta, 0 pontos (suspensa até ter amostra); time
+apostado com desfalque de titular importante, −15 pontos.
+
+**Sobre o desfalque valer zero:** não é que ele não importe. É que ele ainda não
+existe quando o Score é calculado. Medido em 05/09/2026 sobre 296 partidas: nas
+próximas 24 horas, 78% dos jogos já têm a lista de lesionados; até 3 dias, 47%; a
+mais de 3 dias, zero. O board publica dias antes. Não é dado que falta, é dado
+que chega tarde para o que a gente pergunta.
+
+### 4.3 Handicap asiático — `asian_handicap`
+
+A aposta é num time com vantagem ou desvantagem de gols. As premissas se dividem
+por lado, e **o lado sai do sinal da linha**: mandante com linha negativa é
+favorito, visitante com linha positiva também é (a linha é sempre guardada na
+ótica do mandante). Handicap zero nunca acende premissa nenhuma e é excluído
+explicitamente.
+
+**Lado favorito** (35 pontos, 5 premissas contam)
+
+| Premissa | Peso | Grupo |
+|---|---:|---|
+| Costuma ganhar por muitos gols | 16 | decide |
+| Muito superior ao adversário | 12 | decide |
+| Deve entrar com força máxima | 3 | decide |
+| Adversário fraco fora de casa | 2 | preço |
+| Manda muito bem em casa | 2 | preço |
+
+**Lado azarão** (13 pontos, **só 2 premissas contam**)
+
+| Premissa | Peso | Grupo |
+|---|---:|---|
+| Defesa sólida jogando fora | 10 | decide |
+| Quando perde, perde apertado | 3 | decide |
+
+**Penalidade:** handicap muito alto, 0 pontos (efeito zero nos dois testes).
+
+Duas coisas importantes aqui:
+
+**O azarão só passa na porta se as duas premissas acenderem.** Ele tem exatamente
+duas premissas de peso, e a porta exige duas. Não é regra especial — é
+consequência aritmética, e faz do azarão o lado mais difícil de publicar do
+produto inteiro.
+
+**"Quando perde, perde apertado" já quebrou na mão do usuário.** Ela se chamava
+"Raramente perde por dois ou mais", e isso enuncia uma condição de aposta que só
+vale em duas das sete linhas do handicap: num mais 0,5 a aposta morre em qualquer
+derrota, então a margem da derrota não responde nada. O sinal é real e sobrevive
+ao controle por faixa de odd acima de 1,30 — o defeito era a frase, não o
+cálculo.
+
+**Este mercado está fora da vitrine desde 01/09/2026.** Continua sendo publicado
+e medido no board; só não é exibido nem alertado. A decisão está na migration 116
+e a data de corte importa: as 23 linhas anteriores ao corte foram publicadas e
+vistas de verdade; as 31 posteriores nunca estiveram na tela.
+
+### 4.4 Ambos marcam — `btts`
+
+A aposta é se os dois times marcam.
+
+**Lado Sim** (34 pontos, 4 premissas contam)
+
+| Premissa | Peso | Grupo |
+|---|---:|---|
+| Os dois costumam marcar | 12 | decide |
+| Os dois atacam bem | 8 | decide |
+| Defesas frágeis dos dois lados | 8 | decide |
+| Nos últimos jogos, os dois marcaram | 6 | preço |
+
+**Lado Não** (28 pontos, 3 premissas contam)
+
+| Premissa | Peso | Grupo |
+|---|---:|---|
+| Defesa forte de um dos lados | 12 | decide |
+| Um dos ataques costuma passar em branco | 10 | decide |
+| Jogos recentes sem os dois marcarem | 6 | preço |
+
+Sem penalidades.
+
+⚠️ **Estes pesos foram recuperados do dado, não decididos.** O documento da
+recalibragem deixou este mercado pendente. Em 05/09/2026 os pesos foram deduzidos
+de volta: no board de produção, linhas com uma única premissa acesa e nenhuma
+penalidade têm a soma de pontos igual ao peso daquela premissa. As sete
+apareceram assim, e a soma fecha com os tetos que o Score já usava. Se algum peso
+estivesse errado, a soma não fecharia — mas continua sendo engenharia reversa, e
+não decisão registrada.
+
+**Cuidado com a premissa "Defesas frágeis dos dois lados".** Ela existe em dois
+mercados, com pesos diferentes (12 em Gols, 8 em Ambos marcam) e critérios de
+famílias diferentes: em Gols é média de gols sofridos contra a linha, em Ambos
+marcam é percentual de jogos sem sofrer gol de cada time. Qualquer agrupamento
+por slug sem o mercado junto mistura as duas.
+
+### 4.5 Dupla chance — `double_chance`
+
+A aposta cobre dois dos três resultados. Teto de 34 pontos; 4 premissas contam
+para a porta, e as mesmas valem para qualquer saída.
+
+| Premissa | Peso | Grupo |
+|---|---:|---|
+| O lado coberto é forte | 12 | decide |
+| Equilíbrio defensivo | 8 | decide |
+| Adversário com campanha fraca | 8 | decide |
+| Invicto nos últimos jogos | 6 | preço |
+
+Sem penalidades. Mesma ressalva do Ambos marcam: pesos recuperados do dado.
+
+---
+
+## 5. O que vale para todos os mercados
+
+### Avisos de preço (penalidade global)
+
+Falam da odd, então valem para qualquer aposta. Em ordem de severidade, que é a
+ordem em que devem ser oferecidos:
+
+| Aviso | Peso |
+|---|---:|
+| Só uma casa paga essa odd, pode ser linha furada | −30 |
+| Odd alta de zebra, entra com cautela | −15 |
+| Poucas casas cotando esse mercado | −12 |
+| Odd baixa, retorno pequeno pro risco | −10 |
+
+### Evidências de preço
+
+Também globais, e também competem por peso com as premissas do mercado:
+
+| Evidência | Peso |
+|---|---:|
+| As principais casas e o modelo da API apontam o mesmo lado | 8 |
+| As principais casas vêm baixando a odd desse lado | 8 |
+| Modelo da API concorda com esse lado | 0 |
+
+O modelo da API vale zero porque a recalibragem tirou os pontos dele da nota: ele
+troca mando por empate errando 14 pontos.
+
+### Premissas que existem e não vão à tela
+
+Seis slugs são calculados e escondidos. Cinco descrevem **preço** — movimento de
+linha, movimento das casas, concordância do modelo — e deixaram de ser razão
+quando o preço saiu da nota. A sexta, "favorito irregular", acende em 43% das
+linhas e vale zero ponto.
+
+### O peso vira palavra na tela
+
+O número nunca aparece para o assinante:
+
+| Peso | Palavra |
+|---|---|
+| 10 ou mais | Pesa muito |
+| 5 a 9 | Pesa |
+| 1 a 4 | Pesa pouco |
+| 0 | Não ajuda |
+
+"Não ajuda", e não "não conta": a premissa está na lista **a favor**, porque o
+modelo a acendeu. Dizer que ela não conta ao lado disso faz a tela discordar de
+si mesma.
+
+---
+
+## 6. Onde cada peça mora
+
+Isto importa mais do que parece, porque decide o que dá para medir e o que dá
+para mudar sem release.
+
+| Peça | Onde | Muda como |
+|---|---|---|
+| Se a premissa acendeu | Mart no BigQuery, tabelas `int_futebol_premissas_*` | Deploy do dbt |
+| Soma de pontos e Score | Mart no BigQuery | Deploy do dbt |
+| Faixa (Alta/Média/Baixa) | Mart no BigQuery | Deploy do dbt |
+| **Peso de cada premissa** | **Só no frontend**, `src/utils/futebol-premissas.ts` | Release do app |
+| Rótulo e copy da premissa | Frontend, e uma cópia em `futebol_premissa_copy` | Release / UPDATE |
+| Critério transcrito (só Gols) | Frontend, `src/utils/futebol-criterio.ts` | Release do app |
+| Quais premissas se aplicam a cada saída | **Duas cópias**: mart e migration 112 | Deploy nos dois |
+| Mercado na vitrine | Tabela `futebol_mercados_ocultos` | UPDATE, sem release |
+| Regra de liquidação (green/red) | **Só no navegador**, `src/utils/futebol-settlement.ts` | Release do app |
+
+---
+
+## 7. O que este documento não consegue dizer
+
+Lacunas reais, encontradas ao escrever isto. Todas verificadas.
+
+**Os critérios de quatro dos cinco mercados não estão escritos em lugar nenhum
+deste repositório.** Só os do mercado de Gols foram transcritos. Para Resultado,
+Handicap, Ambos marcam e Dupla chance, sabemos o nome da premissa e o peso, mas
+não o número que ela compara nem contra qual corte. Isso vive só no dbt.
+
+**O documento fonte dos pesos não existe.** O código e a migration 093 citam
+`docs/premissas-recalibragem.md` como origem de tudo: pesos decididos, tetos,
+achado transversal, decisão de aposentar mercado. O arquivo não está no
+repositório. Toda a justificativa dos pesos chega até nós por citação em
+comentário de código.
+
+**O peso existe em duas versões que ninguém garante iguais.** O mart soma os
+pontos com os pesos dele; o catálogo do frontend tem os pesos dele. Para dois
+mercados o catálogo é literalmente uma dedução a partir do dado do mart. Existe
+um teste de paridade entre o catálogo e a migration 122, mas ele compara a copy,
+não o peso que o BigQuery aplica.
+
+**Não existe versão nem histórico de peso.** Se um peso mudar amanhã, nada
+registra quando. Só a *escala do Score* é versionada (`legacy` e `contexto_v1`),
+e isso é outra coisa.
+
+**A soma dos dois lados do handicap não bate com o comentário do código.** O
+cabeçalho diz "teto equilibrado em 35 nos dois lados". Somando o catálogo, o
+favorito dá 35 e o azarão dá 13. Ou o comentário descreve uma intenção que os
+pesos não realizam, ou a normalização acontece no mart. Precisa ser checado antes
+de qualquer comparação de Score entre os dois lados.
+
+**O Score parece normalizado, mas a fórmula não está aqui.** A faixa Alta começa
+em 60 e nenhum mercado tem teto de pontos acima de 40, então o Score não pode ser
+a soma crua. Um comentário registra Score médio de 40,0 no Ambos marcam, cujo
+teto é 34 — o que confirma a normalização. A conta em si está no mart.
+
+**Nada disso é medido contra resultado.** Não existe registro persistido de que
+uma oportunidade ganhou ou perdeu. A regra de liquidação existe e é boa, cobrindo
+os cinco mercados incluindo o quarto de gol do handicap asiático, mas roda no
+navegador e é descartada ao fechar a aba. Os ingredientes estão guardados — a odd
+do momento da publicação em duas tabelas, o placar final em outras duas —, só
+nunca foram cruzados fora do cliente.
+
+---
+
+## Fontes
+
+- `src/utils/futebol-premissas.ts` — catálogo, pesos, grupos, porta de contexto
+- `src/utils/futebol-criterio.ts` — critérios transcritos do mercado de Gols
+- `src/utils/futebol-score.ts` — faixas e escalas
+- `src/utils/futebol-settlement.ts` — regra de liquidação
+- `supabase/migrations/093_futebol_mapa_premissas.sql` — a virada de metodologia
+- `supabase/migrations/20260829120000_112_futebol_score_contexto_contrato.sql` — Score de contexto e matriz de premissas aplicáveis
+- `supabase/migrations/20260901200000_116_futebol_mercados_ocultos.sql` e `20260905180000_119_futebol_vitrine_com_data.sql` — vitrine
+- `CONTEXT.md` — glossário

--- a/docs/futebol-revisao-handicap.md
+++ b/docs/futebol-revisao-handicap.md
@@ -10,11 +10,80 @@ board. Este documento mede as premissas dele contra resultado, separando lado,
 tamanho da linha, preço, mando e campeonato, e responde o que precisa ser
 arrumado antes de religar.
 
-A resposta curta: **as premissas do handicap funcionam melhor do que a
-metodologia escrita supõe, e o encanamento entre o mart e a tela está trocado.**
-O que não funciona é a porta — ela publica no pedaço mais caro do mercado, e o
-preço, que a metodologia tirou da nota de propósito, é o único número que separa
-ganhador de perdedor de forma consistente.
+---
+
+## 0. A causa raiz
+
+**O produto publica pagando pior que a referência sharp, e a odd longa multiplica
+esse erro. Não há nada além disso.**
+
+A média de vantagem das 600 oportunidades de handicap publicadas é −2,74%, e só
+49 delas têm vantagem positiva. Isso não é acidente de execução: é a consequência
+direta da revisão de 01/08/2026, que tirou o preço da nota **de propósito** e o
+rebaixou a filtro de sanidade. A porta de publicação passou a ser contexto puro.
+Uma porta que não olha preço publica descorrelacionada do preço, e o board cai
+onde cair.
+
+O quanto isso custa depende de onde a linha cai, e é aí que o handicap entra:
+
+| Vantagem sobre a linha sharp | odd < 2,00 | odd ≥ 2,00 |
+|---|---:|---:|
+| acima de −2% | +18,1% (n=56) | +20,7% (n=28) |
+| abaixo de −2% | −3,0% (n=87) | −24,9% (n=173) |
+
+A tabela se lê pelas linhas. **Com preço bom, a faixa de odd não importa** — 18%
+contra 21% é a mesma coisa. **Com preço ruim, a faixa de odd decide tudo** — de
+−3% para −25%. A odd longa não causa prejuízo: ela multiplica o prejuízo de ter
+pago mal. O handicap é o pior mercado do board porque é o que vive nas odds
+longas, e não porque as premissas dele sejam piores que as dos outros.
+
+### O que NÃO é causa
+
+Três recortes que parecem vazamento e são o preço aparecendo com outro nome. O
+teste é sempre o mesmo: segurar a faixa de odd e ver se a diferença sobrevive.
+
+| Recorte | Diferença bruta | Controlada por preço |
+|---|---:|---:|
+| favorito contra azarão | −11,9pp | **+12,2pp** |
+| handicap de 1,5 ou mais contra 0,5 | −5,6pp | **+0,4pp** |
+| mandante contra visitante | −5,8pp | −4,9pp |
+
+O lado **inverte de sinal**. Na tabela bruta o azarão parece muito melhor que o
+favorito; dentro da mesma faixa de odd o favorito rende 12,2pp a mais. A vantagem
+aparente do azarão era composição: favorito vive em odd longa, azarão em odd
+curta. O tamanho do handicap **evapora**, de −5,6pp para nada, porque handicap
+grande e odd longa são a mesma variável dita duas vezes. Só o mando sobrevive, e
+fraco.
+
+### O que é causa secundária, e de tamanho errado para resolver
+
+As premissas carregam sinal próprio, e ele **sobrevive** ao controle de preço:
+
+| Premissa | Controlando tamanho da linha | Controlando preço |
+|---|---:|---:|
+| `supremacia` | +13,4pp ± 8,2 | +10,8pp ± 7,5 |
+| `tende_golear` | +11,6pp ± 10,1 | +10,5pp ± 9,7 |
+| `sem_rodizio` | +6,7pp ± 8,1 | +6,2pp ± 8,2 |
+| `favorito_irregular` | +5,0pp ± 3,3 | +4,2pp ± 2,5 |
+| `raramente_perde_por_2` | +3,4pp ± 3,2 | +1,7pp ± 2,4 |
+| `mando_forte` | −3,2pp ± 8,0 | −4,6pp ± 7,1 |
+| `defesa_fora_solida` | −2,1pp ± 2,8 | −3,8pp ± 2,4 |
+| `adversario_fragil_fora` | −5,5pp ± 7,8 | −6,3pp ± 7,1 |
+
+Então o método não está errado, está subdimensionado. Os defeitos de encanamento
+da seção 2 — peso divergente entre mart e catálogo, premissa que a tela não
+conhece, porta que não é porta — são reais e valem consertar, mas mexem nesses 5
+a 10 pontos. Não encostam nos 25 que o preço custa.
+
+### Por que nada disso apareceu antes
+
+Até 09/09/2026 nada era medido contra resultado: a regra de liquidação rodava no
+navegador e era descartada ao fechar a aba, e o script que fecha essa malha tem
+cinco dias (#388). Num sistema sem malha fechada toda regra é decidida por
+argumento, e nada denuncia o desacordo. É por isso que a recalibragem de agosto
+pôde chegar ao frontend e não ao mart e durar um mês, e é por isso que
+`linha_sharp_confirma` está `false` em 100% das 2.371 publicações desde sempre
+sem ninguém notar.
 
 ---
 
@@ -93,9 +162,13 @@ com o motivo "efeito zero nos dois testes". No mart ela desconta 12 pontos, o qu
 
 ---
 
-## 3. Onde o dinheiro vaza
+## 3. As tabelas brutas, e por que elas enganam
 
-### O lado, e o tamanho da linha
+Esta seção existe para registrar o que se vê antes de controlar por preço, porque
+é o que qualquer um vai ver ao abrir o dado pela primeira vez — e porque duas
+destas três leituras estão erradas, do jeito descrito na seção 0.
+
+### O lado, e o tamanho da linha (artefato de preço)
 
 | Recorte | n | taxa | ROI (melhor odd) | erro-padrão |
 |---|---:|---:|---:|---:|
@@ -105,13 +178,13 @@ com o motivo "efeito zero nos dois testes". No mart ela desconta 12 pontos, o qu
 | handicap −0,5 | 965 | 40,5% | −7,5% | ±4,1pp |
 | handicap +1,5 | 946 | 79,4% | −2,2% | ±1,8pp |
 
-O lado do favorito perde quatro vezes mais que o do azarão, e a maior parte do
-buraco está numa célula só: o favorito dando 1,5 gol de vantagem, que perde 25%
-em quase mil linhas. Isso importa porque **é exatamente para lá que as premissas
-do favorito empurram** — `tende_golear` e `supremacia` acendem justamente quando
-o time é muito superior, que é quando a casa cobra handicap grande.
+Lido assim, o favorito perde quatro vezes mais que o azarão e o buraco todo está
+no handicap de 1,5 gol. **Está errado.** Dentro da mesma faixa de odd o favorito
+rende 12,2pp a MAIS que o azarão, e o handicap grande some junto, porque handicap
+grande e odd longa são a mesma coisa dita duas vezes. O que estas duas tabelas
+medem é a faixa de preço em que cada lado costuma viver.
 
-### O preço
+### O preço (a causa)
 
 | Faixa de odd | n | taxa | ROI (melhor odd) | erro-padrão |
 |---|---:|---:|---:|---:|
@@ -128,17 +201,18 @@ handicap entre 1,50 e 4,00, ou seja, **a faixa de publicação atravessa a front
 e pega os dois lados dela**. No board de 344 linhas liquidadas, 201 estão acima de
 2,00.
 
-### O mando
+### O mando (sobrevive, e é pequeno)
 
 | Recorte | n | taxa | ROI | erro-padrão |
 |---|---:|---:|---:|---:|
 | mandante | 2.608 | 47,2% | −12,6% | ±2,7pp |
 | visitante | 2.600 | 51,8% | −6,7% | ±2,7pp |
 
-Apostar no time de casa é pior nos dois lados do handicap, e a diferença sobrevive
-ao erro-padrão. Isso conversa com a seção seguinte: as duas premissas do catálogo
-que falam de mando (`mando_forte` e `adversario_fragil_fora`) são as duas que não
-medem nada.
+Este é o único dos três recortes brutos que sobra depois do controle: a diferença
+cai de 5,8pp para 4,9pp quando se segura a faixa de odd. Apostar no time de casa
+é de fato um pouco pior. Isso conversa com a seção 4: as duas premissas do
+catálogo que falam de mando (`mando_forte` e `adversario_fragil_fora`) são as duas
+que não medem nada.
 
 ---
 
@@ -204,6 +278,9 @@ favorito parece melhor mas tem 124 linhas e ±13,3pp: não decide nada.
 
 ## 5. A premissa que falta é o preço
 
+Esta seção é a seção 0 vista de perto: o mesmo achado, com os números que o
+sustentam e o que mais veio junto.
+
 A revisão de 01/08/2026 tirou o preço da nota e o transformou em filtro de
 sanidade, com o argumento de que a regra antiga "vantagem maior que zero" era a
 única das quatro testadas que perdia dinheiro. No handicap, o dado de hoje diz o
@@ -253,26 +330,46 @@ marcam são publicadas sem premissa nenhuma.
 
 ## 6. O que precisa acontecer para religar
 
-Em ordem, e cada item é verificável isolado.
+A ordem é por tamanho de efeito, não por facilidade. Os dois primeiros itens
+mexem na causa; os outros quatro mexem em consequências, e nenhum deles salva o
+mercado sozinho.
 
-1. **Sincronizar peso entre mart e catálogo, e versionar a régua.** Enquanto as
-   duas existirem em desacordo, nenhuma recalibragem tem onde pousar. É o único
-   item que bloqueia todos os outros.
-2. **Registrar `favorito_irregular` no catálogo.** Ela é a premissa mais forte do
+**Primeiro, o que vale os 25 pontos:**
+
+1. **Vantagem mínima como porta de exclusão.** Não publicar o que está muito
+   abaixo da linha sharp. É o inverso da regra que a revisão de agosto aposentou:
+   aquela usava preço como porta de ENTRADA, e publicar tudo que tem vantagem
+   positiva contra uma linha mal estimada é armadilha. Esta usa preço como corte
+   de SAÍDA, e é a única mudança grande o suficiente para inverter o sinal do
+   mercado. Vale para os cinco mercados — os cinco publicam com vantagem média
+   negativa, entre −1,87% e −4,62%.
+2. **Fechar a malha antes de mudar qualquer peso.** O script de #388 e o deste
+   documento medem, mas nada roda sozinho e nada alerta. Enquanto a medição for um
+   comando que alguém lembra de rodar, a próxima divergência entre mart e frontend
+   vai durar o mesmo mês que esta durou.
+
+**Depois, o que vale os 5 a 10 pontos** — e que só compensa fazer porque é barato,
+não porque decide:
+
+3. **Sincronizar peso entre mart e catálogo, e versionar a régua.** Enquanto as
+   duas existirem em desacordo, nenhuma recalibragem tem onde pousar. Bloqueia os
+   dois itens seguintes.
+4. **Registrar `favorito_irregular` no catálogo.** Ela é a premissa mais forte do
    lado do azarão e a tela não sabe que ela existe. Precisa de nome, frase,
    negativo e evidência, como qualquer outra.
-3. **Trocar os pesos do azarão pelo que a medição mostra.** `favorito_irregular` e
+5. **Trocar os pesos do azarão pelo que a medição mostra.** `favorito_irregular` e
    `raramente_perde_por_2` na frente, `defesa_fora_solida` para o grupo de preço.
-4. **Estreitar a faixa de odd do handicap.** A fronteira de 2,00 é nítida e a
-   faixa atual (1,50 a 4,00) atravessa ela.
-5. **Adotar vantagem mínima como porta de exclusão**, não como porta de entrada:
-   não publicar o que está muito abaixo da linha sharp. Vale para os cinco
-   mercados, e o handicap é só onde o efeito é maior.
 6. **Reconciliar a porta de contexto com o que o mart faz.** Ou o mart passa a
    exigir duas premissas, ou a metodologia para de dizer que ele exige.
 
-Só depois disso a pergunta "o handicap volta à vitrine?" tem como ser respondida,
-porque só depois disso o mercado que voltaria é o que este documento mediu.
+O que **não** está nesta lista, e estava na primeira versão deste documento:
+estreitar a faixa de odd. A odd longa não é causa — ela multiplica o erro de
+preço, e com preço bom não custa nada (+18,1% abaixo de 2,00 contra +20,7% acima).
+Cortar odd longa sem corrigir preço joga fora metade do board para tratar o
+sintoma; corrigir preço torna o corte desnecessário.
+
+Só depois do item 1 a pergunta "o handicap volta à vitrine?" tem como ser
+respondida, porque só depois dele o mercado que voltaria é outro.
 
 ---
 

--- a/docs/futebol-revisao-handicap.md
+++ b/docs/futebol-revisao-handicap.md
@@ -1,0 +1,316 @@
+# Revisão do handicap asiático
+
+> **Status:** medição concluída em 2026-09-10 · **Branch:** `analise/futebol-handicap`
+> **Pergunta:** por que as premissas do handicap não performam, e o que precisa
+> mudar para o mercado voltar à vitrine.
+> **Reprodução:** `node scripts/futebol-handicap-premissas.mjs`
+
+O handicap saiu da vitrine em 01/09/2026 e continua sendo publicado e medido no
+board. Este documento mede as premissas dele contra resultado, separando lado,
+tamanho da linha, preço, mando e campeonato, e responde o que precisa ser
+arrumado antes de religar.
+
+A resposta curta: **as premissas do handicap funcionam melhor do que a
+metodologia escrita supõe, e o encanamento entre o mart e a tela está trocado.**
+O que não funciona é a porta — ela publica no pedaço mais caro do mercado, e o
+preço, que a metodologia tirou da nota de propósito, é o único número que separa
+ganhador de perdedor de forma consistente.
+
+---
+
+## 1. O que foi medido
+
+Duas populações diferentes, e a diferença entre elas é o ponto de partida.
+
+**O board** são as 600 oportunidades de handicap publicadas na escala
+`contexto_v1`, das quais 344 já têm placar. É o que `scripts/futebol-roi.mjs` já
+media. Serve para dizer quanto o produto rendeu, e não serve para avaliar
+premissa: toda linha ali dentro já passou pela porta, então a amostra é o próprio
+filtro que se quer julgar.
+
+**O universo** são as 5.208 linhas de handicap de meio gol que tiveram preço
+coletado a T−24h em pelo menos três casas, com jogo encerrado, entre 16/06 e
+10/09/2026 — publicadas ou não. É quinze vezes o board, e é a única população em
+que a pergunta "esta premissa separa?" tem resposta, porque inclui as linhas que
+a porta recusou.
+
+O preço do universo foi reconstruído de `fact_odds_snapshot`, que é imutável.
+`int_futebol_odds_devig` **não serve**: ela é recalculada a cada rodada do dbt, e
+contra as linhas já liquidadas a odd dela está em média 0,75 acima da que foi
+publicada, o que sozinho transforma um ROI de −10,6% em +33%. A reconstrução foi
+conferida contra o board: em 598 das 600 linhas publicadas, a melhor odd
+reconstruída bate com a que foi ao ar.
+
+Duas leituras de preço saem em toda tabela. A **melhor odd** entre as casas é o
+que o assinante consegue, e é o número do produto. A **mediana** é o mercado, e é
+a régua para comparar recortes sem que o vencedor de cada um seja "quem teve uma
+casa fora da curva". No universo inteiro: taxa 49,5%, ROI −9,7% na melhor odd e
+−13,2% na mediana.
+
+---
+
+## 2. Três defeitos de encanamento, antes de qualquer discussão de método
+
+Estes não são achados estatísticos. São divergências verificáveis entre o que o
+mart calcula e o que `src/utils/futebol-premissas.ts` descreve, e qualquer
+recalibragem feita antes de resolvê-los recalibra o arquivo errado.
+
+**Os pesos do mart não são os pesos do catálogo.** Recuperados do dado pelo mesmo
+método que o comentário do catálogo já usa para Ambos marcam e Dupla chance —
+linha com uma única premissa acesa e nenhuma penalidade tem `pts_premissas` igual
+ao peso daquela premissa:
+
+| Premissa | Peso no mart | Peso no catálogo | Lado |
+|---|---:|---:|---|
+| `supremacia` | 12 | 12 | favorito |
+| `tende_golear` | 10 | **16** | favorito |
+| `adversario_fragil_fora` | 8 | **2** | favorito |
+| `mando_forte` | 6 | **2** | favorito |
+| `sem_rodizio` | 4 | **3** | favorito |
+| `raramente_perde_por_2` | 12 | **3** | azarão |
+| `defesa_fora_solida` | 10 | 10 | azarão |
+| `favorito_irregular` | 8 | **não existe** | azarão |
+| `handicap_alto` (penalidade) | −12 | **0** | ambos |
+
+O mart aplica uma escada genérica de 12/10/8/6/4 e a soma dos dois lados dá 40 e
+30, não os 35 e 13 que o catálogo descreve. A recalibragem de 01/08/2026 — a que
+concluiu que histórico recente não ajuda e que característica estrutural ajuda —
+**chegou ao frontend e não chegou ao mart**. A nota que gera, ordena e publica o
+handicap é anterior a ela.
+
+**Existe uma nona premissa que a tela não conhece.** `favorito_irregular` acende
+em 1.725 das 2.575 linhas de azarão do universo, vale 8 pontos no mart, e não
+está no catálogo. Consequência direta: uma linha publicada por causa dela mostra
+menos premissas na tela do que o backend usou para publicá-la, e o azarão — que
+o catálogo descreve como "só passa se as duas acenderem, o lado mais difícil de
+publicar do produto inteiro" — na verdade tem três premissas e passa com
+folga. Os 144 azarões liquidados no board contra 200 favoritos confirmam: o lado
+supostamente impossível publica quase tanto quanto o outro.
+
+**A penalidade de handicap alto existe e pesa 12.** O catálogo registra peso 0
+com o motivo "efeito zero nos dois testes". No mart ela desconta 12 pontos, o que
+é o segundo maior número do mercado.
+
+---
+
+## 3. Onde o dinheiro vaza
+
+### O lado, e o tamanho da linha
+
+| Recorte | n | taxa | ROI (melhor odd) | erro-padrão |
+|---|---:|---:|---:|---:|
+| azarão | 2.575 | 73,3% | −3,6% | ±1,3pp |
+| favorito | 2.633 | 26,2% | −15,6% | ±3,5pp |
+| handicap −1,5 | 970 | 20,1% | −25,0% | ±5,7pp |
+| handicap −0,5 | 965 | 40,5% | −7,5% | ±4,1pp |
+| handicap +1,5 | 946 | 79,4% | −2,2% | ±1,8pp |
+
+O lado do favorito perde quatro vezes mais que o do azarão, e a maior parte do
+buraco está numa célula só: o favorito dando 1,5 gol de vantagem, que perde 25%
+em quase mil linhas. Isso importa porque **é exatamente para lá que as premissas
+do favorito empurram** — `tende_golear` e `supremacia` acendem justamente quando
+o time é muito superior, que é quando a casa cobra handicap grande.
+
+### O preço
+
+| Faixa de odd | n | taxa | ROI (melhor odd) | erro-padrão |
+|---|---:|---:|---:|---:|
+| 1,00–1,39 | 1.718 | 85,7% | −0,9% | ±1,0pp |
+| 1,40–1,59 | 361 | 68,7% | +1,8% | ±3,6pp |
+| 1,60–1,99 | 546 | 58,2% | +3,2% | ±3,8pp |
+| 2,00–2,59 | 490 | 39,8% | −10,6% | ±5,0pp |
+| 2,60–3,99 | 665 | 26,5% | −14,7% | ±5,6pp |
+| 4,00+ | 1.428 | 11,8% | −25,3% | ±5,8pp |
+
+Monótona, com erro-padrão pequeno, em 5.208 linhas. Acima de 2,00 o mercado
+sangra, e abaixo de 2,00 ele é neutro ou levemente positivo. O produto publica
+handicap entre 1,50 e 4,00, ou seja, **a faixa de publicação atravessa a fronteira
+e pega os dois lados dela**. No board de 344 linhas liquidadas, 201 estão acima de
+2,00.
+
+### O mando
+
+| Recorte | n | taxa | ROI | erro-padrão |
+|---|---:|---:|---:|---:|
+| mandante | 2.608 | 47,2% | −12,6% | ±2,7pp |
+| visitante | 2.600 | 51,8% | −6,7% | ±2,7pp |
+
+Apostar no time de casa é pior nos dois lados do handicap, e a diferença sobrevive
+ao erro-padrão. Isso conversa com a seção seguinte: as duas premissas do catálogo
+que falam de mando (`mando_forte` e `adversario_fragil_fora`) são as duas que não
+medem nada.
+
+---
+
+## 4. O que cada premissa vale de fato
+
+A coluna que decide é a **diferença estratificada**: acesa contra apagada dentro
+de cada tamanho de handicap, e só depois somada. Sem estratificar, a comparação
+mede o tamanho da linha e chama isso de premissa, porque as premissas do favorito
+acendem mais nos handicaps grandes, que são os que mais perdem.
+
+**Favorito** (2.633 linhas, ROI base −15,6%)
+
+| Premissa | n acesa | ROI acesa | ROI apagada | Diferença estratificada | Peso no mart |
+|---|---:|---:|---:|---:|---:|
+| `supremacia` | 761 | −5,4% | −19,7% | **+13,4pp ± 8,2** | 12 |
+| `tende_golear` | 378 | −4,2% | −17,5% | **+11,6pp ± 10,1** | 10 |
+| `sem_rodizio` | 673 | −10,7% | −17,2% | +6,7pp ± 8,1 | 4 |
+| `adversario_fragil_fora` | 791 | −18,4% | −14,4% | −5,5pp ± 7,8 | 8 |
+| `mando_forte` | 782 | −16,3% | −15,2% | −3,2pp ± 8,0 | 6 |
+
+**Azarão** (2.575 linhas, ROI base −3,6%)
+
+| Premissa | n acesa | ROI acesa | ROI apagada | Diferença estratificada | Peso no mart |
+|---|---:|---:|---:|---:|---:|
+| `favorito_irregular` | 1.725 | −2,0% | −6,9% | **+5,0pp ± 3,3** | 8 |
+| `raramente_perde_por_2` | 1.623 | −2,5% | −5,6% | **+3,4pp ± 3,2** | 12 |
+| `defesa_fora_solida` | 1.049 | −4,9% | −2,7% | −2,1pp ± 2,8 | 10 |
+
+Quatro leituras:
+
+**As premissas separam.** Cinco das oito apontam na direção certa, e duas de cada
+lado chegam a 1,5 erro-padrão em amostra de milhares de linhas. Isso é mais do que
+a metodologia escrita concede ao mercado, e é o argumento contra aposentá-lo.
+
+**O catálogo acertou o favorito e errou o azarão.** No lado do favorito, o
+catálogo já sabia que `mando_forte` e `adversario_fragil_fora` são preço — deu 2 a
+cada uma — e a medição confirma: as duas não separam nada. No lado do azarão ele
+errou nas três: deu 10 a `defesa_fora_solida`, a única do lado que não separa;
+deu 3 a `raramente_perde_por_2` com o motivo
+"sinal quase nulo, mas é o que abre a porta do azarão", e ela mede; e não
+registrou `favorito_irregular`, que é a premissa mais forte do lado.
+
+**O mart erra onde o catálogo acerta, e vice-versa.** O mart dá 8 e 6 às duas
+premissas de mando que não medem nada, e dá 12 a `raramente_perde_por_2`, que
+mede. Nenhuma das duas réguas está certa; elas estão erradas em lugares
+diferentes.
+
+**Empilhar ajuda até certo ponto:**
+
+| Recorte | n | taxa | ROI | erro-padrão |
+|---|---:|---:|---:|---:|
+| azarão, `favorito_irregular` + `raramente_perde_por_2` | 1.297 | 77,4% | −0,8% | ±1,7pp |
+| as duas, odd entre 1,40 e 2,00 | 298 | 64,1% | +4,4% | ±4,6pp |
+| as duas, odd 1,40–2,00, visitante | 227 | 64,3% | +6,4% | ±5,4pp |
+| favorito, `supremacia` + `tende_golear` | 124 | 46,8% | +10,5% | ±13,3pp |
+
+As duas premissas do azarão, sozinhas, tiram o lado do vermelho em 1.297 linhas.
+Com o filtro de preço ele vira positivo, e com o recorte de visitante fica em
++6,4% — a 1,2 erro-padrão, o que é promissor e não é prova. O empilhamento do
+favorito parece melhor mas tem 124 linhas e ±13,3pp: não decide nada.
+
+---
+
+## 5. A premissa que falta é o preço
+
+A revisão de 01/08/2026 tirou o preço da nota e o transformou em filtro de
+sanidade, com o argumento de que a regra antiga "vantagem maior que zero" era a
+única das quatro testadas que perdia dinheiro. No handicap, o dado de hoje diz o
+contrário do que essa decisão supõe:
+
+| Board publicado, por vantagem sobre a linha da Pinnacle | n | taxa | ROI | erro-padrão |
+|---|---:|---:|---:|---:|
+| vantagem acima de zero | 25 | 76,0% | +42,2% | ±17,6pp |
+| vantagem entre −2% e zero | 59 | 57,6% | +9,1% | ±13,0pp |
+| vantagem abaixo de −2% | 260 | 37,7% | −17,6% | ±7,0pp |
+
+É a separação mais forte que este documento encontrou em qualquer recorte, e o
+número que a produz é o único que a nota decidiu não olhar.
+
+O que explica a contradição com a revisão de agosto é a diferença entre **usar o
+preço como porta** e **usar o preço como corte de exclusão**. A regra antiga
+publicava tudo que tinha vantagem positiva, e vantagem positiva contra uma linha
+mal estimada é uma armadilha. O que a tabela acima mostra é o outro uso: vantagem
+muito negativa é motivo para **não** publicar. São 260 das 344 linhas liquidadas —
+três quartos do board de handicap está no pedaço que perde 17,6%.
+
+E há um número que resume o mercado inteiro: das 600 oportunidades de handicap
+publicadas, **49 têm vantagem positiva** e a média é de −2,74%. O produto publica,
+em média, linhas cotadas quase três por cento pior do que a referência sharp. Isso
+não é específico do handicap — os cinco mercados publicam com vantagem média
+negativa, entre −1,87% e −4,62% —, mas o handicap é onde dói mais, porque é o
+mercado que vive nas odds longas, e é lá que o preço ruim cobra caro.
+
+Dois outros achados de encanamento na mesma família:
+
+**`linha_sharp_confirma` nunca acendeu.** É `false` nas 2.371 oportunidades
+publicadas de todos os mercados, sem exceção. Ela está no catálogo como evidência
+global de peso 8, que é o peso que define onde ela entra na fila de cada mercado,
+e nunca entrou em fila nenhuma.
+
+**`modelo_api_concorda` só existe no Resultado.** Acende em 285 das 390 linhas de
+`match_winner` e em zero linha dos outros quatro mercados, handicap incluído.
+
+**A porta de contexto não é a porta.** 61 das 600 oportunidades de handicap foram
+publicadas com `pts_premissas` igual a zero, ou seja, sem nenhuma premissa acesa.
+A `PORTA_PREMISSAS = 2` que a metodologia descreve como porta de publicação vive
+em `src/utils/futebol-premissas.ts` e não governa o que o mart publica. Nos outros
+mercados o buraco é maior: 42,8% das linhas de Resultado e 25,4% das de Ambos
+marcam são publicadas sem premissa nenhuma.
+
+---
+
+## 6. O que precisa acontecer para religar
+
+Em ordem, e cada item é verificável isolado.
+
+1. **Sincronizar peso entre mart e catálogo, e versionar a régua.** Enquanto as
+   duas existirem em desacordo, nenhuma recalibragem tem onde pousar. É o único
+   item que bloqueia todos os outros.
+2. **Registrar `favorito_irregular` no catálogo.** Ela é a premissa mais forte do
+   lado do azarão e a tela não sabe que ela existe. Precisa de nome, frase,
+   negativo e evidência, como qualquer outra.
+3. **Trocar os pesos do azarão pelo que a medição mostra.** `favorito_irregular` e
+   `raramente_perde_por_2` na frente, `defesa_fora_solida` para o grupo de preço.
+4. **Estreitar a faixa de odd do handicap.** A fronteira de 2,00 é nítida e a
+   faixa atual (1,50 a 4,00) atravessa ela.
+5. **Adotar vantagem mínima como porta de exclusão**, não como porta de entrada:
+   não publicar o que está muito abaixo da linha sharp. Vale para os cinco
+   mercados, e o handicap é só onde o efeito é maior.
+6. **Reconciliar a porta de contexto com o que o mart faz.** Ou o mart passa a
+   exigir duas premissas, ou a metodologia para de dizer que ele exige.
+
+Só depois disso a pergunta "o handicap volta à vitrine?" tem como ser respondida,
+porque só depois disso o mercado que voltaria é o que este documento mediu.
+
+---
+
+## 7. O que este documento não consegue dizer
+
+**Os critérios continuam sem transcrição.** Sabemos o nome, o peso e agora o
+efeito de cada premissa do handicap. Continuamos sem saber qual número ela compara
+e contra qual corte: isso vive no dbt, e nenhuma das nove premissas tem critério
+escrito neste repositório. Sem isso, "arrumar a premissa" só pode significar
+mudar peso, nunca mudar corte.
+
+**Não dá para propor premissa nova a partir daqui.** Testar um sinal que ainda
+não existe exige calcular o insumo, e os insumos moram no mart. O que este
+documento consegue afirmar é que as premissas existentes separam, que duas delas
+atrapalham, e que o preço separa mais que todas — não que exista um sinal
+estrutural ausente.
+
+**A janela é de três meses e uma delas é atípica.** O universo vai de 16/06 a
+10/09/2026 e inclui 842 linhas de `copa_mundo`, que é competição de seleção e não
+de clube. Nenhum recorte por campeonato deste documento tem tamanho para decidir
+sozinho.
+
+**O universo usa T−24h para todas as linhas.** O produto escolhe a janela por
+linha, e as publicadas usaram janelas variadas. Contra o board a reconstrução
+bate, mas para as linhas nunca publicadas a odd é a de 24 horas antes, e não a que
+o produto teria escolhido.
+
+**Erro-padrão maior que a diferença entre dois recortes significa que a diferença
+ainda não existe.** Vale para a tabela do favorito empilhado, e vale para todo
+recorte de campeonato.
+
+---
+
+## Fontes
+
+- `scripts/futebol-handicap-premissas.mjs` — a medição deste documento
+- `scripts/futebol-roi.mjs` — taxa e ROI do board, e a regra de liquidação
+- `futebol.int_futebol_premissas_ah` — as nove premissas, linha a linha
+- `futebol.fact_odds_snapshot` — o preço imutável, por casa e por janela
+- `src/utils/futebol-premissas.ts` — o catálogo de pesos do frontend
+- `docs/futebol-metodologia-por-mercado.md` — a metodologia que este documento revisa

--- a/docs/futebol-revisao-handicap.md
+++ b/docs/futebol-revisao-handicap.md
@@ -17,7 +17,7 @@ arrumado antes de religar.
 **O produto publica pagando pior que a referência sharp, e a odd longa multiplica
 esse erro. Não há nada além disso.**
 
-A média de vantagem das 600 oportunidades de handicap publicadas é −2,74%, e só
+A média de vantagem das 604 oportunidades de handicap publicadas é −2,74%, e só
 49 delas têm vantagem positiva. Isso não é acidente de execução: é a consequência
 direta da revisão de 01/08/2026, que tirou o preço da nota **de propósito** e o
 rebaixou a filtro de sanidade. A porta de publicação passou a ser contexto puro.
@@ -28,14 +28,24 @@ O quanto isso custa depende de onde a linha cai, e é aí que o handicap entra:
 
 | Vantagem sobre a linha sharp | odd < 2,00 | odd ≥ 2,00 |
 |---|---:|---:|
-| acima de −2% | +18,1% (n=56) | +20,7% (n=28) |
-| abaixo de −2% | −3,0% (n=87) | −24,9% (n=173) |
+| acima de −2% | +16,3% (n=60) | +27,5% (n=33) |
+| abaixo de −2% | −6,3% (n=95) | −23,2% (n=186) |
 
-A tabela se lê pelas linhas. **Com preço bom, a faixa de odd não importa** — 18%
-contra 21% é a mesma coisa. **Com preço ruim, a faixa de odd decide tudo** — de
-−3% para −25%. A odd longa não causa prejuízo: ela multiplica o prejuízo de ter
-pago mal. O handicap é o pior mercado do board porque é o que vive nas odds
-longas, e não porque as premissas dele sejam piores que as dos outros.
+E a mesma tabela só com o que foi detectado **depois do tombamento** de 04/09
+14h35, que é a régua de hoje (ver a seção 1 sobre por que isso precisa ser
+separado):
+
+| Vantagem sobre a linha sharp | odd < 2,00 | odd ≥ 2,00 |
+|---|---:|---:|
+| acima de −2% | +23,8% (n=25) | +59,2% (n=9) |
+| abaixo de −2% | −7,3% (n=32) | −36,1% (n=60) |
+
+A tabela se lê pelas linhas. **Com preço bom, a odd longa não atrapalha** — ela
+até ajuda, porque ganhar pagando bem paga mais. **Com preço ruim, a faixa de odd
+decide tudo** — de −6% para −23% no board inteiro, e de −7% para −36% na metade
+recente. A odd longa não causa prejuízo: ela multiplica o prejuízo de ter pago
+mal. O handicap é o pior mercado do board porque é o que vive nas odds longas, e
+não porque as premissas dele sejam piores que as dos outros.
 
 ### O que NÃO é causa
 
@@ -91,11 +101,26 @@ sem ninguém notar.
 
 Duas populações diferentes, e a diferença entre elas é o ponto de partida.
 
-**O board** são as 600 oportunidades de handicap publicadas na escala
-`contexto_v1`, das quais 344 já têm placar. É o que `scripts/futebol-roi.mjs` já
-media. Serve para dizer quanto o produto rendeu, e não serve para avaliar
+**O board** são as 604 oportunidades de handicap publicadas na escala
+`contexto_v1`, das quais 374 já têm placar. Os dois números crescem a cada rodada
+do dbt — subiram de 600 e 344 no meio da escrita deste documento —, então qualquer
+total aqui é a foto de 10/09/2026 e o script vai devolver outro. É o que
+`scripts/futebol-roi.mjs` já media. Serve para dizer quanto o produto rendeu, e não serve para avaliar
 premissa: toda linha ali dentro já passou pela porta, então a amostra é o próprio
 filtro que se quer julgar.
+
+O board tem um problema de composição que precisa ser dito antes de qualquer
+número dele: **248 das 374 linhas liquidadas vêm de um único dia**. Em 03/09 o
+snapshot capturou o board inteiro de uma vez, e essa captura responde por dois
+terços da amostra. Além disso, em 04/09 às 14h35 UTC o denominador da nota trocou
+do p95 para o teto de pontos, e linha anterior a isso tem Score em outra escala.
+Por isso toda tabela de board neste documento sai duas vezes: o board inteiro, e
+só o que foi detectado depois do tombamento.
+
+A vantagem sobre a linha sharp **não** foi afetada pela troca de escala — ela é
+estável em todos os dias, entre −2,4% e −3,3%. É por isso que as duas metades
+respondem a mesma pergunta, e é por isso que o achado da seção 0 sobrevive: ele
+aparece nas duas, e mais forte na metade recente.
 
 **O universo** são as 5.208 linhas de handicap de meio gol que tiveram preço
 coletado a T−24h em pelo menos três casas, com jogo encerrado, entre 16/06 e
@@ -286,11 +311,17 @@ sanidade, com o argumento de que a regra antiga "vantagem maior que zero" era a
 única das quatro testadas que perdia dinheiro. No handicap, o dado de hoje diz o
 contrário do que essa decisão supõe:
 
-| Board publicado, por vantagem sobre a linha da Pinnacle | n | taxa | ROI | erro-padrão |
+| Board inteiro, por vantagem sobre a linha da Pinnacle | n | taxa | ROI | erro-padrão |
 |---|---:|---:|---:|---:|
-| vantagem acima de zero | 25 | 76,0% | +42,2% | ±17,6pp |
-| vantagem entre −2% e zero | 59 | 57,6% | +9,1% | ±13,0pp |
-| vantagem abaixo de −2% | 260 | 37,7% | −17,6% | ±7,0pp |
+| vantagem acima de zero | 30 | 70,0% | +32,0% | ±17,0pp |
+| vantagem entre −2% e zero | 63 | 58,7% | +14,7% | ±13,1pp |
+| vantagem abaixo de −2% | 281 | 37,7% | −17,5% | ±6,7pp |
+
+| Só depois do tombamento | n | taxa | ROI | erro-padrão |
+|---|---:|---:|---:|---:|
+| vantagem acima de zero | 15 | 73,3% | +34,5% | ±22,7pp |
+| vantagem entre −2% e zero | 19 | 63,2% | +32,1% | ±27,0pp |
+| vantagem abaixo de −2% | 92 | 34,8% | −26,1% | ±11,4pp |
 
 É a separação mais forte que este documento encontrou em qualquer recorte, e o
 número que a produz é o único que a nota decidiu não olhar.
@@ -300,9 +331,9 @@ preço como porta** e **usar o preço como corte de exclusão**. A regra antiga
 publicava tudo que tinha vantagem positiva, e vantagem positiva contra uma linha
 mal estimada é uma armadilha. O que a tabela acima mostra é o outro uso: vantagem
 muito negativa é motivo para **não** publicar. São 260 das 344 linhas liquidadas —
-três quartos do board de handicap está no pedaço que perde 17,6%.
+três quartos do board de handicap está no pedaço que perde 17,5%.
 
-E há um número que resume o mercado inteiro: das 600 oportunidades de handicap
+E há um número que resume o mercado inteiro: das 604 oportunidades de handicap
 publicadas, **49 têm vantagem positiva** e a média é de −2,74%. O produto publica,
 em média, linhas cotadas quase três por cento pior do que a referência sharp. Isso
 não é específico do handicap — os cinco mercados publicam com vantagem média
@@ -319,7 +350,7 @@ e nunca entrou em fila nenhuma.
 **`modelo_api_concorda` só existe no Resultado.** Acende em 285 das 390 linhas de
 `match_winner` e em zero linha dos outros quatro mercados, handicap incluído.
 
-**A porta de contexto não é a porta.** 61 das 600 oportunidades de handicap foram
+**A porta de contexto não é a porta.** 61 das 604 oportunidades de handicap foram
 publicadas com `pts_premissas` igual a zero, ou seja, sem nenhuma premissa acesa.
 A `PORTA_PREMISSAS = 2` que a metodologia descreve como porta de publicação vive
 em `src/utils/futebol-premissas.ts` e não governa o que o mart publica. Nos outros
@@ -391,6 +422,15 @@ estrutural ausente.
 10/09/2026 e inclui 842 linhas de `copa_mundo`, que é competição de seleção e não
 de clube. Nenhum recorte por campeonato deste documento tem tamanho para decidir
 sozinho.
+
+**O board tem uma semana útil de vida, e dois terços dela são um dia só.** Tudo
+que depende de `edge` — ou seja, a causa raiz da seção 0 e o de-para da seção 6 —
+mede 374 linhas, das quais 248 vieram da captura em massa de 03/09. Separado, o
+que veio depois do tombamento são 126 linhas, e o recorte de vantagem boa dentro
+delas tem 34. O achado aparece nas duas metades e é grande nas duas, mas 34 linhas
+com erro-padrão de ±17,9pp não fixam o tamanho do efeito — fixam o sinal dele.
+Nada disso vale para as conclusões de premissa, que vivem no universo de 5.208
+linhas e não dependem do board.
 
 **O universo usa T−24h para todas as linhas.** O produto escolhe a janela por
 linha, e as publicadas usaram janelas variadas. Contra o board a reconstrução

--- a/scripts/futebol-escanteios-retrato.mjs
+++ b/scripts/futebol-escanteios-retrato.mjs
@@ -53,7 +53,9 @@ async function q(sql) {
 /** O par do jogo: cada linha vira (feitos, sofridos) para um time. */
 const PARES_ESCANTEIO = `
   select a.fixture_id, a.date_utc, a.team_id, a.team_side lado,
-         a.corner_kicks feitos, b.corner_kicks sofridos
+         a.corner_kicks feitos, b.corner_kicks sofridos,
+         a.corner_kicks - b.corner_kicks saldo,
+         a.total_shots chutes, a.ball_possession posse
   from futebol.fact_fixture_stats a
   join futebol.fact_fixture_stats b
     on b.fixture_id = a.fixture_id and b.team_id <> a.team_id
@@ -149,6 +151,134 @@ async function separacao() {
   console.log(`\nSeparação entre o 1º e o 5º quintil: escanteio ${spread(esc).toFixed(1)}pp · gol ${spread(gol).toFixed(1)}pp`);
 }
 
+/**
+ * Escanteio não é um mercado, são cinco. Cada um pede um insumo diferente, e o
+ * saldo — que é o do handicap — persiste MAIS que as duas pontas que o formam.
+ */
+async function porMercado() {
+  const [saldo] = await q(`
+    with pares as (${PARES_ESCANTEIO}), ord as (
+      select *, row_number() over (partition by team_id order by date_utc) rn,
+             count(*) over (partition by team_id) tot from pares
+    ), met as (
+      select team_id, avg(case when rn <= tot/2 then saldo end) a1,
+             avg(case when rn > tot/2 then saldo end) a2, max(tot) tot
+      from ord group by 1)
+    select round(corr(a1,a2)::numeric,3) persistencia from met where tot >= 30`);
+
+  const mando = await q(`
+    with pares as (${PARES_ESCANTEIO}), ord as (
+      select *, row_number() over (partition by team_id, lado order by date_utc) rn,
+             count(*) over (partition by team_id, lado) tot from pares
+    ), met as (
+      select team_id, lado, avg(case when rn <= tot/2 then feitos end) f1,
+             avg(case when rn > tot/2 then feitos end) f2, max(tot) tot
+      from ord group by 1,2)
+    select lado, round(corr(f1,f2)::numeric,3) persistencia from met where tot >= 20 group by 1`);
+
+  const [tempo] = await q(`
+    select count(*) colunas_de_escanteio from information_schema.columns
+    where table_schema = 'futebol' and column_name ilike '%corner%'`);
+
+  console.log('\nOS CINCO MERCADOS DE ESCANTEIO — persistência do insumo de cada um');
+  console.table([
+    { id: 56, mercado: 'Handicap de escanteios', insumo: 'saldo', persistencia: saldo.persistencia },
+    { id: 45, mercado: 'Total do jogo', insumo: 'a favor + sofridos', persistencia: 'ver acima' },
+    { id: 57, mercado: 'Escanteios do mandante', insumo: 'a favor em casa', persistencia: mando.find((r) => r.lado === 'home')?.persistencia },
+    { id: 58, mercado: 'Escanteios do visitante', insumo: 'a favor fora', persistencia: mando.find((r) => r.lado === 'away')?.persistencia },
+    { id: 77, mercado: 'Total do 1º tempo', insumo: 'escanteio por tempo', persistencia: 'SEM INSUMO' },
+  ]);
+  console.log(`A base inteira tem ${tempo.colunas_de_escanteio} coluna de escanteio, e ela é do jogo completo.`);
+}
+
+/** A separação do handicap, que é a que inverte a ordem óbvia. */
+async function separacaoHandicap() {
+  const quintis = (pares, coberto) => `
+    with pares as (${pares}), pit as (
+      select *, avg(saldo) over (partition by team_id order by date_utc rows between 10 preceding and 1 preceding) m,
+             count(*) over (partition by team_id order by date_utc rows between 10 preceding and 1 preceding) n
+      from pares
+    ), jogo as (
+      select h.saldo real, (h.m - a.m) / 2.0 prev
+      from pit h join pit a on a.fixture_id = h.fixture_id and a.lado = 'away'
+      where h.lado = 'home' and h.n >= 10 and a.n >= 10
+    ), q5 as (select *, ntile(5) over (order by prev) quintil from jogo)
+    select quintil, count(*) jogos, round(avg(prev)::numeric,2) previsto,
+      round(avg(real)::numeric,2) saldo_real,
+      round(100.0 * sum(case when real > ${coberto} then 1 else 0 end) / count(*), 1) pct_acima
+    from q5 group by 1 order by 1`;
+
+  const esc = await q(quintis(PARES_ESCANTEIO, 0.5));
+  console.log('\nHANDICAP DE ESCANTEIO — quintis da supremacia prevista (mandante cobre o −0,5)');
+  console.table(esc);
+
+  const paresGol = `
+    select fixture_id, date_utc, home_team_id team_id, 'home' lado, goals_home - goals_away saldo
+    from futebol.fact_fixtures where status_short = 'FT' and goals_home is not null
+    union all
+    select fixture_id, date_utc, away_team_id, 'away', goals_away - goals_home
+    from futebol.fact_fixtures where status_short = 'FT' and goals_home is not null`;
+  const gol = await q(quintis(paresGol, 0.5));
+  console.log('\nHANDICAP DE GOLS — a mesma conta, como régua');
+  console.table(gol);
+
+  const spread = (t) => Number(t.at(-1).pct_acima) - Number(t[0].pct_acima);
+  console.log(`\nSeparação: handicap de escanteio ${spread(esc).toFixed(1)}pp · handicap de gol ${spread(gol).toFixed(1)}pp`);
+}
+
+/**
+ * Os cortes do catálogo. Saem da distribuição da nossa base — p75, mediana,
+ * quartil —, o que decide quantas vezes a premissa acende, não se ela vale.
+ * O que ela vale é a fase 5, e ela precisa de odds.
+ */
+async function limiares() {
+  const t = await q(`
+    with pares as (${PARES_ESCANTEIO}), m as (
+      select team_id, lado, avg(feitos) mf, avg(sofridos) ms, avg(saldo) msa
+      from pares group by 1,2 having count(*) >= 15)
+    select lado,
+      round(percentile_cont(0.50) within group (order by mf)::numeric,2)  a_favor_mediana,
+      round(percentile_cont(0.75) within group (order by ms)::numeric,2)  sofridos_p75,
+      round(percentile_cont(0.25) within group (order by msa)::numeric,2) saldo_p25,
+      round(percentile_cont(0.75) within group (order by msa)::numeric,2) saldo_p75
+    from m group by 1`);
+  console.log('\nLIMIARES MEDIDOS, por mando (times com >= 15 jogos no lado)');
+  console.table(t);
+
+  const [j] = await q(`
+    with pares as (${PARES_ESCANTEIO}), jogo as (
+      select h.chutes + a.chutes chutes_total, abs(h.posse - a.posse) gap_posse
+      from pares h join pares a on a.fixture_id = h.fixture_id and a.lado = 'away'
+      where h.lado = 'home')
+    select round(percentile_cont(0.50) within group (order by chutes_total)::numeric,1) chutes_mediana,
+           round(percentile_cont(0.75) within group (order by chutes_total)::numeric,1) chutes_p75,
+           round(percentile_cont(0.50) within group (order by gap_posse)::numeric,1) gap_posse_mediana,
+           round(percentile_cont(0.75) within group (order by gap_posse)::numeric,1) gap_posse_p75
+    from jogo`);
+  console.log('\nPOR JOGO — finalizações somadas e diferença de posse');
+  console.table([j]);
+
+  // A premissa de estilo que morreu na fase 3: a razão quase não varia entre times.
+  const [r] = await q(`
+    with pares as (
+      select a.team_id, a.corner_kicks feitos, a.total_shots chutes
+      from futebol.fact_fixture_stats a
+      join futebol.fact_fixture_stats b on b.fixture_id = a.fixture_id and b.team_id <> a.team_id
+      where a.corner_kicks is not null and a.total_shots > 0
+    ), m as (select team_id, sum(feitos)::numeric / sum(chutes) r from pares group by 1 having count(*) >= 30)
+    select round(percentile_cont(0.10) within group (order by r)::numeric,3) p10,
+           round(percentile_cont(0.50) within group (order by r)::numeric,3) mediana,
+           round(percentile_cont(0.90) within group (order by r)::numeric,3) p90,
+           round(stddev(r)::numeric,3) desvio
+    from m`);
+  console.log('\nESCANTEIOS POR FINALIZAÇÃO — a premissa de estilo, cortada na fase 3');
+  console.log('Quase não varia entre times: é constante do futebol, não traço de time.');
+  console.table([r]);
+}
+
 await cobertura();
 await persistencia();
+await porMercado();
 await separacao();
+await separacaoHandicap();
+await limiares();

--- a/scripts/futebol-escanteios-retrato.mjs
+++ b/scripts/futebol-escanteios-retrato.mjs
@@ -1,0 +1,154 @@
+/**
+ * Retrato do mercado de escanteios — a fase 1 do método de premissas.
+ *
+ * Reproduz as medições da seção 5 de docs/futebol-metodologia-de-premissas.md.
+ * Existe porque a lição da seção 0 daquele documento é exatamente esta: a
+ * rodada de medição anterior ficou num diretório temporário do sistema e só é
+ * retomável hoje por sorte.
+ *
+ * Uso (o token é o mesmo SUPABASE_ACCESS_TOKEN do .env.local):
+ *   SUPABASE_ACCESS_TOKEN=... node scripts/futebol-escanteios-retrato.mjs
+ *
+ * Quatro armadilhas que este script evita, e que qualquer reescrita precisa
+ * continuar evitando:
+ *
+ * 1. POINT-IN-TIME. As médias de time usam `rows between 10 preceding and 1
+ *    preceding`. O `1 preceding` é o que exclui a própria partida. Sem ele o
+ *    número sobe e a medição vira a task [0] de novo.
+ *
+ * 2. O PAR DO JOGO. `fact_fixture_stats` tem uma linha por time por jogo. Os
+ *    escanteios sofridos por um time são os escanteios feitos pelo outro na
+ *    mesma partida — daí o self-join por fixture_id com team_id diferente.
+ *    Somar a coluna errada mede a mesma coisa duas vezes.
+ *
+ * 3. AMOSTRA MÍNIMA. Times com menos de 10 jogos de histórico saem da conta de
+ *    separação, e com menos de 30 saem da conta de persistência. Amostra curta
+ *    fabrica sinal, e esse é o achado mais caro da base.
+ *
+ * 4. A RÉGUA. Todo número de escanteio vem ao lado do mesmo número em gols. Sem
+ *    a régua, 10,3 pontos de separação parecem muito. Ao lado dos 19,4 de gols,
+ *    parecem o que são.
+ */
+
+const PROJETO = process.env.SUPABASE_PROJECT_REF || 'lavclmlvvfzkblrstojd';
+const TOKEN = process.env.SUPABASE_ACCESS_TOKEN;
+
+if (!TOKEN) {
+  console.error('falta SUPABASE_ACCESS_TOKEN no ambiente (está no .env.local)');
+  process.exit(1);
+}
+
+/** Leitura pelo Management API. `read_only` é a garantia de que isto não escreve. */
+async function q(sql) {
+  const r = await fetch(`https://api.supabase.com/v1/projects/${PROJETO}/database/query`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: sql, read_only: true }),
+  });
+  const t = await r.text();
+  if (!r.ok) throw new Error(`HTTP ${r.status}: ${t.slice(0, 300)}`);
+  return JSON.parse(t);
+}
+
+/** O par do jogo: cada linha vira (feitos, sofridos) para um time. */
+const PARES_ESCANTEIO = `
+  select a.fixture_id, a.date_utc, a.team_id, a.team_side lado,
+         a.corner_kicks feitos, b.corner_kicks sofridos
+  from futebol.fact_fixture_stats a
+  join futebol.fact_fixture_stats b
+    on b.fixture_id = a.fixture_id and b.team_id <> a.team_id
+  where a.corner_kicks is not null and b.corner_kicks is not null`;
+
+const PARES_GOL = `
+  select fixture_id, date_utc, home_team_id team_id, 'home' lado,
+         goals_home feitos, goals_away sofridos
+  from futebol.fact_fixtures where status_short = 'FT' and goals_home is not null
+  union all
+  select fixture_id, date_utc, away_team_id, 'away', goals_away, goals_home
+  from futebol.fact_fixtures where status_short = 'FT' and goals_home is not null`;
+
+/** Média dos 10 jogos ANTERIORES — o `1 preceding` é o point-in-time. */
+const pit = (pares) => `
+  with pares as (${pares}), pit as (
+    select *,
+      avg(feitos)   over (partition by team_id order by date_utc rows between 10 preceding and 1 preceding) mf,
+      avg(sofridos) over (partition by team_id order by date_utc rows between 10 preceding and 1 preceding) ms,
+      count(*)      over (partition by team_id order by date_utc rows between 10 preceding and 1 preceding) n
+    from pares
+  ), jogo as (
+    select h.fixture_id, h.feitos + h.sofridos total,
+           (h.mf + a.ms + a.mf + h.ms) / 2.0 prev
+    from pit h join pit a on a.fixture_id = h.fixture_id and a.lado = 'away'
+    where h.lado = 'home' and h.n >= 10 and a.n >= 10
+  )`;
+
+async function cobertura() {
+  const r = await q(`
+    select f.competition,
+      count(distinct f.fixture_id) jogos_ft,
+      round(100.0 * count(distinct s.fixture_id) / count(distinct f.fixture_id), 1) cobertura
+    from futebol.fact_fixtures f
+    left join futebol.fact_fixture_stats s
+      on s.fixture_id = f.fixture_id and s.corner_kicks is not null
+    where f.status_short = 'FT' and f.date_utc >= '2026-01-01'
+    group by 1 order by 2 desc`);
+  console.log('\nCOBERTURA DE ESCANTEIO POR COMPETIÇÃO (encerrados em 2026)');
+  console.table(r);
+}
+
+/** A pergunta que decide o mercado: isso é traço do time ou é ruído? */
+async function persistencia() {
+  const conta = (pares) => `
+    with pares as (${pares}), ord as (
+      select *, row_number() over (partition by team_id order by date_utc) rn,
+             count(*) over (partition by team_id) tot from pares
+    ), met as (
+      select team_id,
+        avg(case when rn <= tot/2 then feitos   end) f1, avg(case when rn > tot/2 then feitos   end) f2,
+        avg(case when rn <= tot/2 then sofridos end) s1, avg(case when rn > tot/2 then sofridos end) s2,
+        max(tot) tot from ord group by 1
+    )
+    select round(corr(f1,f2)::numeric,3) a_favor,
+           round(corr(s1,s2)::numeric,3) sofridos,
+           count(*) times
+    from met where tot >= 30`;
+
+  const linhas = [];
+  const colunas = ['ball_possession', 'expected_goals', 'total_shots', 'fouls', 'yellow_cards', 'corner_kicks'];
+  for (const col of colunas) {
+    const pares = PARES_ESCANTEIO.replaceAll('corner_kicks', col);
+    const [r] = await q(conta(pares));
+    linhas.push({ estatistica: col, ...r });
+  }
+  const [g] = await q(conta(PARES_GOL));
+  linhas.push({ estatistica: 'gols (régua)', ...g });
+
+  console.log('\nPERSISTÊNCIA — metade 1 x metade 2 dos jogos do time (>= 30 jogos)');
+  console.log('Abaixo de 0,4 não existe premissa estrutural possível.');
+  console.table(linhas.sort((a, b) => Number(b.a_favor) - Number(a.a_favor)));
+}
+
+/** Quanto dá para ordenar jogo — sempre ao lado da régua de gols. */
+async function separacao() {
+  const quintis = (pares, linha) => `${pit(pares)},
+    q5 as (select *, ntile(5) over (order by prev) quintil from jogo)
+    select quintil, count(*) jogos,
+      round(avg(prev)::numeric,2) previsto, round(avg(total)::numeric,2) real,
+      round(100.0 * sum(case when total > ${linha} then 1 else 0 end) / count(*), 1) pct_acima
+    from q5 group by 1 order by 1`;
+
+  const esc = await q(quintis(PARES_ESCANTEIO, 9.5));
+  console.log('\nESCANTEIOS — quintis da previsão point-in-time (linha 9,5)');
+  console.table(esc);
+
+  const gol = await q(quintis(PARES_GOL, 2.5));
+  console.log('\nGOLS — a mesma conta, como régua (linha 2,5)');
+  console.table(gol);
+
+  const spread = (t) => Number(t.at(-1).pct_acima) - Number(t[0].pct_acima);
+  console.log(`\nSeparação entre o 1º e o 5º quintil: escanteio ${spread(esc).toFixed(1)}pp · gol ${spread(gol).toFixed(1)}pp`);
+}
+
+await cobertura();
+await persistencia();
+await separacao();

--- a/scripts/futebol-handicap-premissas.mjs
+++ b/scripts/futebol-handicap-premissas.mjs
@@ -159,16 +159,21 @@ function estatistica(linhas, campo = 'lucro') {
 }
 
 /**
- * Quanto a premissa acrescenta, já descontado o tamanho do handicap.
+ * Quanto a premissa acrescenta, já descontado o que `chave` isola.
  *
- * Dentro de cada linha compara acesa contra apagada; depois soma as diferenças
+ * Dentro de cada célula compara acesa contra apagada; depois soma as diferenças
  * pesadas pelo número de linhas acesas. Célula com menos de dez de cada lado
  * fica de fora: ela não mede, só balança o total.
+ *
+ * A chave é parâmetro porque as duas estratificações respondem coisas
+ * diferentes. Por TAMANHO DE HANDICAP, a pergunta é se a premissa mede algo além
+ * do tamanho da linha. Por FAIXA DE PREÇO, a pergunta é se ela mede algo que o
+ * mercado ainda não cobrou — e essa é a que decide se vale a pena tê-la.
  */
-function diferencaEstratificada(linhas, premissa) {
+function diferencaEstratificada(linhas, premissa, chave = (l) => Number(l.side_handicap)) {
   const celulas = new Map();
   for (const l of linhas) {
-    const k = Number(l.side_handicap);
+    const k = chave(l);
     if (!celulas.has(k)) celulas.set(k, []);
     celulas.get(k).push(l);
   }
@@ -233,6 +238,55 @@ const faixaDeOdd = (o) => {
   return '4.00+';
 };
 
+/**
+ * Faixas estreitas de preço, para segurar o mercado constante.
+ *
+ * Mais estreitas que `faixaDeOdd`, que é a faixa de leitura do produto: aqui o
+ * objetivo é que dentro de cada célula o mercado esteja dizendo a mesma coisa,
+ * e faixa larga demais deixa preço sobrando dentro da célula.
+ */
+const bandaDePreco = (o) => {
+  const x = Number(o);
+  if (x < 1.15) return 'a <1,15';
+  if (x < 1.30) return 'b 1,15–1,29';
+  if (x < 1.45) return 'c 1,30–1,44';
+  if (x < 1.65) return 'd 1,45–1,64';
+  if (x < 1.90) return 'e 1,65–1,89';
+  if (x < 2.20) return 'f 1,90–2,19';
+  if (x < 2.70) return 'g 2,20–2,69';
+  if (x < 3.50) return 'h 2,70–3,49';
+  if (x < 5.00) return 'i 3,50–4,99';
+  return 'j 5,00+';
+};
+
+/**
+ * A diferença entre dois recortes, antes e depois de segurar o preço.
+ *
+ * É o teste que separa causa de artefato, e o único do relatório que já mudou
+ * uma conclusão: o lado favorito/azarão INVERTE de sinal quando o preço é
+ * controlado, porque favorito vive em odd longa e azarão em odd curta. Lido
+ * bruto, o recorte mede a faixa de preço de cada grupo e chama isso de lado.
+ */
+function contraPreco(rotulo, linhas, pertence) {
+  const a0 = linhas.filter(pertence), b0 = linhas.filter((l) => !pertence(l));
+  const bruta = estatistica(a0).roi - estatistica(b0).roi;
+  const celulas = new Map();
+  for (const l of linhas) {
+    const k = bandaDePreco(l.melhor ?? l.best_odd);
+    if (!celulas.has(k)) celulas.set(k, []);
+    celulas.get(k).push(l);
+  }
+  let peso = 0, soma = 0;
+  for (const [, v] of celulas) {
+    const a = v.filter(pertence), b = v.filter((l) => !pertence(l));
+    if (a.length < 20 || b.length < 20) continue;
+    const w = Math.min(a.length, b.length);
+    peso += w;
+    soma += w * (estatistica(a).roi - estatistica(b).roi);
+  }
+  console.log(`| ${rotulo} | ${pp(bruta)} | ${peso ? pp(soma / peso) : '—'} |`);
+}
+
 // ── programa ───────────────────────────────────────────────────────────────
 
 function liquidarLinhas(brutas, odd, extras = () => ({})) {
@@ -283,17 +337,31 @@ async function principal() {
   tabela('Universo, por faixa de odd', universo, (l) => faixaDeOdd(l.melhor));
   tabela('Universo, por mando', universo, (l) => (l.outcome === 'Home' ? 'mandante' : 'visitante'));
 
+  console.log('\n### Causa ou artefato de preço?');
+  console.log('| recorte | diferença bruta | controlada por preço |');
+  console.log('|---|---:|---:|');
+  contraPreco('favorito contra azarão', universo, (l) => l.lado === 'favorito');
+  contraPreco('mandante contra visitante', universo, (l) => l.outcome === 'Home');
+  contraPreco('handicap de 1,5 ou mais contra 0,5', universo,
+    (l) => Math.abs(Number(l.side_handicap)) >= 1.5);
+  console.log(
+    '\n> Recorte que INVERTE de sinal ao controlar o preço não é causa: é a faixa ' +
+    'de preço do grupo, com outro nome.',
+  );
+
   for (const [nome, linhas] of [['FAVORITO', favorito], ['AZARÃO', azarao]]) {
     const e = estatistica(linhas);
     console.log(`\n### ${nome} — o que cada premissa acrescenta (${linhas.length} linhas, ROI base ${pct(e.roi)})`);
-    console.log('| premissa | n acesa | ROI acesa | n apagada | ROI apagada | diferença estratificada |');
+    console.log('| premissa | n acesa | ROI acesa | ROI apagada | controlando a linha | controlando o PREÇO |');
     console.log('|---|---:|---:|---:|---:|---:|');
     for (const p of PREMISSAS) {
       const d = diferencaEstratificada(linhas, p);
       if (!d) continue;
+      const q = diferencaEstratificada(linhas, p, (l) => bandaDePreco(l.melhor));
       console.log(
-        `| ${p} | ${d.nAcesa} | ${pct(d.roiAcesa)} | ${d.nApagada} | ${pct(d.roiApagada)} | ` +
-        `${pp(d.dif)} ± ${(d.ep * 100).toFixed(1)} |`,
+        `| ${p} | ${d.nAcesa} | ${pct(d.roiAcesa)} | ${pct(d.roiApagada)} | ` +
+        `${pp(d.dif)} ± ${(d.ep * 100).toFixed(1)} | ` +
+        `${q ? `${pp(q.dif)} ± ${(q.ep * 100).toFixed(1)}` : '—'} |`,
       );
     }
   }
@@ -315,6 +383,20 @@ async function principal() {
   linha('vantagem acima de zero', board.filter((l) => Number(l.edge) > 0));
   linha('vantagem entre -2% e zero', board.filter((l) => Number(l.edge) <= 0 && Number(l.edge) > -0.02));
   linha('vantagem abaixo de -2%', board.filter((l) => Number(l.edge) <= -0.02));
+
+  // A tabela que estabelece a ordem causal entre preço pago e odd longa. Lida
+  // pelas LINHAS: com vantagem boa, a faixa de odd não muda quase nada; com
+  // vantagem ruim, ela decide tudo. Logo a odd longa não causa o prejuízo, ela
+  // multiplica o prejuízo de ter pago mal — e cortar odd longa sem corrigir
+  // preço é tratar o sintoma.
+  cabecalho('Vantagem contra faixa de odd — qual das duas manda');
+  for (const [rot, ok] of [['vantagem acima de -2%', (l) => Number(l.edge) > -0.02],
+                           ['vantagem abaixo de -2%', (l) => Number(l.edge) <= -0.02]]) {
+    for (const [banda, dentro] of [['odd < 2,00', (l) => Number(l.best_odd) < 2],
+                                   ['odd >= 2,00', (l) => Number(l.best_odd) >= 2]]) {
+      linha(`${rot}, ${banda}`, board.filter((l) => ok(l) && dentro(l)));
+    }
+  }
   tabela('Board publicado, por faixa de odd', board, (l) => faixaDeOdd(l.best_odd));
   tabela('Board publicado, por campeonato', board, (l) => l.competition);
 

--- a/scripts/futebol-handicap-premissas.mjs
+++ b/scripts/futebol-handicap-premissas.mjs
@@ -51,6 +51,38 @@ import { liquidar, lucroDaAposta, ehAcerto } from './futebol-roi.mjs';
 const RAIZ = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const PROJETO_PRD = 'lavclmlvvfzkblrstojd';
 
+/**
+ * O tombamento: em 04/09/2026 ~14h35 UTC o denominador da nota trocou do p95
+ * para o teto de pontos.
+ *
+ * Importa aqui por um motivo diferente do que importa em `futebol-roi.mjs`. Lá
+ * o problema é o Score, que antes disso está em outra escala. Aqui o problema é
+ * a COMPOSIÇÃO: em 03/09 o snapshot capturou o board inteiro de uma vez, e esse
+ * dia sozinho responde por 229 das 374 linhas liquidadas do handicap. Sem
+ * separar, 61% de qualquer conclusão sobre o board vem de uma única captura.
+ *
+ * A vantagem sobre a linha sharp NÃO foi afetada pela troca — ela é estável em
+ * todos os dias, entre −2,4% e −3,3% —, então as duas metades respondem a mesma
+ * pergunta e as duas saem no relatório.
+ */
+const TOMBAMENTO = '2026-09-04 14:35';
+
+/**
+ * Explode se o carimbo não vier na consulta, em vez de deixar passar.
+ *
+ * A primeira versão comparava `String(l.dbt_valid_from)` direto, e a consulta
+ * não trazia a coluna: `"undefined" >= "2026-09-04 14:35"` é VERDADEIRO em
+ * texto, porque 'u' vem depois de '2'. O relatório saiu dizendo que as 374
+ * linhas eram posteriores ao tombamento e que a captura em massa tinha zero,
+ * sem errar em lugar nenhum. Filtro de data que falha aberto mente calado.
+ */
+const depoisDoTombamento = (l) => {
+  if (l.dbt_valid_from == null) {
+    throw new Error('a consulta não trouxe `dbt_valid_from`: o corte do tombamento não tem como ser aplicado');
+  }
+  return String(l.dbt_valid_from).replace('T', ' ') >= TOMBAMENTO;
+};
+
 /** As nove colunas de premissa do mart. A nona não existe no catálogo da tela. */
 const PREMISSAS = [
   'supremacia', 'tende_golear', 'adversario_fragil_fora', 'mando_forte',
@@ -126,7 +158,8 @@ const SQL_BOARD = `
 with primeiro as (
   select distinct on (h.opportunity_key)
     h.fixture_id, h.outcome, h.line_value, h.best_odd, h.edge, h.score,
-    h.pts_premissas, h.competition, h.linha_sharp_confirma, h.modelo_api_concorda
+    h.pts_premissas, h.competition, h.linha_sharp_confirma, h.modelo_api_concorda,
+    h.dbt_valid_from
   from futebol.fact_value_opportunities_hist h
   where h.score_versao = 'contexto_v1' and h.market = 'asian_handicap'
   order by h.opportunity_key, h.dbt_valid_from asc
@@ -379,23 +412,40 @@ async function principal() {
     (l) => Number(l.melhor) >= 1.4 && Number(l.melhor) < 2.0 && l.outcome === 'Away',
   ));
 
-  cabecalho('Board publicado, pelo preço que a nota não olha');
-  linha('vantagem acima de zero', board.filter((l) => Number(l.edge) > 0));
-  linha('vantagem entre -2% e zero', board.filter((l) => Number(l.edge) <= 0 && Number(l.edge) > -0.02));
-  linha('vantagem abaixo de -2%', board.filter((l) => Number(l.edge) <= -0.02));
+  const pos = board.filter(depoisDoTombamento);
+  console.log(
+    `\n> Do board, ${board.length - pos.length} linhas vêm da captura em massa de ` +
+    `03/09 e ${pos.length} são posteriores ao tombamento de ${TOMBAMENTO}. As duas ` +
+    'metades saem separadas: sem isso, a maior parte da conclusão vem de um dia só.',
+  );
 
-  // A tabela que estabelece a ordem causal entre preço pago e odd longa. Lida
-  // pelas LINHAS: com vantagem boa, a faixa de odd não muda quase nada; com
-  // vantagem ruim, ela decide tudo. Logo a odd longa não causa o prejuízo, ela
-  // multiplica o prejuízo de ter pago mal — e cortar odd longa sem corrigir
-  // preço é tratar o sintoma.
-  cabecalho('Vantagem contra faixa de odd — qual das duas manda');
-  for (const [rot, ok] of [['vantagem acima de -2%', (l) => Number(l.edge) > -0.02],
-                           ['vantagem abaixo de -2%', (l) => Number(l.edge) <= -0.02]]) {
-    for (const [banda, dentro] of [['odd < 2,00', (l) => Number(l.best_odd) < 2],
-                                   ['odd >= 2,00', (l) => Number(l.best_odd) >= 2]]) {
-      linha(`${rot}, ${banda}`, board.filter((l) => ok(l) && dentro(l)));
+  for (const [nome, pop] of [['todo o board', board], ['só depois do tombamento', pos]]) {
+    cabecalho(`Board publicado, pelo preço que a nota não olha (${nome})`);
+    linha('vantagem acima de zero', pop.filter((l) => Number(l.edge) > 0));
+    linha('vantagem entre -2% e zero', pop.filter((l) => Number(l.edge) <= 0 && Number(l.edge) > -0.02));
+    linha('vantagem abaixo de -2%', pop.filter((l) => Number(l.edge) <= -0.02));
+
+    // A tabela que estabelece a ordem causal entre preço pago e odd longa. Lida
+    // pelas LINHAS: com vantagem boa, a faixa de odd não muda quase nada; com
+    // vantagem ruim, ela decide tudo. Logo a odd longa não causa o prejuízo, ela
+    // multiplica o prejuízo de ter pago mal — e cortar odd longa sem corrigir
+    // preço é tratar o sintoma.
+    cabecalho(`Vantagem contra faixa de odd — qual das duas manda (${nome})`);
+    for (const [rot, ok] of [['vantagem acima de -2%', (l) => Number(l.edge) > -0.02],
+                             ['vantagem abaixo de -2%', (l) => Number(l.edge) <= -0.02]]) {
+      for (const [banda, dentro] of [['odd < 2,00', (l) => Number(l.best_odd) < 2],
+                                     ['odd >= 2,00', (l) => Number(l.best_odd) >= 2]]) {
+        linha(`${rot}, ${banda}`, pop.filter((l) => ok(l) && dentro(l)));
+      }
     }
+
+    // O de-para que a decisão de produto usa: o board como está contra o board
+    // com o corte de valor. `n` cai para um quarto — isso é a proposta, não
+    // efeito colateral.
+    cabecalho(`De-para: o corte de valor na vitrine (${nome})`);
+    linha('AS-IS, board como está', pop);
+    linha('TO-BE, valor acima de -2%', pop.filter((l) => Number(l.edge) > -0.02));
+    linha('TO-BE, valor acima de zero', pop.filter((l) => Number(l.edge) > 0));
   }
   tabela('Board publicado, por faixa de odd', board, (l) => faixaDeOdd(l.best_odd));
   tabela('Board publicado, por campeonato', board, (l) => l.competition);

--- a/scripts/futebol-handicap-premissas.mjs
+++ b/scripts/futebol-handicap-premissas.mjs
@@ -1,0 +1,330 @@
+// ============================================================================
+// As premissas do handicap asiático, medidas contra resultado
+// ============================================================================
+// Uso:
+//   node scripts/futebol-handicap-premissas.mjs
+//
+// Credencial: `SUPABASE_ACCESS_TOKEN` do ambiente, ou de `.env.local`. Só faz
+// SELECT, com `read_only` no endpoint. Nunca imprime segredo.
+//
+// `scripts/futebol-roi.mjs` mede o BOARD: o que foi publicado. Este mede o
+// UNIVERSO: toda linha de handicap que teve preço, publicada ou não. São
+// perguntas diferentes. A primeira responde "quanto o produto rendeu"; esta
+// responde "a premissa separa ganhador de perdedor", e para isso é preciso ver
+// também as linhas que a porta recusou — senão a amostra é o próprio filtro que
+// se quer avaliar.
+//
+// ── Quatro armadilhas que este script existe para não deixar você cair ──────
+//
+// 1. A LINHA TEM DUAS ÓTICAS. `int_futebol_premissas_ah.line_value` e
+//    `fact_odds_snapshot.line_value` guardam a linha na ótica do MANDANTE;
+//    `side_handicap` guarda na ótica do time apostado. Casar preço com premissa
+//    por `side_handicap` casa o azarão de um lado com a odd do favorito do
+//    outro, e o relatório sai com ROI de +145% sem reclamar de nada. O join
+//    correto é por `line_value`: contra as 600 linhas publicadas, a melhor odd
+//    reconstruída assim bate com a que foi ao ar em 598 casos.
+//
+// 2. `int_futebol_odds_devig` NÃO SERVE DE HISTÓRICO. Ela é recalculada a cada
+//    rodada do dbt, então o preço que está lá hoje não é o que foi publicado.
+//    Contra as linhas já liquidadas, a odd dela é em média 0,75 mais alta, e o
+//    ROI sai +33% em vez de -10,6%. O preço honesto se reconstrói de
+//    `fact_odds_snapshot`, que é imutável.
+//
+// 3. MEDIANA E MELHOR ODD RESPONDEM COISAS DIFERENTES. A melhor odd entre as
+//    casas é o que o assinante consegue, e é o número do produto. A mediana é o
+//    mercado, e é a régua para comparar recortes sem que o vencedor de cada
+//    recorte seja "quem teve uma casa fora da curva". As duas saem.
+//
+// 4. TAMANHO DE HANDICAP CONFUNDE TUDO. Um -2,5 perde muito mais que um -0,5,
+//    e as premissas do favorito acendem mais nos handicaps grandes. Comparar
+//    "premissa acesa" com "premissa apagada" sem separar por linha mede o
+//    tamanho do handicap e chama isso de premissa. Por isso a coluna que decide
+//    é a DIFERENÇA ESTRATIFICADA: acesa contra apagada dentro de cada linha, e
+//    só depois somada.
+// ============================================================================
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { liquidar, lucroDaAposta, ehAcerto } from './futebol-roi.mjs';
+
+const RAIZ = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PROJETO_PRD = 'lavclmlvvfzkblrstojd';
+
+/** As nove colunas de premissa do mart. A nona não existe no catálogo da tela. */
+const PREMISSAS = [
+  'supremacia', 'tende_golear', 'adversario_fragil_fora', 'mando_forte',
+  'sem_rodizio', 'raramente_perde_por_2', 'defesa_fora_solida',
+  'favorito_irregular', 'handicap_alto',
+];
+
+// ── consulta ───────────────────────────────────────────────────────────────
+
+function tokenDeAcesso() {
+  if (process.env.SUPABASE_ACCESS_TOKEN) return process.env.SUPABASE_ACCESS_TOKEN;
+  let env;
+  try {
+    env = readFileSync(resolve(RAIZ, '.env.local'), 'utf8');
+  } catch {
+    throw new Error('sem SUPABASE_ACCESS_TOKEN no ambiente e sem .env.local para ler.');
+  }
+  const m = /^SUPABASE_ACCESS_TOKEN=(.*)$/m.exec(env);
+  if (!m) throw new Error('SUPABASE_ACCESS_TOKEN não encontrado no ambiente nem em .env.local');
+  return m[1].trim().replace(/^["']|["']$/g, '');
+}
+
+async function consultar(sql) {
+  const r = await fetch(`https://api.supabase.com/v1/projects/${PROJETO_PRD}/database/query`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${tokenDeAcesso()}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: sql, read_only: true }),
+  });
+  const corpo = await r.text();
+  if (!r.ok) throw new Error(`consulta recusada (HTTP ${r.status}): ${corpo.slice(0, 300)}`);
+  const j = JSON.parse(corpo);
+  if (!Array.isArray(j)) throw new Error(`consulta falhou: ${JSON.stringify(j).slice(0, 300)}`);
+  return j;
+}
+
+/**
+ * Toda linha de handicap com preço, em jogo já encerrado.
+ *
+ * O corte de três casas é o mesmo piso que o produto usa para não publicar
+ * linha de casa única, e as oito linhas de meio gol são as únicas que o produto
+ * publica — deixar o quarto de gol entrar aqui compararia o método com um
+ * universo que ele não aposta.
+ */
+const SQL_UNIVERSO = `
+with odds as (
+  select fixture_id, outcome_side, line_value,
+         max(odd_decimal) melhor,
+         percentile_cont(0.5) within group (order by odd_decimal) mediana,
+         count(distinct bookmaker_id) casas
+  from futebol.fact_odds_snapshot
+  where market_name = 'Asian Handicap'
+    and collection_window = 't24h'
+    and line_value in (-3.5, -2.5, -1.5, -0.5, 0.5, 1.5, 2.5, 3.5)
+  group by 1, 2, 3
+  having count(distinct bookmaker_id) >= 3
+)
+select a.fixture_id, a.outcome, a.line_value, a.side_handicap,
+       a.is_favorito, a.is_azarao, a.competition, a.pts_premissas,
+       ${PREMISSAS.map((p) => `a.${p}`).join(', ')},
+       o.melhor, o.mediana, o.casas,
+       f.goals_home, f.goals_away
+from futebol.int_futebol_premissas_ah a
+join odds o
+  on o.fixture_id = a.fixture_id
+ and o.outcome_side = a.outcome
+ and o.line_value = a.line_value
+join futebol.fact_fixtures f on f.fixture_id = a.fixture_id
+where f.status_short in ('FT', 'AET', 'PEN')
+`;
+
+/** O board publicado, com a foto de quando cada oportunidade nasceu. */
+const SQL_BOARD = `
+with primeiro as (
+  select distinct on (h.opportunity_key)
+    h.fixture_id, h.outcome, h.line_value, h.best_odd, h.edge, h.score,
+    h.pts_premissas, h.competition, h.linha_sharp_confirma, h.modelo_api_concorda
+  from futebol.fact_value_opportunities_hist h
+  where h.score_versao = 'contexto_v1' and h.market = 'asian_handicap'
+  order by h.opportunity_key, h.dbt_valid_from asc
+)
+select p.*, a.side_handicap, a.is_favorito,
+       ${PREMISSAS.map((p) => `a.${p}`).join(', ')},
+       f.status_short, f.goals_home, f.goals_away
+from primeiro p
+join futebol.int_futebol_premissas_ah a
+  on a.fixture_id = p.fixture_id and a.outcome = p.outcome and a.line_value = p.line_value
+join futebol.fact_fixtures f on f.fixture_id = p.fixture_id
+`;
+
+// ── estatística ────────────────────────────────────────────────────────────
+
+/** Média, erro-padrão e taxa de acerto. Ver o cabeçalho de `futebol-roi.mjs`. */
+function estatistica(linhas, campo = 'lucro') {
+  const n = linhas.length;
+  if (n === 0) return { n: 0, roi: 0, ep: 0, taxa: null };
+  const lucros = linhas.map((l) => l[campo]);
+  const media = lucros.reduce((a, b) => a + b, 0) / n;
+  const variancia = n > 1 ? lucros.reduce((a, b) => a + (b - media) ** 2, 0) / (n - 1) : 0;
+  const decididas = linhas.filter((l) => l.resultado !== 'push').length;
+  return {
+    n,
+    roi: media,
+    ep: Math.sqrt(variancia / n),
+    taxa: decididas ? linhas.filter((l) => ehAcerto(l.resultado)).length / decididas : null,
+  };
+}
+
+/**
+ * Quanto a premissa acrescenta, já descontado o tamanho do handicap.
+ *
+ * Dentro de cada linha compara acesa contra apagada; depois soma as diferenças
+ * pesadas pelo número de linhas acesas. Célula com menos de dez de cada lado
+ * fica de fora: ela não mede, só balança o total.
+ */
+function diferencaEstratificada(linhas, premissa) {
+  const celulas = new Map();
+  for (const l of linhas) {
+    const k = Number(l.side_handicap);
+    if (!celulas.has(k)) celulas.set(k, []);
+    celulas.get(k).push(l);
+  }
+  let peso = 0, soma = 0, variancia = 0;
+  let nAcesa = 0, roiAcesa = 0, nApagada = 0, roiApagada = 0;
+  for (const [, v] of celulas) {
+    const acesa = v.filter((x) => x[premissa] === true);
+    const apagada = v.filter((x) => x[premissa] === false);
+    if (acesa.length < 10 || apagada.length < 10) continue;
+    const a = estatistica(acesa), b = estatistica(apagada);
+    peso += a.n;
+    soma += a.n * (a.roi - b.roi);
+    variancia += a.n * a.n * (a.ep ** 2 + b.ep ** 2);
+    nAcesa += a.n; roiAcesa += a.n * a.roi;
+    nApagada += b.n; roiApagada += b.n * b.roi;
+  }
+  if (!peso) return null;
+  return {
+    dif: soma / peso, ep: Math.sqrt(variancia) / peso,
+    nAcesa, roiAcesa: roiAcesa / nAcesa,
+    nApagada, roiApagada: roiApagada / nApagada,
+  };
+}
+
+// ── apresentação ───────────────────────────────────────────────────────────
+
+const pct = (x) => (x == null ? '—' : `${(x * 100).toFixed(1)}%`);
+const pp = (x) => `${x >= 0 ? '+' : ''}${(x * 100).toFixed(1)}pp`;
+
+function cabecalho(titulo, coluna = 'ROI') {
+  console.log(`\n### ${titulo}`);
+  console.log(`| recorte | n | taxa | ${coluna} | erro-padrão |`);
+  console.log('|---|---:|---:|---:|---:|');
+}
+
+function linha(rotulo, linhas, campo = 'lucro') {
+  const e = estatistica(linhas, campo);
+  console.log(`| ${rotulo} | ${e.n} | ${pct(e.taxa)} | ${pct(e.roi)} | ±${(e.ep * 100).toFixed(1)}pp |`);
+}
+
+function tabela(titulo, linhas, chave, campo = 'lucro', coluna = 'ROI') {
+  const grupos = new Map();
+  for (const l of linhas) {
+    const k = chave(l);
+    if (k == null) continue;
+    if (!grupos.has(k)) grupos.set(k, []);
+    grupos.get(k).push(l);
+  }
+  cabecalho(titulo, coluna);
+  for (const [k, v] of [...grupos.entries()].sort((a, b) => String(a[0]).localeCompare(String(b[0])))) {
+    linha(k, v, campo);
+  }
+}
+
+const faixaDeOdd = (o) => {
+  const x = Number(o);
+  if (x < 1.4) return '1.00–1.39';
+  if (x < 1.6) return '1.40–1.59';
+  if (x < 2.0) return '1.60–1.99';
+  if (x < 2.6) return '2.00–2.59';
+  if (x < 4.0) return '2.60–3.99';
+  return '4.00+';
+};
+
+// ── programa ───────────────────────────────────────────────────────────────
+
+function liquidarLinhas(brutas, odd, extras = () => ({})) {
+  const saida = [];
+  for (const l of brutas) {
+    const r = liquidar('asian_handicap', l.outcome, l.line_value, l.goals_home, l.goals_away);
+    if (r == null) continue;
+    saida.push({
+      ...l, ...extras(l), resultado: r,
+      lado: l.is_favorito ? 'favorito' : 'azarao',
+      lucro: lucroDaAposta(r, Number(odd(l))),
+    });
+  }
+  return saida;
+}
+
+async function principal() {
+  const universo = liquidarLinhas(await consultar(SQL_UNIVERSO), (l) => l.melhor, (l) => ({
+    lucroMediana: lucroDaAposta(
+      liquidar('asian_handicap', l.outcome, l.line_value, l.goals_home, l.goals_away),
+      Number(l.mediana),
+    ),
+  }));
+  const board = liquidarLinhas(
+    (await consultar(SQL_BOARD)).filter((l) => ['FT', 'AET', 'PEN'].includes(l.status_short)),
+    (l) => l.best_odd,
+  );
+
+  console.log('# Premissas do handicap asiático, contra resultado');
+  console.log(`\n> Fonte: projeto ${PROJETO_PRD} (PRODUÇÃO), somente leitura.`);
+  console.log(
+    `\n${universo.length} linhas cotadas e liquidadas no universo · ` +
+    `${board.length} delas publicadas no board.`,
+  );
+
+  const g = estatistica(universo);
+  const gm = estatistica(universo, 'lucroMediana');
+  console.log(
+    `\nUniverso inteiro: taxa ${pct(g.taxa)} · ROI na melhor odd ${pct(g.roi)} ± ` +
+    `${(g.ep * 100).toFixed(1)}pp · na mediana ${pct(gm.roi)}`,
+  );
+
+  const favorito = universo.filter((l) => l.lado === 'favorito');
+  const azarao = universo.filter((l) => l.lado === 'azarao');
+
+  tabela('Universo, por lado', universo, (l) => l.lado);
+  tabela('Universo, por tamanho do handicap', universo, (l) => Number(l.side_handicap).toFixed(1).padStart(5));
+  tabela('Universo, por faixa de odd', universo, (l) => faixaDeOdd(l.melhor));
+  tabela('Universo, por mando', universo, (l) => (l.outcome === 'Home' ? 'mandante' : 'visitante'));
+
+  for (const [nome, linhas] of [['FAVORITO', favorito], ['AZARÃO', azarao]]) {
+    const e = estatistica(linhas);
+    console.log(`\n### ${nome} — o que cada premissa acrescenta (${linhas.length} linhas, ROI base ${pct(e.roi)})`);
+    console.log('| premissa | n acesa | ROI acesa | n apagada | ROI apagada | diferença estratificada |');
+    console.log('|---|---:|---:|---:|---:|---:|');
+    for (const p of PREMISSAS) {
+      const d = diferencaEstratificada(linhas, p);
+      if (!d) continue;
+      console.log(
+        `| ${p} | ${d.nAcesa} | ${pct(d.roiAcesa)} | ${d.nApagada} | ${pct(d.roiApagada)} | ` +
+        `${pp(d.dif)} ± ${(d.ep * 100).toFixed(1)} |`,
+      );
+    }
+  }
+
+  cabecalho('Empilhando as premissas que separam');
+  linha('favorito, base', favorito);
+  linha('favorito, supremacia', favorito.filter((l) => l.supremacia));
+  linha('favorito, supremacia + tende_golear', favorito.filter((l) => l.supremacia && l.tende_golear));
+  linha('azarão, base', azarao);
+  linha('azarão, favorito_irregular', azarao.filter((l) => l.favorito_irregular));
+  const duas = azarao.filter((l) => l.favorito_irregular && l.raramente_perde_por_2);
+  linha('azarão, favorito_irregular + raramente_perde_por_2', duas);
+  linha('as duas, odd entre 1,40 e 2,00', duas.filter((l) => Number(l.melhor) >= 1.4 && Number(l.melhor) < 2.0));
+  linha('as duas, odd entre 1,40 e 2,00, visitante', duas.filter(
+    (l) => Number(l.melhor) >= 1.4 && Number(l.melhor) < 2.0 && l.outcome === 'Away',
+  ));
+
+  cabecalho('Board publicado, pelo preço que a nota não olha');
+  linha('vantagem acima de zero', board.filter((l) => Number(l.edge) > 0));
+  linha('vantagem entre -2% e zero', board.filter((l) => Number(l.edge) <= 0 && Number(l.edge) > -0.02));
+  linha('vantagem abaixo de -2%', board.filter((l) => Number(l.edge) <= -0.02));
+  tabela('Board publicado, por faixa de odd', board, (l) => faixaDeOdd(l.best_odd));
+  tabela('Board publicado, por campeonato', board, (l) => l.competition);
+
+  console.log(
+    '\n> Erro-padrão maior que a diferença entre dois recortes significa que a ' +
+    'diferença ainda não existe. Recorte com menos de 30 linhas não decide nada.',
+  );
+}
+
+principal().catch((e) => {
+  console.error(String(e.message ?? e));
+  process.exit(1);
+});


### PR DESCRIPTION
PR de documentação. **Nenhuma linha de código do app muda** — são cinco arquivos novos, três documentos e dois scripts de medição, e nada existente é tocado.

## Por que isto entra no repositório

O `docs/futebol-metodologia-de-premissas.md` abre com o motivo, e ele vale para o próprio PR: três documentos são citados como a origem de toda a metodologia — o playbook das premissas, o benchmark que o fundamentava e a recalibragem de 01/08 — em comentário de código e em cabeçalho de migration. **Nenhum dos três jamais esteve neste repositório**, e não estão no histórico do git.

O método sobreviveu espalhado em descrição de task do ClickUp, issue do analytics-engineering e ADR do dbt. Deixar este material só como anexo de task seria repetir o mesmo erro com arquivo novo: anexo é foto, não tem histórico, e quando o número muda ninguém sabe que mudou.

## O que entra

**`docs/futebol-metodologia-por-mercado.md`** — a única descrição escrita do que roda hoje. Premissas, pesos, critérios e porta de publicação dos cinco mercados, lida do código e não de memória. É o único dos cinco arquivos que não existe em nenhum outro lugar.

**`docs/futebol-metodologia-de-premissas.md`** — como uma premissa nasce, é medida e morre. Reconstrói o processo a partir das fontes que sobraram, com data e link, e o transforma num procedimento de sete fases com porta explícita em cada uma. Aplica as fases 0 a 4 a escanteios, com a simulação de ROI sobre 1.464 linhas e 373 jogos.

**`docs/futebol-revisao-handicap.md`** — o diagnóstico que levou ao corte de valor: a causa raiz do handicap é preço, e dois achados anteriores eram preço disfarçado de premissa.

**`scripts/futebol-handicap-premissas.mjs`** e **`scripts/futebol-escanteios-retrato.mjs`** — as medições, reproduzíveis linha a linha. Os dois trazem no cabeçalho as armadilhas que pegaram quem escreveu: a ótica da linha de handicap, o par do jogo, o piso de amostra e a régua de comparação.

## O que não entra

Nenhuma decisão de produto, nenhuma migration, nenhuma mudança de comportamento. As decisões que estes documentos sustentam vivem nas tasks `wdx6zf1gpn` e `wdx6zf1tt8`, que têm os mesmos arquivos anexados.

## Como revisar

Pelo método, não pelas conclusões. As duas coisas que mais merecem olhar crítico:

A **ótica da linha de handicap**. Nos dois mercados as casas cotam os dois lados com o mesmo `line_value`, sempre na ótica do mandante. Liquidar pelo rótulo inverte um lado e produz número plausível e errado — aconteceu duas vezes aqui. A validação que fecha está nos dois documentos: casa e fora têm que somar exatamente 100% em cada linha.

O **controle por lado**. Medir premissa sem controlar o lado dá tudo positivo em casa e tudo negativo fora, e isso é viés de mando se disfarçando de efeito de premissa.

Nenhum número de escanteio neste PR é significativo isoladamente — os erros-padrão vão de 4 a 25 pontos sobre efeitos de 5 a 19, em 373 jogos. Estão escritos como hipótese nomeada, e o documento diz isso em três lugares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
