### PR TITLE
O teste grátis do futebol passa de 7 dias para 48 horas

### DIFF
--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -766,7 +766,7 @@ end; $function$
 ;
 
 -- ── 5. RPCs public.get_futebol_* (security definer; leem futebol.*) ───────────
--- Quanto dura o teste grátis para quem começa agora (migration 134). Quem já
+-- Quanto dura o teste grátis para quem começa agora (migration 136). Quem já
 -- tinha relógio correndo não passa por aqui: o fim dessa pessoa está gravado em
 -- `futebol_trial_ends_at`, e é por isso que encurtar o teste não encurta o de
 -- ninguém que já estava dentro.
@@ -775,6 +775,19 @@ CREATE OR REPLACE FUNCTION public.futebol_trial_duracao()
  LANGUAGE sql
  IMMUTABLE
 AS $function$ select interval '48 hours' $function$
+
+;
+
+-- O acesso vigente, num lugar só: três consultas faziam a mesma pergunta com
+-- o mesmo par de linhas copiado. STABLE, e não IMMUTABLE, porque depende de now().
+CREATE OR REPLACE FUNCTION public.futebol_acesso_vigente(
+  p_status text,
+  p_fim timestamptz
+)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE
+AS $function$ select coalesce(coalesce(p_status, 'free') = 'premium' or p_fim > now(), false) $function$
 
 ;
 
@@ -2587,10 +2600,7 @@ AS $function$
   FROM public.users u
   WHERE u.telegram_chat_id IS NOT NULL
     AND coalesce(u.futebol_publication_alerts_enabled, true) = true
-    AND (
-      coalesce(u.futebol_subscription_status, 'free') = 'premium'
-      OR u.futebol_trial_ends_at > now()
-    );
+    AND public.futebol_acesso_vigente(u.futebol_subscription_status, u.futebol_trial_ends_at);
 $function$;
 
 CREATE OR REPLACE FUNCTION public.claim_futebol_publication_alert_deliveries()
@@ -2620,10 +2630,7 @@ BEGIN
         SELECT 1 FROM public.futebol_publication_alerts a
         WHERE a.batch_id = d.batch_id AND a.kickoff_utc > now()
       )
-      AND (
-        coalesce(u.futebol_subscription_status, 'free') = 'premium'
-        OR u.futebol_trial_ends_at > now()
-      )
+      AND public.futebol_acesso_vigente(u.futebol_subscription_status, u.futebol_trial_ends_at)
     RETURNING d.batch_id, d.user_id, u.telegram_chat_id::text, d.attempt_id
   )
   SELECT c.batch_id, c.user_id, c.telegram_chat_id, c.attempt_id,
@@ -2644,6 +2651,7 @@ $function$;
 
 -- ── 6. Grants de execução (anon / authenticated / service_role) ──────────────
 grant execute on function public._futebol_team_form(p_team_id bigint, p_competition text, p_season bigint, p_before date) to anon, authenticated, service_role;
+grant execute on function public.futebol_acesso_vigente(p_status text, p_fim timestamptz) to anon, authenticated, service_role;
 grant execute on function public.futebol_trial_duracao() to anon, authenticated, service_role;
 grant execute on function public.get_futebol_access() to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_detail(p_fixture_id bigint) to anon, authenticated, service_role;
@@ -2855,7 +2863,7 @@ on conflict (market) do nothing;
 
 -- ── 7. Reverse trial (48 horas, sem cartão) — colunas no public.users ────────
 -- São DUAS colunas, e o fim não é derivado do início: é gravado junto com ele
--- (migration 134). Quem começou o teste antes do corte de 12/09/2026 tem 7 dias
+-- (migration 136). Quem começou o teste antes do corte de 12/09/2026 tem 7 dias
 -- gravados ali, porque foi isso que a página prometeu; quem começa agora tem 48
 -- horas. Quem lê nunca precisa saber qual é o caso.
 alter table public.users add column if not exists futebol_trial_started_at timestamptz;

--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -821,8 +821,15 @@ begin
 
   -- 1º acesso: o relógio larga agora, e o fim é gravado na MESMA escrita — uma
   -- linha com início e sem fim seria um teste de duração indefinida.
+  --
+  -- Os dois valores são decididos ANTES da escrita, e não lidos de volta com
+  -- `returning`: um usuário logado sem linha em public.users faria o UPDATE
+  -- casar zero linhas, o fim ficaria nulo, a defesa somaria sobre início também
+  -- nulo, e `now() < null` cairia no else devolvendo 'expired'.
   if v_started is null then
-    update public.users set futebol_trial_started_at = now(), futebol_trial_ends_at = now() + public.futebol_trial_duracao() where id = v_uid returning futebol_trial_ends_at into v_ends;
+    v_started := now();
+    v_ends := v_started + public.futebol_trial_duracao();
+    update public.users set futebol_trial_started_at = v_started, futebol_trial_ends_at = v_ends where id = v_uid;
   end if;
 
   -- Defesa para a linha que não deveria existir: conta do início DESTA pessoa,

--- a/docs/futebol-prod-deploy.sql
+++ b/docs/futebol-prod-deploy.sql
@@ -766,6 +766,18 @@ end; $function$
 ;
 
 -- ── 5. RPCs public.get_futebol_* (security definer; leem futebol.*) ───────────
+-- Quanto dura o teste grátis para quem começa agora (migration 134). Quem já
+-- tinha relógio correndo não passa por aqui: o fim dessa pessoa está gravado em
+-- `futebol_trial_ends_at`, e é por isso que encurtar o teste não encurta o de
+-- ninguém que já estava dentro.
+CREATE OR REPLACE FUNCTION public.futebol_trial_duracao()
+ RETURNS interval
+ LANGUAGE sql
+ IMMUTABLE
+AS $function$ select interval '48 hours' $function$
+
+;
+
 CREATE OR REPLACE FUNCTION public.get_futebol_access()
  RETURNS jsonb
  LANGUAGE plpgsql
@@ -775,38 +787,44 @@ AS $function$
 declare
   v_uid uuid := auth.uid();
   v_started timestamptz;
-  v_status text;
-  v_trial_days int := 7;
   v_ends timestamptz;
+  v_status text;
   v_days_left int;
+  v_hours_left int;
 begin
   -- Deslogado: bloqueado, CTA pra criar conta
   if v_uid is null then
-    return jsonb_build_object('state','anon','unlocked',false,'days_left',null,'trial_ends_at',null);
+    return jsonb_build_object('state','anon','unlocked',false,'days_left',null,'hours_left',null,'trial_ends_at',null);
   end if;
 
-  select u.futebol_trial_started_at, coalesce(u.futebol_subscription_status,'free')
-    into v_started, v_status
+  select u.futebol_trial_started_at, u.futebol_trial_ends_at, coalesce(u.futebol_subscription_status,'free')
+    into v_started, v_ends, v_status
   from public.users u where u.id = v_uid;
 
   -- Assinante do Futebol: liberado
   if v_status = 'premium' then
-    return jsonb_build_object('state','subscribed','unlocked',true,'days_left',null,'trial_ends_at',null);
+    return jsonb_build_object('state','subscribed','unlocked',true,'days_left',null,'hours_left',null,'trial_ends_at',null);
   end if;
 
-  -- 1º acesso: começa o relógio agora (idempotente)
+  -- 1º acesso: o relógio larga agora, e o fim é gravado na MESMA escrita — uma
+  -- linha com início e sem fim seria um teste de duração indefinida.
   if v_started is null then
-    update public.users set futebol_trial_started_at = now() where id = v_uid;
-    v_started := now();
+    update public.users set futebol_trial_started_at = now(), futebol_trial_ends_at = now() + public.futebol_trial_duracao() where id = v_uid returning futebol_trial_ends_at into v_ends;
   end if;
 
-  v_ends := v_started + make_interval(days => v_trial_days);
+  -- Defesa para a linha que não deveria existir: conta do início DESTA pessoa,
+  -- e não de agora, senão um teste vencido ganharia 48 horas de presente.
+  if v_ends is null then
+    v_ends := v_started + public.futebol_trial_duracao();
+  end if;
+
   v_days_left := greatest(0, ceil(extract(epoch from (v_ends - now())) / 86400.0)::int);
+  v_hours_left := greatest(0, ceil(extract(epoch from (v_ends - now())) / 3600.0)::int);
 
   if now() < v_ends then
-    return jsonb_build_object('state','trial','unlocked',true,'days_left',v_days_left,'trial_ends_at',v_ends);
+    return jsonb_build_object('state','trial','unlocked',true,'days_left',v_days_left,'hours_left',v_hours_left,'trial_ends_at',v_ends);
   else
-    return jsonb_build_object('state','expired','unlocked',false,'days_left',0,'trial_ends_at',v_ends);
+    return jsonb_build_object('state','expired','unlocked',false,'days_left',0,'hours_left',0,'trial_ends_at',v_ends);
   end if;
 end $function$
 
@@ -2549,6 +2567,7 @@ END;
 $function$;
 
 alter table public.users add column if not exists futebol_trial_started_at timestamptz;
+alter table public.users add column if not exists futebol_trial_ends_at timestamptz;
 alter table public.users add column if not exists futebol_subscription_status text not null default 'free';
 -- ⚠️ DÍVIDA: as tabelas da migration 111 (futebol_publication_alerts,
 -- _batches, _deliveries e _pick_refs) nunca entraram neste arquivo, embora as
@@ -2570,10 +2589,7 @@ AS $function$
     AND coalesce(u.futebol_publication_alerts_enabled, true) = true
     AND (
       coalesce(u.futebol_subscription_status, 'free') = 'premium'
-      OR (
-        u.futebol_trial_started_at IS NOT NULL
-        AND u.futebol_trial_started_at + interval '7 days' > now()
-      )
+      OR u.futebol_trial_ends_at > now()
     );
 $function$;
 
@@ -2606,8 +2622,7 @@ BEGIN
       )
       AND (
         coalesce(u.futebol_subscription_status, 'free') = 'premium'
-        OR (u.futebol_trial_started_at IS NOT NULL
-          AND u.futebol_trial_started_at + interval '7 days' > now())
+        OR u.futebol_trial_ends_at > now()
       )
     RETURNING d.batch_id, d.user_id, u.telegram_chat_id::text, d.attempt_id
   )
@@ -2629,6 +2644,7 @@ $function$;
 
 -- ── 6. Grants de execução (anon / authenticated / service_role) ──────────────
 grant execute on function public._futebol_team_form(p_team_id bigint, p_competition text, p_season bigint, p_before date) to anon, authenticated, service_role;
+grant execute on function public.futebol_trial_duracao() to anon, authenticated, service_role;
 grant execute on function public.get_futebol_access() to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_detail(p_fixture_id bigint) to anon, authenticated, service_role;
 grant execute on function public.get_futebol_fixture_extras(p_fixture_id bigint) to anon, authenticated, service_role;
@@ -2837,8 +2853,13 @@ values (
 )
 on conflict (market) do nothing;
 
--- ── 7. Reverse trial (7 dias, sem cartão) — colunas no public.users ──────────
+-- ── 7. Reverse trial (48 horas, sem cartão) — colunas no public.users ────────
+-- São DUAS colunas, e o fim não é derivado do início: é gravado junto com ele
+-- (migration 134). Quem começou o teste antes do corte de 12/09/2026 tem 7 dias
+-- gravados ali, porque foi isso que a página prometeu; quem começa agora tem 48
+-- horas. Quem lê nunca precisa saber qual é o caso.
 alter table public.users add column if not exists futebol_trial_started_at timestamptz;
+alter table public.users add column if not exists futebol_trial_ends_at timestamptz;
 alter table public.users add column if not exists futebol_subscription_status text not null default 'free';
 
 

--- a/src/components/futebol/FutebolGate.tsx
+++ b/src/components/futebol/FutebolGate.tsx
@@ -47,17 +47,16 @@ export function FutebolTrialChip() {
     // Sem tempo não há pílula: uma pílula de teste sem número restante não
     // informa nada e ainda ocupa o lugar de quem informa.
     if (!tempo) return null;
+    // A pílula aparece no celular também. Era `hidden sm:inline-flex`, e sumia
+    // abaixo de 640px — o que significava nenhum contador no celular, porque
+    // durante o teste ela é a ÚNICA superfície que mostra o tempo restante: a
+    // faixa do gate não aparece no estado de teste, de propósito. Com 7 dias
+    // isso passava; com 48 horas a urgência é o produto, e esconder o relógio
+    // de quem está no celular é esconder a oferta de quase todo o tráfego.
     return (
       <button
         onClick={() => navigate('/futebol/assinar')}
         title={`Teste grátis · ${tempo.longo}`}
-        // Aparece no celular também. Era `hidden sm:inline-flex`, e some abaixo
-        // de 640px — o que significava nenhum contador no celular, porque
-        // durante o teste esta pílula é a ÚNICA superfície que mostra o tempo
-        // restante: a faixa do gate não aparece no estado de teste, de
-        // propósito. Com 7 dias isso passava; com 48 horas a urgência é o
-        // produto, e esconder o relógio de quem está no celular é esconder a
-        // oferta de quase todo mundo.
         className={`inline-flex items-center gap-1.5 h-8 px-2.5 rounded-full text-[11px] font-semibold border transition ${
           tempo.acabando ? 'border-amber/50 bg-amber/15 text-amber-2 hover:bg-amber/25' : 'border-line bg-canvas-2 text-ink-2 hover:bg-canvas'
         }`}

--- a/src/components/futebol/FutebolGate.tsx
+++ b/src/components/futebol/FutebolGate.tsx
@@ -3,10 +3,11 @@ import { useNavigate } from 'react-router-dom';
 import { Lock, Sparkles } from 'lucide-react';
 import { useFutebolAccess } from '@/hooks/use-futebol-data';
 import type { FutebolAccess } from '@/services/futebol-data.service';
+import { tempoDeTeste } from './tempo-de-teste';
 
 /**
- * Reverse trial do Futebol (7 dias, sem cartão). A camada de VALOR (o pick em si)
- * fica borrada pra quem não tem acesso; o resto (Score, análise) é livre.
+ * Reverse trial do Futebol (48 horas, sem cartão). A camada de VALOR (o pick em
+ * si) fica borrada pra quem não tem acesso; o resto (Score, análise) é livre.
  */
 
 /** Borra o conteúdo (FOMO) quando `active`. Mantém o layout/espaço. */
@@ -28,16 +29,12 @@ export function LockPill({ className = '' }: { className?: string }) {
   );
 }
 
-function dayWord(n: number | null): string {
-  return n === 1 ? 'dia' : 'dias';
-}
-
 /**
  * Chip discreto de status do trial pro cabeçalho (padrão de mercado).
  * Busca o acesso sozinho — só renderizar nas rotas de Futebol.
- * - trial: pílula neutra "Teste · Nd" (vira âmbar nos últimos 2 dias)
+ * - trial: pílula neutra "Teste · 31h" (vira âmbar nas últimas 12 horas)
  * - expirado: "Assinar Futebol" (forest)
- * - deslogado: "7 dias grátis" (forest)
+ * - deslogado: "48 horas grátis" (forest)
  * - assinante: nada
  */
 export function FutebolTrialChip() {
@@ -46,17 +43,19 @@ export function FutebolTrialChip() {
   if (!access || access.state === 'subscribed') return null;
 
   if (access.state === 'trial') {
-    const d = access.days_left ?? 0;
-    const ending = d <= 2;
+    const tempo = tempoDeTeste(access);
+    // Sem tempo não há pílula: uma pílula de teste sem número restante não
+    // informa nada e ainda ocupa o lugar de quem informa.
+    if (!tempo) return null;
     return (
       <button
         onClick={() => navigate('/futebol/assinar')}
-        title={`Teste grátis · ${d} ${dayWord(d)} restantes`}
+        title={`Teste grátis · ${tempo.longo}`}
         className={`hidden sm:inline-flex items-center gap-1.5 h-8 px-2.5 rounded-full text-[11px] font-semibold border transition ${
-          ending ? 'border-amber/50 bg-amber/15 text-amber-2 hover:bg-amber/25' : 'border-line bg-canvas-2 text-ink-2 hover:bg-canvas'
+          tempo.acabando ? 'border-amber/50 bg-amber/15 text-amber-2 hover:bg-amber/25' : 'border-line bg-canvas-2 text-ink-2 hover:bg-canvas'
         }`}
       >
-        <Sparkles className="w-3 h-3" /> Teste · {d}d
+        <Sparkles className="w-3 h-3" /> Teste · {tempo.curto}
       </button>
     );
   }
@@ -68,16 +67,16 @@ export function FutebolTrialChip() {
       className="hidden sm:inline-flex items-center gap-1.5 h-8 px-3 rounded-full text-[11px] font-bold bg-forest text-canvas hover:bg-forest-2 transition"
     >
       {expired ? <Lock className="w-3 h-3" /> : <Sparkles className="w-3 h-3" />}
-      {expired ? 'Assinar Futebol' : '7 dias grátis'}
+      {expired ? 'Assinar Futebol' : '48 horas grátis'}
     </button>
   );
 }
 
 /**
  * Faixa de estado do acesso, pra colocar no topo das telas de valor:
- * - trial: contador "X dias restantes"
+ * - trial: nada (o chip do cabeçalho é quem conta o tempo)
  * - expired: CTA pra assinar
- * - anon: CTA pra criar conta (libera 7 dias)
+ * - anon: CTA pra criar conta (libera 48 horas)
  * - subscribed: nada
  */
 export function FutebolAccessBanner({ access, className = '' }: { access?: FutebolAccess; className?: string }) {
@@ -92,11 +91,11 @@ export function FutebolAccessBanner({ access, className = '' }: { access?: Futeb
       <div className="flex items-start gap-2.5 flex-1 min-w-0">
         <span className="w-8 h-8 rounded-full bg-forest text-canvas grid place-items-center shrink-0"><Lock className="w-4 h-4" /></span>
         <div className="min-w-0">
-          <div className="text-[13px] font-bold text-ink">{expired ? 'Seu teste grátis acabou' : 'Veja as oportunidades — 7 dias grátis'}</div>
+          <div className="text-[13px] font-bold text-ink">{expired ? 'Seu teste grátis acabou' : 'Veja as oportunidades — 48 horas grátis'}</div>
           <p className="text-[12px] text-ink-2 leading-snug">
             {expired
               ? 'As oportunidades do dia estão bloqueadas. Assine o Futebol pra continuar vendo os picks.'
-              : 'Crie sua conta e libere os picks do dia por 7 dias, sem cartão.'}
+              : 'Crie sua conta e libere os picks do dia por 48 horas, sem cartão.'}
           </p>
         </div>
       </div>

--- a/src/components/futebol/FutebolGate.tsx
+++ b/src/components/futebol/FutebolGate.tsx
@@ -51,7 +51,14 @@ export function FutebolTrialChip() {
       <button
         onClick={() => navigate('/futebol/assinar')}
         title={`Teste grátis · ${tempo.longo}`}
-        className={`hidden sm:inline-flex items-center gap-1.5 h-8 px-2.5 rounded-full text-[11px] font-semibold border transition ${
+        // Aparece no celular também. Era `hidden sm:inline-flex`, e some abaixo
+        // de 640px — o que significava nenhum contador no celular, porque
+        // durante o teste esta pílula é a ÚNICA superfície que mostra o tempo
+        // restante: a faixa do gate não aparece no estado de teste, de
+        // propósito. Com 7 dias isso passava; com 48 horas a urgência é o
+        // produto, e esconder o relógio de quem está no celular é esconder a
+        // oferta de quase todo mundo.
+        className={`inline-flex items-center gap-1.5 h-8 px-2.5 rounded-full text-[11px] font-semibold border transition ${
           tempo.acabando ? 'border-amber/50 bg-amber/15 text-amber-2 hover:bg-amber/25' : 'border-line bg-canvas-2 text-ink-2 hover:bg-canvas'
         }`}
       >

--- a/src/components/futebol/FutebolTrialChip.test.tsx
+++ b/src/components/futebol/FutebolTrialChip.test.tsx
@@ -69,6 +69,19 @@ describe('a pílula durante o teste de 48 horas', () => {
   });
 });
 
+describe('a pílula existe no celular', () => {
+  it('não é escondida abaixo do breakpoint', () => {
+    // Era `hidden sm:inline-flex`, e sumia abaixo de 640px. Durante o teste
+    // esta pílula é a ÚNICA superfície com o tempo restante — a faixa do gate
+    // não aparece no estado de teste, de propósito —, então esconder no celular
+    // era não ter contador nenhum para a maior parte do tráfego.
+    montar(emTeste(31));
+    const chip = screen.getByRole('button');
+    expect(chip.className).not.toMatch(/\bhidden\b/);
+    expect(chip.className).toMatch(/\binline-flex\b/);
+  });
+});
+
 describe('o âmbar da última reta', () => {
   it('fica neutra com um dia e meio pela frente', () => {
     montar(emTeste(36));

--- a/src/components/futebol/FutebolTrialChip.test.tsx
+++ b/src/components/futebol/FutebolTrialChip.test.tsx
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { FutebolAccess } from '@/services/futebol-data.service';
+import { useFutebolAccess } from '@/hooks/use-futebol-data';
+import { FutebolTrialChip } from './FutebolGate';
+
+vi.mock('@/hooks/use-futebol-data', () => ({ useFutebolAccess: vi.fn() }));
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
+
+// ============================================================================
+// A pílula do cabeçalho, agora que o teste dura 48 horas
+// ============================================================================
+// O que esta suíte trava não é o cálculo — isso é de `tempo-de-teste.ts` e tem
+// teste próprio. É a LIGAÇÃO: a pílula lia `days_left` direto do contrato e
+// escrevia "Nd" na mão, e com 48 horas isso só conseguia dizer "2d" e depois
+// "1d". Se alguém religar a pílula no `days_left`, quebra aqui.
+//
+// O âmbar também mudou de régua: era "faltam 2 dias ou menos", que num teste de
+// 48 horas nasceria âmbar e ficaria âmbar até o fim.
+// ============================================================================
+
+const mock = vi.mocked(useFutebolAccess);
+
+/** Um acesso em teste que termina daqui a `h` horas, como o servidor responde. */
+function emTeste(h: number, override: Partial<FutebolAccess> = {}): FutebolAccess {
+  return {
+    state: 'trial',
+    unlocked: true,
+    days_left: Math.max(0, Math.ceil(h / 24)),
+    hours_left: Math.max(0, h),
+    trial_ends_at: new Date(Date.now() + h * 3600000).toISOString(),
+    ...override,
+  };
+}
+
+function montar(access: FutebolAccess | undefined) {
+  // O hook devolve muito mais que `data`; a pílula só lê isso.
+  mock.mockReturnValue({ data: access } as ReturnType<typeof useFutebolAccess>);
+  render(<FutebolTrialChip />);
+}
+
+const ambar = (el: HTMLElement) => /amber/.test(el.className);
+
+beforeEach(() => {
+  mock.mockReset();
+});
+
+describe('a pílula durante o teste de 48 horas', () => {
+  it('conta em horas, e não em dias', () => {
+    montar(emTeste(31));
+    const chip = screen.getByRole('button');
+    expect(chip).toHaveTextContent('Teste · 31h');
+    expect(chip).toHaveAttribute('title', 'Teste grátis · faltam 31 horas');
+  });
+
+  it('nasce dizendo 48h', () => {
+    montar(emTeste(48));
+    expect(screen.getByRole('button')).toHaveTextContent('Teste · 48h');
+  });
+
+  it('na última hora fala no singular', () => {
+    montar(emTeste(1));
+    expect(screen.getByRole('button')).toHaveAttribute('title', 'Teste grátis · falta 1 hora');
+  });
+
+  it('não anuncia zero para quem ainda tem acesso', () => {
+    montar(emTeste(0));
+    expect(screen.getByRole('button')).toHaveTextContent('Teste · <1h');
+  });
+});
+
+describe('o âmbar da última reta', () => {
+  it('fica neutra com um dia e meio pela frente', () => {
+    montar(emTeste(36));
+    expect(ambar(screen.getByRole('button'))).toBe(false);
+  });
+
+  it('vira âmbar nas últimas doze horas', () => {
+    montar(emTeste(12));
+    expect(ambar(screen.getByRole('button'))).toBe(true);
+  });
+
+  it('não nasce âmbar num teste de 48 horas', () => {
+    // A régua antiga era "2 dias ou menos". Com 48 horas ela acenderia no
+    // primeiro segundo e o aviso não avisaria nada.
+    montar(emTeste(48));
+    expect(ambar(screen.getByRole('button'))).toBe(false);
+  });
+});
+
+describe('a coorte que ainda tem 7 dias', () => {
+  it('continua vendo dias, porque 161 horas não é informação', () => {
+    montar(emTeste(24 * 7));
+    expect(screen.getByRole('button')).toHaveTextContent('Teste · 7d');
+  });
+
+  it('e também chega no âmbar quando o fim se aproxima', () => {
+    montar(emTeste(5));
+    expect(ambar(screen.getByRole('button'))).toBe(true);
+  });
+});
+
+describe('quando não há pílula para mostrar', () => {
+  it('assinante não vê nada', () => {
+    montar({ state: 'subscribed', unlocked: true, days_left: null, hours_left: null, trial_ends_at: null });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('sem resposta do servidor, nada', () => {
+    montar(undefined);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('em teste mas sem tempo apurável, nada — em vez de uma pílula vazia', () => {
+    montar(emTeste(0, { hours_left: null, trial_ends_at: null }));
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('expirado troca a pílula pelo CTA de assinar', () => {
+    montar({ state: 'expired', unlocked: false, days_left: 0, hours_left: 0, trial_ends_at: null });
+    expect(screen.getByRole('button')).toHaveTextContent('Assinar Futebol');
+  });
+
+  it('deslogado convida com as 48 horas', () => {
+    montar({ state: 'anon', unlocked: false, days_left: null, hours_left: null, trial_ends_at: null });
+    expect(screen.getByRole('button')).toHaveTextContent('48 horas grátis');
+  });
+});

--- a/src/components/futebol/futebol-teste-migration.test.ts
+++ b/src/components/futebol/futebol-teste-migration.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { comando, lerMigration } from '../socios/crm-migration-de-teste';
 
@@ -21,11 +23,45 @@ import { comando, lerMigration } from '../socios/crm-migration-de-teste';
 
 const MIGRATION = lerMigration('20260914200000_136_futebol_teste_48_horas.sql');
 
+/**
+ * A MESMA função, na outra cópia: o shape file de provisão.
+ *
+ * `get_futebol_access` existe duas vezes — na migration, que corre no banco
+ * vivo, e em `docs/futebol-prod-deploy.sql`, que é o DDL colado à mão para
+ * levantar ambiente novo. A guarda do shape file compara NOMES de função, não
+ * corpos, então as duas podem divergir caladas.
+ *
+ * E divergiram: a correção do usuário sem linha em `public.users` entrou só na
+ * migration, e o shape file ficou com a versão que devolvia 'expired'. Quem
+ * provisionasse ambiente novo receberia o bug já corrigido. Por isso as
+ * asserções de COMPORTAMENTO desta suíte rodam nas duas.
+ */
+const SHAPE = readFileSync(
+  resolve(__dirname, '../../../docs/futebol-prod-deploy.sql'),
+  'utf8',
+)
+  .replace(/\r\n/g, '\n')
+  .replace(/--.*$/gm, '');
+
 const ACESSO = comando(
   MIGRATION,
   /create or replace function public\.get_futebol_access/i,
   '$function$;',
 );
+const ACESSO_NO_SHAPE = comando(
+  SHAPE,
+  /create or replace function public\.get_futebol_access/i,
+  // No shape file o corpo fecha em `end $function$` com o `;` numa linha
+  // solta, então `$function$;` não casa — e `$function$` sozinho casaria com o
+  // delimitador de ABERTURA, devolvendo só a assinatura.
+  'end $function$',
+);
+
+/** As duas cópias de `get_futebol_access`, para asserção de comportamento. */
+const AS_DUAS_COPIAS: [string, string | null][] = [
+  ['migration 136', ACESSO],
+  ['shape file', ACESSO_NO_SHAPE],
+];
 const DURACAO = comando(
   MIGRATION,
   /create or replace function public\.futebol_trial_duracao/i,
@@ -108,18 +144,33 @@ describe('get_futebol_access', () => {
     expect(ACESSO).toMatch(/public\.futebol_trial_duracao\(\)/i);
   });
 
-  it('não depende de a linha do usuário existir para liberar o teste', () => {
-    // O bug que isto trava: a primeira versão lia o fim de volta com
-    // `returning ... into v_ends`. Um usuário logado sem linha em public.users
-    // fazia o UPDATE casar zero linhas, v_ends ficava nulo, a defesa somava
-    // sobre v_started também nulo, e `now() < null` caía no ramo do else
-    // devolvendo 'expired' — teste negado a quem nunca teve teste.
-    expect(ACESSO).not.toMatch(/returning\s+futebol_trial_ends_at\s+into/i);
-    // Até `end if;`, e não até o primeiro `;`: o bloco tem três comandos, e
-    // cortar no primeiro deixaria de fora justamente a linha do fim.
-    const largada = comando(ACESSO ?? '', /if v_started is null then/i, 'end if;');
-    expect(largada).toMatch(/v_started\s*:=\s*now\(\)/i);
-    expect(largada).toMatch(/v_ends\s*:=\s*v_started\s*\+\s*public\.futebol_trial_duracao\(\)/i);
+  // Roda nas DUAS cópias. A correção deste bug entrou só na migration e o
+  // shape file ficou com a versão quebrada, porque nenhuma guarda comparava
+  // corpos — só nomes de função. Quem provisionasse ambiente novo receberia o
+  // bug já corrigido.
+  it.each(AS_DUAS_COPIAS)(
+    '%s não depende de a linha do usuário existir para liberar o teste',
+    (_onde, copia) => {
+      // O bug que isto trava: a primeira versão lia o fim de volta com
+      // `returning ... into v_ends`. Um usuário logado sem linha em
+      // public.users fazia o UPDATE casar zero linhas, v_ends ficava nulo, a
+      // defesa somava sobre v_started também nulo, e `now() < null` caía no
+      // ramo do else devolvendo 'expired' — teste negado a quem nunca teve.
+      expect(copia).not.toBeNull();
+      expect(copia).not.toMatch(/returning\s+futebol_trial_ends_at\s+into/i);
+      // Até `end if;`, e não até o primeiro `;`: o bloco tem três comandos, e
+      // cortar no primeiro deixaria de fora justamente a linha do fim.
+      const largada = comando(copia ?? '', /if v_started is null then/i, 'end if;');
+      expect(largada).toMatch(/v_started\s*:=\s*now\(\)/i);
+      expect(largada).toMatch(/v_ends\s*:=\s*v_started\s*\+\s*public\.futebol_trial_duracao\(\)/i);
+    },
+  );
+
+  it.each(AS_DUAS_COPIAS)('%s devolve as horas e lê a coluna do fim', (_onde, copia) => {
+    // As duas cópias precisam concordar também no contrato, não só na largada.
+    expect(copia).toMatch(/'hours_left'/);
+    expect(copia).toMatch(/futebol_trial_ends_at/i);
+    expect(copia).not.toMatch(/v_trial_days|interval '7 days'/i);
   });
 
   it('devolve as horas que faltam, não só os dias', () => {
@@ -129,8 +180,10 @@ describe('get_futebol_access', () => {
   });
 
   it('mantém days_left no contrato', () => {
-    // A tela ainda lê days_left. Tirar agora quebraria o gate antes da fatia
-    // que ensina a tela a falar em horas.
+    // Não porque a tela leia — depois deste PR nenhuma lê. O banco sobe antes
+    // do bundle, e quem está com a página aberta ou com o JS antigo em cache
+    // continua pedindo `days_left`. Removido do contrato, vira `undefined` lá e
+    // o contador zera na tela de quem tem acesso.
     expect(ACESSO).toMatch(/'days_left'/);
   });
 

--- a/src/components/futebol/futebol-teste-migration.test.ts
+++ b/src/components/futebol/futebol-teste-migration.test.ts
@@ -19,7 +19,7 @@ import { comando, lerMigration } from '../socios/crm-migration-de-teste';
 // as duas coortes sem saber que existem duas.
 // ============================================================================
 
-const MIGRATION = lerMigration('20260914140000_134_futebol_teste_48_horas.sql');
+const MIGRATION = lerMigration('20260914200000_136_futebol_teste_48_horas.sql');
 
 const ACESSO = comando(
   MIGRATION,
@@ -148,7 +148,7 @@ describe('as consultas que decidem quem recebe alerta', () => {
     // literal `\(\)` perde a barra e `()` vira grupo vazio, então o guarda
     // passaria a exigir o grant SEM os parênteses e ficaria vermelho com o
     // SQL certo.
-    expect(MIGRATION).toMatch(new RegExp(`(revoke all|revoke execute) on function public\\.${nome}`, 'i'));
+    expect(MIGRATION).toMatch(new RegExp(`revoke execute on function public\\.${nome}`, 'i'));
     expect(MIGRATION.toLowerCase()).toContain(
       `grant execute on function public.${nome}() to service_role`,
     );

--- a/src/components/futebol/futebol-teste-migration.test.ts
+++ b/src/components/futebol/futebol-teste-migration.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { comando, lerMigration } from '../socios/crm-migration-de-teste';
+
+// ============================================================================
+// O teste grátis do futebol passa de 7 dias para 48 horas
+// ============================================================================
+// A duração era um número solto repetido em cinco lugares do servidor, e cada
+// cópia decidia sozinha quem ainda tinha acesso. Esta migration materializa o
+// FIM do teste numa coluna, gravada no instante em que o relógio começa, e faz
+// todo mundo passar a ler essa coluna.
+//
+// O corte é o que a coluna guarda: quem já tinha relógio correndo foi
+// preenchido com início + 7 dias, porque foi isso que a página prometeu para
+// essa pessoa. Quem ainda não abriu o módulo recebe 48 horas quando abrir,
+// independente de quando se cadastrou.
+//
+// O ganho é que a decisão passa a ser tomada uma vez, na largada, e nunca mais:
+// não sobra data de corte pendurada no código, e as consultas de alerta acertam
+// as duas coortes sem saber que existem duas.
+// ============================================================================
+
+const MIGRATION = lerMigration('20260914140000_134_futebol_teste_48_horas.sql');
+
+const ACESSO = comando(
+  MIGRATION,
+  /create or replace function public\.get_futebol_access/i,
+  '$function$;',
+);
+const DURACAO = comando(
+  MIGRATION,
+  /create or replace function public\.futebol_trial_duracao/i,
+  '$function$;',
+);
+const TESTE_NA_MAO = comando(
+  MIGRATION,
+  /create or replace function public\.crm_definir_teste_do_futebol/i,
+  '$function$;',
+);
+
+describe('a coluna que guarda o fim do teste', () => {
+  it('nasce na tabela de usuários', () => {
+    expect(MIGRATION).toMatch(
+      /alter table public\.users[\s\S]*?add column if not exists futebol_trial_ends_at timestamptz/i,
+    );
+  });
+
+  it('se explica na própria coluna', () => {
+    expect(MIGRATION).toMatch(/comment on column public\.users\.futebol_trial_ends_at/i);
+  });
+});
+
+describe('o corte entre as duas coortes', () => {
+  it('dá sete dias para quem já tinha o relógio correndo', () => {
+    // O corte é medido pelo relógio, não pela data de cadastro: o teste começa
+    // na primeira vez que a pessoa abre o módulo, então quem se cadastrou há
+    // meses e nunca abriu NÃO é da coorte antiga.
+    const backfill = comando(MIGRATION, /update public\.users[\s\S]*?futebol_trial_ends_at =/i);
+    expect(backfill).toMatch(/futebol_trial_started_at \+ interval '7 days'/i);
+    expect(backfill).toMatch(/where[\s\S]*futebol_trial_started_at is not null/i);
+  });
+
+  it('não reescreve um fim que já esteja gravado', () => {
+    // Rodar a migration duas vezes não pode esticar o teste de ninguém.
+    const backfill = comando(MIGRATION, /update public\.users[\s\S]*?futebol_trial_ends_at =/i);
+    expect(backfill).toMatch(/futebol_trial_ends_at is null/i);
+  });
+});
+
+describe('a duração nova mora num lugar só', () => {
+  it('existe como função', () => {
+    expect(DURACAO).not.toBeNull();
+  });
+
+  it('são 48 horas', () => {
+    expect(DURACAO).toMatch(/interval '48 hours'/i);
+  });
+
+  it('é imutável, para o planejador poder embutir', () => {
+    expect(DURACAO).toMatch(/immutable/i);
+  });
+});
+
+describe('get_futebol_access', () => {
+  it('existe', () => {
+    expect(ACESSO).not.toBeNull();
+  });
+
+  it('lê o fim gravado na coluna, em vez de recalcular', () => {
+    expect(ACESSO).toMatch(/futebol_trial_ends_at/i);
+  });
+
+  it('não carrega mais a duração escrita na mão', () => {
+    // O bug que isto evita: manter `v_trial_days int := 7` aqui faria a função
+    // discordar da coluna, e a tela mostraria acesso para um teste vencido.
+    expect(ACESSO).not.toMatch(/v_trial_days/i);
+    expect(ACESSO).not.toMatch(/interval '7 days'/i);
+  });
+
+  it('grava o fim no mesmo instante em que larga o relógio', () => {
+    // Início e fim são gravados juntos, na mesma escrita: se o fim ficasse para
+    // depois, uma linha com início e sem fim seria um teste de duração
+    // indefinida, e é justamente essa a linha que não pode existir.
+    const largada = comando(ACESSO ?? '', /update public\.users set futebol_trial_started_at/i);
+    expect(largada).toMatch(/futebol_trial_ends_at\s*=/i);
+    expect(largada).toMatch(/public\.futebol_trial_duracao\(\)/i);
+  });
+
+  it('devolve as horas que faltam, não só os dias', () => {
+    // Com 48 horas, "2 dias" e depois "1 dia" é a única coisa que a tela
+    // conseguiria dizer, e é o oposto da urgência que motivou encurtar.
+    expect(ACESSO).toMatch(/'hours_left'/);
+  });
+
+  it('mantém days_left no contrato', () => {
+    // A tela ainda lê days_left. Tirar agora quebraria o gate antes da fatia
+    // que ensina a tela a falar em horas.
+    expect(ACESSO).toMatch(/'days_left'/);
+  });
+
+  it('segue rodando como dono do banco, com search_path travado', () => {
+    expect(ACESSO).toMatch(/security definer/i);
+    expect(ACESSO).toMatch(/set search_path to ''/i);
+  });
+});
+
+describe('as consultas que decidem quem recebe alerta', () => {
+  const NOMES = [
+    'get_opportunity_recipients',
+    'get_futebol_publication_alert_recipients',
+    'claim_futebol_publication_alert_deliveries',
+  ];
+
+  const corpo = (nome: string) =>
+    comando(MIGRATION, new RegExp(`create or replace function public\\.${nome}`, 'i'), '$function$;');
+
+  it.each(NOMES)('%s passa a ler o fim do teste', (nome) => {
+    const fn = corpo(nome);
+    expect(fn).not.toBeNull();
+    expect(fn).toMatch(/futebol_trial_ends_at > now\(\)/i);
+  });
+
+  it.each(NOMES)('%s não deixa sobrar a conta antiga', (nome) => {
+    expect(corpo(nome)).not.toMatch(/futebol_trial_started_at \+ interval '7 days'/i);
+  });
+
+  it.each(NOMES)('%s continua fora do alcance de quem está logado', (nome) => {
+    // O grant é conferido por string, e não por regex montada: num template
+    // literal `\(\)` perde a barra e `()` vira grupo vazio, então o guarda
+    // passaria a exigir o grant SEM os parênteses e ficaria vermelho com o
+    // SQL certo.
+    expect(MIGRATION).toMatch(new RegExp(`(revoke all|revoke execute) on function public\\.${nome}`, 'i'));
+    expect(MIGRATION.toLowerCase()).toContain(
+      `grant execute on function public.${nome}() to service_role`,
+    );
+  });
+});
+
+describe('o teste dado na mão pelo sócio', () => {
+  it('grava as duas colunas', () => {
+    // Sem isto, o sócio liga o teste na ficha, a coluna de fim fica nula, e a
+    // pessoa cai como vencida na hora — acesso concedido que não acontece.
+    expect(TESTE_NA_MAO).toMatch(/futebol_trial_started_at\s*=/i);
+    expect(TESTE_NA_MAO).toMatch(/futebol_trial_ends_at\s*=/i);
+  });
+
+  it('usa a mesma duração do produto', () => {
+    expect(TESTE_NA_MAO).toMatch(/public\.futebol_trial_duracao\(\)/i);
+  });
+
+  it('limpa as duas quando o sócio encerra', () => {
+    expect(TESTE_NA_MAO).toMatch(/v_fim\s+timestamptz/i);
+  });
+
+  it('segue só para sócio', () => {
+    expect(TESTE_NA_MAO).toMatch(/if not public\.eh_socio\(\)/i);
+    expect(MIGRATION).toMatch(/revoke execute on function public\.crm_definir_teste_do_futebol/i);
+  });
+});

--- a/src/components/futebol/futebol-teste-migration.test.ts
+++ b/src/components/futebol/futebol-teste-migration.test.ts
@@ -102,7 +102,24 @@ describe('get_futebol_access', () => {
     // indefinida, e é justamente essa a linha que não pode existir.
     const largada = comando(ACESSO ?? '', /update public\.users set futebol_trial_started_at/i);
     expect(largada).toMatch(/futebol_trial_ends_at\s*=/i);
-    expect(largada).toMatch(/public\.futebol_trial_duracao\(\)/i);
+  });
+
+  it('usa a duração do produto para calcular a largada', () => {
+    expect(ACESSO).toMatch(/public\.futebol_trial_duracao\(\)/i);
+  });
+
+  it('não depende de a linha do usuário existir para liberar o teste', () => {
+    // O bug que isto trava: a primeira versão lia o fim de volta com
+    // `returning ... into v_ends`. Um usuário logado sem linha em public.users
+    // fazia o UPDATE casar zero linhas, v_ends ficava nulo, a defesa somava
+    // sobre v_started também nulo, e `now() < null` caía no ramo do else
+    // devolvendo 'expired' — teste negado a quem nunca teve teste.
+    expect(ACESSO).not.toMatch(/returning\s+futebol_trial_ends_at\s+into/i);
+    // Até `end if;`, e não até o primeiro `;`: o bloco tem três comandos, e
+    // cortar no primeiro deixaria de fora justamente a linha do fim.
+    const largada = comando(ACESSO ?? '', /if v_started is null then/i, 'end if;');
+    expect(largada).toMatch(/v_started\s*:=\s*now\(\)/i);
+    expect(largada).toMatch(/v_ends\s*:=\s*v_started\s*\+\s*public\.futebol_trial_duracao\(\)/i);
   });
 
   it('devolve as horas que faltam, não só os dias', () => {
@@ -123,6 +140,43 @@ describe('get_futebol_access', () => {
   });
 });
 
+describe('o predicado do acesso vigente', () => {
+  const VIGENTE = comando(
+    MIGRATION,
+    /create or replace function public\.futebol_acesso_vigente/i,
+    '$function$;',
+  );
+
+  it('existe, para as três consultas não copiarem a mesma pergunta', () => {
+    expect(VIGENTE).not.toBeNull();
+  });
+
+  it('responde pelas duas portas: assinatura e teste de pé', () => {
+    expect(VIGENTE).toMatch(/= 'premium'/);
+    expect(VIGENTE).toMatch(/p_fim > now\(\)/i);
+  });
+
+  it('é stable, e não immutable, porque depende de now()', () => {
+    expect(VIGENTE).toMatch(/stable/i);
+    expect(VIGENTE).not.toMatch(/immutable/i);
+  });
+
+  it('não sabe quanto o teste dura', () => {
+    // Se a duração entrasse aqui, a coorte de 7 dias voltaria a ser recalculada
+    // e o fim gravado perderia a autoridade.
+    expect(VIGENTE).not.toMatch(/futebol_trial_duracao|interval/i);
+  });
+
+  it('devolve falso, e nunca nulo, para quem não tem fim gravado', () => {
+    // Medido num Postgres de verdade: sem o coalesce de fora, fim nulo dava
+    // `false or null` = NULL. Dentro de um `where` isso se comporta como falso
+    // e ninguém nota, mas o primeiro chamador que escrever `if not vigente(...)`
+    // recebe NULL e o ramo não executa — acesso negado virando acesso liberado.
+    expect(VIGENTE).toMatch(/coalesce\(\s*coalesce\(p_status/i);
+    expect(VIGENTE).toMatch(/,\s*false\s*\)/i);
+  });
+});
+
 describe('as consultas que decidem quem recebe alerta', () => {
   const NOMES = [
     'get_opportunity_recipients',
@@ -133,14 +187,22 @@ describe('as consultas que decidem quem recebe alerta', () => {
   const corpo = (nome: string) =>
     comando(MIGRATION, new RegExp(`create or replace function public\\.${nome}`, 'i'), '$function$;');
 
-  it.each(NOMES)('%s passa a ler o fim do teste', (nome) => {
+  it.each(NOMES)('%s pergunta pelo predicado, em vez de copiá-lo', (nome) => {
     const fn = corpo(nome);
     expect(fn).not.toBeNull();
-    expect(fn).toMatch(/futebol_trial_ends_at > now\(\)/i);
+    expect(fn).toMatch(
+      /public\.futebol_acesso_vigente\(\s*u\.futebol_subscription_status,\s*u\.futebol_trial_ends_at\s*\)/i,
+    );
   });
 
   it.each(NOMES)('%s não deixa sobrar a conta antiga', (nome) => {
     expect(corpo(nome)).not.toMatch(/futebol_trial_started_at \+ interval '7 days'/i);
+  });
+
+  it.each(NOMES)('%s não remonta o predicado na mão', (nome) => {
+    // A cópia que esta migration veio apagar. Se ela voltar aqui, volta em três
+    // lugares de uma vez, que é como ela chegou.
+    expect(corpo(nome)).not.toMatch(/= 'premium'/);
   });
 
   it.each(NOMES)('%s continua fora do alcance de quem está logado', (nome) => {

--- a/src/components/futebol/tempo-de-teste.test.ts
+++ b/src/components/futebol/tempo-de-teste.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+import type { FutebolAccess } from '@/services/futebol-data.service';
+import { horasRestantes, tempoDeTeste } from './tempo-de-teste';
+
+// ============================================================================
+// O contador do teste grátis, agora que o teste dura 48 horas
+// ============================================================================
+// Em dias arredondados, um teste de 48 horas só consegue dizer "2 dias" e
+// depois "1 dia" — e some. Isso é o oposto da urgência que motivou encurtar, e
+// é por isso que a contagem passa a ser em horas.
+//
+// O detalhe que obriga as duas unidades a conviverem: existem DUAS coortes
+// vivas. Quem começou antes do corte tem até 7 dias (168 horas) gravados, e
+// "faltam 161 horas" não é informação, é ruído. Então a unidade acompanha a
+// ordem de grandeza: acima de 48 horas fala em dias, dentro de 48 fala em
+// horas.
+// ============================================================================
+
+const AGORA = Date.parse('2026-09-12T12:00:00Z');
+
+/** Um acesso em teste que termina daqui a `h` horas. */
+function emTeste(h: number, override: Partial<FutebolAccess> = {}): FutebolAccess {
+  return {
+    state: 'trial',
+    unlocked: true,
+    days_left: Math.max(0, Math.ceil(h / 24)),
+    hours_left: Math.max(0, h),
+    trial_ends_at: new Date(AGORA + h * 3600000).toISOString(),
+    ...override,
+  };
+}
+
+describe('horasRestantes', () => {
+  it('acredita no servidor quando ele responde', () => {
+    // O relógio do servidor é o que decide o acesso. Preferir o dele evita a
+    // tela dizer "falta 1 hora" num celular com o horário adiantado.
+    expect(horasRestantes(emTeste(30), AGORA)).toBe(30);
+  });
+
+  it('cai para a data de término quando o servidor não mandou as horas', () => {
+    // Acontece de verdade em duas situações: resposta antiga guardada em cache
+    // pelo react-query, e ambiente onde a migration 134 ainda não subiu.
+    const semHoras = emTeste(30, { hours_left: null });
+    expect(horasRestantes(semHoras, AGORA)).toBe(30);
+  });
+
+  it('arredonda para cima a fração de hora', () => {
+    const meiaHora = emTeste(0, { hours_left: null, trial_ends_at: new Date(AGORA + 1800000).toISOString() });
+    expect(horasRestantes(meiaHora, AGORA)).toBe(1);
+  });
+
+  it('não devolve número negativo', () => {
+    expect(horasRestantes(emTeste(-5), AGORA)).toBe(0);
+  });
+
+  it('devolve nulo quando não há nada de onde tirar', () => {
+    expect(horasRestantes({ state: 'anon', unlocked: false, days_left: null, hours_left: null, trial_ends_at: null }, AGORA)).toBeNull();
+    expect(horasRestantes(undefined, AGORA)).toBeNull();
+  });
+
+  it('ignora data de término ilegível', () => {
+    const quebrado = emTeste(0, { hours_left: null, trial_ends_at: 'sei lá' });
+    expect(horasRestantes(quebrado, AGORA)).toBeNull();
+  });
+});
+
+describe('tempoDeTeste dentro das 48 horas', () => {
+  it('fala em horas', () => {
+    expect(tempoDeTeste(emTeste(31), AGORA)).toMatchObject({
+      curto: '31h',
+      longo: 'faltam 31 horas',
+    });
+  });
+
+  it('usa o singular na última hora', () => {
+    expect(tempoDeTeste(emTeste(1), AGORA)).toMatchObject({
+      curto: '1h',
+      longo: 'falta 1 hora',
+    });
+  });
+
+  it('nas 48 horas cheias ainda fala em horas', () => {
+    // A borda é o valor que um teste novo tem no primeiro segundo.
+    expect(tempoDeTeste(emTeste(48), AGORA)?.curto).toBe('48h');
+  });
+
+  it('avisa que acabou o tempo sem dizer zero', () => {
+    // "0h restantes" numa pílula que existe só enquanto o teste vale é pior que
+    // não dizer nada: a pessoa lê que perdeu o acesso que ainda tem.
+    expect(tempoDeTeste(emTeste(0), AGORA)).toMatchObject({
+      curto: '<1h',
+      longo: 'falta menos de 1 hora',
+    });
+  });
+});
+
+describe('tempoDeTeste acima das 48 horas (a coorte de 7 dias)', () => {
+  it('fala em dias', () => {
+    expect(tempoDeTeste(emTeste(24 * 7), AGORA)).toMatchObject({
+      curto: '7d',
+      longo: 'faltam 7 dias',
+    });
+  });
+
+  it('arredonda o dia para cima, como o servidor faz', () => {
+    expect(tempoDeTeste(emTeste(49), AGORA)?.curto).toBe('3d');
+  });
+
+  it('usa o singular quando sobra um dia', () => {
+    // Só alcançável por quem tem mais de 48h e menos de 24h ao mesmo tempo, o
+    // que é impossível — a guarda existe para a frase não nascer errada se o
+    // corte das 48 horas mudar de valor depois.
+    expect(tempoDeTeste(emTeste(24), AGORA)?.longo).not.toBe('faltam 1 dias');
+  });
+});
+
+describe('a última reta', () => {
+  it('não está acabando com um dia e meio pela frente', () => {
+    expect(tempoDeTeste(emTeste(36), AGORA)?.acabando).toBe(false);
+  });
+
+  it('está acabando nas últimas doze horas', () => {
+    expect(tempoDeTeste(emTeste(12), AGORA)?.acabando).toBe(true);
+    expect(tempoDeTeste(emTeste(2), AGORA)?.acabando).toBe(true);
+  });
+
+  it('a coorte de 7 dias também chega na última reta', () => {
+    // O aviso é sobre o tempo que sobra, não sobre qual coorte a pessoa é.
+    expect(tempoDeTeste(emTeste(5), AGORA)?.acabando).toBe(true);
+  });
+});
+
+describe('tempoDeTeste fora do teste', () => {
+  it('não inventa contador para quem não está em teste', () => {
+    expect(tempoDeTeste({ state: 'subscribed', unlocked: true, days_left: null, hours_left: null, trial_ends_at: null }, AGORA)).toBeNull();
+    expect(tempoDeTeste(undefined, AGORA)).toBeNull();
+  });
+});

--- a/src/components/futebol/tempo-de-teste.test.ts
+++ b/src/components/futebol/tempo-de-teste.test.ts
@@ -39,7 +39,7 @@ describe('horasRestantes', () => {
 
   it('cai para a data de término quando o servidor não mandou as horas', () => {
     // Acontece de verdade em duas situações: resposta antiga guardada em cache
-    // pelo react-query, e ambiente onde a migration 134 ainda não subiu.
+    // pelo react-query, e ambiente onde a migration 136 ainda não subiu.
     const semHoras = emTeste(30, { hours_left: null });
     expect(horasRestantes(semHoras, AGORA)).toBe(30);
   });

--- a/src/components/futebol/tempo-de-teste.ts
+++ b/src/components/futebol/tempo-de-teste.ts
@@ -1,0 +1,91 @@
+import type { FutebolAccess } from '@/services/futebol-data.service';
+
+/**
+ * Quanto tempo sobra do teste grátis, já em texto.
+ *
+ * Isto é uma peça à parte porque a resposta aparece em dois lugares que não se
+ * falam — a pílula do cabeçalho e a página de assinar — e cada um tinha a sua
+ * conta. Enquanto o teste durava 7 dias as duas cópias diziam a mesma coisa por
+ * sorte; com 48 horas elas divergiriam na primeira borda.
+ *
+ * A regra de unidade existe porque há DUAS coortes vivas ao mesmo tempo: quem
+ * começou antes do corte tem até 7 dias gravados, quem começou depois tem 48
+ * horas. Contar tudo em horas daria "faltam 161 horas", e contar tudo em dias
+ * daria "2 dias" num teste de dois dias. Então a unidade acompanha a ordem de
+ * grandeza, e nenhuma das duas telas precisa saber de coorte.
+ */
+
+/** Acima daqui a frase troca de unidade: é a duração de um teste novo. */
+const HORAS_QUE_VIRAM_DIAS = 48;
+
+/** Última reta: o chip muda de cor para avisar que está no fim. */
+const HORAS_DA_ULTIMA_RETA = 12;
+
+export type TempoDeTeste = {
+  /** Texto curto, para a pílula: "31h", "7d", "<1h". */
+  curto: string;
+  /** Frase inteira, para texto corrido: "faltam 31 horas". */
+  longo: string;
+  /** Está na última reta — a tela pode chamar atenção. */
+  acabando: boolean;
+};
+
+/**
+ * Horas que faltam, arredondadas para cima. Nunca negativo.
+ *
+ * Prefere o número do servidor: é o relógio dele que decide o acesso, então
+ * deixar a tela calcular a partir do horário do aparelho faria a pílula
+ * discordar do gate num celular com a hora errada. A data de término é a
+ * reserva, e cobre dois casos reais — resposta antiga guardada em cache pelo
+ * react-query, e ambiente onde a migration 134 ainda não subiu.
+ */
+export function horasRestantes(
+  access: FutebolAccess | undefined | null,
+  agora: number = Date.now(),
+): number | null {
+  if (!access) return null;
+
+  if (typeof access.hours_left === 'number') {
+    return Math.max(0, access.hours_left);
+  }
+
+  if (!access.trial_ends_at) return null;
+  const fim = new Date(access.trial_ends_at).getTime();
+  if (Number.isNaN(fim)) return null;
+
+  return Math.max(0, Math.ceil((fim - agora) / 3600000));
+}
+
+export function tempoDeTeste(
+  access: FutebolAccess | undefined | null,
+  agora: number = Date.now(),
+): TempoDeTeste | null {
+  if (!access || access.state !== 'trial') return null;
+
+  const horas = horasRestantes(access, agora);
+  if (horas === null) return null;
+
+  const acabando = horas <= HORAS_DA_ULTIMA_RETA;
+
+  if (horas > HORAS_QUE_VIRAM_DIAS) {
+    const dias = Math.ceil(horas / 24);
+    return {
+      curto: `${dias}d`,
+      longo: `${dias === 1 ? 'falta' : 'faltam'} ${dias} ${dias === 1 ? 'dia' : 'dias'}`,
+      acabando,
+    };
+  }
+
+  // Zero horas dentro do estado de teste é a última fração de hora. Dizer "0h"
+  // numa pílula que só existe enquanto o teste vale faria a pessoa ler que
+  // perdeu o acesso que ainda tem.
+  if (horas <= 0) {
+    return { curto: '<1h', longo: 'falta menos de 1 hora', acabando: true };
+  }
+
+  return {
+    curto: `${horas}h`,
+    longo: `${horas === 1 ? 'falta' : 'faltam'} ${horas} ${horas === 1 ? 'hora' : 'horas'}`,
+    acabando,
+  };
+}

--- a/src/components/futebol/tempo-de-teste.ts
+++ b/src/components/futebol/tempo-de-teste.ts
@@ -37,7 +37,7 @@ export type TempoDeTeste = {
  * deixar a tela calcular a partir do horário do aparelho faria a pílula
  * discordar do gate num celular com a hora errada. A data de término é a
  * reserva, e cobre dois casos reais — resposta antiga guardada em cache pelo
- * react-query, e ambiente onde a migration 134 ainda não subiu.
+ * react-query, e ambiente onde a migration 136 ainda não subiu.
  */
 export function horasRestantes(
   access: FutebolAccess | undefined | null,

--- a/src/components/lp/LpOferta.tsx
+++ b/src/components/lp/LpOferta.tsx
@@ -4,7 +4,7 @@ import type { LpVariant } from "@/pages/lp/variants";
 // ============================================================
 // Oferta, bônus, ancoragem e preço. Fecha a página.
 //
-// O bloco muda com o eixo de oferta da variação: trial mostra "7 dias grátis,
+// O bloco muda com o eixo de oferta da variação: trial mostra "48 horas grátis,
 // depois R$ X", pagamento mostra o preço direto com o valor cheio riscado.
 //
 // PENDENTE: o "Guia Prático dos 10 Filtros" não existe ainda. A página não pode
@@ -29,11 +29,11 @@ export function LpOferta({ variant, onCta }: { variant: LpVariant; onCta: () => 
             A oferta
           </p>
           <h2 className="font-display text-[28px] sm:text-[38px] font-black leading-[1.1] tracking-tight text-ink text-balance">
-            Teste 7 dias grátis. Depois, a Smart Betting trabalha em cada análise por{" "}
+            Teste 48 horas grátis. Depois, a Smart Betting trabalha em cada análise por{" "}
             <span className="text-forest">R$ {variant.preco.valor}</span> por mês.
           </h2>
           <p className="text-[17px] text-ink-2 leading-relaxed mt-5">
-            Você entra sem cartão e usa a plataforma completa por 7 dias, consultando as
+            Você entra sem cartão e usa a plataforma completa por 48 horas, consultando as
             oportunidades já analisadas pela Inteligência Artificial nos 10 filtros. Só paga se
             quiser continuar.
           </p>
@@ -113,7 +113,7 @@ export function LpOferta({ variant, onCta }: { variant: LpVariant; onCta: () => 
             <span className="text-[15px] sm:text-[16px] text-ink-2 whitespace-nowrap">por mês</span>
           </div>
           <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-amber-2 mt-2.5">
-            Preço de lançamento · só depois dos 7 dias
+            Preço de lançamento · só depois das 48 horas
           </p>
           <p className="text-[16px] text-ink-2 leading-relaxed mt-5 max-w-[52ch] mx-auto">
             Sem precisar contratar ferramenta diferente para cada coisa, nem depender de palpite sem
@@ -129,7 +129,7 @@ export function LpOferta({ variant, onCta }: { variant: LpVariant; onCta: () => 
             <ArrowRight className="h-5 w-5 shrink-0" />
           </button>
           <p className="text-[13px] text-ink-3 mt-3.5 leading-snug max-w-[46ch] mx-auto">
-            Acesso liberado na hora, sem cartão. Passados os 7 dias, a assinatura é mensal, com
+            Acesso liberado na hora, sem cartão. Passadas as 48 horas, a assinatura é mensal, com
             renovação automática e cancelamento quando quiser.
           </p>
           <p className="text-[12px] text-ink-3 mt-5 leading-snug">

--- a/src/hooks/use-futebol-data.ts
+++ b/src/hooks/use-futebol-data.ts
@@ -37,7 +37,7 @@ import {
 } from '@/services/futebol-data.service';
 
 /**
- * Acesso ao módulo Futebol (reverse trial 7 dias, sem cartão).
+ * Acesso ao módulo Futebol (reverse trial 48 horas, sem cartão).
  * O RPC inicia o relógio no 1º acesso logado e devolve o estado atual.
  * Key por usuário pra refazer ao logar/deslogar.
  */

--- a/src/hooks/use-futebol-publication-alerts.ts
+++ b/src/hooks/use-futebol-publication-alerts.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/integrations/supabase/client';
 import { useAuth } from '@/hooks/use-auth';
-import { temAcessoAoFutebol } from '@/utils/futebol-acesso';
+import { temAcessoAoFutebolPeloFim } from '@/utils/futebol-acesso';
 
 export interface FutebolPublicationAlerts {
   enabled: boolean;
@@ -14,7 +14,12 @@ export interface FutebolPublicationAlerts {
 /**
  * Uma única fonte para o controle que existe no site e no Telegram. A consulta
  * não chama get_futebol_access porque abrir Configurações não deve iniciar o
- * teste gratuito de sete dias.
+ * teste gratuito de 48 horas.
+ *
+ * Pergunta pelo FIM do teste, e não pelo início: as duas consultas do servidor
+ * que decidem a entrega de alerta cortam por `futebol_trial_ends_at`, e medir
+ * aqui a partir do início faria esta tela dizer que os alertas estão ativos por
+ * sete dias enquanto o servidor para de mandar em 48 horas.
  */
 export function useFutebolPublicationAlerts() {
   const { user } = useAuth();
@@ -28,7 +33,7 @@ export function useFutebolPublicationAlerts() {
     queryFn: async () => {
       const { data, error } = await supabase
         .from('users')
-        .select('telegram_chat_id, futebol_publication_alerts_enabled, futebol_publication_alerts_ack_at, futebol_subscription_status, futebol_trial_started_at')
+        .select('telegram_chat_id, futebol_publication_alerts_enabled, futebol_publication_alerts_ack_at, futebol_subscription_status, futebol_trial_ends_at')
         .eq('id', user!.id)
         .maybeSingle();
       if (error) throw error;
@@ -36,7 +41,7 @@ export function useFutebolPublicationAlerts() {
       return {
         enabled: data.futebol_publication_alerts_enabled ?? true,
         telegramLinked: !!data.telegram_chat_id,
-        accessActive: temAcessoAoFutebol(data.futebol_subscription_status, data.futebol_trial_started_at),
+        accessActive: temAcessoAoFutebolPeloFim(data.futebol_subscription_status, data.futebol_trial_ends_at),
         onboardingAcknowledged: !!data.futebol_publication_alerts_ack_at,
       };
     },

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -648,6 +648,7 @@ export type Database = {
           futebol_publication_alerts_ack_at: string | null
           futebol_publication_alerts_enabled: boolean
           futebol_subscription_status: string
+          futebol_trial_ends_at: string | null
           futebol_trial_started_at: string | null
           has_report_access: boolean | null
           id: string
@@ -692,6 +693,7 @@ export type Database = {
           futebol_publication_alerts_ack_at?: string | null
           futebol_publication_alerts_enabled?: boolean
           futebol_subscription_status?: string
+          futebol_trial_ends_at?: string | null
           futebol_trial_started_at?: string | null
           has_report_access?: boolean | null
           id?: string
@@ -736,6 +738,7 @@ export type Database = {
           futebol_publication_alerts_ack_at?: string | null
           futebol_publication_alerts_enabled?: boolean
           futebol_subscription_status?: string
+          futebol_trial_ends_at?: string | null
           futebol_trial_started_at?: string | null
           has_report_access?: boolean | null
           id?: string

--- a/src/pages/FutebolAssinar.tsx
+++ b/src/pages/FutebolAssinar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { Check, Loader2, Lock, MessageCircle } from 'lucide-react';
 import AnalyticsNav from '@/components/AnalyticsNav';
+import { tempoDeTeste } from '@/components/futebol/tempo-de-teste';
 import { Button } from '@/components/ui/button';
 import { whatsappDoTime } from '@/config/contato';
 import { useAuth } from '@/hooks/use-auth';
@@ -134,7 +135,7 @@ export default function FutebolAssinar() {
 
   const expirou = access?.state === 'expired';
   const noTeste = access?.state === 'trial';
-  const diasRestantes = access?.days_left ?? 0;
+  const tempo = tempoDeTeste(access);
 
   return (
     <div className="theme-bolao min-h-screen bg-canvas text-ink flex flex-col">
@@ -153,8 +154,8 @@ export default function FutebolAssinar() {
             <p className="text-[15px] text-ink-2">
               {expirou
                 ? 'A análise continua livre pra você. Só o pick de valor de cada oportunidade é que fica com assinante.'
-                : noTeste
-                  ? `Você ainda tem ${diasRestantes} ${diasRestantes === 1 ? 'dia' : 'dias'} de teste. Assinando agora, não perde o acesso quando acabar.`
+                : noTeste && tempo
+                  ? `Ainda ${tempo.longo} de teste. Assinando agora, você não perde o acesso quando acabar.`
                   : 'O pick de valor de cada jogo, com o porquê do lado.'}
             </p>
           </div>

--- a/src/pages/FutebolLP.tsx
+++ b/src/pages/FutebolLP.tsx
@@ -140,7 +140,7 @@ const FutebolLP = () => {
     },
     {
       q: "É grátis pra testar?",
-      a: "São 7 dias de Premium completo, sem cartão. Depois segue free: você continua vendo o Score, a leitura do jogo, a classificação e os times — só o pick de valor de cada oportunidade fica bloqueado.",
+      a: "São 48 horas de Premium completo, sem cartão. Depois segue free: você continua vendo o Score, a leitura do jogo, a classificação e os times — só o pick de valor de cada oportunidade fica bloqueado.",
     },
     {
       q: "Preciso entender de estatística?",
@@ -208,7 +208,7 @@ const FutebolLP = () => {
               className="inline-flex items-center justify-center gap-2 h-12 px-6 rounded-rebrand-md bg-amber text-white hover:bg-amber-2 font-bold text-[15px] shadow-md transition-colors"
             >
               <PlayCircle className="h-5 w-5 shrink-0" />
-              Criar conta — 7 dias grátis
+              Criar conta — 48 horas grátis
             </button>
             <button
               type="button"
@@ -219,7 +219,7 @@ const FutebolLP = () => {
             </button>
           </div>
           <p className="text-[12px] text-white/55 mt-4">
-            7 dias de Premium, sem cartão · Depois segue free com a análise toda · Sem promessa de lucro, a decisão é sua
+            48 horas de Premium, sem cartão · Depois segue free com a análise toda · Sem promessa de lucro, a decisão é sua
           </p>
         </div>
       </section>
@@ -385,7 +385,7 @@ const FutebolLP = () => {
             Ver as oportunidades de verdade
           </button>
           <p className="text-sm text-ink-3 mt-3">
-            Sem login pra olhar · 7 dias de Premium ao criar a conta
+            Sem login pra olhar · 48 horas de Premium ao criar a conta
           </p>
         </div>
       </section>
@@ -529,7 +529,7 @@ const FutebolLP = () => {
         <div className="border-t border-line py-14 sm:py-20 grid md:grid-cols-[1fr_auto] gap-8 md:gap-12 items-center">
           <div>
             <h2 className="font-display text-3xl sm:text-4xl lg:text-5xl font-black text-ink leading-tight mb-3">
-              Testa 7 dias grátis.
+              Testa 48 horas grátis.
             </h2>
             <p className="text-[15px] text-ink-2 leading-relaxed max-w-lg">
               Premium completo, sem cartão. Depois segue free com a análise toda —

--- a/src/pages/Planos.tsx
+++ b/src/pages/Planos.tsx
@@ -54,8 +54,8 @@ const annualTotal = (billed: string) => {
 };
 const PLAN_JSONLD_DESC: Record<PaidTier, string> = {
   entrada: 'Betinho ilimitado no Telegram: registra e liquida suas apostas e manda o resumo semanal da banca. Sem as análises de futebol e NBA.',
-  essencial: 'Futebol completo (Brasileirão e Copa) + Betinho ilimitado. Teste grátis de 7 dias.',
-  completo: 'Tudo do Essencial + análise NBA completa (prop bets e Análise 360). Teste grátis de 7 dias.',
+  essencial: 'Futebol completo (Brasileirão e Copa) + Betinho ilimitado. Teste grátis de 48 horas.',
+  completo: 'Tudo do Essencial + análise NBA completa (prop bets e Análise 360). Teste grátis de 48 horas.',
 };
 
 const PLANS_JSONLD = {
@@ -205,7 +205,7 @@ export default function Planos() {
             escolhe até onde quer ir — e sobe de nível quando quiser.
           </p>
           <div className="flex flex-wrap gap-x-4 gap-y-1.5 mt-4 text-[13.5px] text-ink-3">
-            {['7 dias grátis pra testar', 'Cancele quando quiser', 'Pix ou cartão'].map((t) => (
+            {['48 horas grátis pra testar', 'Cancele quando quiser', 'Pix ou cartão'].map((t) => (
               <span key={t} className="inline-flex items-center gap-1.5">
                 <Check className="w-[15px] h-[15px] text-status-success" /> {t}
               </span>
@@ -261,7 +261,7 @@ export default function Planos() {
                 {freeCta.label}
               </button>
               <ul className="mt-5 pt-5 border-t border-line flex flex-col gap-2.5 text-sm">
-                <Feat>Futebol: <b className="text-ink font-semibold">7 dias grátis</b> de acesso completo</Feat>
+                <Feat>Futebol: <b className="text-ink font-semibold">48 horas grátis</b> de acesso completo</Feat>
                 <Feat>NBA: <b className="text-ink font-semibold">2 picks do dia</b> liberados</Feat>
                 <Feat>Betinho: até <b className="text-ink font-semibold">3 apostas por dia</b></Feat>
               </ul>
@@ -347,7 +347,7 @@ export default function Planos() {
           </div>
 
           <p className="text-center text-[13px] text-ink-3 mt-4">
-            Todos os planos pagos incluem o Betinho ilimitado e o teste grátis de 7 dias.
+            Todos os planos pagos incluem o Betinho ilimitado e o teste grátis de 48 horas.
           </p>
         </section>
 
@@ -386,7 +386,7 @@ export default function Planos() {
                 </tr>
                 <tr>
                   <th className="text-left px-4 text-sm font-semibold text-ink">Análise de futebol</th>
-                  <td>7 dias grátis</td>
+                  <td>48 horas grátis</td>
                   <td className="text-ink-3">Não inclui</td>
                   <td>Completa</td>
                   <td className="bg-forest-tint !text-forest font-semibold">Completa</td>
@@ -426,7 +426,7 @@ export default function Planos() {
                 a: (<>O NBA é a nossa análise <b className="text-ink">mais robusta</b> — prop bets, Análise 360 e o que temos de mais avançado. O Essencial já entrega o futebol completo pro seu dia a dia; o Completo é pra quem quer <b className="text-ink">tudo</b> junto. Você não paga por esporte solto: paga por até onde quer ir.</>),
               },
               { q: 'Posso trocar de plano depois?', a: <>Pode, quando quiser. Se subir de plano, o valor é ajustado proporcionalmente; se descer, a troca vale no fim do ciclo. Sem multa, sem burocracia.</> },
-              { q: 'Como funciona o teste grátis?', a: <>Você cria a conta e tem <b className="text-ink">7 dias</b> de acesso completo pra experimentar de verdade. Só cobra depois — e você decide se continua.</> },
+              { q: 'Como funciona o teste grátis?', a: <>Você cria a conta e tem <b className="text-ink">48 horas</b> de acesso completo pra experimentar de verdade. Só cobra depois — e você decide se continua.</> },
               { q: 'Consigo pagar com Pix?', a: <>Sim. Aceitamos <b className="text-ink">Pix</b> e cartão. No anual, o Pix sai à vista com o desconto de lançamento aplicado.</> },
               { q: 'Como eu cancelo?', a: <>Em dois cliques, na sua conta. O acesso continua até o fim do período que você já pagou — nada de corte no meio.</> },
             ].map(({ q, a, open }) => (
@@ -446,7 +446,7 @@ export default function Planos() {
           <div className="rounded-[20px] bg-forest text-white text-center px-8 py-12">
             <h2 className="text-[26px] md:text-[38px] font-extrabold tracking-tight">Comece grátis hoje</h2>
             <p className="mt-3 mb-7 mx-auto max-w-[46ch]" style={{ color: '#a9c4b7' }}>
-              Cria a conta, testa 7 dias e só depois decide. Se não for pra você, é só cancelar.
+              Cria a conta, testa 48 horas e só depois decide. Se não for pra você, é só cancelar.
             </p>
             <button onClick={freeCta.onClick} className="inline-block h-12 px-8 rounded-rebrand-sm text-base font-bold transition hover:brightness-95" style={{ background: '#d4a017', color: '#2a1f00' }}>
               {freeCta.label}

--- a/src/pages/lp/LpVariant.tsx
+++ b/src/pages/lp/LpVariant.tsx
@@ -60,7 +60,7 @@ function LpConteudo({ variant }: { variant: LpVariantConfig }) {
   }, [posthog, variant.slug]);
 
   /**
-   * Cadastro e o reverse trial do Futebol libera os 7 dias no primeiro acesso.
+   * Cadastro e o reverse trial do Futebol libera as 48 horas no primeiro acesso.
    * O destino é o próprio produto, não a página de assinatura: quem clicou num
    * CTA de teste grátis não pode cair num botão de pagamento desabilitado.
    */

--- a/src/pages/lp/variants.ts
+++ b/src/pages/lp/variants.ts
@@ -67,8 +67,8 @@ export interface LpVariant {
 const PRECO = { valor: "39,90", de: "49,90" };
 
 /**
- * CTA do teste grátis de 7 dias, que é o que o produto entrega hoje: o reverse
- * trial do Futebol libera tudo por 7 dias, sem cartão.
+ * CTA do teste grátis de 48 horas, que é o que o produto entrega hoje: o reverse
+ * trial do Futebol libera tudo por 48 horas, sem cartão.
  *
  * O documento de copy fecha em "QUERO ACESSAR A SMARTBET" com acesso após o
  * pagamento, mas o gateway não existe (/planos mostra "Pagamento em breve" para
@@ -76,7 +76,7 @@ const PRECO = { valor: "39,90", de: "49,90" };
  * e o trial é verdade e converte melhor em tráfego frio.
  */
 const CTA = {
-  label: "Quero testar 7 dias grátis",
+  label: "Quero testar 48 horas grátis",
   microcopy: "Sem cartão para testar. Depois, R$ 39,90 por mês, e cancela quando quiser.",
 };
 
@@ -99,7 +99,7 @@ export const LP_VARIANTS: LpVariant[] = [
     seo: {
       title: "Mais razões para acreditar na sua aposta | Smart Betting",
       description:
-        "A Inteligência Artificial testa cada cenário do jogo em 10 filtros e mede quantos dados apontam para o mesmo lado. Teste 7 dias grátis, sem cartão.",
+        "A Inteligência Artificial testa cada cenário do jogo em 10 filtros e mede quantos dados apontam para o mesmo lado. Teste 48 horas grátis, sem cartão.",
     },
     hero: {
       titulo:
@@ -121,7 +121,7 @@ export const LP_VARIANTS: LpVariant[] = [
     seo: {
       title: "Uma estatística sozinha conta a história errada | Smart Betting",
       description:
-        "Dado isolado justifica quase qualquer aposta. Uma oportunidade só ganha força quando diferentes sinais apontam para o mesmo lado. Teste 7 dias grátis.",
+        "Dado isolado justifica quase qualquer aposta. Uma oportunidade só ganha força quando diferentes sinais apontam para o mesmo lado. Teste 48 horas grátis.",
     },
     hero: {
       titulo: "Uma boa estatística, sozinha, pode contar a história errada.",
@@ -142,7 +142,7 @@ export const LP_VARIANTS: LpVariant[] = [
     seo: {
       title: "Analisar sem método resulta em RED | Smart Betting",
       description:
-        "Em vez de abrir vários sites antes de apostar, a Inteligência Artificial aplica 10 filtros no jogo e entrega a leitura pronta. Teste 7 dias grátis.",
+        "Em vez de abrir vários sites antes de apostar, a Inteligência Artificial aplica 10 filtros no jogo e entrega a leitura pronta. Teste 48 horas grátis.",
     },
     hero: {
       titulo: "Analisar sem método resulta em !!RED!!. A Smart Betting dá método baseado em fato.",
@@ -165,7 +165,7 @@ export const LP_VARIANTS: LpVariant[] = [
     seo: {
       title: "Mais clareza para analisar, mais segurança para decidir | Smart Betting",
       description:
-        "Sem depender apenas de palpite, de opinião ou de uma estatística isolada. Veja quantos dos 10 filtros apontam para o mesmo lado. Teste 7 dias grátis.",
+        "Sem depender apenas de palpite, de opinião ou de uma estatística isolada. Veja quantos dos 10 filtros apontam para o mesmo lado. Teste 48 horas grátis.",
     },
     hero: {
       titulo: "Mais clareza para analisar. Mais segurança para decidir.",

--- a/src/seo/public-routes.json
+++ b/src/seo/public-routes.json
@@ -15,7 +15,7 @@
   {
     "path": "/futebol/comecar",
     "title": "Aposta de Valor no Futebol: Brasil, América do Sul e Europa | Smart Betting",
-    "description": "Um Score de Confiabilidade que compara a chance real com a odd da casa e mostra onde a odd paga mais do que o risco. As principais competições do Brasil, América do Sul e Europa. 7 dias grátis, sem cartão.",
+    "description": "Um Score de Confiabilidade que compara a chance real com a odd da casa e mostra onde a odd paga mais do que o risco. As principais competições do Brasil, América do Sul e Europa. 48 horas grátis, sem cartão.",
     "image": "/og/og-futebol.jpg",
     "sitemap": { "changefreq": "weekly", "priority": "0.8", "lastmod": "2026-07-24" }
   },
@@ -43,7 +43,7 @@
   {
     "path": "/planos",
     "title": "Planos e Preços: Futebol, NBA e Betinho | Smart Betting",
-    "description": "Comece grátis, leve só o Betinho por R$ 14,90/mês, ou assine o Essencial (futebol completo) ou o Completo (tudo + NBA). Teste grátis de 7 dias, sem fidelidade.",
+    "description": "Comece grátis, leve só o Betinho por R$ 14,90/mês, ou assine o Essencial (futebol completo) ou o Completo (tudo + NBA). Teste grátis de 48 horas, sem fidelidade.",
     "sitemap": { "changefreq": "weekly", "priority": "0.8", "lastmod": "2026-07-25" }
   },
   {

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -432,7 +432,7 @@ export interface FutebolAccess {
   days_left: number | null;
   /**
    * Horas arredondadas para cima. É a unidade do teste de 48 horas, e chega
-   * nula de resposta antiga em cache ou de ambiente sem a migration 134 —
+   * nula de resposta antiga em cache ou de ambiente sem a migration 136 —
    * `tempo-de-teste.ts` cai para `trial_ends_at` nesse caso.
    */
   hours_left: number | null;

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -425,9 +425,11 @@ export interface FutebolAccess {
   state: FutebolAccessState;
   unlocked: boolean;
   /**
-   * Dias arredondados para cima. Continua no contrato porque a coorte que
-   * começou o teste antes do corte de 12/09/2026 tem até 7 dias, e para ela
-   * dia ainda é a unidade que informa.
+   * Dias arredondados para cima. Nenhuma tela lê mais — `tempo-de-teste.ts`
+   * decide a unidade a partir das horas. Continua no contrato porque o banco
+   * sobe antes do bundle: até o deploy do frontend, e depois dele para quem
+   * está com a página aberta ou com o JS antigo em cache, existe navegador
+   * pedindo este campo.
    */
   days_left: number | null;
   /**

--- a/src/services/futebol-data.service.ts
+++ b/src/services/futebol-data.service.ts
@@ -419,12 +419,23 @@ export const FUTEBOL_ZONE_LABEL: Record<Exclude<FutebolZone, null>, string> = {
   rebaixamento: 'Rebaixamento',
 };
 
-/** Estado de acesso ao módulo Futebol (reverse trial 7 dias, sem cartão). */
+/** Estado de acesso ao módulo Futebol (reverse trial 48 horas, sem cartão). */
 export type FutebolAccessState = 'anon' | 'trial' | 'expired' | 'subscribed';
 export interface FutebolAccess {
   state: FutebolAccessState;
   unlocked: boolean;
+  /**
+   * Dias arredondados para cima. Continua no contrato porque a coorte que
+   * começou o teste antes do corte de 12/09/2026 tem até 7 dias, e para ela
+   * dia ainda é a unidade que informa.
+   */
   days_left: number | null;
+  /**
+   * Horas arredondadas para cima. É a unidade do teste de 48 horas, e chega
+   * nula de resposta antiga em cache ou de ambiente sem a migration 134 —
+   * `tempo-de-teste.ts` cai para `trial_ends_at` nesse caso.
+   */
+  hours_left: number | null;
   trial_ends_at: string | null;
 }
 
@@ -830,7 +841,7 @@ export const futebolDataService = {
     return withRetry(async () => {
       const { data, error } = await supabaseClient.rpc('get_futebol_access');
       if (error) throw error;
-      return (data || { state: 'anon', unlocked: false, days_left: null, trial_ends_at: null }) as FutebolAccess;
+      return (data || { state: 'anon', unlocked: false, days_left: null, hours_left: null, trial_ends_at: null }) as FutebolAccess;
     });
   },
 

--- a/src/utils/futebol-acesso-paridade.test.ts
+++ b/src/utils/futebol-acesso-paridade.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { temAcessoAoFutebolPeloFim } from './futebol-acesso';
+import { temAcessoAoFutebol as noTelegram } from '../../supabase/functions/shared/acesso-ao-futebol';
+
+// ============================================================================
+// A guarda que impede as duas cópias do acesso ao futebol de divergirem
+// ============================================================================
+// "O acesso está de pé?" existe DUAS vezes, e tem de existir: o site roda no
+// browser e o bot roda em Deno, que não alcança o `src/`. É a mesma fronteira
+// da vitrine de mercados ocultos.
+//
+// A diferença é que ali a divergência esconde um mercado, e aqui ela decide se
+// a pessoa recebe ou não o alerta que ela pediu. O site diria "alertas ativos"
+// e o Telegram pararia de mandar, ou o contrário — e ninguém veria, porque as
+// duas superfícies são lidas em momentos diferentes.
+//
+// Foi exatamente esse par que divergiu na migration 136: o site media sete dias
+// a partir do início do teste enquanto o servidor já cortava em 48 horas pelo
+// fim gravado.
+//
+// Esta guarda compara COMPORTAMENTO, caso a caso, e não texto.
+// ============================================================================
+
+const AGORA = Date.parse('2026-09-12T12:00:00Z');
+const emHoras = (h: number) => new Date(AGORA + h * 3600000).toISOString();
+
+const CASOS: { nome: string; status: string | null; fim: string | null }[] = [
+  { nome: 'assinante sem teste', status: 'premium', fim: null },
+  { nome: 'assinante com teste vencido', status: 'premium', fim: emHoras(-100) },
+  { nome: 'teste correndo, coorte de 48 horas', status: 'free', fim: emHoras(31) },
+  { nome: 'teste correndo, coorte de 7 dias', status: 'free', fim: emHoras(24 * 6) },
+  { nome: 'última hora do teste', status: 'free', fim: emHoras(1) },
+  { nome: 'teste vencido por uma hora', status: 'free', fim: emHoras(-1) },
+  { nome: 'instante exato do fim', status: 'free', fim: emHoras(0) },
+  { nome: 'nunca abriu o módulo', status: 'free', fim: null },
+  { nome: 'status nulo e sem teste', status: null, fim: null },
+  { nome: 'status nulo com teste correndo', status: null, fim: emHoras(5) },
+  { nome: 'data de fim ilegível', status: 'free', fim: 'sei lá' },
+];
+
+describe('site e Telegram respondem igual sobre o acesso ao futebol', () => {
+  it.each(CASOS)('$nome', ({ status, fim }) => {
+    const site = temAcessoAoFutebolPeloFim(status, fim, AGORA);
+    const telegram = noTelegram(
+      { futebol_subscription_status: status, futebol_trial_ends_at: fim },
+      AGORA,
+    );
+    expect(site).toBe(telegram);
+  });
+
+  it('e a resposta não é a mesma para todos os casos, senão a guarda não guarda nada', () => {
+    // Sem isto, duas funções que devolvessem sempre `false` passariam na
+    // comparação acima e a suíte ficaria verde sobre um produto quebrado.
+    const respostas = new Set(
+      CASOS.map(({ status, fim }) => temAcessoAoFutebolPeloFim(status, fim, AGORA)),
+    );
+    expect(respostas).toEqual(new Set([true, false]));
+  });
+});

--- a/src/utils/futebol-acesso.ts
+++ b/src/utils/futebol-acesso.ts
@@ -1,18 +1,53 @@
-/** Quantos dias dura o teste gratuito do futebol. */
-const DIAS_DE_TESTE = 7;
-
 /**
  * O acesso ao futebol está ativo?
  *
- * Duas portas: assinatura em premium, ou o teste gratuito ainda dentro do
- * prazo. Vive aqui porque duas telas fazem a mesma pergunta — as configurações
- * de alertas e a ficha do CRM —, e duas cópias divergiriam no dia em que o
- * prazo mudasse.
+ * Duas portas: assinatura em premium, ou o teste gratuito ainda de pé. Vive
+ * aqui porque duas telas fazem a mesma pergunta — as configurações de alertas
+ * e a ficha do CRM —, e duas cópias divergiriam no dia em que o prazo mudasse.
  *
- * ⚠️ O que este arquivo NÃO unifica: as edge functions do Telegram têm a
- * própria conta dos sete dias, em Deno, e não conseguem importar daqui. São
- * runtimes diferentes sem módulo compartilhado. Mudar o prazo exige mexer nos
- * dois lados, e este comentário existe para lembrar do segundo.
+ * Esse dia chegou: a migration 136 passou o teste de 7 dias para 48 horas e
+ * gravou o FIM de cada teste em `futebol_trial_ends_at`. Quem pergunta pelo
+ * fim acerta as duas coortes vivas sem saber que existem duas, e é por isso
+ * que a duração não aparece mais aqui.
+ *
+ * ⚠️ O que este arquivo NÃO unifica: as edge functions do Telegram rodam em
+ * Deno e não alcançam o `src/`, então a mesma pergunta existe de novo em
+ * `supabase/functions/shared/acesso-ao-futebol.ts`. A cópia é inevitável (dois
+ * runtimes, nenhum módulo comum) e está travada por
+ * `futebol-acesso-paridade.test.ts`, no mesmo padrão da vitrine de mercados
+ * ocultos.
+ */
+export function temAcessoAoFutebolPeloFim(
+  status: string | null | undefined,
+  fimDoTeste: string | null | undefined,
+  agora = Date.now(),
+): boolean {
+  if (status === 'premium') return true;
+  if (!fimDoTeste) return false;
+
+  const fim = new Date(fimDoTeste).getTime();
+  if (Number.isNaN(fim)) return false;
+  return fim > agora;
+}
+
+/** Quantos dias durava o teste antes da migration 136. */
+const DIAS_DE_TESTE = 7;
+
+/**
+ * A mesma pergunta, respondida a partir do INÍCIO do teste.
+ *
+ * ⚠️ DÍVIDA, com prazo: esta é a versão que ainda mede sete dias, e ela
+ * responde errado para quem começou o teste depois da migration 136 — vai dizer
+ * que o acesso está de pé por sete dias quando o servidor corta em 48 horas.
+ *
+ * Continua aqui porque as três telas do CRM (`crm-acesso`, `crm-etiquetas`,
+ * `crm-ficha`) a chamam passando `futebol_trial_started_at`, e o CRM ficou
+ * FORA desta branch de propósito: há outra sessão de trabalho aberta nesses
+ * arquivos, e trocar a assinatura desta função daqui obrigaria a editá-los.
+ *
+ * Quem for fechar essa dívida: apagar esta função, apontar as três telas para
+ * `temAcessoAoFutebolPeloFim` com `futebol_trial_ends_at`, e acertar as duas
+ * cópias de `DIAS_DE_TESTE` que vivem em `crm-acesso.ts` e `crm-etiquetas.ts`.
  */
 export function temAcessoAoFutebol(
   status: string | null | undefined,

--- a/src/utils/futebol-promessa-do-teste.test.ts
+++ b/src/utils/futebol-promessa-do-teste.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ============================================================================
+// A guarda que impede a promessa do teste de divergir do produto
+// ============================================================================
+// A duração do teste grátis é uma PROMESSA, e ela estava escrita em 26 lugares
+// de copy espalhados por cinco arquivos: landing do futebol, as quatro
+// variações de landing, o bloco de oferta, a tabela de planos, o FAQ, o gate.
+// Nenhum deles sabia da existência dos outros.
+//
+// Enquanto o produto entregou 7 dias isso passou, porque as 26 cópias diziam a
+// mesma coisa por sorte. No dia em que o produto passou para 48 horas, cada
+// cópia esquecida virou uma página prometendo o que o produto não entrega — e
+// promessa de teste na landing não é detalhe de texto, é o que a pessoa viu
+// antes de criar a conta.
+//
+// Esta guarda não confere texto igual: confere UNIDADE. Se alguém voltar a
+// medir o teste em dias em qualquer uma dessas telas, quebra aqui.
+//
+// Mesmo modo de falha das guardas do shape file (#250) e da copy de premissa
+// (#272): divergência silenciosa que só aparece quando alguém lê.
+// ============================================================================
+
+const RAIZ = resolve(__dirname, '../..');
+
+/** Toda tela que fala da duração do teste grátis para o usuário. */
+const TELAS = [
+  'src/components/lp/LpOferta.tsx',
+  'src/components/futebol/FutebolGate.tsx',
+  'src/pages/FutebolLP.tsx',
+  'src/pages/FutebolAssinar.tsx',
+  'src/pages/Planos.tsx',
+  'src/pages/lp/LpVariant.tsx',
+  'src/pages/lp/variants.ts',
+];
+
+/**
+ * Jeitos de prometer o teste em DIAS.
+ *
+ * Cada padrão exige um número antes de "dia", porque "picks do dia" e "3
+ * apostas por dia" são outra coisa e continuam válidos nessas mesmas telas.
+ */
+const PROMESSA_EM_DIAS = [
+  /\d+\s+dias?\s+grátis/i,
+  /grátis\s+de\s+\d+\s+dias?/i,
+  /(?:por|testa|teste)\s+\d+\s+dias?/i,
+  /\d+\s+dias?\s+de\s+(?:premium|acesso|teste)/i,
+];
+
+describe('a promessa do teste grátis', () => {
+  it.each(TELAS)('%s não mede o teste em dias', (tela) => {
+    const conteudo = readFileSync(resolve(RAIZ, tela), 'utf8');
+    const achados = PROMESSA_EM_DIAS.flatMap((re) => conteudo.match(re) ?? []);
+    expect(
+      achados,
+      `${tela} promete o teste em dias: ${achados.join(' | ')}. O produto entrega 48 horas.`,
+    ).toEqual([]);
+  });
+
+  it('as telas de venda continuam dizendo quanto o teste dura', () => {
+    // Sem isto, apagar a promessa passaria pela guarda de cima: a tela ficaria
+    // silenciosa sobre a duração, que é pior que dizê-la errada.
+    const vendem = [
+      'src/components/lp/LpOferta.tsx',
+      'src/pages/FutebolLP.tsx',
+      'src/pages/Planos.tsx',
+      'src/pages/lp/variants.ts',
+    ];
+    for (const tela of vendem) {
+      const conteudo = readFileSync(resolve(RAIZ, tela), 'utf8');
+      expect(conteudo, `${tela} não diz quanto dura o teste`).toMatch(/48\s+horas/i);
+    }
+  });
+});

--- a/src/utils/futebol-promessa-do-teste.test.ts
+++ b/src/utils/futebol-promessa-do-teste.test.ts
@@ -25,7 +25,15 @@ import { resolve } from 'node:path';
 
 const RAIZ = resolve(__dirname, '../..');
 
-/** Toda tela que fala da duração do teste grátis para o usuário. */
+/**
+ * Toda tela que fala da duração do teste grátis para o usuário.
+ *
+ * `src/seo/public-routes.json` entra aqui porque é a promessa que sai ANTES da
+ * tela: `scripts/gen-route-heads.mjs` o transforma no `<head>` servido, e é dele
+ * que saem o snippet do Google e o texto de compartilhamento de /futebol/comecar
+ * e /planos. Ele foi o único esquecido na primeira varredura, justamente por não
+ * parecer tela.
+ */
 const TELAS = [
   'src/components/lp/LpOferta.tsx',
   'src/components/futebol/FutebolGate.tsx',
@@ -34,6 +42,7 @@ const TELAS = [
   'src/pages/Planos.tsx',
   'src/pages/lp/LpVariant.tsx',
   'src/pages/lp/variants.ts',
+  'src/seo/public-routes.json',
 ];
 
 /**
@@ -67,6 +76,7 @@ describe('a promessa do teste grátis', () => {
       'src/pages/FutebolLP.tsx',
       'src/pages/Planos.tsx',
       'src/pages/lp/variants.ts',
+      'src/seo/public-routes.json',
     ];
     for (const tela of vendem) {
       const conteudo = readFileSync(resolve(RAIZ, tela), 'utf8');

--- a/supabase/functions/shared/acesso-ao-futebol.ts
+++ b/supabase/functions/shared/acesso-ao-futebol.ts
@@ -10,7 +10,7 @@
  *
  * A duração do teste NÃO aparece aqui, e é o ponto. O fim do teste é gravado em
  * `futebol_trial_ends_at` no instante em que o relógio larga (ver a migration
- * 134), então quem lê não precisa saber quanto ele dura — e continua certo para
+ * 136), então quem lê não precisa saber quanto ele dura — e continua certo para
  * as duas coortes vivas: quem começou antes do corte tem 7 dias gravados, quem
  * começou depois tem 48 horas, e esta função não distingue.
  */

--- a/supabase/functions/shared/acesso-ao-futebol.ts
+++ b/supabase/functions/shared/acesso-ao-futebol.ts
@@ -1,0 +1,37 @@
+/**
+ * Se esta pessoa tem acesso ao futebol AGORA.
+ *
+ * Isto vive em `shared/` pelo mesmo motivo do `concessoes.ts`: a mesma pergunta
+ * era respondida em dois lugares do `telegram-webhook` — no callback das
+ * preferências e no comando `/mensagens` — com a conta escrita na mão nos dois,
+ * `início + 7 * 86400000`. Duas cópias da mesma regra de acesso é o bug que
+ * ninguém reproduz: o menu diz que os alertas estão disponíveis e o callback
+ * diz que não, dependendo de qual dos dois respondeu por último.
+ *
+ * A duração do teste NÃO aparece aqui, e é o ponto. O fim do teste é gravado em
+ * `futebol_trial_ends_at` no instante em que o relógio larga (ver a migration
+ * 134), então quem lê não precisa saber quanto ele dura — e continua certo para
+ * as duas coortes vivas: quem começou antes do corte tem 7 dias gravados, quem
+ * começou depois tem 48 horas, e esta função não distingue.
+ */
+
+/** O recorte de `public.users` que a resposta precisa. Nada além disto. */
+export type AcessoAoFutebol = {
+  futebol_subscription_status?: string | null;
+  futebol_trial_ends_at?: string | null;
+};
+
+export function temAcessoAoFutebol(
+  u: AcessoAoFutebol | null | undefined,
+  agora: number = Date.now(),
+): boolean {
+  if (!u) return false;
+  if (u.futebol_subscription_status === "premium") return true;
+  if (!u.futebol_trial_ends_at) return false;
+
+  const fim = new Date(u.futebol_trial_ends_at).getTime();
+  // Data ilegível não vira acesso: `NaN > agora` é falso, mas deixar implícito
+  // já custou um bug em outro lugar do CRM.
+  if (Number.isNaN(fim)) return false;
+  return fim > agora;
+}

--- a/supabase/functions/telegram-webhook/callbacks.ts
+++ b/supabase/functions/telegram-webhook/callbacks.ts
@@ -3,6 +3,7 @@
 // ============================================================
 // Extraído de index.ts na Onda 6b da revisão (split mecânico, move-only).
 import { BETS_DASHBOARD_URL } from "./config.ts";
+import { temAcessoAoFutebol } from "../shared/acesso-ao-futebol.ts";
 import type { TelegramCallbackQuery } from "./types.ts";
 import {
   answerCallbackQuery,
@@ -124,11 +125,9 @@ async function handleCallbackQuery(
   // Alterna a preferência e REESCREVE a própria mensagem com o estado novo.
   if (data === "prefliq" || data === "prefres" || data === "prefpub") {
     const { data: cur } = await supabase
-      .from("users").select("settlement_reminders_muted, weekly_summary_muted, futebol_publication_alerts_enabled, futebol_subscription_status, futebol_trial_started_at")
+      .from("users").select("settlement_reminders_muted, weekly_summary_muted, futebol_publication_alerts_enabled, futebol_subscription_status, futebol_trial_ends_at")
       .eq("id", user.id).maybeSingle();
-    const publicationAvailable = cur?.futebol_subscription_status === "premium" ||
-      (!!cur?.futebol_trial_started_at &&
-        new Date(cur.futebol_trial_started_at).getTime() + 7 * 86400000 > Date.now());
+    const publicationAvailable = temAcessoAoFutebol(cur);
     const p = {
       settlementMuted: cur?.settlement_reminders_muted ?? false,
       weeklyMuted: cur?.weekly_summary_muted ?? false,

--- a/supabase/functions/telegram-webhook/index.ts
+++ b/supabase/functions/telegram-webhook/index.ts
@@ -10,6 +10,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { maskPhone } from "../shared/phone.ts";
+import { temAcessoAoFutebol } from "../shared/acesso-ao-futebol.ts";
 import {
   generateTraceId,
   identifyUser,
@@ -480,11 +481,9 @@ serve(async (req) => {
     if (command === "/mensagens") {
       const { data: pref } = await supabase
         .from("users").select(
-          "settlement_reminders_muted, weekly_summary_muted, futebol_publication_alerts_enabled, futebol_subscription_status, futebol_trial_started_at",
+          "settlement_reminders_muted, weekly_summary_muted, futebol_publication_alerts_enabled, futebol_subscription_status, futebol_trial_ends_at",
         ).eq("id", user.id).maybeSingle();
-      const accessActive = pref?.futebol_subscription_status === "premium" ||
-        (!!pref?.futebol_trial_started_at &&
-          new Date(pref.futebol_trial_started_at).getTime() + 7 * 86400000 > Date.now());
+      const accessActive = temAcessoAoFutebol(pref);
       const p = {
         settlementMuted: pref?.settlement_reminders_muted ?? false,
         weeklyMuted: pref?.weekly_summary_muted ?? false,

--- a/supabase/functions/tests/acesso-ao-futebol.test.ts
+++ b/supabase/functions/tests/acesso-ao-futebol.test.ts
@@ -1,0 +1,54 @@
+// Acesso ao futebol lido pelo Telegram (shared/acesso-ao-futebol.ts).
+//
+// A regra estava copiada no callback das preferências e no /mensagens, com
+// `início + 7 * 86400000` nos dois. Agora é uma função só, e ela lê o FIM
+// gravado — não a duração. Estes casos existem para provar que ela não voltou a
+// saber quanto o teste dura.
+import { assert, assertEquals } from "./_assert.ts";
+import { temAcessoAoFutebol } from "../shared/acesso-ao-futebol.ts";
+
+const AGORA = Date.parse("2026-09-12T12:00:00Z");
+const emHoras = (h: number) => new Date(AGORA + h * 3600000).toISOString();
+
+Deno.test("assinante entra, mesmo sem teste nenhum", () => {
+  assert(
+    temAcessoAoFutebol({ futebol_subscription_status: "premium", futebol_trial_ends_at: null }, AGORA),
+  );
+});
+
+Deno.test("teste correndo entra", () => {
+  assert(temAcessoAoFutebol({ futebol_trial_ends_at: emHoras(1) }, AGORA));
+});
+
+Deno.test("teste vencido nao entra", () => {
+  assertEquals(temAcessoAoFutebol({ futebol_trial_ends_at: emHoras(-1) }, AGORA), false);
+});
+
+Deno.test("quem nunca abriu o modulo nao entra", () => {
+  // Fim nulo é quem ainda não tem relógio: o teste só larga no primeiro acesso
+  // ao futebol, e é a RPC de acesso que grava. O Telegram nunca larga o relógio.
+  assertEquals(temAcessoAoFutebol({ futebol_trial_ends_at: null }, AGORA), false);
+});
+
+Deno.test("as duas coortes vivas passam pela mesma conta", () => {
+  // Quem começou antes do corte tem 7 dias gravados; quem começou depois tem 48
+  // horas. A função não distingue, e é exatamente isso que ela precisa provar.
+  assert(temAcessoAoFutebol({ futebol_trial_ends_at: emHoras(24 * 6) }, AGORA), "coorte de 7 dias");
+  assert(temAcessoAoFutebol({ futebol_trial_ends_at: emHoras(47) }, AGORA), "coorte de 48 horas");
+});
+
+Deno.test("linha sem dados nao entra", () => {
+  assertEquals(temAcessoAoFutebol(null, AGORA), false);
+  assertEquals(temAcessoAoFutebol(undefined, AGORA), false);
+  assertEquals(temAcessoAoFutebol({}, AGORA), false);
+});
+
+Deno.test("data ilegivel nao entra", () => {
+  assertEquals(temAcessoAoFutebol({ futebol_trial_ends_at: "sei lá" }, AGORA), false);
+});
+
+Deno.test("o instante exato do fim ja esta fora", () => {
+  // Empate conta como vencido: o fim é o primeiro instante SEM acesso, e é essa
+  // a borda que a RPC de acesso usa (`now() < v_ends`).
+  assertEquals(temAcessoAoFutebol({ futebol_trial_ends_at: emHoras(0) }, AGORA), false);
+});

--- a/supabase/migrations/20260914140000_134_futebol_teste_48_horas.sql
+++ b/supabase/migrations/20260914140000_134_futebol_teste_48_horas.sql
@@ -1,0 +1,287 @@
+-- ============================================================================
+-- 134_futebol_teste_48_horas — o teste grátis do futebol passa de 7d para 48h
+-- ============================================================================
+-- A duração era um número escrito na mão em cinco lugares do servidor, e cada
+-- cópia decidia sozinha quem ainda tinha acesso: a RPC de acesso, a lista do
+-- daily de oportunidades, as duas da fila de alerta em tempo real, e a função
+-- que o sócio usa para ligar o teste na ficha.
+--
+-- Aqui o FIM do teste vira coluna, gravada no mesmo instante em que o relógio
+-- larga. Todo mundo passa a ler a coluna, e a duração deixa de ser conhecida
+-- por quem lê.
+--
+-- O CORTE ENTRE AS DUAS COORTES é o que a coluna já guarda, e não uma data
+-- pendurada no código:
+--   · quem já tinha relógio correndo é preenchido com início + 7 dias, porque
+--     foi isso que a página prometeu a essa pessoa;
+--   · quem ainda não abriu o módulo recebe 48 horas quando abrir, mesmo que
+--     tenha se cadastrado meses atrás.
+--
+-- O critério é o RELÓGIO, não a data de cadastro. O teste não começa no
+-- cadastro: começa na primeira vez que a pessoa abre o futebol. Cortar por
+-- "cadastrados nos últimos dias" mataria no nascimento o teste de quem se
+-- cadastrou antes e abriu agora, e protegeria quem nunca abriu e não tem
+-- relógio nenhum para proteger.
+--
+-- O ganho de materializar é que a decisão é tomada uma vez, na largada, e nunca
+-- mais: as consultas de alerta acertam as duas coortes sem saber que existem
+-- duas, e não sobra data de corte para alguém esquecer de remover depois.
+-- ============================================================================
+
+-- ── A duração, num lugar só ─────────────────────────────────────────────────
+-- Função, e não constante repetida: são dois escritores do relógio (a RPC de
+-- acesso e a função do sócio), e eles precisam concordar. É a próxima coisa que
+-- vai mudar de valor, então ela tem endereço.
+create or replace function public.futebol_trial_duracao()
+ returns interval
+ language sql
+ immutable
+as $function$ select interval '48 hours' $function$;
+
+comment on function public.futebol_trial_duracao() is
+  'Quanto dura o teste grátis do futebol para quem começa agora. Quem já tinha o relógio correndo não passa por aqui: o fim dessa pessoa já está gravado.';
+
+-- ── A coluna do fim ─────────────────────────────────────────────────────────
+alter table public.users
+  add column if not exists futebol_trial_ends_at timestamptz;
+
+comment on column public.users.futebol_trial_ends_at is
+  'Quando o teste grátis do futebol termina para esta pessoa. Gravada junto com o início e nunca recalculada: é ela que faz a promessa vista na largada valer até o fim, mesmo depois de a duração do produto mudar.';
+
+-- ── O corte: quem já estava correndo mantém os 7 dias ───────────────────────
+-- O `futebol_trial_ends_at is null` no filtro deixa a migration idempotente: se
+-- rodar de novo, não estica o teste de ninguém.
+update public.users
+   set futebol_trial_ends_at = futebol_trial_started_at + interval '7 days'
+ where futebol_trial_started_at is not null
+   and futebol_trial_ends_at is null;
+
+-- ── A RPC de acesso ─────────────────────────────────────────────────────────
+-- Além de passar a ler a coluna, ela ganha `hours_left`. Com 48 horas, o
+-- arredondamento em dias só consegue dizer "2 dias" e depois "1 dia", que é o
+-- oposto da urgência que motivou encurtar. O `days_left` fica no contrato
+-- porque a tela ainda lê: tirar agora quebraria o gate antes de a tela
+-- aprender a falar em horas.
+create or replace function public.get_futebol_access()
+ returns jsonb
+ language plpgsql
+ security definer
+ set search_path to ''
+as $function$
+declare
+  v_uid uuid := auth.uid();
+  v_started timestamptz;
+  v_ends timestamptz;
+  v_status text;
+  v_days_left int;
+  v_hours_left int;
+begin
+  -- Deslogado: bloqueado, CTA pra criar conta
+  if v_uid is null then
+    return jsonb_build_object('state','anon','unlocked',false,'days_left',null,'hours_left',null,'trial_ends_at',null);
+  end if;
+
+  select u.futebol_trial_started_at, u.futebol_trial_ends_at, coalesce(u.futebol_subscription_status,'free')
+    into v_started, v_ends, v_status
+  from public.users u where u.id = v_uid;
+
+  -- Assinante do Futebol: liberado
+  if v_status = 'premium' then
+    return jsonb_build_object('state','subscribed','unlocked',true,'days_left',null,'hours_left',null,'trial_ends_at',null);
+  end if;
+
+  -- 1º acesso: o relógio larga agora, e o fim é gravado na MESMA escrita. Se o
+  -- fim ficasse para um passo seguinte, uma linha com início e sem fim seria um
+  -- teste de duração indefinida — e é justamente essa linha que não pode
+  -- existir. O `returning` lê de volta o que foi gravado, em vez de repetir a
+  -- conta aqui.
+  if v_started is null then
+    update public.users set futebol_trial_started_at = now(), futebol_trial_ends_at = now() + public.futebol_trial_duracao() where id = v_uid returning futebol_trial_ends_at into v_ends;
+  end if;
+
+  -- Defesa para uma linha que não deveria existir: relógio correndo com fim
+  -- nulo. Conta a partir do início desta pessoa, e não de agora — senão um
+  -- teste vencido há meses ganharia 48 horas novas de presente.
+  if v_ends is null then
+    v_ends := v_started + public.futebol_trial_duracao();
+  end if;
+
+  v_days_left := greatest(0, ceil(extract(epoch from (v_ends - now())) / 86400.0)::int);
+  v_hours_left := greatest(0, ceil(extract(epoch from (v_ends - now())) / 3600.0)::int);
+
+  if now() < v_ends then
+    return jsonb_build_object('state','trial','unlocked',true,'days_left',v_days_left,'hours_left',v_hours_left,'trial_ends_at',v_ends);
+  else
+    return jsonb_build_object('state','expired','unlocked',false,'days_left',0,'hours_left',0,'trial_ends_at',v_ends);
+  end if;
+end $function$;
+
+revoke all on function public.get_futebol_access() from public, anon;
+grant execute on function public.get_futebol_access() to authenticated;
+
+-- ── O daily de oportunidades (ver 081 e 090) ────────────────────────────────
+-- Só muda como o segmento A é medido. O teto de 5 envios do segmento B segue
+-- como a 090 deixou.
+create or replace function public.get_opportunity_recipients()
+returns table(user_id uuid, chat_id text, user_name text, segment text, sends_without_click integer)
+language sql stable security definer set search_path to 'public'
+as $function$
+  with base as (
+    select u.id, u.telegram_chat_id, u.name,
+           (coalesce(u.futebol_subscription_status,'free') = 'premium'
+             or u.futebol_trial_ends_at > now()) as futebol_ativo,
+           (select max(b.bet_date) from bets b where b.user_id = u.id) as ultima_aposta
+    from users u
+    where u.telegram_chat_id is not null
+      and coalesce(u.settlement_reminders_muted, false) = false
+  )
+  select b.id, b.telegram_chat_id::text, b.name::text,
+         case when b.futebol_ativo then 'A' else 'B' end as segment,
+         coalesce(s.sends_without_click, 0)
+  from base b
+  left join opportunity_dispatch_state s on s.user_id = b.id
+  where b.futebol_ativo
+     or (
+       -- reativação: inativo há 14+ dias (ou nunca apostou) e regra dos 5 envios
+       (b.ultima_aposta is null or b.ultima_aposta < now() - interval '14 days')
+       and coalesce(s.sends_without_click, 0) < 5
+     );
+$function$;
+
+revoke all on function public.get_opportunity_recipients() from public, anon, authenticated;
+grant execute on function public.get_opportunity_recipients() to service_role;
+
+-- ── A fila do alerta em tempo real (ver 111 e a preferência de 28/08) ───────
+create or replace function public.get_futebol_publication_alert_recipients()
+returns table(user_id uuid, chat_id text, user_name text)
+language sql stable security definer set search_path to 'public'
+as $function$
+  select u.id, u.telegram_chat_id::text, u.name::text
+  from public.users u
+  where u.telegram_chat_id is not null
+    and coalesce(u.futebol_publication_alerts_enabled, true) = true
+    and (
+      coalesce(u.futebol_subscription_status, 'free') = 'premium'
+      or u.futebol_trial_ends_at > now()
+    );
+$function$;
+
+revoke all on function public.get_futebol_publication_alert_recipients() from public, anon, authenticated;
+grant execute on function public.get_futebol_publication_alert_recipients() to service_role;
+
+-- Reconfere a preferência quando a entrega é reservada. Pausar no site ou no
+-- Telegram vale imediatamente inclusive para lotes que já estavam na fila.
+create or replace function public.claim_futebol_publication_alert_deliveries()
+returns table(batch_id uuid, user_id uuid, chat_id text, attempt_id uuid, opportunities jsonb)
+language plpgsql security definer set search_path to 'public'
+as $function$
+begin
+  update public.futebol_publication_alert_deliveries d
+  set status = 'expired', attempt_id = null, claimed_at = null
+  where d.status in ('pending', 'failed', 'processing')
+    and not exists (
+      select 1 from public.futebol_publication_alerts a
+      where a.batch_id = d.batch_id and a.kickoff_utc > now()
+    );
+
+  return query
+  with claimed as (
+    update public.futebol_publication_alert_deliveries d
+    set status = 'processing',
+        attempts = d.attempts + 1,
+        attempt_id = gen_random_uuid(),
+        claimed_at = now(),
+        last_attempt_at = now()
+    from public.users u
+    where d.user_id = u.id
+      and d.status in ('pending', 'failed')
+      and u.telegram_chat_id is not null
+      and coalesce(u.futebol_publication_alerts_enabled, true) = true
+      and exists (
+        select 1 from public.futebol_publication_alerts a
+        where a.batch_id = d.batch_id and a.kickoff_utc > now()
+      )
+      and (
+        coalesce(u.futebol_subscription_status, 'free') = 'premium'
+        or u.futebol_trial_ends_at > now()
+      )
+    returning d.batch_id, d.user_id, u.telegram_chat_id::text, d.attempt_id
+  )
+  select c.batch_id,
+         c.user_id,
+         c.telegram_chat_id,
+         c.attempt_id,
+         jsonb_agg(
+           jsonb_build_object(
+             'alert_id', a.id,
+             'fixture_id', a.fixture_id,
+             'home_team_name', a.home_team_name,
+             'away_team_name', a.away_team_name,
+             'competition', a.competition,
+             'kickoff_utc', a.kickoff_utc,
+             'market', a.market,
+             'outcome', a.outcome,
+             'line_value', a.line_value,
+             'best_odd', a.best_odd,
+             'score', a.score,
+             'faixa', a.faixa,
+             'evidencias', a.evidencias
+           ) order by a.score desc
+         )
+  from claimed c
+  join public.futebol_publication_alerts a on a.batch_id = c.batch_id
+  where a.kickoff_utc > now()
+  group by c.batch_id, c.user_id, c.telegram_chat_id, c.attempt_id;
+end;
+$function$;
+
+revoke all on function public.claim_futebol_publication_alert_deliveries() from public, anon, authenticated;
+grant execute on function public.claim_futebol_publication_alert_deliveries() to service_role;
+
+-- ── O teste que o sócio liga na ficha (ver 129) ─────────────────────────────
+-- Passa a gravar as duas colunas. Sem isto o sócio ligaria o teste, a coluna do
+-- fim ficaria nula e a pessoa cairia como vencida na hora: acesso concedido que
+-- não acontece.
+create or replace function public.crm_definir_teste_do_futebol(
+  p_user_id uuid,
+  p_ligado boolean
+)
+returns timestamptz
+language plpgsql
+security definer
+set search_path to ''
+as $function$
+declare
+  v_inicio timestamptz := case when p_ligado then now() else null end;
+  v_fim timestamptz := case when p_ligado then v_inicio + public.futebol_trial_duracao() else null end;
+begin
+  if not public.eh_socio() then
+    raise exception 'apenas socios';
+  end if;
+
+  update public.users
+    set futebol_trial_started_at = v_inicio,
+        futebol_trial_ends_at = v_fim
+    where id = p_user_id;
+
+  if not found then
+    raise exception 'pessoa nao encontrada';
+  end if;
+
+  insert into public.crm_anotacao (user_id, tipo, texto, criada_por)
+  values (
+    p_user_id,
+    'acesso',
+    case when p_ligado then 'Teste do futebol: comecou hoje' else 'Teste do futebol: encerrado' end,
+    (select auth.uid())
+  );
+
+  return v_inicio;
+end;
+$function$;
+
+comment on function public.crm_definir_teste_do_futebol(uuid, boolean) is
+  'Começa ou encerra o teste gratuito do futebol. Grava início e fim juntos, com a duração vigente do produto, e nunca mexe no status de assinatura.';
+
+revoke execute on function public.crm_definir_teste_do_futebol(uuid, boolean) from public;
+grant execute on function public.crm_definir_teste_do_futebol(uuid, boolean) to authenticated;

--- a/supabase/migrations/20260914200000_136_futebol_teste_48_horas.sql
+++ b/supabase/migrations/20260914200000_136_futebol_teste_48_horas.sql
@@ -80,9 +80,14 @@ update public.users
 -- ── A RPC de acesso ─────────────────────────────────────────────────────────
 -- Além de passar a ler a coluna, ela ganha `hours_left`. Com 48 horas, o
 -- arredondamento em dias só consegue dizer "2 dias" e depois "1 dia", que é o
--- oposto da urgência que motivou encurtar. O `days_left` fica no contrato
--- porque a tela ainda lê: tirar agora quebraria o gate antes de a tela
--- aprender a falar em horas.
+-- oposto da urgência que motivou encurtar.
+--
+-- O `days_left` fica no contrato, e não porque a tela leia — depois deste PR
+-- nenhuma lê. Fica porque o banco sobe antes do bundle: entre a migration
+-- aplicada e o deploy do frontend, e depois dele para quem está com a página
+-- aberta ou com o JS antigo em cache, existe navegador pedindo `days_left`. Um
+-- campo removido do contrato vira `undefined` lá, e o contador zera na tela de
+-- quem tem acesso.
 create or replace function public.get_futebol_access()
  returns jsonb
  language plpgsql
@@ -116,6 +121,15 @@ begin
   -- teste de duração indefinida — e é justamente essa linha que não pode
   -- existir. O `returning` lê de volta o que foi gravado, em vez de repetir a
   -- conta aqui.
+  --
+  -- ⚠️ Sem `if not found`, de propósito: se a linha não existe, o UPDATE não
+  -- grava nada e a função devolve um teste que ela não persistiu, então a
+  -- chamada seguinte cunha outras 48 horas — teste perpétuo. É o comportamento
+  -- que já existia antes desta migration, com 7 dias, pela mesma razão
+  -- (`v_started := now()` solto depois de um UPDATE que podia casar zero
+  -- linhas). Mantido aqui porque mudar semântica de ACESSO numa migration sobre
+  -- DURAÇÃO trocaria um teste perpétuo raro por um bloqueio possível durante a
+  -- corrida entre criar a conta e criar a linha. Decisão à parte.
   if v_started is null then
     v_started := now();
     v_ends := v_started + public.futebol_trial_duracao();

--- a/supabase/migrations/20260914200000_136_futebol_teste_48_horas.sql
+++ b/supabase/migrations/20260914200000_136_futebol_teste_48_horas.sql
@@ -38,6 +38,9 @@ create or replace function public.futebol_trial_duracao()
  immutable
 as $function$ select interval '48 hours' $function$;
 
+revoke execute on function public.futebol_trial_duracao() from public;
+grant execute on function public.futebol_trial_duracao() to anon, authenticated, service_role;
+
 comment on function public.futebol_trial_duracao() is
   'Quanto dura o teste grátis do futebol para quem começa agora. Quem já tinha o relógio correndo não passa por aqui: o fim dessa pessoa já está gravado.';
 
@@ -116,8 +119,8 @@ begin
   end if;
 end $function$;
 
-revoke all on function public.get_futebol_access() from public, anon;
-grant execute on function public.get_futebol_access() to authenticated;
+revoke execute on function public.get_futebol_access() from public;
+grant execute on function public.get_futebol_access() to anon, authenticated, service_role;
 
 -- ── O daily de oportunidades (ver 081 e 090) ────────────────────────────────
 -- Só muda como o segmento A é medido. O teto de 5 envios do segmento B segue
@@ -148,7 +151,7 @@ as $function$
      );
 $function$;
 
-revoke all on function public.get_opportunity_recipients() from public, anon, authenticated;
+revoke execute on function public.get_opportunity_recipients() from public;
 grant execute on function public.get_opportunity_recipients() to service_role;
 
 -- ── A fila do alerta em tempo real (ver 111 e a preferência de 28/08) ───────
@@ -166,7 +169,7 @@ as $function$
     );
 $function$;
 
-revoke all on function public.get_futebol_publication_alert_recipients() from public, anon, authenticated;
+revoke execute on function public.get_futebol_publication_alert_recipients() from public;
 grant execute on function public.get_futebol_publication_alert_recipients() to service_role;
 
 -- Reconfere a preferência quando a entrega é reservada. Pausar no site ou no
@@ -235,7 +238,7 @@ begin
 end;
 $function$;
 
-revoke all on function public.claim_futebol_publication_alert_deliveries() from public, anon, authenticated;
+revoke execute on function public.claim_futebol_publication_alert_deliveries() from public;
 grant execute on function public.claim_futebol_publication_alert_deliveries() to service_role;
 
 -- ── O teste que o sócio liga na ficha (ver 129) ─────────────────────────────

--- a/supabase/migrations/20260914200000_136_futebol_teste_48_horas.sql
+++ b/supabase/migrations/20260914200000_136_futebol_teste_48_horas.sql
@@ -1,6 +1,6 @@
--- ============================================================================
--- 134_futebol_teste_48_horas — o teste grátis do futebol passa de 7d para 48h
--- ============================================================================
+-- 20260914200000_136_futebol_teste_48_horas
+--
+-- O teste grátis do futebol passa de 7 dias para 48 horas.
 -- A duração era um número escrito na mão em cinco lugares do servidor, e cada
 -- cópia decidia sozinha quem ainda tinha acesso: a RPC de acesso, a lista do
 -- daily de oportunidades, as duas da fila de alerta em tempo real, e a função
@@ -43,6 +43,24 @@ grant execute on function public.futebol_trial_duracao() to anon, authenticated,
 
 comment on function public.futebol_trial_duracao() is
   'Quanto dura o teste grátis do futebol para quem começa agora. Quem já tinha o relógio correndo não passa por aqui: o fim dessa pessoa já está gravado.';
+
+-- ── O acesso vigente, num lugar só ──────────────────────────────────────────
+-- Três funções deste arquivo faziam a mesma pergunta com o mesmo par de linhas
+-- copiado. STABLE, e não IMMUTABLE, porque a resposta depende de now().
+create or replace function public.futebol_acesso_vigente(
+  p_status text,
+  p_fim timestamptz
+)
+ returns boolean
+ language sql
+ stable
+as $function$ select coalesce(coalesce(p_status, 'free') = 'premium' or p_fim > now(), false) $function$;
+
+comment on function public.futebol_acesso_vigente(text, timestamptz) is
+  'Se o acesso ao futebol está de pé agora: assinante, ou teste cujo fim ainda não chegou. Não sabe quanto o teste dura — quem larga o relógio já gravou o fim.';
+
+revoke execute on function public.futebol_acesso_vigente(text, timestamptz) from public;
+grant execute on function public.futebol_acesso_vigente(text, timestamptz) to anon, authenticated, service_role;
 
 -- ── A coluna do fim ─────────────────────────────────────────────────────────
 alter table public.users
@@ -99,7 +117,9 @@ begin
   -- existir. O `returning` lê de volta o que foi gravado, em vez de repetir a
   -- conta aqui.
   if v_started is null then
-    update public.users set futebol_trial_started_at = now(), futebol_trial_ends_at = now() + public.futebol_trial_duracao() where id = v_uid returning futebol_trial_ends_at into v_ends;
+    v_started := now();
+    v_ends := v_started + public.futebol_trial_duracao();
+    update public.users set futebol_trial_started_at = v_started, futebol_trial_ends_at = v_ends where id = v_uid;
   end if;
 
   -- Defesa para uma linha que não deveria existir: relógio correndo com fim
@@ -131,8 +151,7 @@ language sql stable security definer set search_path to 'public'
 as $function$
   with base as (
     select u.id, u.telegram_chat_id, u.name,
-           (coalesce(u.futebol_subscription_status,'free') = 'premium'
-             or u.futebol_trial_ends_at > now()) as futebol_ativo,
+           public.futebol_acesso_vigente(u.futebol_subscription_status, u.futebol_trial_ends_at) as futebol_ativo,
            (select max(b.bet_date) from bets b where b.user_id = u.id) as ultima_aposta
     from users u
     where u.telegram_chat_id is not null
@@ -163,10 +182,7 @@ as $function$
   from public.users u
   where u.telegram_chat_id is not null
     and coalesce(u.futebol_publication_alerts_enabled, true) = true
-    and (
-      coalesce(u.futebol_subscription_status, 'free') = 'premium'
-      or u.futebol_trial_ends_at > now()
-    );
+    and public.futebol_acesso_vigente(u.futebol_subscription_status, u.futebol_trial_ends_at);
 $function$;
 
 revoke execute on function public.get_futebol_publication_alert_recipients() from public;
@@ -204,10 +220,7 @@ begin
         select 1 from public.futebol_publication_alerts a
         where a.batch_id = d.batch_id and a.kickoff_utc > now()
       )
-      and (
-        coalesce(u.futebol_subscription_status, 'free') = 'premium'
-        or u.futebol_trial_ends_at > now()
-      )
+      and public.futebol_acesso_vigente(u.futebol_subscription_status, u.futebol_trial_ends_at)
     returning d.batch_id, d.user_id, u.telegram_chat_id::text, d.attempt_id
   )
   select c.batch_id,


### PR DESCRIPTION
O teste grátis do futebol passa de 7 dias para 48 horas, com corte por coorte.

## A decisão de produto

Encurtar sem quebrar promessa. Há duas coortes vivas:

- **Quem já tem o relógio correndo mantém 7 dias.** Essa pessoa criou conta vendo "7 dias grátis" escrito na landing e no gate. Encurtar retroativamente tira algo já prometido.
- **Quem ainda não abriu o módulo recebe 48 horas** quando abrir, independente de quando se cadastrou.

O critério é **o relógio já ter começado**, e não a data de cadastro. O teste não começa no cadastro: começa na primeira vez que a pessoa abre o módulo. Cortar por "cadastrados nos últimos dias" mataria no nascimento o teste de quem se cadastrou antes e abriu agora, e protegeria quem nunca abriu e não tem relógio nenhum a proteger.

## O desenho

A duração estava escrita na mão em **sete lugares** do servidor, e cada cópia decidia sozinha quem ainda tinha acesso: a RPC de acesso, a lista do daily de oportunidades, as duas da fila de alerta em tempo real, a função que o sócio usa para ligar o teste na ficha, e mais duas em JavaScript nas edge functions do Telegram.

A 136 materializa o **fim** do teste numa coluna, gravada no mesmo instante em que o relógio larga. Todo mundo passa a ler a coluna, e quem lê deixa de saber quanto o teste dura. É isso que faz as duas coortes passarem pela mesma comparação sem que nenhuma consulta saiba que existem duas — e que não sobre data de corte pendurada no código para alguém esquecer de remover depois.

Duas peças novas dão endereço ao que estava repetido: `futebol_trial_duracao()` para a duração e `futebol_acesso_vigente()` para o predicado. As duas cópias do Telegram viraram um helper em `functions/shared/`, pelo mesmo motivo já escrito no `concessoes.ts`.

## A tela

O contador passa a falar em horas, porque em dias arredondados um teste de 48 horas só consegue dizer "2 dias" e depois "1 dia" — o oposto da urgência que motivou encurtar.

A unidade acompanha a ordem de grandeza: acima de 48 horas fala em dias, dentro de 48 fala em horas. Isso resolve os dois extremos ruins ("faltam 161 horas" para a coorte de 7 dias, e "2 dias" num teste de dois dias) sem nenhuma tela precisar saber de coorte. A última reta passa de 2 dias para 12 horas, senão a pílula nasceria âmbar e ficaria âmbar até o fim.

A pílula também **passa a aparecer no celular**. Era `hidden sm:inline-flex` e sumia abaixo de 640px — e durante o teste ela é a única superfície com o tempo restante, porque a faixa do gate não aparece nesse estado. Ou seja: não havia contador nenhum no celular. Medido a 390px e a 360px, nada estoura a borda.

A promessa foi trocada em **27 lugares de copy**, em seis arquivos, incluindo o `public-routes.json`, que é de onde saem o `<head>` servido, o snippet do Google e o texto de compartilhamento.

## Verificação

A migration foi aplicada num **Postgres 15 de verdade**, sobre uma base mínima, e o comportamento conferido caso a caso: o backfill dá 168h a quem tinha relógio e nada a quem não tinha; quem começou há 3 dias segue com 96h; quem começou há 6d20h segue com 4h; o de 30 dias está expirado; o assinante entra sem teste; o primeiro acesso de quem nunca abriu grava 48h; o segundo acesso não estica; o backfill repetido altera zero linhas; e o usuário sem linha em `users` entra em teste em vez de ficar trancado.

No navegador, contra o staging, o cadastro de um usuário novo e a pílula renderizando o tempo restante.

Suíte: 1495 testes, typecheck sem erro novo, lint sem erro.

## Guardas novas

Três, todas nascidas de divergências que aconteceram de fato durante este trabalho:

- **A promessa do teste** (`futebol-promessa-do-teste.test.ts`) não confere texto igual, confere **unidade**: se alguma das sete telas voltar a medir o teste em dias, quebra. O `public-routes.json` tinha passado batido na primeira varredura justamente por não parecer tela.
- **O acesso, site contra Telegram** (`futebol-acesso-paridade.test.ts`): a cópia entre browser e Deno é inevitável, a divergência não. Foi esse par que divergiu aqui.
- **As duas cópias da RPC de acesso**: `get_futebol_access` existe na migration e no shape file, e a guarda do shape file compara nomes de função, nunca corpos. As duas divergiram durante o PR — a correção do usuário sem linha entrou só na migration. Agora as asserções de comportamento rodam nas duas.

## Fora de escopo, de propósito

O frontend do CRM não foi tocado. Ele tem duas cópias próprias da regra dos 7 dias, e havia outra sessão de trabalho aberta nesses arquivos. Consequência conhecida: o painel do sócio mostrará dias onde o produto entrega horas até que essa dívida feche. A dívida está documentada em `src/utils/futebol-acesso.ts`, com as instruções de quem for fechá-la.

Duas coisas ficaram registradas ali e merecem decisão à parte:

- `crm-mensagens.ts` ainda promete "o teste de sete dias" numa mensagem que vai **para o lead**. É uma linha de copy, e é promessa errada saindo para cliente — categoria diferente de painel interno desatualizado.
- Um usuário logado sem linha em `public.users` ganha teste perpétuo, porque o UPDATE não grava e cada chamada cunha 48 horas novas. Já era assim antes desta migration, com 7 dias, pelo mesmo motivo. Mantido de propósito: mudar semântica de acesso numa migration sobre duração trocaria um teste perpétuo raro por um bloqueio possível na corrida entre criar a conta e criar a linha.

## Ponto de integração com a catraca

Existe em `develop` local, ainda não publicado, um commit que instala a catraca das funções `security definer` e o arquivo `PASSIVO-definidoras-abertas.txt`. Esta branch foi baseada em `origin/develop`, que não tem nenhum dos dois, então o arquivo de passivo **não** viaja neste PR.

Quando aquele commit entrar, três linhas precisam sair daquela lista, porque a 136 fecha essas três funções:

```
claim_futebol_publication_alert_deliveries
get_futebol_publication_alert_recipients
get_opportunity_recipients
```

O próprio teste `o passivo só encolhe` acusa se esquecerem. O lugar natural dessa remoção é o PR que traz a catraca, já que a lista é dele.
